### PR TITLE
ci: publicação automática no npm via GitHub Release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,41 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Verify version matches release tag
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          PKG_VERSION="$(jq -r .version package.json)"
+          EXPECTED_TAG="v${PKG_VERSION}"
+          if [ "$EXPECTED_TAG" != "$RELEASE_TAG" ]; then
+            echo "::error::Release tag '$RELEASE_TAG' does not match package.json version (expected '$EXPECTED_TAG')"
+            exit 1
+          fi
+          echo "Version $PKG_VERSION matches release tag $RELEASE_TAG"
+
+      - name: Release check
+        run: bun run release:check
+
+      - name: Publish to npm
+        run: bun run publish:npm
+        env:
+          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,4 +38,5 @@ jobs:
       - name: Publish to npm
         run: bun run publish:npm
         env:
+          # scripts/bun-publish-with-npm-token reads NPM_CONFIG_TOKEN (not NODE_AUTH_TOKEN)
           NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -373,14 +373,16 @@ dirs.
 - `docs/integration.md` — setup/update/remove ownership model.
 - `docs/troubleshooting.md` — runtime troubleshooting.
 
-`CHANGELOG.md` is historical — treat it as read-only during regular development; it is updated only when cutting a release (see section 8).
+`CHANGELOG.md` is historical — treat it as read-only during regular
+development; it is updated only when cutting a release (see section 8).
 
 ## 8. Release
 
 Releases publish `@noctuacore/agent-bar` to npm automatically. The
 `.github/workflows/publish.yml` workflow runs on the `release: published`
 event: it verifies `package.json` matches the release tag, runs
-`bun run release:check` (tests, typecheck, lint, build, and a pack dry-run), then publishes with `bun run publish:npm`.
+`bun run release:check` (tests, typecheck, lint, build, and a pack dry-run),
+then publishes with `bun run publish:npm`.
 
 To cut a release:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -375,3 +375,24 @@ dirs.
 
 `CHANGELOG.md` is historical — treat it as non-operational unless explicitly
 editing release notes.
+
+## 8. Release
+
+Releases publish `@noctuacore/agent-bar` to npm automatically. The
+`.github/workflows/publish.yml` workflow runs on the `release: published`
+event: it verifies `package.json` matches the release tag, runs
+`bun run release:check`, then publishes with `bun run publish:npm`.
+
+To cut a release:
+
+1. Bump `version` in `package.json`.
+2. Update `CHANGELOG.md` — move or create the section for the new version.
+3. Commit both changes.
+4. Create a GitHub Release with tag `v<version>` (matching `package.json`) and
+   notes. Publishing the Release triggers the workflow.
+
+The workflow needs an `NPM_TOKEN` repository secret: an npm automation /
+granular access token with publish permission. npm 2FA blocks interactive
+publishing, and automation tokens bypass 2FA — so this secret is required for
+CI publishing to work. Set it in GitHub → Settings → Secrets and variables →
+Actions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -373,21 +373,20 @@ dirs.
 - `docs/integration.md` — setup/update/remove ownership model.
 - `docs/troubleshooting.md` — runtime troubleshooting.
 
-`CHANGELOG.md` is historical — treat it as non-operational unless explicitly
-editing release notes.
+`CHANGELOG.md` is historical — treat it as read-only during regular development; it is updated only when cutting a release (see section 8).
 
 ## 8. Release
 
 Releases publish `@noctuacore/agent-bar` to npm automatically. The
 `.github/workflows/publish.yml` workflow runs on the `release: published`
 event: it verifies `package.json` matches the release tag, runs
-`bun run release:check`, then publishes with `bun run publish:npm`.
+`bun run release:check` (tests, typecheck, lint, build, and a pack dry-run), then publishes with `bun run publish:npm`.
 
 To cut a release:
 
 1. Bump `version` in `package.json`.
 2. Update `CHANGELOG.md` — move or create the section for the new version.
-3. Commit both changes.
+3. Commit both changes and push to the main branch.
 4. Create a GitHub Release with tag `v<version>` (matching `package.json`) and
    notes. Publishing the Release triggers the workflow.
 
@@ -396,3 +395,6 @@ granular access token with publish permission. npm 2FA blocks interactive
 publishing, and automation tokens bypass 2FA — so this secret is required for
 CI publishing to work. Set it in GitHub → Settings → Secrets and variables →
 Actions.
+
+For a manual local publish, `bun run publish:npm` reads the npm token from the
+`NPM_CONFIG_TOKEN` environment variable or from `~/.npmrc`.

--- a/docs/superpowers/plans/2026-05-19-publicacao-automatica-npm.md
+++ b/docs/superpowers/plans/2026-05-19-publicacao-automatica-npm.md
@@ -1,0 +1,178 @@
+# Publicação Automática no npm — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Publicar `@noctuacore/agent-bar` no npm automaticamente quando uma GitHub Release é publicada, com testes e checagens como gate.
+
+**Architecture:** Um único workflow do GitHub Actions disparado pelo evento `release: published`. O job confere que `package.json` bate com a tag da Release, roda `bun run release:check`, e publica via o script `scripts/bun-publish-with-npm-token` já existente (que consome a env var `NPM_CONFIG_TOKEN`). Mais uma seção "Release" no `AGENTS.md` documentando o fluxo.
+
+**Tech Stack:** GitHub Actions, Bun, `oven-sh/setup-bun`, `actions/checkout`.
+
+**Spec:** `docs/superpowers/specs/2026-05-19-publicacao-automatica-npm-design.md`
+
+**Nota sobre testes:** um workflow de CI não tem teste automatizado. A verificação é por revisão estrutural e, no fim, pela próxima Release real. Os passos abaixo refletem isso — não há ciclo TDD.
+
+---
+
+### Task 1: Workflow de publicação
+
+**Files:**
+- Create: `.github/workflows/publish.yml`
+
+- [ ] **Step 1: Criar o diretório e o arquivo do workflow**
+
+Criar `.github/workflows/publish.yml` com exatamente este conteúdo:
+
+```yaml
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Verify version matches release tag
+        run: |
+          PKG_VERSION="$(jq -r .version package.json)"
+          EXPECTED_TAG="v${PKG_VERSION}"
+          ACTUAL_TAG="${{ github.event.release.tag_name }}"
+          if [ "$EXPECTED_TAG" != "$ACTUAL_TAG" ]; then
+            echo "::error::Release tag '$ACTUAL_TAG' does not match package.json version (expected '$EXPECTED_TAG')"
+            exit 1
+          fi
+          echo "Version $PKG_VERSION matches release tag $ACTUAL_TAG"
+
+      - name: Release check
+        run: bun run release:check
+
+      - name: Publish to npm
+        run: bun run publish:npm
+        env:
+          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
+```
+
+Justificativa de cada parte (não copiar para o arquivo):
+- `on: release: types: [published]` — dispara só quando uma Release é publicada (não em draft/prerelease edit).
+- `permissions: contents: read` — menor privilégio; o job só lê o repo, não escreve nada no GitHub.
+- `actions/checkout@v4` — no evento `release`, faz checkout do commit que a tag aponta.
+- `oven-sh/setup-bun@v2` — instala o Bun no runner.
+- `bun install --frozen-lockfile` — instala deps respeitando o `bun.lock`.
+- Guarda de versão — `jq` é pré-instalado no `ubuntu-latest`; compara `v<version>` com `github.event.release.tag_name` e falha cedo no mismatch.
+- `bun run release:check` — script já existente: `bun test && bun run typecheck && bun run lint && bun run build && bun pm pack --dry-run --ignore-scripts`.
+- `bun run publish:npm` — script já existente: `bash ./scripts/bun-publish-with-npm-token --access public`. O script lê `NPM_CONFIG_TOKEN` da env; quando presente, pula o fallback do `~/.npmrc` e roda `bun publish --access public`.
+- `NPM_CONFIG_TOKEN` vem do secret `NPM_TOKEN` (criado manualmente pelo usuário — ver Task de documentação).
+
+- [ ] **Step 2: Verificar a sintaxe YAML**
+
+Se `actionlint` estiver instalado, rodar: `actionlint .github/workflows/publish.yml`
+Expected: sem erros.
+
+Se `actionlint` não estiver disponível (`command -v actionlint` vazio), validar o YAML com:
+
+Run: `bun -e "const f=require('fs').readFileSync('.github/workflows/publish.yml','utf8'); if(!f.includes('release:')||!f.includes('publish:npm')) throw new Error('conteúdo inesperado'); console.log('arquivo presente e com as chaves esperadas');"`
+Expected: imprime "arquivo presente e com as chaves esperadas".
+
+Depois, revisar o arquivo visualmente contra o checklist:
+- `on:` é `release` / `types: [published]`.
+- Os 6 passos estão presentes e na ordem: Checkout, Setup Bun, Install, Verify version, Release check, Publish.
+- O passo Publish tem o bloco `env:` com `NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}`.
+- A indentação é consistente (2 espaços, sem tabs).
+
+- [ ] **Step 3: Verificar que os scripts referenciados existem**
+
+Run: `bun run --silent 2>&1 | grep -E "release:check|publish:npm" || jq -r '.scripts | keys[]' package.json | grep -E "release:check|publish:npm"`
+Expected: lista `publish:npm` e `release:check` — confirma que o workflow chama scripts que existem no `package.json`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/publish.yml
+git commit -m "ci: publica no npm ao publicar uma Release"
+```
+
+---
+
+### Task 2: Documentar o fluxo de release no AGENTS.md
+
+**Files:**
+- Modify: `AGENTS.md` (adicionar uma seção "Release")
+
+- [ ] **Step 1: Encontrar o ponto de inserção**
+
+Abrir `AGENTS.md` e localizar a seção sobre paths/runtime no final do arquivo (a tabela de owned paths que termina com `~/.config/waybar/scripts/agent-bar-open-terminal`). A nova seção "Release" deve ser adicionada logo após essa seção de paths, antes de qualquer seção de fechamento. Se a estrutura não casar com isso, inserir a seção "Release" como última seção do arquivo.
+
+- [ ] **Step 2: Adicionar a seção "Release"**
+
+Inserir esta seção (em inglês, para casar com o resto do `AGENTS.md`):
+
+```markdown
+## Release
+
+Releases publish `@noctuacore/agent-bar` to npm automatically. The
+`.github/workflows/publish.yml` workflow runs on the `release: published`
+event: it verifies `package.json` matches the release tag, runs
+`bun run release:check`, then publishes with `bun run publish:npm`.
+
+To cut a release:
+
+1. Bump `version` in `package.json`.
+2. Update `CHANGELOG.md` — move or create the section for the new version.
+3. Commit both changes.
+4. Create a GitHub Release with tag `v<version>` (matching `package.json`) and
+   notes. Publishing the Release triggers the workflow.
+
+The workflow needs an `NPM_TOKEN` repository secret: an npm automation /
+granular access token with publish permission. npm 2FA blocks interactive
+publishing, and automation tokens bypass 2FA — so this secret is required for
+CI publishing to work. Set it in GitHub → Settings → Secrets and variables →
+Actions.
+```
+
+- [ ] **Step 3: Verificar lint e links**
+
+Run: `bun run lint`
+Expected: sem erros (o lint do biome não cobre `.md`, mas confirma que nada quebrou).
+
+Revisar visualmente: a seção "Release" tem heading `##`, os code fences estão balanceados, e a numeração 1-4 está correta.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add AGENTS.md
+git commit -m "docs: documenta o fluxo de release automático"
+```
+
+---
+
+## Verification
+
+Após as duas tasks:
+
+1. `.github/workflows/publish.yml` existe, YAML válido, com o trigger `release: published` e os 6 passos.
+2. `AGENTS.md` tem a seção "Release" descrevendo o fluxo e o pré-requisito do secret.
+3. `bun run lint` passa.
+4. A validação de ponta a ponta acontece na próxima Release real — não é testável localmente.
+
+## Passos manuais do usuário (fora deste plano)
+
+Estes não são tarefas de implementação — são pré-requisitos que só o usuário pode fazer, e devem ser explicados a ele ao final:
+
+1. Criar um token de automação no npmjs.com com permissão de publish em `@noctuacore/agent-bar`.
+2. Adicionar o token como secret `NPM_TOKEN` no repositório GitHub.
+
+Sem o secret, o workflow falha no passo Publish.

--- a/docs/superpowers/specs/2026-05-19-publicacao-automatica-npm-design.md
+++ b/docs/superpowers/specs/2026-05-19-publicacao-automatica-npm-design.md
@@ -1,0 +1,108 @@
+# Design — publicação automática no npm
+
+Data: 2026-05-19
+Status: aprovado, pronto para plano de implementação
+
+## Problema
+
+Publicar o pacote `@noctuacore/agent-bar` no npm é hoje totalmente manual: bump
+de versão, `bun run publish:npm`, autenticação 2FA via navegador, criação de tag
+git. O passo de 2FA não pode rodar em CI, então não há automação possível sem
+antes resolver a autenticação.
+
+## Objetivo
+
+Publicar o pacote no npm automaticamente quando uma GitHub Release é publicada,
+com os testes e checagens rodando como gate antes da publicação.
+
+## Decisões
+
+| # | Decisão | Escolha |
+|---|---------|---------|
+| 1 | Gatilho da publicação | GitHub Release publicada (`on: release: types: [published]`) |
+| 2 | Autenticação npm em CI | Token de automação npm, guardado como secret `NPM_TOKEN` |
+| 3 | Gate antes de publicar | `bun run release:check` (testes, typecheck, lint, build, pack) |
+| 4 | Consistência versão/tag | Workflow falha se `package.json` não bater com a tag da Release |
+| 5 | CI de testes em PRs | Fora de escopo (YAGNI) — `release:check` já roda os testes |
+| 6 | Onde documentar o processo | `AGENTS.md` (doc canônica; `CLAUDE.md` é só shim) |
+
+## Pré-requisito manual (uma vez, feito pelo usuário)
+
+O 2FA da conta npm impede publicação não-interativa. A solução é um **token de
+automação**:
+
+1. Em npmjs.com, criar um Granular Access Token (ou classic Automation token)
+   com permissão de publish no pacote `@noctuacore/agent-bar`. Tokens de
+   automação ignoram o 2FA na publicação.
+2. Adicionar o token como secret do repositório em GitHub → Settings → Secrets
+   and variables → Actions, com o nome `NPM_TOKEN`.
+
+Sem esse secret, o workflow falha no passo de publish com mensagem clara.
+
+## Workflow `.github/workflows/publish.yml`
+
+**Trigger:**
+
+```yaml
+on:
+  release:
+    types: [published]
+```
+
+**Job único, em `ubuntu-latest`. Passos:**
+
+1. **Checkout** — `actions/checkout`. No evento `release`, isso pega o commit
+   que a tag da Release aponta, então publica exatamente o estado da Release.
+2. **Setup Bun** — `oven-sh/setup-bun`.
+3. **Instalar dependências** — `bun install --frozen-lockfile`.
+4. **Guarda de versão** — lê `version` do `package.json` e compara com
+   `github.event.release.tag_name`. A tag esperada é `v<version>` (ex.: versão
+   `4.0.3` ↔ tag `v4.0.3`). Se não baterem, o passo falha com mensagem
+   explicando o mismatch — antes de qualquer interação com o npm.
+5. **Release check** — `bun run release:check`. Roda testes, typecheck, lint,
+   build e pack dry-run. Qualquer falha aborta o job e nada é publicado.
+6. **Publish** — `bun run publish:npm`, com a env var `NPM_CONFIG_TOKEN`
+   definida a partir do secret `NPM_TOKEN`. O script
+   `scripts/bun-publish-with-npm-token` já consome `NPM_CONFIG_TOKEN` — não
+   precisa de alteração.
+
+**Tratamento de falhas:** os passos rodam em sequência; qualquer falha aborta o
+job e nada é publicado. O mismatch de versão/tag falha no passo 4, antes do
+`release:check` e do publish.
+
+## Documentação em `AGENTS.md`
+
+Adicionar uma seção "Release" descrevendo o fluxo de release a partir de agora:
+
+1. Bump da versão no `package.json`.
+2. Atualizar o `CHANGELOG.md` (mover/criar a seção da versão).
+3. Commit das duas mudanças.
+4. Criar uma GitHub Release com tag `v<versão>` e notas.
+5. O workflow `publish.yml` publica no npm automaticamente.
+
+A seção também registra o pré-requisito do secret `NPM_TOKEN` e o porquê (2FA).
+
+## Arquivos afetados
+
+| Arquivo | Mudança |
+|---------|---------|
+| `.github/workflows/publish.yml` | Criar — o workflow de publicação |
+| `AGENTS.md` | Adicionar a seção "Release" |
+
+## Verificação
+
+Não há testes automatizados para um workflow de CI. A verificação é:
+
+- O YAML é válido e o workflow aparece na aba Actions do GitHub após o merge.
+- O passo da guarda de versão é exercitado conceitualmente: tag `v<version>`
+  igual ao `package.json` passa; diferente falha.
+- A validação real de ponta a ponta acontece na próxima Release de verdade.
+  Até lá, o workflow pode ser revisado por leitura.
+
+## Fora de escopo
+
+- CI de testes em pull requests e pushes (decisão 5).
+- Criação automática de tag ou de GitHub Release — a Release é criada
+  manualmente pelo usuário, e isso é o gatilho.
+- Geração automática de release notes / changelog.
+- Publicação em outros registries além do npm.


### PR DESCRIPTION
## Summary

- Adiciona `.github/workflows/publish.yml` — primeiro workflow de CI do repo. Publica `@noctuacore/agent-bar` no npm automaticamente quando uma GitHub Release é publicada.
- O job confere que `package.json` bate com a tag da Release, roda `bun run release:check` (testes, typecheck, lint, build, pack) como gate, e publica via `bun run publish:npm`.
- Documenta o fluxo de release na nova seção 8 do `AGENTS.md`, incluindo o pré-requisito do secret `NPM_TOKEN`.

## Detalhes

- Trigger: `on: release: types: [published]`.
- Segurança: `permissions: contents: read`; a tag da Release passa por `env:` (sem interpolação `${{ }}` direta no shell — evita script injection); secret `NPM_TOKEN` escopado só ao passo de publish.
- Actions pinadas a tag major (`@v4`, `@v2`) — escolha deliberada de baixa manutenção.
- O script `scripts/bun-publish-with-npm-token` já consome `NPM_CONFIG_TOKEN` — zero alteração nele.

## Pré-requisito manual

Antes do primeiro release automático, é preciso criar o secret `NPM_TOKEN` no repositório (token de automação npm — ignora o 2FA). Sem ele o workflow falha no passo de publish.

## Test Plan

- [x] `bun test` — 387 pass, 0 fail
- [x] `bun run typecheck` / `bun run lint` — limpos
- [x] YAML revisado; scripts referenciados (`release:check`, `publish:npm`) existem
- [ ] Validação ponta a ponta: criar uma GitHub Release real após configurar o secret `NPM_TOKEN`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated npm package publishing workflow triggered by GitHub Releases.
  * Version validation ensures package.json matches release tag format.

* **Documentation**
  * Updated release procedures and guidelines in project documentation.
  * Added comprehensive implementation guides for the automated publishing workflow.
  * Clarified that changelog is read-only during regular development.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/othavioquiliao/agent-bar/pull/3?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->