### PR TITLE
Hardening de providers/Waybar + output JSON (--format json / --watch)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,15 +50,27 @@ For development (live edits reflected in Waybar on the next poll), see
 ## Commands
 
 ```bash
-agent-bar             # Waybar JSON
-agent-bar status      # Terminal quota view
-agent-bar menu        # Login and layout TUI
-agent-bar update      # Update the install (npm package or managed checkout)
-agent-bar setup       # Re-apply Waybar integration
-agent-bar uninstall   # Interactive removal
-agent-bar remove      # Forced removal
-agent-bar doctor      # Detect & clean leftovers in $HOME
+agent-bar               # Waybar JSON
+agent-bar status        # Terminal quota view
+agent-bar menu          # Login and layout TUI
+agent-bar update        # Update the install (npm package or managed checkout)
+agent-bar setup         # Re-apply Waybar integration
+agent-bar uninstall     # Interactive removal
+agent-bar remove        # Forced removal
+agent-bar doctor        # Detect & clean leftovers in $HOME
+agent-bar --version     # Print version
 ```
+
+### Use with other bars (Quickshell, Eww, Ironbar)
+
+Waybar is the default, but any bar can consume the raw, versioned JSON contract:
+
+```bash
+agent-bar --format json   # one-shot structured JSON (all providers, no Pango)
+agent-bar --watch         # stream NDJSON: one JSON object per line (default 60s)
+```
+
+See [JSON output](docs/json-output.md) for the schema and a Quickshell example.
 
 `agent-bar update` detects the install type. For the managed `~/.agent-bar`
 checkout (the install.sh path) it fetches and resets to upstream. For an

--- a/README.md
+++ b/README.md
@@ -74,3 +74,4 @@ and tells you to use `git pull`.
 - [Waybar contract](docs/waybar-contract.md)
 - [Troubleshooting](docs/troubleshooting.md)
 - [New provider guide](docs/new-provider.md)
+- [JSON output (Quickshell/Eww)](docs/json-output.md)

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
   "files": {
     "includes": ["src/**/*.ts", "tests/**/*.ts"]
   },
@@ -17,7 +17,7 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true,
+      "preset": "recommended",
       "complexity": {
         "noForEach": "off"
       },

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ Operational docs for `agent-bar`.
 
 - [Waybar contract](waybar-contract.md) — generated modules, CSS, assets, and classes.
 - [New provider guide](new-provider.md) — provider implementation checklist.
+- [JSON output](json-output.md) — `--format json` / `--watch` contract for non-Waybar bars (Quickshell, Eww).
 
 ## Source Of Truth
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -9,6 +9,22 @@
 | `agent-bar menu` | Open provider login, model, and layout settings. | Settings and provider auth as requested |
 | `agent-bar update` | Update the install: managed `~/.agent-bar` checkout, or npm/Bun global package. | `~/.agent-bar` or global package, managed Waybar files |
 
+## JSON Output (non-Waybar bars)
+
+For Quickshell, Eww, Ironbar, or any consumer that renders natively and wants
+raw structured data instead of the Waybar Pango envelope.
+
+| Command | Purpose | Writes |
+| --- | --- | --- |
+| `agent-bar --format json` | One-shot versioned JSON envelope for all registered providers (Pango-free). | Cache only |
+| `agent-bar --format json --provider <id>` | Same, single provider. | Cache only |
+| `agent-bar --watch [--interval <s>]` | Stream NDJSON (one envelope per line) until killed. | Cache only |
+
+The schema, stability policy, and a Quickshell QML example live in
+[`docs/json-output.md`](json-output.md). Unlike the Waybar path, JSON output is
+**not** filtered by the `waybar.providers` setting — it emits all registered
+providers and the consumer decides what to show.
+
 ## Install And Removal
 
 | Command | Purpose | Writes |
@@ -54,7 +70,11 @@ These are mostly for tests, packagers, and manual integration.
 | `-p`, `--provider <id>` | Limit output to `claude`, `codex`, `copilot`, or `amp`. |
 | `-r`, `--refresh` | Ignore cache and fetch fresh provider data. |
 | `-t`, `--terminal` | Force terminal output mode. |
-| `-v`, `--verbose` | Enable diagnostic logging. |
+| `--format <waybar\|json>` | Output format. Default `waybar`. `json` emits the versioned contract (see below). |
+| `--watch` | Stream NDJSON (one envelope per line); implies `--format json`. |
+| `--interval <seconds>` | Watch poll floor (default 60). Only meaningful with `--watch`. |
+| `-v`, `--verbose` | Enable diagnostic logging (stderr). |
+| `-V`, `--version` | Print version and exit. |
 | `-h`, `--help` | Print CLI help. |
 
 ## Update Behavior

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -1,0 +1,121 @@
+# JSON output (`--format json` + `--watch`)
+
+For non-Waybar bars (Quickshell, Eww, Ironbar) that render natively and want raw
+structured data instead of the Waybar Pango envelope.
+
+## Modes
+
+```bash
+agent-bar --format json                    # one-shot snapshot, all registered providers
+agent-bar --format json --provider claude  # one-shot, single provider
+agent-bar --watch                          # stream: one JSON object per line (NDJSON), default 60s
+agent-bar --watch --interval 30            # custom poll floor
+```
+
+- `--watch` implies `--format json`.
+- `--interval` is a **floor**, not a strict period: each provider has a ~10s
+  fetch timeout, so a slow tick can take longer than the interval. Use ≥ 30s.
+- json/watch emit **all registered providers**, independent of the Waybar
+  enabled-providers setting. `--provider X` emits a single-provider envelope.
+- stdout is pure JSON/NDJSON; logs go to stderr.
+
+## Envelope
+
+```json
+{
+  "schemaVersion": 1,
+  "fetchedAt": "2026-06-17T19:00:00.000Z",
+  "providers": [
+    {
+      "provider": "claude",
+      "displayName": "Claude",
+      "available": true,
+      "plan": "Max",
+      "primary":   { "remaining": 30, "used": 70, "resetsAt": "2026-06-17T20:09:59Z", "windowMinutes": 300 },
+      "secondary": { "remaining": 65, "resetsAt": "2026-06-19T22:59:59Z" },
+      "models":    { "Sonnet": { "remaining": 89, "resetsAt": "2026-06-19T22:59:59Z" } },
+      "extra":     { "weeklyModels": { "Sonnet": { "remaining": 89, "resetsAt": "2026-06-19T22:59:59Z" } } }
+    },
+    { "provider": "amp", "displayName": "Amp", "available": false, "error": "Not logged in." }
+  ]
+}
+```
+
+## Fields
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `schemaVersion` | number | Contract version. See stability below. |
+| `fetchedAt` | string (ISO) | When agent-bar produced the snapshot — **not** the network fetch time. On a cache hit the underlying data can be up to the cache TTL (~5min) older. |
+| `providers[]` | array | One entry per provider. Order is registry order (currently `amp`, `claude`, `codex`, `copilot`) and is **not** part of the contract — key on the `provider` field, never on array index. |
+| `provider` | string | `claude` / `codex` / `copilot` / `amp`. |
+| `displayName` | string | Human label. |
+| `available` | boolean | Authenticated and fetched OK. |
+| `account` / `plan` / `planType` | string | Optional; omitted when absent. |
+| `primary` / `secondary` | `Window` | Optional quota windows. |
+| `models` | map of `Window` | Optional per-model/bucket windows. |
+| `extra` | object | **Unstable** — see below. |
+| `error` | string | Present only on failure (key omitted when OK — check `'error' in p`). |
+
+`Window`: `{ remaining: number, used?: number|null, resetsAt: string|null, windowMinutes?: number|null }`.
+`remaining`/`used` are percentages (0-100; Copilot `used` can exceed 100 with overage).
+
+## Stability
+
+The top-level fields and `primary`/`secondary`/`models` (`Window`) are the
+**stable contract** covered by `schemaVersion`. `extra` mirrors internal
+provider-specific structures and is **best-effort/unstable** — it may change
+without a `schemaVersion` bump. Don't depend on `extra` shapes long-term.
+
+Bump policy: `schemaVersion` increments when a stable field is removed, renamed,
+or changes type/meaning. Adding a new optional field does **not** bump.
+
+Absence convention: optional fields are **omitted** when absent (never `null`,
+never a serialized `undefined`). Provider/window array order is not guaranteed.
+
+## Quickshell example
+
+One-shot (poll with a Timer):
+
+```qml
+import Quickshell.Io
+
+Process {
+  id: proc
+  command: ["agent-bar", "--format", "json", "--provider", "claude"]
+  running: true
+  stdout: StdioCollector {
+    onStreamFinished: {
+      const data = JSON.parse(this.text);
+      const p = data.providers[0];
+      label.text = p.error ?? (p.primary.remaining + "%");
+    }
+  }
+}
+```
+
+Stream (one long-lived process, NDJSON via SplitParser):
+
+```qml
+import Quickshell.Io
+
+Process {
+  command: ["agent-bar", "--watch", "--interval", "60"]
+  running: true
+  stdout: SplitParser {           // splits on "\n" by default
+    onRead: (line) => {
+      const data = JSON.parse(line);
+      const claude = data.providers.find((p) => p.provider === "claude");
+      label.text = claude ? claude.primary.remaining + "%" : "?";
+    }
+  }
+}
+```
+
+`Process.command` is an argv array (no shell) — keep each argument separate.
+
+## Future
+
+A native Omarchy Quickshell bar-widget plugin
+(`~/.config/omarchy/plugins/agent-bar/`) is a future step once Omarchy ships its
+Quickshell release (v4).

--- a/docs/superpowers/plans/2026-06-17-output-architecture-json.md
+++ b/docs/superpowers/plans/2026-06-17-output-architecture-json.md
@@ -1,0 +1,861 @@
+# Output Architecture (`--format json` + `--watch`) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expor um contrato JSON estável e versionado (`--format json`) e um modo stream NDJSON (`--watch`) para que bars não-Waybar (Quickshell, Eww, Ironbar) consumam o agent-bar, mantendo o Waybar como default.
+
+**Architecture:** Um mapper puro (`src/formatters/json.ts`) converte o modelo interno `ProviderQuota`/`AllQuotas` (pré-render, sem Pango) num envelope versionado. A CLI ganha flags ortogonais ao `command`. O `index.ts` roteia one-shot json; um módulo `src/watch.ts` faz o loop NDJSON. Providers, cache, settings e render-pango não mudam.
+
+**Tech Stack:** Bun, TypeScript strict, ESM, `bun:test`, Biome.
+
+## Global Constraints
+
+- **Bun only.** Sem Node/npm/pnpm/yarn/ts-node em runtime ou testes.
+- **stdout limpo:** só JSON/NDJSON no stdout; todo log vai pra stderr (o `logger` já faz).
+- **Nunca `!` (non-null assertion).** Estreitar com guard explícito.
+- **Provider error strings são contrato** — não alterar as existentes.
+- **XML/Pango escape só em `render-pango.ts`** — o json não toca render-pango.
+- TypeScript strict, ESM, Biome (2 espaços, single quote, 120 cols, unused import = erro).
+- Identificadores/arquivos em inglês; commits em PT, Conventional Commits, subject ≤ 50 chars.
+- Verificação por task: rodar os testes da task; antes do handoff `bun test && bun run typecheck && bun run lint`.
+
+## File Structure
+
+- `src/formatters/json.ts` (novo) — `SCHEMA_VERSION`, tipos `JsonWindow`/`JsonProvider`/`JsonOutput`, `toJsonWindow`/`toProviderOutput`/`toJsonOutput`. Puro, sem I/O.
+- `src/cli.ts` (modificar) — `CliOptions` += `format`/`watch`/`intervalSeconds`; cases no parser; validação cross-flag pós-parse; entradas no `--help`.
+- `src/index.ts` (modificar) — branch watch (chama `startWatch`), branch one-shot json, desvio dos 2 guards do caminho Waybar.
+- `src/watch.ts` (novo) — `buildWatchLine` (puro) e `startWatch` (loop, EPIPE, scheduling).
+- `tests/formatters-json.test.ts` (novo).
+- `tests/cli.test.ts` (modificar).
+- `tests/watch.test.ts` (novo) — `buildWatchLine` + handler EPIPE.
+- `docs/json-output.md` (novo), `README.md`/`docs/README.md` (links), `package.json` `files`, `tests/package.test.ts`.
+
+---
+
+### Task 1: JSON formatter (mapper puro)
+
+**Files:**
+- Create: `src/formatters/json.ts`
+- Test: `tests/formatters-json.test.ts`
+
+**Interfaces:**
+- Consumes: `AllQuotas`, `ProviderQuota`, `QuotaWindow` de `src/providers/types.ts`.
+- Produces: `SCHEMA_VERSION: number`, `interface JsonWindow`, `interface JsonProvider`, `interface JsonOutput`, `toJsonWindow(w: QuotaWindow): JsonWindow`, `toProviderOutput(p: ProviderQuota): JsonProvider`, `toJsonOutput(quotas: AllQuotas): JsonOutput`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/formatters-json.test.ts`:
+
+```ts
+import { describe, expect, it } from 'bun:test';
+import type { AllQuotas, ProviderQuota } from '../src/providers/types';
+import { SCHEMA_VERSION, toJsonOutput, toProviderOutput } from '../src/formatters/json';
+
+const claude: ProviderQuota = {
+  provider: 'claude',
+  displayName: 'Claude',
+  available: true,
+  plan: 'Max',
+  primary: { remaining: 30, used: 70, resetsAt: '2026-06-17T20:00:00Z', windowMinutes: 300 },
+  secondary: { remaining: 65, resetsAt: '2026-06-19T22:00:00Z' },
+  models: { Sonnet: { remaining: 89, resetsAt: '2026-06-19T22:00:00Z' } },
+  extra: { weeklyModels: { Sonnet: { remaining: 89, resetsAt: '2026-06-19T22:00:00Z' } } },
+};
+
+const ampError: ProviderQuota = {
+  provider: 'amp',
+  displayName: 'Amp',
+  available: false,
+  error: 'Not logged in.',
+};
+
+const allQuotas: AllQuotas = { providers: [claude, ampError], fetchedAt: '2026-06-17T19:00:00.000Z' };
+
+describe('json formatter', () => {
+  it('wraps providers in a versioned envelope', () => {
+    const out = toJsonOutput(allQuotas);
+    expect(out.schemaVersion).toBe(SCHEMA_VERSION);
+    expect(out.fetchedAt).toBe('2026-06-17T19:00:00.000Z');
+    expect(out.providers).toHaveLength(2);
+  });
+
+  it('maps primary/secondary/models/used and keeps extra', () => {
+    const p = toProviderOutput(claude);
+    expect(p.primary).toEqual({ remaining: 30, used: 70, resetsAt: '2026-06-17T20:00:00Z', windowMinutes: 300 });
+    expect(p.secondary).toEqual({ remaining: 65, resetsAt: '2026-06-19T22:00:00Z' });
+    expect(p.models?.Sonnet.remaining).toBe(89);
+    expect(p.extra?.weeklyModels).toBeDefined();
+  });
+
+  it('omits absent optional fields (no null, no undefined key) on an available provider', () => {
+    const p = toProviderOutput(claude);
+    expect('error' in p).toBe(false);
+    expect('account' in p).toBe(false);
+  });
+
+  it('includes error and omits primary on a failed provider', () => {
+    const p = toProviderOutput(ampError);
+    expect(p.available).toBe(false);
+    expect(p.error).toBe('Not logged in.');
+    expect('primary' in p).toBe(false);
+  });
+
+  it('never contains Pango markup', () => {
+    expect(JSON.stringify(toJsonOutput(allQuotas))).not.toContain('<span');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test tests/formatters-json.test.ts`
+Expected: FAIL — `Cannot find module '../src/formatters/json'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/formatters/json.ts`:
+
+```ts
+import type { AllQuotas, ProviderQuota, QuotaWindow } from '../providers/types';
+
+/** Bump on incompatible schema change (remove/rename/retype a stable field). Adding optional fields does not require a bump. */
+export const SCHEMA_VERSION = 1;
+
+export interface JsonWindow {
+  remaining: number;
+  used?: number | null;
+  resetsAt: string | null;
+  windowMinutes?: number | null;
+}
+
+export interface JsonProvider {
+  provider: string;
+  displayName: string;
+  available: boolean;
+  account?: string;
+  plan?: string;
+  planType?: string;
+  primary?: JsonWindow;
+  secondary?: JsonWindow;
+  models?: Record<string, JsonWindow>;
+  /** Provider-specific, pre-render data (weeklyModels, modelsDetailed, extraUsage, meta, quotaSnapshots). NOT covered by schemaVersion stability. */
+  extra?: Record<string, unknown>;
+  error?: string;
+}
+
+export interface JsonOutput {
+  schemaVersion: number;
+  fetchedAt: string;
+  providers: JsonProvider[];
+}
+
+export function toJsonWindow(w: QuotaWindow): JsonWindow {
+  const out: JsonWindow = { remaining: w.remaining, resetsAt: w.resetsAt };
+  if (w.used !== undefined) out.used = w.used;
+  if (w.windowMinutes !== undefined) out.windowMinutes = w.windowMinutes;
+  return out;
+}
+
+export function toProviderOutput(p: ProviderQuota): JsonProvider {
+  const out: JsonProvider = {
+    provider: p.provider,
+    displayName: p.displayName,
+    available: p.available,
+  };
+  if (p.account !== undefined) out.account = p.account;
+  if (p.plan !== undefined) out.plan = p.plan;
+  if (p.planType !== undefined) out.planType = p.planType;
+  if (p.primary) out.primary = toJsonWindow(p.primary);
+  if (p.secondary) out.secondary = toJsonWindow(p.secondary);
+  if (p.models) {
+    const models: Record<string, JsonWindow> = {};
+    for (const [name, w] of Object.entries(p.models)) {
+      models[name] = toJsonWindow(w);
+    }
+    out.models = models;
+  }
+  if (p.extra && Object.keys(p.extra).length > 0) {
+    out.extra = p.extra as Record<string, unknown>;
+  }
+  if (p.error !== undefined) out.error = p.error;
+  return out;
+}
+
+export function toJsonOutput(quotas: AllQuotas): JsonOutput {
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    fetchedAt: quotas.fetchedAt,
+    providers: quotas.providers.map(toProviderOutput),
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test tests/formatters-json.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Typecheck and commit**
+
+Run: `bun run typecheck`
+Expected: no output (sucesso).
+
+```bash
+git add src/formatters/json.ts tests/formatters-json.test.ts
+git commit -m "feat: mapper json versionado (contrato de output)"
+```
+
+---
+
+### Task 2: CLI flags (`--format`, `--watch`, `--interval`)
+
+**Files:**
+- Modify: `src/cli.ts`
+- Test: `tests/cli.test.ts`
+
+**Interfaces:**
+- Produces: `CliOptions.format: 'waybar' | 'json'`, `CliOptions.watch: boolean`, `CliOptions.intervalSeconds: number`. `parseArgs` aplica: `--watch` implica `format='json'`; `--watch` + `--format waybar` explícito → exit 1; `--interval` sem `--watch` → warning stderr; `--format`/`--interval` inválidos → exit 1.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/cli.test.ts` inside `describe('parseArgs')`, after the `--version` test in the `commands` block (or a new `describe`):
+
+```ts
+describe('output format flags', () => {
+  it('defaults format to waybar, watch false, interval 60', () => {
+    const o = parseArgs([]);
+    expect(o.format).toBe('waybar');
+    expect(o.watch).toBe(false);
+    expect(o.intervalSeconds).toBe(60);
+  });
+
+  it('parses --format json', () => {
+    expect(parseArgs(['--format', 'json']).format).toBe('json');
+  });
+
+  it('--watch implies json', () => {
+    const o = parseArgs(['--watch']);
+    expect(o.watch).toBe(true);
+    expect(o.format).toBe('json');
+  });
+
+  it('parses --interval', () => {
+    expect(parseArgs(['--watch', '--interval', '30']).intervalSeconds).toBe(30);
+  });
+
+  function expectExit1(args: string[], needle: string) {
+    const origExit = process.exit;
+    const origErr = console.error;
+    const codes: number[] = [];
+    const errs: string[] = [];
+    process.exit = ((c?: number) => {
+      codes.push(c ?? 0);
+      throw new Error('__exit__');
+    }) as typeof process.exit;
+    console.error = (...a: unknown[]) => {
+      errs.push(a.join(' '));
+    };
+    try {
+      expect(() => parseArgs(args)).toThrow('__exit__');
+      expect(codes).toEqual([1]);
+      expect(errs.join('\n')).toContain(needle);
+    } finally {
+      process.exit = origExit;
+      console.error = origErr;
+    }
+  }
+
+  it('exits 1 on invalid --format', () => {
+    expectExit1(['--format', 'xml'], "--format must be");
+  });
+
+  it('exits 1 on invalid --interval', () => {
+    expectExit1(['--watch', '--interval', 'abc'], '--interval must be');
+  });
+
+  it('exits 1 on --watch with explicit --format waybar', () => {
+    expectExit1(['--watch', '--format', 'waybar'], '--watch requires --format json');
+  });
+
+  it('warns (no exit) on --interval without --watch', () => {
+    const origErr = console.error;
+    const errs: string[] = [];
+    console.error = (...a: unknown[]) => {
+      errs.push(a.join(' '));
+    };
+    try {
+      const o = parseArgs(['--interval', '30']);
+      expect(o.watch).toBe(false);
+      expect(errs.join('\n')).toContain('--interval has no effect without --watch');
+    } finally {
+      console.error = origErr;
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test tests/cli.test.ts`
+Expected: FAIL — `o.format` undefined / cases não existem.
+
+- [ ] **Step 3: Extend `CliOptions` and defaults**
+
+In `src/cli.ts`, add to the `CliOptions` interface (after `verbose: boolean;`):
+
+```ts
+  format: 'waybar' | 'json';
+  watch: boolean;
+  intervalSeconds: number;
+```
+
+In `parseArgs`, change the initial `options` object to:
+
+```ts
+  const options: CliOptions = {
+    command: 'waybar',
+    refresh: false,
+    verbose: false,
+    format: 'waybar',
+    watch: false,
+    intervalSeconds: 60,
+  };
+```
+
+- [ ] **Step 4: Add parser cases and post-parse validation**
+
+In `src/cli.ts`, declare two trackers at the top of `parseArgs` (right after the `options` object):
+
+```ts
+  let formatGiven = false;
+  let intervalGiven = false;
+```
+
+Add these cases to the `switch (arg)` (place near `--verbose`):
+
+```ts
+      case '--format': {
+        const val = requireNextArg(args, i, '--format');
+        if (val !== 'waybar' && val !== 'json') {
+          console.error(`Error: --format must be 'waybar' or 'json' (got '${val}')`);
+          process.exit(1);
+        }
+        options.format = val;
+        formatGiven = true;
+        i++;
+        break;
+      }
+      case '--watch':
+        options.watch = true;
+        break;
+      case '--interval': {
+        const val = requireNextArg(args, i, '--interval');
+        const n = Number.parseInt(val, 10);
+        if (!Number.isInteger(n) || n <= 0) {
+          console.error(`Error: --interval must be a positive integer (got '${val}')`);
+          process.exit(1);
+        }
+        options.intervalSeconds = n;
+        intervalGiven = true;
+        i++;
+        break;
+      }
+```
+
+Add the post-parse validation block immediately before `return options;`:
+
+```ts
+  if (options.watch) {
+    if (formatGiven && options.format === 'waybar') {
+      console.error('Error: --watch requires --format json');
+      process.exit(1);
+    }
+    options.format = 'json';
+  }
+  if (intervalGiven && !options.watch) {
+    console.error('[agent-bar] --interval has no effect without --watch');
+  }
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `bun test tests/cli.test.ts`
+Expected: PASS (todos, incl. os novos).
+
+- [ ] **Step 6: Add `--help` entries**
+
+In `showHelp()`, inside the `Flags` section (after the `--version` line added previously), insert:
+
+```ts
+  console.log(optLine('--format <fmt>', 'Output format: waybar (default) | json'));
+  console.log(optLine('--watch', 'Stream NDJSON (implies --format json)'));
+  console.log(optLine('--interval <s>', 'Watch poll floor in seconds (default 60)'));
+```
+
+- [ ] **Step 7: Typecheck and commit**
+
+Run: `bun run typecheck && bun test tests/cli.test.ts`
+Expected: typecheck limpo; testes PASS.
+
+```bash
+git add src/cli.ts tests/cli.test.ts
+git commit -m "feat: flags --format/--watch/--interval na CLI"
+```
+
+---
+
+### Task 3: One-shot `--format json` wiring (`index.ts`)
+
+**Files:**
+- Modify: `src/index.ts`
+
+**Interfaces:**
+- Consumes: `toJsonOutput` (Task 1), `options.format` (Task 2), `getAllQuotas`/`getQuotaFor` (existentes).
+- Produces: comportamento — `agent-bar --format json [--provider X]` emite o envelope JSON e sai 0; ignora a lista `settings.waybar.providers`.
+
+- [ ] **Step 1: Bypass the provider-disabled guard in json mode**
+
+In `src/index.ts`, find the single-provider guard (atual ~linha 152-158):
+
+```ts
+    if (!settings.waybar.providers.includes(options.provider)) {
+      console.log(JSON.stringify({ text: '', tooltip: '', class: APP_HIDDEN_CLASS }));
+      process.exit(0);
+    }
+```
+
+Replace the condition so json never emits the hidden Waybar envelope:
+
+```ts
+    if (options.format !== 'json' && !settings.waybar.providers.includes(options.provider)) {
+      console.log(JSON.stringify({ text: '', tooltip: '', class: APP_HIDDEN_CLASS }));
+      process.exit(0);
+    }
+```
+
+- [ ] **Step 2: Bypass the Waybar settings filter in json mode**
+
+Find (atual ~linha 172):
+
+```ts
+    if (options.command === 'waybar') {
+      quotas.providers = quotas.providers.filter((p) => settings.waybar.providers.includes(p.provider));
+    }
+```
+
+Replace the condition:
+
+```ts
+    if (options.command === 'waybar' && options.format !== 'json') {
+      quotas.providers = quotas.providers.filter((p) => settings.waybar.providers.includes(p.provider));
+    }
+```
+
+- [ ] **Step 3: Add the json one-shot branch before the output switch**
+
+Immediately before `const mode = settings.waybar.displayMode;` (ou antes do `switch (options.command)`), insert:
+
+```ts
+  if (options.format === 'json') {
+    const { toJsonOutput } = await import('./formatters/json');
+    console.log(JSON.stringify(toJsonOutput(quotas)));
+    process.exit(0);
+  }
+```
+
+- [ ] **Step 4: Verify manually (one-shot)**
+
+Run: `bun run src/index.ts --format json --provider claude | bun -e 'const j=JSON.parse(await Bun.stdin.text()); console.log("schemaVersion=", j.schemaVersion, "providers=", j.providers.length)'`
+Expected: imprime `schemaVersion= 1 providers= 1` (claude presente mesmo se desabilitado no Waybar).
+
+Run: `bun run src/index.ts --format json | bun -e 'const j=JSON.parse(await Bun.stdin.text()); console.log(j.providers.map(p=>p.provider).join(","))'`
+Expected: lista de TODOS os providers registrados (`claude,codex,copilot,amp`), independente do settings.
+
+Run: `bun run src/index.ts --format json | grep -c "<span"`
+Expected: `0` (sem Pango).
+
+- [ ] **Step 5: Regression + commit**
+
+Run: `bun test tests/waybar-contract.test.ts tests/cli.test.ts && bun run typecheck`
+Expected: PASS; typecheck limpo. (Confirma que o caminho Waybar default não regrediu.)
+
+```bash
+git add src/index.ts
+git commit -m "feat: roteia --format json (one-shot)"
+```
+
+---
+
+### Task 4: `--watch` stream (`src/watch.ts` + wiring)
+
+**Files:**
+- Create: `src/watch.ts`
+- Modify: `src/index.ts`
+- Test: `tests/watch.test.ts`
+
+**Interfaces:**
+- Consumes: `getAllQuotas`/`getQuotaFor` (`src/providers`), `toJsonOutput` (Task 1).
+- Produces: `buildWatchLine(quotas: AllQuotas): string` (linha NDJSON com `\n`), `startWatch(opts: { provider?: string; intervalMs: number }): Promise<void>` (nunca resolve; sai via signal/EPIPE).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/watch.test.ts`:
+
+```ts
+import { describe, expect, it } from 'bun:test';
+import type { AllQuotas } from '../src/providers/types';
+import { buildWatchLine } from '../src/watch';
+
+const quotas: AllQuotas = {
+  providers: [{ provider: 'claude', displayName: 'Claude', available: true, primary: { remaining: 50, resetsAt: null } }],
+  fetchedAt: '2026-06-17T19:00:00.000Z',
+};
+
+describe('buildWatchLine', () => {
+  it('produces one valid NDJSON line ending in newline', () => {
+    const line = buildWatchLine(quotas);
+    expect(line.endsWith('\n')).toBe(true);
+    expect(line.includes('\n')).toBe(true);
+    expect(line.trim().split('\n')).toHaveLength(1);
+    const parsed = JSON.parse(line);
+    expect(parsed.schemaVersion).toBe(1);
+    expect(parsed.providers[0].provider).toBe('claude');
+  });
+
+  it('contains no Pango markup', () => {
+    expect(buildWatchLine(quotas)).not.toContain('<span');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test tests/watch.test.ts`
+Expected: FAIL — `Cannot find module '../src/watch'`.
+
+- [ ] **Step 3: Write `src/watch.ts`**
+
+Create `src/watch.ts`:
+
+```ts
+import { toJsonOutput } from './formatters/json';
+import { logger } from './logger';
+import { getAllQuotas, getQuotaFor } from './providers';
+import type { AllQuotas } from './providers/types';
+
+export interface StartWatchOptions {
+  provider?: string;
+  intervalMs: number;
+}
+
+async function fetchQuotas(provider?: string): Promise<AllQuotas> {
+  if (provider) {
+    const quota = await getQuotaFor(provider);
+    return {
+      providers: quota ? [quota] : [],
+      fetchedAt: new Date().toISOString(),
+    };
+  }
+  return getAllQuotas();
+}
+
+/** Serialize one quota snapshot as a single NDJSON line. */
+export function buildWatchLine(quotas: AllQuotas): string {
+  return `${JSON.stringify(toJsonOutput(quotas))}\n`;
+}
+
+/**
+ * Long-running NDJSON emitter. Emits immediately, then every `intervalMs` after
+ * the previous tick's write completes (backpressure-aware, no overlap/drift).
+ * Exits 0 on EPIPE (consumer closed the pipe) or SIGTERM/SIGINT.
+ * Never resolves on its own.
+ */
+export async function startWatch(opts: StartWatchOptions): Promise<void> {
+  process.stdout.on('error', (err: Error & { code?: string }) => {
+    if (err.code === 'EPIPE') process.exit(0);
+  });
+
+  if (process.stdout.isTTY) {
+    process.stderr.write('[agent-bar] watch mode: output is NDJSON — pipe to a consumer\n');
+  }
+
+  let stopping = false;
+  const stop = () => {
+    stopping = true;
+    process.exit(0);
+  };
+  process.on('SIGTERM', stop);
+  process.on('SIGINT', stop);
+
+  const tick = async (): Promise<void> => {
+    if (stopping) return;
+    try {
+      const quotas = await fetchQuotas(opts.provider);
+      process.stdout.write(buildWatchLine(quotas), () => {
+        if (!stopping) setTimeout(tick, opts.intervalMs);
+      });
+    } catch (error) {
+      logger.error('watch tick failed', { error });
+      if (!stopping) setTimeout(tick, opts.intervalMs);
+    }
+  };
+
+  await tick();
+  // Keep the process alive; it exits only via signal or EPIPE.
+  await new Promise<void>(() => {});
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test tests/watch.test.ts`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Wire `--watch` into `index.ts`**
+
+In `src/index.ts`, find the existing refresh block:
+
+```ts
+  if (options.refresh) {
+    const toInvalidate = options.provider ? [options.provider] : getRegisteredProviderIds();
+
+    for (const id of toInvalidate) {
+      const prov = getProvider(id);
+      if (prov) await cache.invalidate(prov.cacheKey);
+    }
+    logger.info('Cache invalidated');
+  }
+```
+
+Immediately AFTER that block (so `--refresh` invalidates once before the loop), insert:
+
+```ts
+  if (options.watch) {
+    const { startWatch } = await import('./watch');
+    await startWatch({ provider: options.provider, intervalMs: options.intervalSeconds * 1000 });
+    return;
+  }
+```
+
+- [ ] **Step 6: Verify manually (stream, EPIPE, interval)**
+
+Run: `timeout 5 bun run src/index.ts --watch --interval 2 | head -2`
+Expected: 2 linhas, cada uma um JSON válido (`schemaVersion:1`); o processo termina sem stack trace (EPIPE tratado quando `head` fecha o pipe).
+
+Run: `bun run src/index.ts --watch --interval 2 2>&1 1>/dev/null | head -1` (TTY/dica)
+Expected (se rodado num terminal): a dica `[agent-bar] watch mode: output is NDJSON` em stderr.
+
+- [ ] **Step 7: Regression + commit**
+
+Run: `bun test && bun run typecheck`
+Expected: tudo PASS; typecheck limpo.
+
+```bash
+git add src/watch.ts src/index.ts tests/watch.test.ts
+git commit -m "feat: modo --watch (stream NDJSON)"
+```
+
+---
+
+### Task 5: Docs + packaging
+
+**Files:**
+- Create: `docs/json-output.md`
+- Modify: `README.md`, `docs/README.md`, `package.json`, `tests/package.test.ts`
+
+**Interfaces:**
+- Consumes: o schema/flags das tasks 1-4.
+- Produces: doc do contrato publicada no npm; `package.test.ts` reflete o novo doc no `files`.
+
+- [ ] **Step 1: Write the failing test (package contract)**
+
+In `tests/package.test.ts`, add `'docs/json-output.md'` to the expected `pkg.files` array — insira logo após `'docs/new-provider.md',`:
+
+```ts
+      'docs/new-provider.md',
+      'docs/json-output.md',
+      'docs/assets/agent-bar-banner.png',
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test tests/package.test.ts`
+Expected: FAIL — `pkg.files` não contém `docs/json-output.md`.
+
+- [ ] **Step 3: Add the doc to `package.json` `files`**
+
+In `package.json`, add `"docs/json-output.md"` to `files`, logo após `"docs/new-provider.md",`:
+
+```json
+    "docs/new-provider.md",
+    "docs/json-output.md",
+    "docs/assets/agent-bar-banner.png"
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test tests/package.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Write `docs/json-output.md`**
+
+Create `docs/json-output.md`:
+
+````markdown
+# JSON output (`--format json` + `--watch`)
+
+For non-Waybar bars (Quickshell, Eww, Ironbar) that render natively and want raw
+structured data instead of the Waybar Pango envelope.
+
+## Modes
+
+```bash
+agent-bar --format json                 # one-shot snapshot, all registered providers
+agent-bar --format json --provider claude  # one-shot, single provider
+agent-bar --watch                       # stream: one JSON object per line (NDJSON), default 60s
+agent-bar --watch --interval 30         # custom poll floor
+```
+
+- `--watch` implies `--format json`.
+- `--interval` is a **floor**, not a strict period: each provider has a ~10s
+  fetch timeout, so a slow tick can take longer than the interval. Use ≥ 30s.
+- json/watch emit **all registered providers**, independent of the Waybar
+  enabled-providers setting. `--provider X` emits a single-provider envelope.
+- stdout is pure JSON/NDJSON; logs go to stderr.
+
+## Envelope
+
+```json
+{
+  "schemaVersion": 1,
+  "fetchedAt": "2026-06-17T19:00:00.000Z",
+  "providers": [
+    {
+      "provider": "claude",
+      "displayName": "Claude",
+      "available": true,
+      "plan": "Max",
+      "primary":   { "remaining": 30, "used": 70, "resetsAt": "2026-06-17T20:09:59Z", "windowMinutes": 300 },
+      "secondary": { "remaining": 65, "resetsAt": "2026-06-19T22:59:59Z" },
+      "models":    { "Sonnet": { "remaining": 89, "resetsAt": "2026-06-19T22:59:59Z" } },
+      "extra":     { "weeklyModels": { "Sonnet": { "remaining": 89, "resetsAt": "2026-06-19T22:59:59Z" } } }
+    },
+    { "provider": "amp", "displayName": "Amp", "available": false, "error": "Not logged in." }
+  ]
+}
+```
+
+## Fields
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `schemaVersion` | number | Contract version. See stability below. |
+| `fetchedAt` | string (ISO) | When agent-bar produced the snapshot — **not** the network fetch time. On a cache hit the underlying data can be up to the cache TTL (~5min) older. |
+| `providers[]` | array | One entry per provider. |
+| `provider` | string | `claude` / `codex` / `copilot` / `amp`. |
+| `displayName` | string | Human label. |
+| `available` | boolean | Authenticated and fetched OK. |
+| `account` / `plan` / `planType` | string | Optional; omitted when absent. |
+| `primary` / `secondary` | `Window` | Optional quota windows. |
+| `models` | map of `Window` | Optional per-model/bucket windows. |
+| `extra` | object | **Unstable** — see below. |
+| `error` | string | Present only on failure (key omitted when OK — check `'error' in p`). |
+
+`Window`: `{ remaining: number, used?: number|null, resetsAt: string|null, windowMinutes?: number|null }`.
+`remaining`/`used` are percentages (0-100; Copilot `used` can exceed 100 with overage).
+
+## Stability
+
+The top-level fields and `primary`/`secondary`/`models` (`Window`) are the
+**stable contract** covered by `schemaVersion`. `extra` mirrors internal
+provider-specific structures and is **best-effort/unstable** — it may change
+without a `schemaVersion` bump. Don't depend on `extra` shapes long-term.
+
+Bump policy: `schemaVersion` increments when a stable field is removed, renamed,
+or changes type/meaning. Adding a new optional field does **not** bump.
+
+Absence convention: optional fields are **omitted** when absent (never `null`,
+never a serialized `undefined`).
+
+## Quickshell example
+
+One-shot (poll with a Timer):
+
+```qml
+import Quickshell.Io
+
+Process {
+  id: proc
+  command: ["agent-bar", "--format", "json", "--provider", "claude"]
+  running: true
+  stdout: StdioCollector {
+    onStreamFinished: {
+      const data = JSON.parse(this.text);
+      const p = data.providers[0];
+      label.text = p.error ?? (p.primary.remaining + "%");
+    }
+  }
+}
+```
+
+Stream (one long-lived process, NDJSON via SplitParser):
+
+```qml
+import Quickshell.Io
+
+Process {
+  command: ["agent-bar", "--watch", "--interval", "60"]
+  running: true
+  stdout: SplitParser {           // splits on "\n" by default
+    onRead: (line) => {
+      const data = JSON.parse(line);
+      label.text = data.providers[0].primary.remaining + "%";
+    }
+  }
+}
+```
+
+`Process.command` is an argv array (no shell) — keep each argument separate.
+
+## Future
+
+A native Omarchy Quickshell bar-widget plugin
+(`~/.config/omarchy/plugins/agent-bar/`) is a future step once Omarchy ships its
+Quickshell release (v4).
+````
+
+- [ ] **Step 6: Add doc links**
+
+In `README.md`, under the `## Docs` list, add after the new-provider line:
+
+```markdown
+- [JSON output (Quickshell/Eww)](docs/json-output.md)
+```
+
+In `docs/README.md`, add an equivalent bullet linking `json-output.md` (match the existing list style in that file).
+
+- [ ] **Step 7: Verify and commit**
+
+Run: `bun test tests/package.test.ts && git diff --check`
+Expected: PASS; `git diff --check` sem erros de whitespace.
+
+```bash
+git add docs/json-output.md README.md docs/README.md package.json tests/package.test.ts
+git commit -m "docs: contrato json-output + links"
+```
+
+---
+
+## Final verification (antes do handoff)
+
+- [ ] Run: `bun test && bun run typecheck && bun run lint`
+  Expected: todos os testes PASS; typecheck limpo; lint exit 0.
+- [ ] Run: `bun run src/index.ts --format json | bun -e 'JSON.parse(await Bun.stdin.text()); console.log("ok")'` → `ok`.
+- [ ] Run: `timeout 5 bun run src/index.ts --watch --interval 2 | head -2` → 2 linhas JSON, sem stack trace.
+- [ ] Run: `bun run src/index.ts` (sem flags, num pipe) → ainda emite o envelope Waybar `{text,tooltip,class}` (não-regressão).
+
+## Self-review (preenchido)
+
+- **Spec coverage:** CLI (Task 2), schema/mapper (Task 1), one-shot wiring + guard bypasses (Task 3), watch/EPIPE/backpressure/TTY (Task 4), docs/estabilidade/QML/packaging (Task 5). `--refresh` once = via bloco existente antes do branch watch (Task 4 Step 5). `--verbose` em watch = stderr pelo logger (sem mudança). Coberto.
+- **Placeholders:** nenhum — todo passo tem código/comando real.
+- **Type consistency:** `JsonOutput`/`JsonProvider`/`JsonWindow`/`SCHEMA_VERSION`/`toJsonOutput` (Task 1) usados em Tasks 3-4; `buildWatchLine`/`startWatch`/`StartWatchOptions` (Task 4); `CliOptions.format/watch/intervalSeconds` (Task 2) usados em Task 3-4. Nomes batem.

--- a/docs/superpowers/specs/2026-06-17-output-architecture-json-design.md
+++ b/docs/superpowers/specs/2026-06-17-output-architecture-json-design.md
@@ -1,0 +1,238 @@
+# Design — Arquitetura de output: `--format json` + `--watch`
+
+- **Data:** 2026-06-17
+- **Status:** aprovado (design); aguardando revisão da spec
+- **Escopo:** Tier 3, sub-projeto A (arquitetura de output) da auditoria de 2026-06-17
+- **Branch:** `analise`
+
+## Contexto e objetivo
+
+O agent-bar hoje só emite o envelope específico do Waybar (`{text, tooltip, class}`
+com Pango markup). O Omarchy está migrando para Quickshell (DHH PR
+basecamp/omarchy#5856), que renderiza nativamente em QML e consome **JSON cru**
+(Pango apareceria como texto literal). O bar Quickshell do Omarchy mantém um
+protocolo command-module compatível com Waybar, então o agent-bar **continua
+funcionando sem mudança** após a migração — mas para cards nativos ricos (e para
+Eww/Ironbar/qualquer bar não-Waybar) é preciso uma saída estruturada estável.
+
+**Objetivo:** expor um contrato JSON estável, versionado e documentado, mantendo
+o Waybar como default e sem quebrar nada. Driver = **prontidão** (não há
+consumidor hoje); o plugin QML nativo do Omarchy é passo futuro (quando v4 sair).
+
+Não-objetivos (YAGNI agora): plugin QML nativo do Omarchy, socket IPC/push,
+formatos não-JSON, qualquer mudança em providers ou cache.
+
+## Decisões (locked no brainstorming)
+
+1. **Superfície CLI = flag**, não comando novo (encaixa no parser atual).
+2. **Modelo completo** na saída: espelha `ProviderQuota` (pré-render, zero Pango),
+   incluindo `used` (Copilot), weekly/models, extra usage, account, plan.
+3. **Reuso do modelo interno** via um mapper explícito (fronteira de contrato),
+   não dump cru do tipo interno.
+4. **`--watch`** incluído agora: stream NDJSON (padrão eficiente do Quickshell
+   `Process` + `SplitParser`).
+
+## Superfície CLI
+
+| Flag | Efeito |
+| --- | --- |
+| `--format <waybar\|json>` | Default `waybar` (comportamento atual intacto). |
+| `--watch` | **Implica `--format json`.** Processo longo; emite 1 envelope por linha (NDJSON) a cada intervalo. |
+| `--interval <segundos>` | Só com `--watch`; default **60**. Inteiro positivo. |
+
+Regras de combinação:
+
+- `--watch` sem `--format` → assume `json`.
+- `--watch` com `--format waybar` explícito → erro stderr + exit 1
+  (`--watch requires --format json`).
+- `--interval` fora de `--watch` → ignorado (sem efeito; não é erro).
+- `--interval` não-numérico ou ≤ 0 → erro stderr + exit 1.
+- `--format` com valor inválido → erro stderr + exit 1.
+- Funciona com `--provider X` (single) ou sem (todos).
+
+Exemplos:
+
+```bash
+agent-bar --format json                    # snapshot, todos os providers
+agent-bar --format json --provider claude  # snapshot, só Claude
+agent-bar --watch                          # stream NDJSON, intervalo 60s
+agent-bar --watch --interval 30 --provider codex
+```
+
+`--help` ganha entradas para `--format`, `--watch`, `--interval`.
+
+## Schema do contrato (versionado)
+
+Envelope **sempre** o mesmo shape — mesmo com 1 provider (array de 1 elemento):
+
+```json
+{
+  "schemaVersion": 1,
+  "fetchedAt": "2026-06-17T19:00:00.000Z",
+  "providers": [
+    {
+      "provider": "claude",
+      "displayName": "Claude",
+      "available": true,
+      "plan": "Max",
+      "primary":   { "remaining": 30, "used": 70, "resetsAt": "2026-06-17T20:09:59Z", "windowMinutes": 300 },
+      "secondary": { "remaining": 65, "resetsAt": "2026-06-19T22:59:59Z" },
+      "models":    { "Sonnet": { "remaining": 89, "resetsAt": "2026-06-19T22:59:59Z" } },
+      "extra":     { "weeklyModels": { "Sonnet": { "remaining": 89, "resetsAt": "…" } } },
+      "error": null
+    },
+    {
+      "provider": "amp",
+      "displayName": "Amp",
+      "available": false,
+      "error": "Amp CLI not installed. Right-click to install and log in."
+    }
+  ]
+}
+```
+
+Em `--watch`, cada tick imprime **um** desses envelopes numa única linha
+terminada por `\n` (NDJSON).
+
+### Tipos de saída (declarados no mapper)
+
+```ts
+interface JsonWindow {
+  remaining: number;
+  used?: number | null;
+  resetsAt: string | null;
+  windowMinutes?: number | null;
+}
+
+interface JsonProvider {
+  provider: string;
+  displayName: string;
+  available: boolean;
+  account?: string;
+  plan?: string;
+  planType?: string;
+  primary?: JsonWindow;
+  secondary?: JsonWindow;
+  models?: Record<string, JsonWindow>;
+  /** Provider-specific bloco de dados pré-render (weeklyModels, modelsDetailed, extraUsage, meta, quotaSnapshots). */
+  extra?: Record<string, unknown>;
+  error?: string;
+}
+
+interface JsonOutput {
+  schemaVersion: number;
+  fetchedAt: string;
+  providers: JsonProvider[];
+}
+```
+
+Campos omitidos quando ausentes (não emitir `undefined`). `error: null` é
+aceitável no exemplo, mas a implementação **omite** `error` quando não há erro
+(consistente com o resto: campo ausente = sem valor). Documentar isso.
+
+## Componentes
+
+| Arquivo | Mudança |
+| --- | --- |
+| `src/formatters/json.ts` (novo) | Puro, sem I/O. `toJsonOutput(quotas: AllQuotas): JsonOutput` e `toProviderOutput(p: ProviderQuota): JsonProvider`. **Cópia campo-a-campo explícita** (não spread), para que adicionar um campo interno NÃO vaze pro contrato sem decisão consciente. Esta é a fronteira de contrato. |
+| `src/index.ts` | Branch para `--format json` one-shot e para `--watch` (loop). Reusa `getAllQuotas()` / `getQuotaFor()`. |
+| `src/cli.ts` | Parse de `--format`, `--watch`, `--interval`; validação; entradas no `--help`. Estende `CliOptions`. |
+| Providers, cache, settings, render-pango, builders | **Sem mudança.** |
+
+### Constante de versão
+
+`SCHEMA_VERSION = 1` definida em `src/formatters/json.ts` e exportada para os
+testes assertarem. Bump manual e consciente em mudança incompatível de schema.
+
+## Data flow
+
+**One-shot json:**
+
+```
+parseArgs → format=json
+  → (provider? getQuotaFor(p) : getAllQuotas())
+  → toJsonOutput(allQuotas)
+  → console.log(JSON.stringify(output))
+  → exit 0
+```
+
+**watch:**
+
+```
+emite imediatamente (tick 0), depois a cada `interval` segundos:
+  tick():
+    quotas = await (provider? getQuotaFor : getAllQuotas)
+    process.stdout.write(JSON.stringify(toJsonOutput(quotas)) + '\n')
+  loop com setTimeout reagendado APÓS cada tick terminar (evita overlap/drift
+  quando um fetch demora mais que o intervalo).
+  SIGTERM/SIGINT → para o timer e exit 0 (handlers já existem em index.ts).
+```
+
+- **Cache-aware** em ambos: `getAllQuotas`/`getQuotaFor` respeitam o cache (TTL
+  5min), então em watch com intervalo 60s a rede é tocada ~a cada 5min e os
+  ticks intermediários emitem dado cacheado. Sem hammer de API.
+- **Seleção de providers:** json/watch emitem **todos os providers registrados**
+  (desacoplado de `settings.waybar.providers` — consumidor não-Waybar decide o
+  que mostrar). `--provider X` → envelope com 1 provider.
+- `fetchedAt` = momento do `getAllQuotas` daquele tick (já setado lá).
+
+## Tratamento de erro
+
+- **Erro por-provider** vai no campo `error` do `JsonProvider` (não-fatal).
+  `getAllQuotas` já captura por provider e nunca rejeita → cada tick sempre
+  produz um envelope válido.
+- **stdout 100% JSON/NDJSON.** Todo log vai pra stderr (o `logger` já faz; em
+  modo waybar/json o logger fica silent salvo `--verbose`). Em watch, garantir
+  que nada além das linhas JSON chegue ao stdout.
+- **Erros de uso** (`--format` inválido, `--interval` inválido, `--watch` +
+  `--format waybar`) → mensagem clara em stderr + exit 1.
+- Em watch, se um tick lançar (improvável, dado que getAllQuotas captura),
+  logar em stderr e continuar o loop (não derrubar o stream).
+
+## Testes
+
+- **`tests/formatters-json.test.ts`** (novo):
+  - shape do envelope (`schemaVersion`, `fetchedAt`, `providers`);
+  - `SCHEMA_VERSION` exportado e refletido na saída;
+  - **ausência de Pango**: `expect(JSON.stringify(out)).not.toContain('<span')`;
+  - mapeia primary/secondary/models/extra/used corretamente;
+  - provider com erro: `available:false` + `error` presente, sem `primary`;
+  - campos ausentes são omitidos (não `undefined` serializado);
+  - single (`--provider`) vs all.
+- **`tests/cli.test.ts`** (estende): parse de `--format json`, `--watch`
+  (implica json), `--interval N`; erros (`--format xpto`, `--interval abc`,
+  `--watch --format waybar`).
+- **watch**: extrair o corpo do tick numa função pura (`buildWatchLine` ou
+  `runTick`) e testá-la isolada; não testar `setTimeout`.
+- Regressão: `bun test && bun run typecheck && bun run lint` continuam verdes
+  (matriz §2 do CLAUDE.md: contrato Waybar, formatters, cli).
+
+## Docs
+
+- **`docs/json-output.md`** (novo): descrição do contrato; tabela de campos com
+  tipos e semântica; nota de estabilidade (`schemaVersion`, política de bump);
+  os modos (`--format json` one-shot, `--watch` NDJSON, `--interval`); **exemplo
+  QML Quickshell** — one-shot via `StdioCollector.onStreamFinished` + `JSON.parse`,
+  e stream via `Process` + `SplitParser` (delimitador `\n`) + `JSON.parse`,
+  lembrando que `command` é array (sem shell). Nota: plugin QML nativo do Omarchy
+  = passo futuro quando o v4 (Quickshell) sair.
+- Linkar em `README.md` (seção Docs) e `docs/README.md`.
+- Adicionar `docs/json-output.md` ao `files` do `package.json` (publicado no npm,
+  como os outros docs) e ao teste `tests/package.test.ts`.
+
+## Riscos e mitigações
+
+- **Acoplamento do contrato ao tipo interno** → mapper com cópia campo-a-campo
+  explícita + `schemaVersion` + doc de estabilidade.
+- **Drift de intervalo / overlap em watch** → reagendar `setTimeout` após o tick
+  terminar (não `setInterval`).
+- **Vazamento de log no stdout em watch** → logger silent por default; teste de
+  ausência de Pango/ruído onde viável.
+- **Pango vazar pro JSON** → o mapper parte de `ProviderQuota` (pré-render); teste
+  explícito `not.toContain('<span')`.
+
+## Fora de escopo (futuro)
+
+- Plugin QML nativo `~/.config/omarchy/plugins/agent-bar/` (espera Omarchy v4).
+- Socket Unix / push IPC.
+- Modo de seleção de providers configurável especificamente para json.

--- a/docs/superpowers/specs/2026-06-17-output-architecture-json-design.md
+++ b/docs/superpowers/specs/2026-06-17-output-architecture-json-design.md
@@ -40,15 +40,37 @@ formatos não-JSON, qualquer mudança em providers ou cache.
 | `--watch` | **Implica `--format json`.** Processo longo; emite 1 envelope por linha (NDJSON) a cada intervalo. |
 | `--interval <segundos>` | Só com `--watch`; default **60**. Inteiro positivo. |
 
-Regras de combinação:
+Regras de combinação (validadas em um **bloco pós-parse** no fim de `parseArgs`,
+não dentro do `switch` sequencial — a checagem cruza flags):
 
 - `--watch` sem `--format` → assume `json`.
 - `--watch` com `--format waybar` explícito → erro stderr + exit 1
   (`--watch requires --format json`).
-- `--interval` fora de `--watch` → ignorado (sem efeito; não é erro).
+- `--interval` fora de `--watch` → **warning em stderr** (`--interval has no
+  effect without --watch`); não-fatal.
 - `--interval` não-numérico ou ≤ 0 → erro stderr + exit 1.
 - `--format` com valor inválido → erro stderr + exit 1.
 - Funciona com `--provider X` (single) ou sem (todos).
+
+`--format` é **ortogonal ao `command`**: `command` continua resolvendo pra
+`'waybar'` por default; o branch de output decide pela flag `options.format`,
+não pelo `command`. Hoje `--format` é uma option desconhecida que cai no
+`default` do parser e **degrada silenciosamente pra Waybar** — a implementação
+precisa adicionar os cases explicitamente (ver CliOptions abaixo).
+
+### CliOptions (parser)
+
+`CliOptions` em `src/cli.ts` ganha:
+
+```ts
+format: 'waybar' | 'json'; // default 'waybar'
+watch: boolean;            // default false
+intervalSeconds: number;   // default 60 (lido só em --watch)
+```
+
+Novos cases no `switch`: `--format` (usa `requireNextArg`, valida `waybar|json`),
+`--watch` (seta `watch=true`), `--interval` (usa `requireNextArg`, `parseInt`,
+valida `> 0`). O bloco pós-parse aplica as regras de combinação acima.
 
 Exemplos:
 
@@ -78,8 +100,7 @@ Envelope **sempre** o mesmo shape — mesmo com 1 provider (array de 1 elemento)
       "primary":   { "remaining": 30, "used": 70, "resetsAt": "2026-06-17T20:09:59Z", "windowMinutes": 300 },
       "secondary": { "remaining": 65, "resetsAt": "2026-06-19T22:59:59Z" },
       "models":    { "Sonnet": { "remaining": 89, "resetsAt": "2026-06-19T22:59:59Z" } },
-      "extra":     { "weeklyModels": { "Sonnet": { "remaining": 89, "resetsAt": "…" } } },
-      "error": null
+      "extra":     { "weeklyModels": { "Sonnet": { "remaining": 89, "resetsAt": "2026-06-19T22:59:59Z" } } }
     },
     {
       "provider": "amp",
@@ -126,16 +147,32 @@ interface JsonOutput {
 }
 ```
 
-Campos omitidos quando ausentes (não emitir `undefined`). `error: null` é
-aceitável no exemplo, mas a implementação **omite** `error` quando não há erro
-(consistente com o resto: campo ausente = sem valor). Documentar isso.
+**Convenção de ausência:** campo **omitido** quando ausente (nunca `null`
+explícito, nunca `undefined` serializado). Inclui `error` — provider sem erro
+não tem a chave `error` (consumidor checa `'error' in p`, não `p.error !== null`).
+
+**Estabilidade / `schemaVersion`:** os campos top-level e `primary`/`secondary`/
+`models` (tipo `JsonWindow`) são o **contrato estável** coberto pelo
+`schemaVersion`. O bloco `extra` espelha estruturas internas provider-specific
+(`weeklyModels`, `modelsDetailed` com `ModelWindows`, `extraUsage`, `meta`,
+`quotaSnapshots`) e é declarado **best-effort/instável**: pode mudar sem bump de
+`schemaVersion`. Documentar isso em destaque no `docs/json-output.md`.
+Política de bump: incrementar `schemaVersion` ao **remover** campo estável,
+**renomear**, ou **mudar o tipo/semântica** de um campo estável; **adicionar**
+campo opcional novo NÃO exige bump.
+
+**`fetchedAt`:** é o instante em que o agent-bar **produziu o snapshot** (a
+chamada `getAllQuotas`), não quando o dado foi buscado da rede. Em cache hit
+(comum em `--watch` com intervalo < TTL de 5min) o dado subjacente pode ser até
+~5min mais velho. Documentar essa semântica; expor idade real por-provider
+(`CacheEntry.fetchedAt`) fica para v2 (fora de escopo).
 
 ## Componentes
 
 | Arquivo | Mudança |
 | --- | --- |
 | `src/formatters/json.ts` (novo) | Puro, sem I/O. `toJsonOutput(quotas: AllQuotas): JsonOutput` e `toProviderOutput(p: ProviderQuota): JsonProvider`. **Cópia campo-a-campo explícita** (não spread), para que adicionar um campo interno NÃO vaze pro contrato sem decisão consciente. Esta é a fronteira de contrato. |
-| `src/index.ts` | Branch para `--format json` one-shot e para `--watch` (loop). Reusa `getAllQuotas()` / `getQuotaFor()`. |
+| `src/index.ts` | Branch para `--format json` one-shot e para `--watch` (loop). Reusa `getAllQuotas()` / `getQuotaFor()`. **Dois guards do caminho Waybar precisam ser desviados no modo json:** (1) o gate `if (!settings.waybar.providers.includes(options.provider))` que cospe o envelope *hidden* (atual `index.ts:152`) — pular quando `format==='json'`; (2) o filtro `if (options.command === 'waybar')` (atual `index.ts:172`) — passar a `if (options.command === 'waybar' && options.format !== 'json')`. Single-provider em json reusa o mesmo wrapping `{ providers: [quota], fetchedAt }` já feito pro Waybar (extrair helper para não duplicar). |
 | `src/cli.ts` | Parse de `--format`, `--watch`, `--interval`; validação; entradas no `--help`. Estende `CliOptions`. |
 | Providers, cache, settings, render-pango, builders | **Sem mudança.** |
 
@@ -159,22 +196,47 @@ parseArgs → format=json
 **watch:**
 
 ```
-emite imediatamente (tick 0), depois a cada `interval` segundos:
-  tick():
-    quotas = await (provider? getQuotaFor : getAllQuotas)
-    process.stdout.write(JSON.stringify(toJsonOutput(quotas)) + '\n')
-  loop com setTimeout reagendado APÓS cada tick terminar (evita overlap/drift
-  quando um fetch demora mais que o intervalo).
-  SIGTERM/SIGINT → para o timer e exit 0 (handlers já existem em index.ts).
+setup (uma vez):
+  process.stdout.on('error', e => { if (e.code === 'EPIPE') process.exit(0) })  // [H1]
+  se options.refresh → invalidar cache UMA vez antes do loop                     // [--refresh]
+  let stopping = false; SIGTERM/SIGINT → stopping = true; process.exit(0)
+
+tick():
+  quotas = await (provider ? wrap(getQuotaFor(p)) : getAllQuotas())
+  const line = JSON.stringify(toJsonOutput(quotas)) + '\n'   // linha ATÔMICA (1 write)
+  process.stdout.write(line, () => {                          // agenda no callback → backpressure-aware [M4]
+    if (!stopping) setTimeout(tick, intervalSeconds * 1000)
+  })
+
+start: tick()  // emite imediatamente (tick 0), depois reagenda
 ```
 
-- **Cache-aware** em ambos: `getAllQuotas`/`getQuotaFor` respeitam o cache (TTL
-  5min), então em watch com intervalo 60s a rede é tocada ~a cada 5min e os
-  ticks intermediários emitem dado cacheado. Sem hammer de API.
+- **Linha atômica:** cada tick faz **um** `write` da linha completa. Logo um
+  SIGTERM no meio do `await` só causa "falta a última linha", nunca uma linha
+  NDJSON parcial — não precisa esperar tick in-flight. [L5]
+- **EPIPE:** consumidor fechando o pipe (reload do bar, lock, logout) → handler
+  sai com 0 em vez de crash. [H1]
+- **Agendamento no callback do `write`** (não `setInterval`): serializa emissão
+  e scheduling e é sensível a backpressure; evita overlap/drift. [M4]
+- **`--interval` é um piso, não período exato:** cada provider tem timeout de
+  `PROVIDER_TIMEOUT_MS` (10s) + 1 retry; um tick lento pode levar ~21s, então o
+  período efetivo é `max(interval, duração do tick)`. Documentar no `--help` e na
+  doc; intervalos < ~10s não dão a cadência ingênua. [H3]
+- **`--refresh`** invalida o cache **uma vez** antes do loop (não por tick). [missing]
+- **`--verbose`** em watch emite debug por tick em **stderr** (stdout segue puro). [missing]
+
+Comum a one-shot e watch:
+
+- **Cache-aware:** `getAllQuotas`/`getQuotaFor` respeitam o cache (TTL 5min);
+  em watch com intervalo 60s a rede é tocada ~a cada 5min e os ticks
+  intermediários emitem dado cacheado. Sem hammer de API. O `inflight` Map do
+  `Cache` se limpa no `.then`/`.catch` → **sem leak** em processo longo. [missing]
 - **Seleção de providers:** json/watch emitem **todos os providers registrados**
-  (desacoplado de `settings.waybar.providers` — consumidor não-Waybar decide o
-  que mostrar). `--provider X` → envelope com 1 provider.
-- `fetchedAt` = momento do `getAllQuotas` daquele tick (já setado lá).
+  (desacoplado de `settings.waybar.providers`). `--provider X` → envelope com 1
+  provider (via `getQuotaFor` embrulhado em `AllQuotas`).
+- **TTY interativo:** rodar `agent-bar --watch` num terminal cospe NDJSON cru;
+  quando `process.stdout.isTTY`, emitir **uma** dica em stderr ("watch mode:
+  output is NDJSON — pipe to a consumer"). [missing]
 
 ## Tratamento de erro
 
@@ -197,39 +259,61 @@ emite imediatamente (tick 0), depois a cada `interval` segundos:
   - **ausência de Pango**: `expect(JSON.stringify(out)).not.toContain('<span')`;
   - mapeia primary/secondary/models/extra/used corretamente;
   - provider com erro: `available:false` + `error` presente, sem `primary`;
-  - campos ausentes são omitidos (não `undefined` serializado);
+  - provider OK: **chave `error` ausente** (`expect('error' in p).toBe(false)`),
+    não `null`; idem demais campos opcionais ausentes;
   - single (`--provider`) vs all.
 - **`tests/cli.test.ts`** (estende): parse de `--format json`, `--watch`
-  (implica json), `--interval N`; erros (`--format xpto`, `--interval abc`,
-  `--watch --format waybar`).
-- **watch**: extrair o corpo do tick numa função pura (`buildWatchLine` ou
-  `runTick`) e testá-la isolada; não testar `setTimeout`.
+  (implica json), `--interval N`; `--interval` sem `--watch` (warning, não erro);
+  erros (`--format xpto`, `--interval abc`, `--interval 0`, `--watch --format
+  waybar`).
+- **watch** (extrair `runTick()` puro que retorna a linha; não testar timers):
+  - `runTick` produz uma linha NDJSON válida terminada em `\n`;
+  - tick 0 emite imediatamente (chamar `runTick` uma vez sem timer);
+  - **não-overlap**: com `getAllQuotas` mockado com delay, garantir que o próximo
+    tick só agenda após o `write` callback (testar a função de agendamento, ou
+    documentar como limitação se inviável sem fake timers);
+  - **EPIPE**: simular `stdout` emitindo `error` com `code:'EPIPE'` → handler
+    chama `process.exit(0)` (spy em `process.exit`).
 - Regressão: `bun test && bun run typecheck && bun run lint` continuam verdes
   (matriz §2 do CLAUDE.md: contrato Waybar, formatters, cli).
 
 ## Docs
 
 - **`docs/json-output.md`** (novo): descrição do contrato; tabela de campos com
-  tipos e semântica; nota de estabilidade (`schemaVersion`, política de bump);
-  os modos (`--format json` one-shot, `--watch` NDJSON, `--interval`); **exemplo
-  QML Quickshell** — one-shot via `StdioCollector.onStreamFinished` + `JSON.parse`,
-  e stream via `Process` + `SplitParser` (delimitador `\n`) + `JSON.parse`,
-  lembrando que `command` é array (sem shell). Nota: plugin QML nativo do Omarchy
-  = passo futuro quando o v4 (Quickshell) sair.
+  tipos e semântica; **nota de estabilidade** (campos top-level + `JsonWindow`
+  são estáveis sob `schemaVersion`; `extra` é best-effort/instável — em destaque)
+  + política de bump (remover/renomear/mudar tipo de campo estável = bump;
+  adicionar opcional = não); semântica de `fetchedAt` (snapshot, não fetch);
+  os modos (`--format json` one-shot, `--watch` NDJSON, `--interval` como **piso**
+  com nota dos timeouts de provider); **exemplo QML Quickshell** — one-shot via
+  `StdioCollector.onStreamFinished` + `JSON.parse`, e stream via `Process` +
+  `SplitParser` (delimitador `\n`) + `JSON.parse`, lembrando que `command` é array
+  (sem shell). Nota: plugin QML nativo do Omarchy = passo futuro quando o v4
+  (Quickshell) sair.
 - Linkar em `README.md` (seção Docs) e `docs/README.md`.
 - Adicionar `docs/json-output.md` ao `files` do `package.json` (publicado no npm,
   como os outros docs) e ao teste `tests/package.test.ts`.
 
 ## Riscos e mitigações
 
+- **EPIPE no watch** (consumidor fecha o pipe) → `process.stdout.on('error')`
+  com saída 0 em EPIPE. [H1]
+- **`--format` degradar silenciosamente pra Waybar** (option desconhecida cai no
+  `default` do parser) → adicionar cases explícitos + bloco de validação. [H4]
+- **`--provider X` + json bater no gate de `waybar.providers`** (cospe envelope
+  hidden) → desviar os guards do `index.ts` no modo json. [H2/M7]
 - **Acoplamento do contrato ao tipo interno** → mapper com cópia campo-a-campo
-  explícita + `schemaVersion` + doc de estabilidade.
-- **Drift de intervalo / overlap em watch** → reagendar `setTimeout` após o tick
-  terminar (não `setInterval`).
-- **Vazamento de log no stdout em watch** → logger silent por default; teste de
-  ausência de Pango/ruído onde viável.
+  explícita + `schemaVersion` + `extra` marcado instável na doc.
+- **Drift/overlap/backpressure em watch** → agendar próximo tick no callback do
+  `write` (não `setInterval`); `--interval` é piso, documentado. [M4/H3]
+- **`fetchedAt` enganar em cache hit** → documentar que é hora do snapshot, não do
+  fetch de rede. [M3]
+- **Vazamento de log no stdout em watch** → logger silent por default; debug só
+  com `--verbose`, sempre em stderr.
 - **Pango vazar pro JSON** → o mapper parte de `ProviderQuota` (pré-render); teste
   explícito `not.toContain('<span')`.
+- **Divergência de seleção de providers** (json mostra desabilitados no Waybar) →
+  decisão consciente (consumidor não-Waybar é independente); documentar.
 
 ## Fora de escopo (futuro)
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "docs/waybar-contract.md",
     "docs/troubleshooting.md",
     "docs/new-provider.md",
+    "docs/json-output.md",
     "docs/assets/agent-bar-banner.png"
   ],
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -7,11 +7,13 @@
   "bin": {
     "agent-bar": "scripts/agent-bar"
   },
+  "engines": {
+    "bun": ">=1.1.0"
+  },
   "files": [
     "dist/",
     "scripts/agent-bar",
     "scripts/agent-bar-open-terminal",
-    "scripts/bun-publish-with-npm-token",
     "icons/",
     "README.md",
     "LICENSE",

--- a/package.json
+++ b/package.json
@@ -65,11 +65,11 @@
     "access": "public"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.15",
-    "@types/bun": "1.3.13",
+    "@biomejs/biome": "2.5.0",
+    "@types/bun": "1.3.14",
     "typescript": "6.0.3"
   },
   "dependencies": {
-    "@clack/prompts": "1.3.0"
+    "@clack/prompts": "1.5.1"
   }
 }

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,4 +1,4 @@
-import { mkdir, unlink } from 'fs/promises';
+import { mkdir, rename, unlink } from 'fs/promises';
 import { join } from 'path';
 import { CONFIG } from './config';
 import { logger } from './logger';
@@ -77,7 +77,13 @@ export class Cache {
     };
 
     try {
-      await Bun.write(path, JSON.stringify(entry, null, 2));
+      // Atomic write: each provider runs as a separate `agent-bar --provider X`
+      // process, so two Waybar polls can write the same key concurrently. Write
+      // to a unique temp file then rename (atomic on the same filesystem) so a
+      // crash or concurrent writer never leaves a partially-written cache file.
+      const tmp = `${path}.${process.pid}.tmp`;
+      await Bun.write(tmp, JSON.stringify(entry, null, 2));
+      await rename(tmp, path);
       logger.debug('Cache write', { key, ttlMs });
     } catch (error) {
       logger.error('Cache write error', { key, error });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,6 +10,7 @@ export interface CliOptions {
     | 'menu'
     | 'status'
     | 'help'
+    | 'version'
     | 'action-right'
     | 'setup'
     | 'assets-install'
@@ -87,6 +88,12 @@ export function showHelp(): void {
   console.log(v());
 
   console.log(label('Flags'));
+  console.log(optLine('--provider, -p <id>', 'Single provider (Waybar module)'));
+  console.log(optLine('--refresh, -r', 'Invalidate cache before output'));
+  console.log(optLine('--verbose, -v', 'Debug logging to stderr'));
+  console.log(optLine('--version, -V', 'Print version and exit'));
+  console.log(optLine('--dry-run', 'Preview changes (doctor)'));
+  console.log(optLine('--yes, -y', 'Assume yes (doctor/uninstall)'));
   console.log(optLine('--waybar-dir <path>', 'Assets install target'));
   console.log(optLine('--scripts-dir <path>', 'Terminal helper target'));
   console.log(optLine('--icons-dir <path>', 'CSS export icon directory'));
@@ -175,6 +182,9 @@ export function parseArgs(args: string[]): CliOptions {
         if (args[i + 1] === 'install') {
           options.command = 'assets-install';
           i += 1;
+        } else {
+          console.error("Unknown subcommand for 'assets'. Did you mean 'assets install'?");
+          process.exit(1);
         }
         break;
       case 'export':
@@ -184,6 +194,9 @@ export function parseArgs(args: string[]): CliOptions {
         } else if (args[i + 1] === 'waybar-css') {
           options.command = 'export-waybar-css';
           i += 1;
+        } else {
+          console.error("Unknown subcommand for 'export'. Use 'export waybar-modules' or 'export waybar-css'.");
+          process.exit(1);
         }
         break;
       case 'update':
@@ -251,6 +264,10 @@ export function parseArgs(args: string[]): CliOptions {
       case '-h':
       case 'help':
         options.command = 'help';
+        break;
+      case '--version':
+      case '-V':
+        options.command = 'version';
         break;
       default:
         if (arg.startsWith('-')) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -268,7 +268,7 @@ export function parseArgs(args: string[]): CliOptions {
         break;
       case '--interval': {
         const val = requireNextArg(args, i, '--interval');
-        const n = Number.parseInt(val, 10);
+        const n = Number(val);
         if (!Number.isInteger(n) || n <= 0) {
           console.error(`Error: --interval must be a positive integer (got '${val}')`);
           process.exit(1);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,6 +23,9 @@ export interface CliOptions {
   refresh: boolean;
   provider?: string;
   verbose: boolean;
+  format: 'waybar' | 'json';
+  watch: boolean;
+  intervalSeconds: number;
   waybarDir?: string;
   scriptsDir?: string;
   iconsDir?: string;
@@ -92,6 +95,9 @@ export function showHelp(): void {
   console.log(optLine('--refresh, -r', 'Invalidate cache before output'));
   console.log(optLine('--verbose, -v', 'Debug logging to stderr'));
   console.log(optLine('--version, -V', 'Print version and exit'));
+  console.log(optLine('--format <fmt>', 'Output format: waybar (default) | json'));
+  console.log(optLine('--watch', 'Stream NDJSON (implies --format json)'));
+  console.log(optLine('--interval <s>', 'Watch poll floor in seconds (default 60)'));
   console.log(optLine('--dry-run', 'Preview changes (doctor)'));
   console.log(optLine('--yes, -y', 'Assume yes (doctor/uninstall)'));
   console.log(optLine('--waybar-dir <path>', 'Assets install target'));
@@ -163,7 +169,13 @@ export function parseArgs(args: string[]): CliOptions {
     command: 'waybar',
     refresh: false,
     verbose: false,
+    format: 'waybar',
+    watch: false,
+    intervalSeconds: 60,
   };
+
+  let formatGiven = false;
+  let intervalGiven = false;
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
@@ -240,6 +252,32 @@ export function parseArgs(args: string[]): CliOptions {
       case '-v':
         options.verbose = true;
         break;
+      case '--format': {
+        const val = requireNextArg(args, i, '--format');
+        if (val !== 'waybar' && val !== 'json') {
+          console.error(`Error: --format must be 'waybar' or 'json' (got '${val}')`);
+          process.exit(1);
+        }
+        options.format = val;
+        formatGiven = true;
+        i++;
+        break;
+      }
+      case '--watch':
+        options.watch = true;
+        break;
+      case '--interval': {
+        const val = requireNextArg(args, i, '--interval');
+        const n = Number.parseInt(val, 10);
+        if (!Number.isInteger(n) || n <= 0) {
+          console.error(`Error: --interval must be a positive integer (got '${val}')`);
+          process.exit(1);
+        }
+        options.intervalSeconds = n;
+        intervalGiven = true;
+        i++;
+        break;
+      }
       case '--waybar-dir':
         options.waybarDir = requireNextArg(args, i, '--waybar-dir');
         i++;
@@ -282,6 +320,17 @@ export function parseArgs(args: string[]): CliOptions {
           process.exit(1);
         }
     }
+  }
+
+  if (options.watch) {
+    if (formatGiven && options.format === 'waybar') {
+      console.error('Error: --watch requires --format json');
+      process.exit(1);
+    }
+    options.format = 'json';
+  }
+  if (intervalGiven && !options.watch) {
+    console.error('[agent-bar] --interval has no effect without --watch');
   }
 
   return options;

--- a/src/config.ts
+++ b/src/config.ts
@@ -46,6 +46,10 @@ export const CONFIG = {
     claude: {
       usageUrl: 'https://api.anthropic.com/api/oauth/usage',
       betaHeader: 'oauth-2025-04-20',
+      // The OAuth usage endpoint is Claude Code's own undocumented endpoint.
+      // Requests without a `claude-code/<version>` User-Agent land in a stricter
+      // rate-limit bucket and hit persistent 429s. Mimic the expected client.
+      userAgent: 'claude-code/2.1.179',
     },
   },
 

--- a/src/formatters/builders/copilot.ts
+++ b/src/formatters/builders/copilot.ts
@@ -2,7 +2,7 @@ import { getCopilotExtra } from '../../providers/extras';
 import type { CopilotQuotaSnapshot, ProviderQuota } from '../../providers/types';
 import { BOX } from '../../theme';
 import { barSegments, colorForDisplay, indicatorSegments, type Line } from '../segments';
-import { formatEta, formatPercent, formatResetTime, toDisplay } from '../shared';
+import { formatEta, formatPercent, formatResetTime, toWindowDisplay } from '../shared';
 import { buildFooterLine, labelLine, raw, vLine } from './shared';
 import type { BuildOptions } from './types';
 
@@ -30,25 +30,6 @@ function formatRawPercent(value: number): string {
 function boundedPercent(value: number | null): number | null {
   if (value === null) return null;
   return Math.max(0, Math.min(100, value));
-}
-
-function copilotUsedPercent(snapshot: CopilotQuotaSnapshot | undefined): number | null {
-  if (!snapshot || snapshot.isUnlimitedEntitlement || snapshot.entitlementRequests <= 0) {
-    return null;
-  }
-  return (snapshot.usedRequests / snapshot.entitlementRequests) * 100;
-}
-
-function copilotDisplayValue(
-  snapshot: CopilotQuotaSnapshot | undefined,
-  remaining: number | null,
-  mode: BuildOptions['mode'],
-): number | null {
-  if (mode === 'used') {
-    const used = copilotUsedPercent(snapshot);
-    if (used !== null) return used;
-  }
-  return toDisplay(remaining, mode);
 }
 
 // ---------------------------------------------------------------------------
@@ -151,7 +132,7 @@ export function buildCopilot(p: ProviderQuota, options: BuildOptions): Line[] {
         const snapshot = snapshots[bucket];
         const window = p.models?.[name];
         const rem = window?.remaining ?? null;
-        const disp = copilotDisplayValue(snapshot, rem, mode);
+        const disp = toWindowDisplay(window, mode);
         const boundedDisp = boundedPercent(disp);
 
         // ETA text: '→ ETA (time)' when resetsAt is known, '→ N/A' otherwise

--- a/src/formatters/json.ts
+++ b/src/formatters/json.ts
@@ -1,0 +1,72 @@
+import type { AllQuotas, ProviderQuota, QuotaWindow } from '../providers/types';
+
+/** Bump on incompatible schema change (remove/rename/retype a stable field). Adding optional fields does not require a bump. */
+export const SCHEMA_VERSION = 1;
+
+export interface JsonWindow {
+  remaining: number;
+  used?: number | null;
+  resetsAt: string | null;
+  windowMinutes?: number | null;
+}
+
+export interface JsonProvider {
+  provider: string;
+  displayName: string;
+  available: boolean;
+  account?: string;
+  plan?: string;
+  planType?: string;
+  primary?: JsonWindow;
+  secondary?: JsonWindow;
+  models?: Record<string, JsonWindow>;
+  /** Provider-specific, pre-render data (weeklyModels, modelsDetailed, extraUsage, meta, quotaSnapshots). NOT covered by schemaVersion stability. */
+  extra?: Record<string, unknown>;
+  error?: string;
+}
+
+export interface JsonOutput {
+  schemaVersion: number;
+  fetchedAt: string;
+  providers: JsonProvider[];
+}
+
+export function toJsonWindow(w: QuotaWindow): JsonWindow {
+  const out: JsonWindow = { remaining: w.remaining, resetsAt: w.resetsAt };
+  if (w.used !== undefined) out.used = w.used;
+  if (w.windowMinutes !== undefined) out.windowMinutes = w.windowMinutes;
+  return out;
+}
+
+export function toProviderOutput(p: ProviderQuota): JsonProvider {
+  const out: JsonProvider = {
+    provider: p.provider,
+    displayName: p.displayName,
+    available: p.available,
+  };
+  if (p.account !== undefined) out.account = p.account;
+  if (p.plan !== undefined) out.plan = p.plan;
+  if (p.planType !== undefined) out.planType = p.planType;
+  if (p.primary) out.primary = toJsonWindow(p.primary);
+  if (p.secondary) out.secondary = toJsonWindow(p.secondary);
+  if (p.models) {
+    const models: Record<string, JsonWindow> = {};
+    for (const [name, w] of Object.entries(p.models)) {
+      models[name] = toJsonWindow(w);
+    }
+    out.models = models;
+  }
+  if (p.extra && Object.keys(p.extra).length > 0) {
+    out.extra = p.extra as Record<string, unknown>;
+  }
+  if (p.error !== undefined) out.error = p.error;
+  return out;
+}
+
+export function toJsonOutput(quotas: AllQuotas): JsonOutput {
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    fetchedAt: quotas.fetchedAt,
+    providers: quotas.providers.map(toProviderOutput),
+  };
+}

--- a/src/formatters/json.ts
+++ b/src/formatters/json.ts
@@ -47,15 +47,16 @@ export function toProviderOutput(p: ProviderQuota): JsonProvider {
   if (p.account !== undefined) out.account = p.account;
   if (p.plan !== undefined) out.plan = p.plan;
   if (p.planType !== undefined) out.planType = p.planType;
-  if (p.primary) out.primary = toJsonWindow(p.primary);
-  if (p.secondary) out.secondary = toJsonWindow(p.secondary);
-  if (p.models) {
+  if (p.primary !== undefined) out.primary = toJsonWindow(p.primary);
+  if (p.secondary !== undefined) out.secondary = toJsonWindow(p.secondary);
+  if (p.models !== undefined) {
     const models: Record<string, JsonWindow> = {};
     for (const [name, w] of Object.entries(p.models)) {
       models[name] = toJsonWindow(w);
     }
     out.models = models;
   }
+  // Omit an empty extra object so the contract stays clean (only emit extra when it carries data).
   if (p.extra && Object.keys(p.extra).length > 0) {
     out.extra = p.extra as Record<string, unknown>;
   }

--- a/src/formatters/render-pango.ts
+++ b/src/formatters/render-pango.ts
@@ -1,7 +1,8 @@
 import { ONE_DARK } from '../theme';
 import type { ColorToken, Line, Segment } from './segments';
 
-const HEX_BY_TOKEN: Record<ColorToken, string> = {
+/** Theme color token → Pango hex. Shared so every Pango caller escapes identically. */
+export const HEX_BY_TOKEN: Record<ColorToken, string> = {
   green: ONE_DARK.green,
   yellow: ONE_DARK.yellow,
   orange: ONE_DARK.orange,
@@ -25,7 +26,12 @@ function escapeXml(text: string): string {
     .replace(/"/g, '&quot;');
 }
 
-function span(color: string, text: string, bold = false): string {
+/**
+ * Wrap text in a Pango `<span>`, XML-escaping the text. This is the single escape
+ * boundary for Pango output — all bar text and tooltips must route through here
+ * (or `renderPango`) so untrusted provider data can never inject markup.
+ */
+export function span(color: string, text: string, bold = false): string {
   return `<span foreground='${color}'${bold ? " weight='bold'" : ''}>${escapeXml(text)}</span>`;
 }
 

--- a/src/formatters/shared.ts
+++ b/src/formatters/shared.ts
@@ -8,6 +8,19 @@ export function toDisplay(remaining: number | null, mode: DisplayMode): number |
   return mode === 'used' ? 100 - remaining : remaining;
 }
 
+/**
+ * Display value for a quota window, honoring a provider-supplied `used` percent
+ * (Copilot) when present. Falls back to `100 - remaining` in `used` mode.
+ */
+export function toWindowDisplay(
+  window: { remaining: number; used?: number | null } | undefined,
+  mode: DisplayMode,
+): number | null {
+  if (!window) return null;
+  if (mode === 'used' && window.used != null) return window.used;
+  return toDisplay(window.remaining, mode);
+}
+
 export function toHealth(displayValue: number | null, mode: DisplayMode): number | null {
   if (displayValue === null) return null;
   return mode === 'used' ? 100 - displayValue : displayValue;

--- a/src/formatters/waybar.ts
+++ b/src/formatters/waybar.ts
@@ -1,7 +1,6 @@
 import { APP_BASE_CLASS } from '../app-identity';
 import { getStatusForPercent } from '../config';
-import { getCopilotExtra } from '../providers/extras';
-import type { AllQuotas, CopilotQuotaSnapshot, ProviderQuota } from '../providers/types';
+import type { AllQuotas, ProviderQuota } from '../providers/types';
 import { type DisplayMode, loadSettingsSync } from '../settings';
 import { ONE_DARK } from '../theme';
 import { buildAmp as buildAmpLines } from './builders/amp';
@@ -10,9 +9,9 @@ import { buildCodex as buildCodexLines } from './builders/codex';
 import { buildCopilot as buildCopilotLines } from './builders/copilot';
 import { buildGeneric } from './builders/generic';
 import { TOOLTIP_BORDER } from './builders/shared';
-import { renderPango } from './render-pango';
-import { type ColorToken, colorForDisplay } from './segments';
-import { formatPercent, normalizePlanLabel, toDisplay } from './shared';
+import { HEX_BY_TOKEN, renderPango, span } from './render-pango';
+import { colorForDisplay } from './segments';
+import { formatPercent, normalizePlanLabel, toWindowDisplay } from './shared';
 import { type CodexViewModel, resolveCodexViewModelFrom } from './view-model';
 
 const SETTINGS_CACHE_TTL_MS = 5_000;
@@ -63,30 +62,12 @@ interface WaybarOutput {
   class: string;
 }
 
-const s = (color: string, text: string, bold = false) =>
-  `<span foreground='${color}'${bold ? " weight='bold'" : ''}>${text}</span>`;
-
-const HEX_BY_TOKEN: Record<ColorToken, string> = {
-  green: ONE_DARK.green,
-  yellow: ONE_DARK.yellow,
-  orange: ONE_DARK.orange,
-  red: ONE_DARK.red,
-  comment: ONE_DARK.comment,
-  text: ONE_DARK.text,
-  textBright: ONE_DARK.textBright,
-  muted: ONE_DARK.muted,
-  magenta: ONE_DARK.magenta,
-  cyan: ONE_DARK.cyan,
-  blue: ONE_DARK.blue,
-  brightBlue: ONE_DARK.brightBlue,
-};
-
 function colorFor(display: number | null, mode: DisplayMode): string {
   return HEX_BY_TOKEN[colorForDisplay(display, mode)];
 }
 
 function pctColored(display: number | null, mode: DisplayMode): string {
-  return s(colorFor(display, mode), formatPercent(display));
+  return span(colorFor(display, mode), formatPercent(display));
 }
 
 /**
@@ -165,30 +146,6 @@ function buildAmpTooltip(p: ProviderQuota, fetchedAt: string | undefined, mode: 
   );
 }
 
-function copilotUsedPercent(snapshot: CopilotQuotaSnapshot | undefined): number | null {
-  if (!snapshot || snapshot.isUnlimitedEntitlement || snapshot.entitlementRequests <= 0) {
-    return null;
-  }
-  return (snapshot.usedRequests / snapshot.entitlementRequests) * 100;
-}
-
-function copilotDisplayValue(
-  snapshot: CopilotQuotaSnapshot | undefined,
-  remaining: number | null,
-  mode: DisplayMode,
-): number | null {
-  if (mode === 'used') {
-    const used = copilotUsedPercent(snapshot);
-    if (used !== null) return used;
-  }
-  return toDisplay(remaining, mode);
-}
-
-function copilotPrimaryDisplayValue(p: ProviderQuota, mode: DisplayMode): number | null {
-  const snapshot = getCopilotExtra(p)?.quotaSnapshots?.premium_interactions;
-  return copilotDisplayValue(snapshot, p.primary?.remaining ?? null, mode);
-}
-
 // ---------------------------------------------------------------------------
 // Tooltip builder registry
 // ---------------------------------------------------------------------------
@@ -234,13 +191,12 @@ function buildText(quotas: AllQuotas, mode: DisplayMode): string {
 
   for (const p of quotas.providers) {
     if (!p.available) continue;
-    const rem = p.primary?.remaining ?? null;
-    const disp = p.provider === 'copilot' ? copilotPrimaryDisplayValue(p, mode) : toDisplay(rem, mode);
+    const disp = toWindowDisplay(p.primary, mode);
     parts.push(pctColored(disp, mode));
   }
 
-  if (parts.length === 0) return s(ONE_DARK.comment, 'No Providers');
-  return parts.join(` ${s(ONE_DARK.comment, '│')} `);
+  if (parts.length === 0) return span(ONE_DARK.comment, 'No Providers');
+  return parts.join(` ${span(ONE_DARK.comment, '│')} `);
 }
 
 function getClass(quotas: AllQuotas): string {
@@ -279,7 +235,7 @@ export function formatProviderForWaybar(quota: ProviderQuota, mode: DisplayMode 
   }
 
   const rem = quota.primary?.remaining ?? null;
-  const disp = quota.provider === 'copilot' ? copilotPrimaryDisplayValue(quota, mode) : toDisplay(rem, mode);
+  const disp = toWindowDisplay(quota.primary, mode);
   // class based on health (raw remaining), not display value
   const health = rem ?? 100;
   const status = getStatusForPercent(health);

--- a/src/index.ts
+++ b/src/index.ts
@@ -163,7 +163,7 @@ async function main() {
   let quotas: AllQuotas;
 
   if (options.provider) {
-    // If provider is disabled in waybar settings, output empty (hidden module)
+    // Waybar: provider disabled in settings → hidden module. (json mode bypasses this gate.)
     if (options.format !== 'json' && !settings.waybar.providers.includes(options.provider)) {
       console.log(JSON.stringify({ text: '', tooltip: '', class: APP_HIDDEN_CLASS }));
       process.exit(0);

--- a/src/index.ts
+++ b/src/index.ts
@@ -150,6 +150,12 @@ async function main() {
     logger.info('Cache invalidated');
   }
 
+  if (options.watch) {
+    const { startWatch } = await import('./watch');
+    await startWatch({ provider: options.provider, intervalMs: options.intervalSeconds * 1000 });
+    return;
+  }
+
   // Load settings
   const settings = await loadSettings();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -158,7 +158,7 @@ async function main() {
 
   if (options.provider) {
     // If provider is disabled in waybar settings, output empty (hidden module)
-    if (!settings.waybar.providers.includes(options.provider)) {
+    if (options.format !== 'json' && !settings.waybar.providers.includes(options.provider)) {
       console.log(JSON.stringify({ text: '', tooltip: '', class: APP_HIDDEN_CLASS }));
       process.exit(0);
     }
@@ -176,9 +176,15 @@ async function main() {
     quotas = await getAllQuotas();
 
     // Filter by settings for waybar output
-    if (options.command === 'waybar') {
+    if (options.command === 'waybar' && options.format !== 'json') {
       quotas.providers = quotas.providers.filter((p) => settings.waybar.providers.includes(p.provider));
     }
+  }
+
+  if (options.format === 'json') {
+    const { toJsonOutput } = await import('./formatters/json');
+    console.log(JSON.stringify(toJsonOutput(quotas)));
+    process.exit(0);
   }
 
   const mode = settings.waybar.displayMode;

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,13 @@ async function main() {
     process.exit(0);
   }
 
+  // Handle version
+  if (options.command === 'version') {
+    const { default: pkg } = await import('../package.json');
+    console.log(pkg.version);
+    process.exit(0);
+  }
+
   // Handle menu
   if (options.command === 'menu') {
     await runTui();

--- a/src/providers/amp.ts
+++ b/src/providers/amp.ts
@@ -1,10 +1,15 @@
 import { AMP_MISSING_ERROR, findAmpBin } from '../amp-cli';
 import { APP_NAME } from '../app-identity';
+import { CONFIG } from '../config';
 import { logger } from '../logger';
 import type { QuotaBase } from './base';
 import { BaseProvider } from './base';
 import { registerProvider } from './registry';
 import type { AmpQuota, AmpQuotaExtra, ProviderQuota, QuotaWindow } from './types';
+
+const NOT_LOGGED_IN_ERROR = `Not logged in. Open \`${APP_NAME} menu\` and choose Provider login.`;
+/** Sentinel thrown by fetchRaw so auth failures bypass the cache and map cleanly. */
+const NOT_LOGGED_IN_SENTINEL = 'amp:not-logged-in';
 
 export class AmpProvider extends BaseProvider {
   readonly id = 'amp';
@@ -19,115 +24,133 @@ export class AmpProvider extends BaseProvider {
     return AMP_MISSING_ERROR;
   }
 
-  protected toUserFacingError(_error: unknown): string {
+  protected toUserFacingError(error: unknown): string {
+    if (error instanceof Error && error.message === NOT_LOGGED_IN_SENTINEL) {
+      return NOT_LOGGED_IN_ERROR;
+    }
     return 'Failed to fetch Amp usage';
   }
 
+  /**
+   * Run `amp usage` and return its raw stdout. Throws (so the cache is not
+   * poisoned) when the CLI errors or the user is not logged in. The subprocess
+   * is always killed — a hung `amp usage` would otherwise leak a zombie on
+   * every Waybar poll.
+   */
   protected async fetchRaw(): Promise<unknown> {
     const bin = findAmpBin();
     if (!bin) {
       throw new Error('Amp CLI not found');
     }
-    const base: AmpQuota = {
-      provider: this.id,
-      displayName: this.name,
-      available: false,
-    };
-    return this.fetchUsage(base, bin);
-  }
 
-  protected buildQuota(raw: unknown, _base: QuotaBase): ProviderQuota {
-    return raw as ProviderQuota;
-  }
+    const proc = Bun.spawn([bin, 'usage'], {
+      stdout: 'pipe',
+      stderr: 'pipe',
+      env: { ...process.env, NO_COLOR: '1', TERM: 'dumb' },
+    });
 
-  private async fetchUsage(base: AmpQuota, bin: string): Promise<AmpQuota> {
+    const killTimer = setTimeout(() => {
+      try {
+        proc.kill();
+      } catch {}
+    }, CONFIG.api.timeoutMs);
+
     try {
-      const proc = Bun.spawn([bin, 'usage'], {
-        stdout: 'pipe',
-        stderr: 'pipe',
-        env: { ...process.env, NO_COLOR: '1', TERM: 'dumb' },
-      });
-
+      // Drain stderr so a large error dump can't deadlock the stdout pipe.
+      void new Response(proc.stderr).text().catch(() => {});
       const stdout = await new Response(proc.stdout).text();
       const exitCode = await proc.exited;
 
-      if (exitCode !== 0) {
-        return { ...base, error: `Not logged in. Open \`${APP_NAME} menu\` and choose Provider login.` };
+      if (exitCode !== 0 || !/Signed in as (\S+)/.test(stdout)) {
+        throw new Error(NOT_LOGGED_IN_SENTINEL);
       }
 
-      const accountMatch = stdout.match(/Signed in as (\S+)/);
-      const account = accountMatch?.[1] || undefined;
+      return stdout;
+    } finally {
+      clearTimeout(killTimer);
+      try {
+        proc.kill();
+      } catch {}
+    }
+  }
 
-      if (!account) {
-        return { ...base, error: `Not logged in. Open \`${APP_NAME} menu\` and choose Provider login.` };
-      }
-
-      const freeMatch = stdout.match(/Amp Free:\s*\$([0-9.]+)\/\$([0-9.]+)\s*remaining/);
-      const replenishMatch = stdout.match(/replenishes \+\$([0-9.]+)\/hour/);
-      const replenishRate = replenishMatch ? `+$${replenishMatch[1]}/hr` : null;
-      const bonusMatch = stdout.match(/\+(\d+)%\s*bonus\s*for\s*(\d+)\s*more\s*days/);
-      const bonus = bonusMatch ? `+${bonusMatch[1]}% (${bonusMatch[2]}d)` : null;
-
-      const parseAmpFreeTier = (
-        match: RegExpMatchArray,
-        replenish: RegExpMatchArray | null,
-        bonusM: RegExpMatchArray | null,
-      ): { pct: number; fullAt: string | null } => {
-        const remaining = parseFloat(match[1]);
-        const total = parseFloat(match[2]);
-        const pct = total > 0 ? Math.round((remaining / total) * 100) : 0;
-        let fullAt: string | null = null;
-        if (replenish && remaining < total) {
-          const ratePerHour = parseFloat(replenish[1]);
-          const effectiveRate = bonusM ? ratePerHour * (1 + parseInt(bonusM[1], 10) / 100) : ratePerHour;
-          const hoursToFull = (total - remaining) / effectiveRate;
-          if (effectiveRate > 0 && Number.isFinite(hoursToFull)) {
-            fullAt = new Date(Date.now() + hoursToFull * 3_600_000).toISOString();
-          }
-        }
-        return { pct, fullAt };
-      };
-
-      const creditsMatch = stdout.match(/Individual credits:\s*\$([0-9.]+)\s*remaining/);
-
-      const models: Record<string, QuotaWindow> = {};
-      const meta: Record<string, string> = {};
-      const extra: AmpQuotaExtra = {};
-      let primary: QuotaWindow | undefined;
-
-      if (freeMatch) {
-        const remaining = parseFloat(freeMatch[1]);
-        const total = parseFloat(freeMatch[2]);
-        const { pct, fullAt } = parseAmpFreeTier(freeMatch, replenishMatch, bonusMatch);
-
-        primary = { remaining: pct, resetsAt: fullAt };
-        models['Free Tier'] = { remaining: pct, resetsAt: fullAt };
-        meta.freeRemaining = `$${remaining}`;
-        meta.freeTotal = `$${total}`;
-        if (replenishRate) meta.replenishRate = replenishRate;
-        if (bonus) meta.bonus = bonus;
-      }
-
-      if (creditsMatch) {
-        const balance = parseFloat(creditsMatch[1]);
-        models.Credits = { remaining: balance > 0 ? 100 : 0, resetsAt: null };
-        meta.creditsBalance = `$${balance}`;
-      }
-
-      if (Object.keys(meta).length > 0) extra.meta = meta;
-
-      return {
-        ...base,
-        available: true,
-        account,
-        primary,
-        models,
-        ...(Object.keys(extra).length > 0 ? { extra } : {}),
-      };
+  protected buildQuota(raw: unknown, base: QuotaBase): ProviderQuota {
+    const stdout = typeof raw === 'string' ? raw : '';
+    try {
+      return this.parseUsage(stdout, base);
     } catch (error) {
       logger.error('Amp usage parse error', { error });
-      return { ...base, error: 'Failed to parse usage' };
+      return { ...base, error: 'Failed to parse usage' } as AmpQuota;
     }
+  }
+
+  private parseUsage(stdout: string, base: QuotaBase): AmpQuota {
+    const accountMatch = stdout.match(/Signed in as (\S+)/);
+    const account = accountMatch?.[1] || undefined;
+
+    const freeMatch = stdout.match(/Amp Free:\s*\$([0-9.]+)\/\$([0-9.]+)\s*remaining/);
+    const replenishMatch = stdout.match(/replenishes \+\$([0-9.]+)\/hour/);
+    const replenishRate = replenishMatch ? `+$${replenishMatch[1]}/hr` : null;
+    const bonusMatch = stdout.match(/\+(\d+)%\s*bonus\s*for\s*(\d+)\s*more\s*days/);
+    const bonus = bonusMatch ? `+${bonusMatch[1]}% (${bonusMatch[2]}d)` : null;
+
+    const parseAmpFreeTier = (
+      match: RegExpMatchArray,
+      replenish: RegExpMatchArray | null,
+      bonusM: RegExpMatchArray | null,
+    ): { pct: number; fullAt: string | null } => {
+      const remaining = parseFloat(match[1]);
+      const total = parseFloat(match[2]);
+      const pct = total > 0 ? Math.round((remaining / total) * 100) : 0;
+      let fullAt: string | null = null;
+      if (replenish && remaining < total) {
+        const ratePerHour = parseFloat(replenish[1]);
+        const effectiveRate = bonusM ? ratePerHour * (1 + parseInt(bonusM[1], 10) / 100) : ratePerHour;
+        const hoursToFull = (total - remaining) / effectiveRate;
+        if (effectiveRate > 0 && Number.isFinite(hoursToFull)) {
+          fullAt = new Date(Date.now() + hoursToFull * 3_600_000).toISOString();
+        }
+      }
+      return { pct, fullAt };
+    };
+
+    const creditsMatch = stdout.match(/Individual credits:\s*\$([0-9.]+)\s*remaining/);
+
+    const models: Record<string, QuotaWindow> = {};
+    const meta: Record<string, string> = {};
+    const extra: AmpQuotaExtra = {};
+    let primary: QuotaWindow | undefined;
+
+    if (freeMatch) {
+      const remaining = parseFloat(freeMatch[1]);
+      const total = parseFloat(freeMatch[2]);
+      const { pct, fullAt } = parseAmpFreeTier(freeMatch, replenishMatch, bonusMatch);
+
+      primary = { remaining: pct, resetsAt: fullAt };
+      models['Free Tier'] = { remaining: pct, resetsAt: fullAt };
+      meta.freeRemaining = `$${remaining}`;
+      meta.freeTotal = `$${total}`;
+      if (replenishRate) meta.replenishRate = replenishRate;
+      if (bonus) meta.bonus = bonus;
+    }
+
+    if (creditsMatch) {
+      const balance = parseFloat(creditsMatch[1]);
+      models.Credits = { remaining: balance > 0 ? 100 : 0, resetsAt: null };
+      meta.creditsBalance = `$${balance}`;
+    }
+
+    if (Object.keys(meta).length > 0) extra.meta = meta;
+
+    return {
+      ...base,
+      provider: this.id,
+      available: true,
+      account,
+      primary,
+      models,
+      ...(Object.keys(extra).length > 0 ? { extra } : {}),
+    };
   }
 }
 

--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -104,18 +104,21 @@ export class ClaudeProvider implements Provider {
             headers: {
               Authorization: `Bearer ${accessToken}`,
               'anthropic-beta': CONFIG.api.claude.betaHeader,
+              'User-Agent': CONFIG.api.claude.userAgent,
             },
             signal: controller.signal,
           });
-
-          clearTimeout(timeout);
 
           if (!response.ok) {
             // keep non-200 out of cache
             throw new Error(`Claude API error: ${response.status}`);
           }
 
-          return await response.json();
+          // Keep the abort timer armed through the body read: a server that
+          // sends headers fast then stalls the body would otherwise hang.
+          const data = await response.json();
+          clearTimeout(timeout);
+          return data;
         },
         CONFIG.cache.ttlMs,
       );

--- a/src/providers/copilot.ts
+++ b/src/providers/copilot.ts
@@ -35,6 +35,12 @@ interface CopilotQuotaRpcResult {
   quotaSnapshots?: Record<string, unknown>;
 }
 
+/** Raw cached payload: RPC snapshots plus the account read from config. */
+interface CopilotRawData {
+  quotaSnapshots?: Record<string, unknown>;
+  account?: string;
+}
+
 interface FrameState {
   buffer: Buffer;
 }
@@ -58,6 +64,15 @@ function stringOrNull(value: unknown): string | null {
 
 function boolOrFalse(value: unknown): boolean {
   return typeof value === 'boolean' ? value : false;
+}
+
+/**
+ * Copilot "used" percent from request counts. Can exceed 100% with overage.
+ * Null when unbounded or unmeasurable, so renderers fall back to 100-remaining.
+ */
+function usedPercentOf(snapshot: CopilotQuotaSnapshot): number | null {
+  if (snapshot.isUnlimitedEntitlement || snapshot.entitlementRequests <= 0) return null;
+  return (snapshot.usedRequests / snapshot.entitlementRequests) * 100;
 }
 
 function formatBucketLabel(bucket: string): string {
@@ -91,16 +106,44 @@ export class CopilotProvider extends BaseProvider {
     if (!bin) {
       throw new Error('Copilot CLI not found');
     }
-    const base: CopilotQuota = {
-      provider: this.id,
-      displayName: this.name,
-      available: false,
-    };
-    return this.fetchUsage(base, bin);
+    const result = await this.fetchQuotaViaCli(bin);
+    // The logged-in account lives in config files, not the RPC result. Cache it
+    // alongside the snapshots so buildQuota stays synchronous (BaseProvider
+    // contract) and the cache holds raw data, not a pre-built quota.
+    const account = await this.readAccountFromConfig();
+    return { quotaSnapshots: result.quotaSnapshots, account } satisfies CopilotRawData;
   }
 
-  protected buildQuota(raw: unknown, _base: QuotaBase): ProviderQuota {
-    return raw as ProviderQuota;
+  protected buildQuota(raw: unknown, base: QuotaBase): ProviderQuota {
+    const payload = (raw ?? {}) as CopilotRawData;
+    const quotaSnapshots = this.normalizeQuotaSnapshots(payload.quotaSnapshots);
+
+    if (Object.keys(quotaSnapshots).length === 0) {
+      return { ...base, provider: this.id, error: 'No Copilot quota snapshots found' } as CopilotQuota;
+    }
+
+    const models = this.buildModels(quotaSnapshots);
+    const primary = models['Premium requests'] ?? Object.values(models)[0];
+    if (!primary) {
+      return { ...base, provider: this.id, error: 'No Copilot quota windows found' } as CopilotQuota;
+    }
+
+    const meta: Record<string, string> = {
+      primaryBucket: quotaSnapshots.premium_interactions ? 'premium_interactions' : Object.keys(quotaSnapshots)[0],
+    };
+
+    return {
+      ...base,
+      provider: this.id,
+      available: true,
+      ...(payload.account ? { account: payload.account } : {}),
+      primary,
+      models,
+      extra: {
+        meta,
+        quotaSnapshots,
+      },
+    } as CopilotQuota;
   }
 
   protected toUserFacingError(error: unknown): string {
@@ -132,38 +175,6 @@ export class CopilotProvider extends BaseProvider {
     }
 
     return undefined;
-  }
-
-  private async fetchUsage(base: CopilotQuota, bin: string): Promise<CopilotQuota> {
-    const result = await this.fetchQuotaViaCli(bin);
-    const quotaSnapshots = this.normalizeQuotaSnapshots(result.quotaSnapshots);
-
-    if (Object.keys(quotaSnapshots).length === 0) {
-      return { ...base, error: 'No Copilot quota snapshots found' };
-    }
-
-    const models = this.buildModels(quotaSnapshots);
-    const primary = models['Premium requests'] ?? Object.values(models)[0];
-    if (!primary) {
-      return { ...base, error: 'No Copilot quota windows found' };
-    }
-
-    const account = await this.readAccountFromConfig();
-    const meta: Record<string, string> = {
-      primaryBucket: quotaSnapshots.premium_interactions ? 'premium_interactions' : Object.keys(quotaSnapshots)[0],
-    };
-
-    return {
-      ...base,
-      available: true,
-      ...(account ? { account } : {}),
-      primary,
-      models,
-      extra: {
-        meta,
-        quotaSnapshots,
-      },
-    };
   }
 
   private normalizeQuotaSnapshots(raw: Record<string, unknown> | undefined): Record<string, CopilotQuotaSnapshot> {
@@ -224,6 +235,7 @@ export class CopilotProvider extends BaseProvider {
       models[formatBucketLabel(bucket)] = {
         remaining: snapshot.isUnlimitedEntitlement ? 100 : clampPercent(snapshot.remainingPercentage),
         resetsAt: snapshot.resetDate,
+        used: usedPercentOf(snapshot),
       };
     }
 

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -8,6 +8,13 @@ export interface QuotaWindow {
   resetsAt: string | null;
   /** Window length in minutes (if provided by provider) */
   windowMinutes?: number | null;
+  /**
+   * Provider-supplied "used" percentage, when it is NOT simply `100 - remaining`.
+   * Copilot derives this from usedRequests/entitlementRequests (can exceed 100%
+   * with overage). Renderers prefer this in `used` display mode and fall back to
+   * `100 - remaining` when undefined. See `toWindowDisplay`.
+   */
+  used?: number | null;
 }
 
 /**

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -39,24 +39,15 @@ export async function startWatch(opts: StartWatchOptions): Promise<void> {
     process.stderr.write('[agent-bar] watch mode: output is NDJSON — pipe to a consumer\n');
   }
 
-  let stopping = false;
-  const stop = () => {
-    stopping = true;
-    process.exit(0);
-  };
-  process.on('SIGTERM', stop);
-  process.on('SIGINT', stop);
-
   const tick = async (): Promise<void> => {
-    if (stopping) return;
     try {
       const quotas = await fetchQuotas(opts.provider);
-      process.stdout.write(buildWatchLine(quotas), () => {
-        if (!stopping) setTimeout(tick, opts.intervalMs);
+      process.stdout.write(buildWatchLine(quotas), (writeErr?: Error | null) => {
+        if (!writeErr) setTimeout(tick, opts.intervalMs);
       });
     } catch (error) {
       logger.error('watch tick failed', { error });
-      if (!stopping) setTimeout(tick, opts.intervalMs);
+      setTimeout(tick, opts.intervalMs);
     }
   };
 

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -1,6 +1,6 @@
 import { toJsonOutput } from './formatters/json';
 import { logger } from './logger';
-import { getAllQuotas, getQuotaFor } from './providers';
+import { getAllQuotas, getProvider, getQuotaFor } from './providers';
 import type { AllQuotas } from './providers/types';
 
 export interface StartWatchOptions {
@@ -31,6 +31,11 @@ export function buildWatchLine(quotas: AllQuotas): string {
  * Never resolves on its own.
  */
 export async function startWatch(opts: StartWatchOptions): Promise<void> {
+  if (opts.provider && !getProvider(opts.provider)) {
+    process.stderr.write(`[agent-bar] Unknown provider: ${opts.provider}\n`);
+    process.exit(1);
+  }
+
   process.stdout.on('error', (err: Error & { code?: string }) => {
     if (err.code === 'EPIPE') process.exit(0);
   });
@@ -43,7 +48,16 @@ export async function startWatch(opts: StartWatchOptions): Promise<void> {
     try {
       const quotas = await fetchQuotas(opts.provider);
       process.stdout.write(buildWatchLine(quotas), (writeErr?: Error | null) => {
-        if (!writeErr) setTimeout(tick, opts.intervalMs);
+        if (!writeErr) {
+          setTimeout(tick, opts.intervalMs);
+          return;
+        }
+        // EPIPE is handled by the stdout 'error' listener (exits 0); any other
+        // write error is fatal — log and exit rather than hang.
+        if ((writeErr as Error & { code?: string }).code !== 'EPIPE') {
+          logger.error('stdout write error', { writeErr });
+          process.exit(1);
+        }
       });
     } catch (error) {
       logger.error('watch tick failed', { error });

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -1,0 +1,66 @@
+import { toJsonOutput } from './formatters/json';
+import { logger } from './logger';
+import { getAllQuotas, getQuotaFor } from './providers';
+import type { AllQuotas } from './providers/types';
+
+export interface StartWatchOptions {
+  provider?: string;
+  intervalMs: number;
+}
+
+async function fetchQuotas(provider?: string): Promise<AllQuotas> {
+  if (provider) {
+    const quota = await getQuotaFor(provider);
+    return {
+      providers: quota ? [quota] : [],
+      fetchedAt: new Date().toISOString(),
+    };
+  }
+  return getAllQuotas();
+}
+
+/** Serialize one quota snapshot as a single NDJSON line. */
+export function buildWatchLine(quotas: AllQuotas): string {
+  return `${JSON.stringify(toJsonOutput(quotas))}\n`;
+}
+
+/**
+ * Long-running NDJSON emitter. Emits immediately, then every `intervalMs` after
+ * the previous tick's write completes (backpressure-aware, no overlap/drift).
+ * Exits 0 on EPIPE (consumer closed the pipe) or SIGTERM/SIGINT.
+ * Never resolves on its own.
+ */
+export async function startWatch(opts: StartWatchOptions): Promise<void> {
+  process.stdout.on('error', (err: Error & { code?: string }) => {
+    if (err.code === 'EPIPE') process.exit(0);
+  });
+
+  if (process.stdout.isTTY) {
+    process.stderr.write('[agent-bar] watch mode: output is NDJSON — pipe to a consumer\n');
+  }
+
+  let stopping = false;
+  const stop = () => {
+    stopping = true;
+    process.exit(0);
+  };
+  process.on('SIGTERM', stop);
+  process.on('SIGINT', stop);
+
+  const tick = async (): Promise<void> => {
+    if (stopping) return;
+    try {
+      const quotas = await fetchQuotas(opts.provider);
+      process.stdout.write(buildWatchLine(quotas), () => {
+        if (!stopping) setTimeout(tick, opts.intervalMs);
+      });
+    } catch (error) {
+      logger.error('watch tick failed', { error });
+      if (!stopping) setTimeout(tick, opts.intervalMs);
+    }
+  };
+
+  await tick();
+  // Keep the process alive; it exits only via signal or EPIPE.
+  await new Promise<void>(() => {});
+}

--- a/src/waybar-integration.ts
+++ b/src/waybar-integration.ts
@@ -112,38 +112,107 @@ interface RewriteArrayResult {
   changed: boolean;
 }
 
+/** Advance past a JSON string literal; `i` points at the opening quote. Returns the index just after the closing quote. */
+function skipString(content: string, i: number): number {
+  i += 1;
+  while (i < content.length) {
+    const c = content[i];
+    if (c === '\\') {
+      i += 2;
+      continue;
+    }
+    if (c === '"') {
+      return i + 1;
+    }
+    i += 1;
+  }
+  return i;
+}
+
+/**
+ * Find the `]` that closes the `[` at `openIdx`, honoring nested brackets,
+ * string literals, and JSONC comments. Returns -1 if unbalanced.
+ *
+ * A flat non-greedy regex (`\[([\s\S]*?)\]`) stops at the FIRST `]`, which
+ * truncates and corrupts the config when an array element contains a nested
+ * `]` (e.g. an inline object with its own array). This scanner is exact.
+ */
+function findMatchingBracket(content: string, openIdx: number): number {
+  let depth = 0;
+  let i = openIdx;
+  while (i < content.length) {
+    const c = content[i];
+    if (c === '"') {
+      i = skipString(content, i);
+      continue;
+    }
+    if (c === '/' && content[i + 1] === '/') {
+      const nl = content.indexOf('\n', i);
+      i = nl === -1 ? content.length : nl;
+      continue;
+    }
+    if (c === '/' && content[i + 1] === '*') {
+      const end = content.indexOf('*/', i + 2);
+      i = end === -1 ? content.length : end + 2;
+      continue;
+    }
+    if (c === '[') {
+      depth += 1;
+    } else if (c === ']') {
+      depth -= 1;
+      if (depth === 0) {
+        return i;
+      }
+    }
+    i += 1;
+  }
+  return -1;
+}
+
 function rewriteStringArrayProperty(
   content: string,
   propertyName: string,
   transform: (values: string[]) => string[],
 ): RewriteArrayResult {
-  const pattern = new RegExp(`("${escapeRegex(propertyName)}"\\s*:\\s*)\\[([\\s\\S]*?)\\]`, 'g');
+  const keyPattern = new RegExp(`"${escapeRegex(propertyName)}"\\s*:\\s*\\[`, 'g');
 
-  let found = false;
-  let changed = false;
+  let match: RegExpExecArray | null = keyPattern.exec(content);
+  while (match !== null) {
+    const matchStart = match.index;
+    const lineStart = content.lastIndexOf('\n', matchStart) + 1;
+    const linePrefix = content.slice(lineStart, matchStart);
 
-  const rewritten = content.replace(
-    pattern,
-    (full: string, prefix: string, body: string, offset: number, source: string): string => {
-      found = true;
-      const lineStart = source.lastIndexOf('\n', offset) + 1;
-      const linePrefix = source.slice(lineStart, offset);
-      const indentMatch = linePrefix.match(/^\s*/);
-      const indent = indentMatch ? indentMatch[0] : '';
+    // Skip occurrences sitting inside a `//` line comment so commented-out
+    // examples are never rewritten.
+    if (linePrefix.includes('//')) {
+      match = keyPattern.exec(content);
+      continue;
+    }
 
-      const currentValues = parseQuotedStrings(body);
-      const nextValues = transform(currentValues);
+    const openIdx = matchStart + match[0].length - 1; // index of the `[`
+    const closeIdx = findMatchingBracket(content, openIdx);
+    if (closeIdx === -1) {
+      match = keyPattern.exec(content);
+      continue;
+    }
 
-      if (arraysEqual(currentValues, nextValues)) {
-        return full;
-      }
+    const body = content.slice(openIdx + 1, closeIdx);
+    const currentValues = parseQuotedStrings(body);
+    const nextValues = transform(currentValues);
 
-      changed = true;
-      return `${prefix}${formatStringArray(nextValues, indent)}`;
-    },
-  );
+    const indentMatch = linePrefix.match(/^\s*/);
+    const indent = indentMatch ? indentMatch[0] : '';
 
-  return { content: rewritten, found, changed };
+    if (arraysEqual(currentValues, nextValues)) {
+      return { content, found: true, changed: false };
+    }
+
+    const prefix = content.slice(matchStart, openIdx); // `"prop"\s*:\s*`
+    const rewritten = `${content.slice(0, matchStart)}${prefix}${formatStringArray(nextValues, indent)}${content.slice(closeIdx + 1)}`;
+    return { content: rewritten, found: true, changed: true };
+  }
+
+  return { content, found: false, changed: false };
 }
 
 function insertPropertyIntoFirstObject(content: string, propertyText: string): string {
@@ -377,6 +446,9 @@ export function removeWaybarIntegration(options: RemoveWaybarIntegrationOptions 
     const nextConfig = modulesResult.content;
     configChanged = includeResult.changed || modulesResult.changed;
     if (configChanged) {
+      // Back up before rewriting, mirroring applyWaybarIntegration — removal
+      // mutates the user's config and must be recoverable.
+      backupIfNeeded(paths.waybarConfigPath);
       writeText(paths.waybarConfigPath, nextConfig);
     }
   }
@@ -387,6 +459,7 @@ export function removeWaybarIntegration(options: RemoveWaybarIntegrationOptions 
     const styleResult = removeStyleImport(currentStyle);
     styleChanged = styleResult.changed;
     if (styleChanged) {
+      backupIfNeeded(paths.waybarStylePath);
       writeText(paths.waybarStylePath, styleResult.content);
     }
   }

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -12,6 +12,28 @@ mock.module('../src/logger', () => ({
 
 import { parseArgs, showHelp } from '../src/cli';
 
+function expectExit1(args: string[], needle: string) {
+  const origExit = process.exit;
+  const origErr = console.error;
+  const codes: number[] = [];
+  const errs: string[] = [];
+  process.exit = ((c?: number) => {
+    codes.push(c ?? 0);
+    throw new Error('__exit__');
+  }) as typeof process.exit;
+  console.error = (...a: unknown[]) => {
+    errs.push(a.join(' '));
+  };
+  try {
+    expect(() => parseArgs(args)).toThrow('__exit__');
+    expect(codes).toEqual([1]);
+    expect(errs.join('\n')).toContain(needle);
+  } finally {
+    process.exit = origExit;
+    console.error = origErr;
+  }
+}
+
 describe('parseArgs', () => {
   // -----------------------------------------------------------------------
   // Default behavior
@@ -293,28 +315,6 @@ describe('output format flags', () => {
     expect(parseArgs(['--watch', '--interval', '30']).intervalSeconds).toBe(30);
   });
 
-  function expectExit1(args: string[], needle: string) {
-    const origExit = process.exit;
-    const origErr = console.error;
-    const codes: number[] = [];
-    const errs: string[] = [];
-    process.exit = ((c?: number) => {
-      codes.push(c ?? 0);
-      throw new Error('__exit__');
-    }) as typeof process.exit;
-    console.error = (...a: unknown[]) => {
-      errs.push(a.join(' '));
-    };
-    try {
-      expect(() => parseArgs(args)).toThrow('__exit__');
-      expect(codes).toEqual([1]);
-      expect(errs.join('\n')).toContain(needle);
-    } finally {
-      process.exit = origExit;
-      console.error = origErr;
-    }
-  }
-
   it('exits 1 on invalid --format', () => {
     expectExit1(['--format', 'xml'], '--format must be');
   });
@@ -325,6 +325,14 @@ describe('output format flags', () => {
 
   it('exits 1 on --watch with explicit --format waybar', () => {
     expectExit1(['--watch', '--format', 'waybar'], '--watch requires --format json');
+  });
+
+  it('exits 1 on --interval 1.5 (non-integer)', () => {
+    expectExit1(['--watch', '--interval', '1.5'], '--interval must be');
+  });
+
+  it('exits 1 on --interval 0', () => {
+    expectExit1(['--watch', '--interval', '0'], '--interval must be');
   });
 
   it('warns (no exit) on --interval without --watch', () => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -316,7 +316,7 @@ describe('output format flags', () => {
   }
 
   it('exits 1 on invalid --format', () => {
-    expectExit1(['--format', 'xml'], "--format must be");
+    expectExit1(['--format', 'xml'], '--format must be');
   });
 
   it('exits 1 on invalid --interval', () => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -271,6 +271,78 @@ describe('unknown commands', () => {
   });
 });
 
+describe('output format flags', () => {
+  it('defaults format to waybar, watch false, interval 60', () => {
+    const o = parseArgs([]);
+    expect(o.format).toBe('waybar');
+    expect(o.watch).toBe(false);
+    expect(o.intervalSeconds).toBe(60);
+  });
+
+  it('parses --format json', () => {
+    expect(parseArgs(['--format', 'json']).format).toBe('json');
+  });
+
+  it('--watch implies json', () => {
+    const o = parseArgs(['--watch']);
+    expect(o.watch).toBe(true);
+    expect(o.format).toBe('json');
+  });
+
+  it('parses --interval', () => {
+    expect(parseArgs(['--watch', '--interval', '30']).intervalSeconds).toBe(30);
+  });
+
+  function expectExit1(args: string[], needle: string) {
+    const origExit = process.exit;
+    const origErr = console.error;
+    const codes: number[] = [];
+    const errs: string[] = [];
+    process.exit = ((c?: number) => {
+      codes.push(c ?? 0);
+      throw new Error('__exit__');
+    }) as typeof process.exit;
+    console.error = (...a: unknown[]) => {
+      errs.push(a.join(' '));
+    };
+    try {
+      expect(() => parseArgs(args)).toThrow('__exit__');
+      expect(codes).toEqual([1]);
+      expect(errs.join('\n')).toContain(needle);
+    } finally {
+      process.exit = origExit;
+      console.error = origErr;
+    }
+  }
+
+  it('exits 1 on invalid --format', () => {
+    expectExit1(['--format', 'xml'], "--format must be");
+  });
+
+  it('exits 1 on invalid --interval', () => {
+    expectExit1(['--watch', '--interval', 'abc'], '--interval must be');
+  });
+
+  it('exits 1 on --watch with explicit --format waybar', () => {
+    expectExit1(['--watch', '--format', 'waybar'], '--watch requires --format json');
+  });
+
+  it('warns (no exit) on --interval without --watch', () => {
+    const origErr = console.error;
+    const errs: string[] = [];
+    console.error = (...a: unknown[]) => {
+      errs.push(a.join(' '));
+    };
+    try {
+      const o = parseArgs(['--interval', '30']);
+      expect(o.watch).toBe(false);
+      expect(errs.join('\n')).toContain('--interval has no effect without --watch');
+    } finally {
+      console.error = origErr;
+    }
+  });
+});
+
 describe('showHelp', () => {
   it('describes npm-era entrypoints and managed checkout updates', () => {
     const lines: string[] = [];

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -93,6 +93,11 @@ describe('parseArgs', () => {
       expect(opts.command).toBe('action-right');
       expect(opts.provider).toBe('claude');
     });
+
+    it('parses --version and -V', () => {
+      expect(parseArgs(['--version']).command).toBe('version');
+      expect(parseArgs(['-V']).command).toBe('version');
+    });
   });
 
   // -----------------------------------------------------------------------
@@ -216,6 +221,32 @@ describe('unknown commands', () => {
       expect(exitCalls).toEqual([1]);
       expect(errors.join('\n')).toContain('Unknown command: xyzzy');
       expect(errors.join('\n')).toContain('help');
+    } finally {
+      process.exit = originalExit;
+      console.error = originalError;
+    }
+  });
+
+  it('exits 1 on a two-word subcommand missing its second word', () => {
+    const originalExit = process.exit;
+    const originalError = console.error;
+    const exitCalls: number[] = [];
+    const errors: string[] = [];
+
+    process.exit = ((code?: number) => {
+      exitCalls.push(code ?? 0);
+      throw new Error('__exit__');
+    }) as typeof process.exit;
+    console.error = (...args: unknown[]) => {
+      errors.push(args.join(' '));
+    };
+
+    try {
+      expect(() => parseArgs(['assets'])).toThrow('__exit__');
+      expect(() => parseArgs(['export'])).toThrow('__exit__');
+      expect(exitCalls).toEqual([1, 1]);
+      expect(errors.join('\n')).toContain('assets install');
+      expect(errors.join('\n')).toContain('waybar-modules');
     } finally {
       process.exit = originalExit;
       console.error = originalError;

--- a/tests/formatters-json.test.ts
+++ b/tests/formatters-json.test.ts
@@ -25,6 +25,7 @@ const allQuotas: AllQuotas = { providers: [claude, ampError], fetchedAt: '2026-0
 describe('json formatter', () => {
   it('wraps providers in a versioned envelope', () => {
     const out = toJsonOutput(allQuotas);
+    expect(SCHEMA_VERSION).toBe(1);
     expect(out.schemaVersion).toBe(SCHEMA_VERSION);
     expect(out.fetchedAt).toBe('2026-06-17T19:00:00.000Z');
     expect(out.providers).toHaveLength(2);

--- a/tests/formatters-json.test.ts
+++ b/tests/formatters-json.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'bun:test';
+import type { AllQuotas, ProviderQuota } from '../src/providers/types';
+import { SCHEMA_VERSION, toJsonOutput, toProviderOutput } from '../src/formatters/json';
+
+const claude: ProviderQuota = {
+  provider: 'claude',
+  displayName: 'Claude',
+  available: true,
+  plan: 'Max',
+  primary: { remaining: 30, used: 70, resetsAt: '2026-06-17T20:00:00Z', windowMinutes: 300 },
+  secondary: { remaining: 65, resetsAt: '2026-06-19T22:00:00Z' },
+  models: { Sonnet: { remaining: 89, resetsAt: '2026-06-19T22:00:00Z' } },
+  extra: { weeklyModels: { Sonnet: { remaining: 89, resetsAt: '2026-06-19T22:00:00Z' } } },
+};
+
+const ampError: ProviderQuota = {
+  provider: 'amp',
+  displayName: 'Amp',
+  available: false,
+  error: 'Not logged in.',
+};
+
+const allQuotas: AllQuotas = { providers: [claude, ampError], fetchedAt: '2026-06-17T19:00:00.000Z' };
+
+describe('json formatter', () => {
+  it('wraps providers in a versioned envelope', () => {
+    const out = toJsonOutput(allQuotas);
+    expect(out.schemaVersion).toBe(SCHEMA_VERSION);
+    expect(out.fetchedAt).toBe('2026-06-17T19:00:00.000Z');
+    expect(out.providers).toHaveLength(2);
+  });
+
+  it('maps primary/secondary/models/used and keeps extra', () => {
+    const p = toProviderOutput(claude);
+    expect(p.primary).toEqual({ remaining: 30, used: 70, resetsAt: '2026-06-17T20:00:00Z', windowMinutes: 300 });
+    expect(p.secondary).toEqual({ remaining: 65, resetsAt: '2026-06-19T22:00:00Z' });
+    expect(p.models?.Sonnet.remaining).toBe(89);
+    expect(p.extra?.weeklyModels).toBeDefined();
+  });
+
+  it('omits absent optional fields (no null, no undefined key) on an available provider', () => {
+    const p = toProviderOutput(claude);
+    expect('error' in p).toBe(false);
+    expect('account' in p).toBe(false);
+  });
+
+  it('includes error and omits primary on a failed provider', () => {
+    const p = toProviderOutput(ampError);
+    expect(p.available).toBe(false);
+    expect(p.error).toBe('Not logged in.');
+    expect('primary' in p).toBe(false);
+  });
+
+  it('never contains Pango markup', () => {
+    expect(JSON.stringify(toJsonOutput(allQuotas))).not.toContain('<span');
+  });
+});

--- a/tests/formatters-json.test.ts
+++ b/tests/formatters-json.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test';
-import type { AllQuotas, ProviderQuota } from '../src/providers/types';
 import { SCHEMA_VERSION, toJsonOutput, toProviderOutput } from '../src/formatters/json';
+import type { AllQuotas, ProviderQuota } from '../src/providers/types';
 
 const claude: ProviderQuota = {
   provider: 'claude',

--- a/tests/formatters.test.ts
+++ b/tests/formatters.test.ts
@@ -60,11 +60,13 @@ function mockCopilotQuota(): CopilotQuota {
     primary: {
       remaining: 0,
       resetsAt: new Date(Date.now() + 3600000).toISOString(),
+      used: (698 / 300) * 100,
     },
     models: {
       'Premium requests': {
         remaining: 0,
         resetsAt: new Date(Date.now() + 3600000).toISOString(),
+        used: (698 / 300) * 100,
       },
       Chat: {
         remaining: 100,

--- a/tests/package.test.ts
+++ b/tests/package.test.ts
@@ -36,6 +36,7 @@ describe('npm package contract', () => {
       'docs/waybar-contract.md',
       'docs/troubleshooting.md',
       'docs/new-provider.md',
+      'docs/json-output.md',
       'docs/assets/agent-bar-banner.png',
     ]);
   });

--- a/tests/package.test.ts
+++ b/tests/package.test.ts
@@ -12,12 +12,19 @@ describe('npm package contract', () => {
     expect(pkg.bin).toEqual({ 'agent-bar': 'scripts/agent-bar' });
   });
 
+  it('declares the Bun runtime requirement', () => {
+    expect(pkg.engines).toEqual({ bun: '>=1.1.0' });
+  });
+
+  it('does not ship the CI-only publish helper to consumers', () => {
+    expect(pkg.files).not.toContain('scripts/bun-publish-with-npm-token');
+  });
+
   it('publishes only runtime assets and public documentation', () => {
     expect(pkg.files).toEqual([
       'dist/',
       'scripts/agent-bar',
       'scripts/agent-bar-open-terminal',
-      'scripts/bun-publish-with-npm-token',
       'icons/',
       'README.md',
       'LICENSE',

--- a/tests/providers/amp.test.ts
+++ b/tests/providers/amp.test.ts
@@ -432,18 +432,16 @@ describe('AmpProvider', () => {
       expect(key).toBe('amp-quota');
     });
 
-    it('returns cached result when cache hits', async () => {
-      const cachedResult: ProviderQuota = {
-        provider: 'amp',
-        displayName: 'Amp',
-        available: true,
-        account: 'cached@email.com',
-      };
-
-      mockCacheGetOrFetch.mockResolvedValue(cachedResult);
+    it('parses the cached raw stdout payload on a cache hit', async () => {
+      // The cache stores raw `amp usage` stdout (not a built quota); buildQuota
+      // parses it on the way out.
+      mockCacheGetOrFetch.mockResolvedValue(
+        ['Signed in as cached@email.com', 'Amp Free: $5.00/$5.00 remaining'].join('\n'),
+      );
 
       const result = await provider.getQuota();
       expect(result.account).toBe('cached@email.com');
+      expect(result.available).toBe(true);
     });
   });
 

--- a/tests/providers/claude.test.ts
+++ b/tests/providers/claude.test.ts
@@ -470,6 +470,7 @@ describe('ClaudeProvider', () => {
       expect(opts.headers).toEqual({
         Authorization: 'Bearer my-secret-token',
         'anthropic-beta': CONFIG.api.claude.betaHeader,
+        'User-Agent': CONFIG.api.claude.userAgent,
       });
       expect(opts.signal).toBeDefined();
     });

--- a/tests/providers/copilot.test.ts
+++ b/tests/providers/copilot.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test';
 import { EventEmitter } from 'node:events';
 import { Readable, Writable } from 'node:stream';
-import type { ProviderQuota } from '../../src/providers/types';
 import { fakeFile } from '../helpers/mocks';
 
 class FakeCopilotProcess extends EventEmitter {
@@ -326,17 +325,25 @@ describe('CopilotProvider', () => {
     expect(result.error).toBe('Failed to fetch Copilot usage');
   });
 
-  it('returns cached results when cache hits', async () => {
-    const cachedResult: ProviderQuota = {
-      provider: 'copilot',
-      displayName: 'Copilot',
-      available: true,
-      primary: { remaining: 42, resetsAt: null },
-    };
-    mockCacheGetOrFetch.mockResolvedValue(cachedResult);
+  it('builds from the cached raw payload on a cache hit', async () => {
+    // The cache stores raw { quotaSnapshots, account }; buildQuota transforms it.
+    mockCacheGetOrFetch.mockResolvedValue({
+      quotaSnapshots: {
+        premium_interactions: {
+          isUnlimitedEntitlement: false,
+          entitlementRequests: 100,
+          usedRequests: 58,
+          remainingPercentage: 42,
+          resetDate: null,
+        },
+      },
+      account: 'octocat',
+    });
 
     const result = await provider.getQuota();
 
+    expect(result.available).toBe(true);
     expect(result.primary?.remaining).toBe(42);
+    expect(result.account).toBe('octocat');
   });
 });

--- a/tests/watch.test.ts
+++ b/tests/watch.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'bun:test';
+import type { AllQuotas } from '../src/providers/types';
+import { buildWatchLine } from '../src/watch';
+
+const quotas: AllQuotas = {
+  providers: [{ provider: 'claude', displayName: 'Claude', available: true, primary: { remaining: 50, resetsAt: null } }],
+  fetchedAt: '2026-06-17T19:00:00.000Z',
+};
+
+describe('buildWatchLine', () => {
+  it('produces one valid NDJSON line ending in newline', () => {
+    const line = buildWatchLine(quotas);
+    expect(line.endsWith('\n')).toBe(true);
+    expect(line.includes('\n')).toBe(true);
+    expect(line.trim().split('\n')).toHaveLength(1);
+    const parsed = JSON.parse(line);
+    expect(parsed.schemaVersion).toBe(1);
+    expect(parsed.providers[0].provider).toBe('claude');
+  });
+
+  it('contains no Pango markup', () => {
+    expect(buildWatchLine(quotas)).not.toContain('<span');
+  });
+});

--- a/tests/watch.test.ts
+++ b/tests/watch.test.ts
@@ -3,7 +3,9 @@ import type { AllQuotas } from '../src/providers/types';
 import { buildWatchLine } from '../src/watch';
 
 const quotas: AllQuotas = {
-  providers: [{ provider: 'claude', displayName: 'Claude', available: true, primary: { remaining: 50, resetsAt: null } }],
+  providers: [
+    { provider: 'claude', displayName: 'Claude', available: true, primary: { remaining: 50, resetsAt: null } },
+  ],
   fetchedAt: '2026-06-17T19:00:00.000Z',
 };
 

--- a/tests/waybar-integration.test.ts
+++ b/tests/waybar-integration.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  applyWaybarIntegration,
+  getAppModuleIDs,
+  removeWaybarIntegration,
+  type WaybarIntegrationPaths,
+} from '../src/waybar-integration';
+
+/** Strip // and /* *\/ comments so a JSONC string can go through JSON.parse. */
+function stripJsonc(text: string): string {
+  return text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+}
+
+describe('waybar config patcher', () => {
+  let dir: string;
+  let paths: WaybarIntegrationPaths;
+  const assetOpts = { appBin: '/bin/agent-bar', terminalScript: '/bin/term', iconsDir: '/icons' };
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'agent-bar-wb-'));
+    paths = {
+      waybarConfigPath: join(dir, 'config.jsonc'),
+      waybarStylePath: join(dir, 'style.css'),
+      modulesIncludePath: join(dir, 'agent-bar', 'modules.jsonc'),
+      styleIncludePath: join(dir, 'agent-bar', 'style.css'),
+    };
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('adds managed modules while preserving existing ones and valid JSON', () => {
+    writeFileSync(
+      paths.waybarConfigPath,
+      `{
+  "modules-right": ["clock", "battery"],
+  "include": ["/existing/include.jsonc"]
+}`,
+    );
+
+    const result = applyWaybarIntegration({ paths, ...assetOpts });
+    expect(result.configChanged).toBe(true);
+
+    const patched = readFileSync(paths.waybarConfigPath, 'utf8');
+    const parsed = JSON.parse(stripJsonc(patched));
+
+    // user modules preserved, managed appended
+    expect(parsed['modules-right']).toContain('clock');
+    expect(parsed['modules-right']).toContain('battery');
+    for (const id of getAppModuleIDs(['claude', 'codex', 'copilot', 'amp'])) {
+      expect(parsed['modules-right']).toContain(id);
+    }
+    // include preserved + managed include added
+    expect(parsed.include).toContain('/existing/include.jsonc');
+    expect(parsed.include).toContain(paths.modulesIncludePath);
+  });
+
+  it('does NOT corrupt the config when modules-right holds a nested array (stays valid JSON)', () => {
+    // The old non-greedy regex truncated at the first nested `]`, producing
+    // invalid JSON. The bracket-aware scanner must keep the file parseable.
+    writeFileSync(
+      paths.waybarConfigPath,
+      `{
+  "modules-right": ["clock", {"name": "x", "items": ["a", "b"]}],
+  "include": []
+}`,
+    );
+
+    applyWaybarIntegration({ paths, ...assetOpts });
+    const patched = readFileSync(paths.waybarConfigPath, 'utf8');
+
+    // The critical guarantee: the result is still parseable JSON (no dangling
+    // `]}` suffix from a truncated match).
+    expect(() => JSON.parse(stripJsonc(patched))).not.toThrow();
+  });
+
+  it('leaves a commented-out modules-right line untouched', () => {
+    writeFileSync(
+      paths.waybarConfigPath,
+      `{
+  // "modules-right": ["old-module"],
+  "modules-right": ["clock"],
+  "include": []
+}`,
+    );
+
+    applyWaybarIntegration({ paths, ...assetOpts });
+    const patched = readFileSync(paths.waybarConfigPath, 'utf8');
+
+    // The comment must still read exactly as authored.
+    expect(patched).toContain('// "modules-right": ["old-module"],');
+    // The live array got the managed modules.
+    const parsed = JSON.parse(stripJsonc(patched));
+    expect(parsed['modules-right']).toContain('clock');
+    expect(parsed['modules-right']).toContain('custom/agent-bar-claude');
+  });
+
+  it('round-trips: remove reverses apply and backs up before mutating', () => {
+    writeFileSync(paths.waybarConfigPath, `{\n  "modules-right": ["clock"],\n  "include": []\n}`);
+    writeFileSync(paths.waybarStylePath, `window { color: red; }\n`);
+
+    applyWaybarIntegration({ paths, ...assetOpts });
+    const removeResult = removeWaybarIntegration({ paths });
+    expect(removeResult.configChanged).toBe(true);
+
+    const finalConfig = JSON.parse(stripJsonc(readFileSync(paths.waybarConfigPath, 'utf8')));
+    for (const id of getAppModuleIDs(['claude', 'codex', 'copilot', 'amp'])) {
+      expect(finalConfig['modules-right']).not.toContain(id);
+    }
+    expect(finalConfig['modules-right']).toContain('clock');
+
+    // backup was created before removal mutated the files
+    expect(readFileSync(`${paths.waybarStylePath}.agent-bar-backup`, 'utf8')).toContain('window { color: red; }');
+  });
+});


### PR DESCRIPTION
## Resumo

Branch de auditoria + endurecimento + nova arquitetura de output. Dois corpos de trabalho:

### 1. Endurecimento + consistência (Tier 1 + 2)
Fixes de causa-raiz e refactor de consistência nos providers e na integração Waybar:

- **Claude:** header `User-Agent: claude-code/<v>` (evita bucket de rate-limit agressivo / 429); abort timer armado até o body read.
- **Waybar patcher:** `config.jsonc` agora é patcheado com matcher de colchetes que respeita strings/comentários (o regex não-greedy corrompia JSON com arrays aninhados e reescrevia linhas comentadas); backup antes de mutar no `removeWaybarIntegration`. +`tests/waybar-integration.test.ts`.
- **Amp:** subprocess com timeout/kill (evita zombie) + drena stderr; erro de auth lança em vez de retornar (não polui o cache).
- **Cache:** `set()` atômico (tmp+rename) contra escrita concorrente.
- **CLI:** `--version`/`-V`, flags faltantes no `--help`, erro explícito em `assets`/`export` sem subcomando.
- **Packaging:** remove `bun-publish-with-npm-token` do `files` (não vazar script de secret pra consumidores npm); declara `engines.bun`.
- **Consistência:** Copilot/Amp passam a seguir o contrato `fetchRaw`(cru)/`buildQuota`(transforma) — cache guarda dado cru; dedup da geração de span Pango (`waybar.ts` usa `render-pango`, fechando gap de escape XML); cálculo de `used` do Copilot movido pro provider (`QuotaWindow.used` + `toWindowDisplay`).

### 2. Arquitetura de output: `--format json` + `--watch`
Contrato JSON estável e versionado pra bars não-Waybar (Quickshell, Eww, Ironbar), mantendo o Waybar como default:

- `--format json` — envelope `{ schemaVersion, fetchedAt, providers[] }` espelhando o `ProviderQuota` interno (pré-render, **zero Pango**), emitindo todos os providers registrados.
- `--watch [--interval N]` — stream NDJSON (1 envelope/linha), backpressure-aware (agenda no callback do `write`), trata EPIPE (sai 0), valida provider desconhecido (sai 1).
- `src/formatters/json.ts` (mapper puro = fronteira de contrato) + `src/watch.ts` (loop). Providers/cache sem mudança.
- Doc do contrato + exemplos QML Quickshell em `docs/json-output.md`.

Contexto: spec e plano em `docs/superpowers/specs|plans/2026-06-17-*`.

## Verificação
- `bun test` → **430 pass / 0 fail**
- `bun run typecheck` → limpo
- `bun run lint` → exit 0 (2 infos pré-existentes do schema do `biome.json`)
- Smokes ao vivo: 4 providers em `--format json`; `--watch` stream + EPIPE limpo; `--watch --provider <desconhecido>` → exit 1.

## Notas
- Bump de deps (biome 2.5.0 / @types/bun 1.3.14 / @clack/prompts 1.5.1) ficou **fora** desta branch (não-commitado localmente) — decidir à parte.
- Limitação conhecida: sem teste unitário de EPIPE (exigiria DI no `startWatch`); EPIPE verificado por smoke manual.
- Próximos passos possíveis (Tier 3, fora deste PR): plugin nativo Omarchy/Quickshell quando o v4 sair, notify-send/burn-rate/TUI, pacote AUR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added JSON output format via `--format json` flag for non-Waybar bar applications
  * Added `--watch` mode for real-time streaming output with configurable refresh intervals
  * Added `--version` / `-V` command

* **Bug Fixes**
  * Improved configuration file patching to correctly handle complex nested bracket structures

* **Documentation**
  * Added comprehensive JSON output documentation with integration examples for Quickshell and Eww

<!-- end of auto-generated comment: release notes by coderabbit.ai -->