### PR TITLE
feat: hardening de produto (trilha B)

### DIFF
--- a/docs/superpowers/specs/2026-07-17-hardening-produto-design.md
+++ b/docs/superpowers/specs/2026-07-17-hardening-produto-design.md
@@ -1,0 +1,39 @@
+# Spec — Hardening de produto (trilha B)
+
+Data: 2026-07-17 · Base: `origin/master` pós-merge PR #11  
+Origem: backlog §10 da spec fundações-confiança + rodadas impeccable.
+
+## Objetivo
+
+Endurecer legibilidade (contraste), consistência dos rótulos de tokens,
+overflow de legenda do chart, revalidação de pricing, e fallback Waybar
+visível em falha de serialize.
+
+## Escopo
+
+| Item | Mudança |
+| --- | --- |
+| B1 Contraste | `Comment`, `Red`, `Series1..6` ≥ 4.5:1 sobre `Bg` #282c34 |
+| B2 Tokens dual | Rótulos "N tok": principal = input+output; sufixo cache se >0 |
+| B3 Legenda chart | Séries omitidas por largura → indicador `…+N` |
+| B4 Pricing | Revalidar tabela oficial (2026-07-17); bump data no módulo |
+| B5 Waybar err | `waybar_error_payload.class` = `agent-bar disconnected` (visível) |
+
+## Não-objetivos
+
+Trilha C (labels Config humanos, chart Min height, help discoverability).
+Split A5. Novos providers.
+
+## Invariantes
+
+CLAUDE.md hard rules. Charts/gauges de intensidade continuam cache-inclusive
+no *plot*; só os *rótulos textuais* de totais usam dual. Snapshots TUI podem
+mudar se o texto dos totais/legendas mudar — atualizar com intenção.
+
+## Decisões de valor
+
+- Comment: `#8b95a5` (~4.63:1)
+- Red: `#e88b93` (~5.70:1)
+- Series: levantar cada slot abaixo de 4.5 para o menor bump que passe AA
+- Dual: `fmt_tokens_dual(io, cache)` → `"9,9M"` ou `"9,9M (+1,4B cache)"`
+- Waybar: `class: "agent-bar disconnected"`, `alt: disconnected`, `text: err`

--- a/src/formatters/render_ansi.rs
+++ b/src/formatters/render_ansi.rs
@@ -49,7 +49,7 @@ mod tests {
     #[test]
     fn bold_segment_includes_bold_code() {
         let out = render_ansi(&[vec![Segment::new("x", ColorToken::Red).bold()]], false);
-        assert_eq!(out, "\x1b[38;2;224;108;117m\x1b[1mx\x1b[0m");
+        assert_eq!(out, "\x1b[38;2;232;139;147m\x1b[1mx\x1b[0m");
     }
 
     #[test]

--- a/src/formatters/waybar.rs
+++ b/src/formatters/waybar.rs
@@ -5,7 +5,7 @@
 
 use serde::Serialize;
 
-use crate::app_identity::{APP_BASE_CLASS, APP_HIDDEN_CLASS};
+use crate::app_identity::APP_BASE_CLASS;
 use crate::config::status_for_percent;
 use crate::formatters::builders::amp::build_amp;
 use crate::formatters::builders::claude::build_claude;
@@ -35,10 +35,12 @@ pub struct WaybarOutput {
 /// Payload degradado quando a serialização do `WaybarOutput` falha.
 /// Campos estáticos garantem que o fallback em si serializa.
 pub fn waybar_error_payload(msg: &str) -> WaybarOutput {
+    // Classe visível (não `agent-bar-hidden`): falha de serialize deve
+    // degradar o módulo, não colapsá-lo como provider desabilitado (trilha B).
     WaybarOutput {
         text: "err".to_string(),
         tooltip: format!("agent-bar: serialize failed: {msg}"),
-        class: APP_HIDDEN_CLASS.to_string(),
+        class: format!("{APP_BASE_CLASS} disconnected"),
         alt: Some("disconnected".to_string()),
         percentage: None,
     }
@@ -55,7 +57,7 @@ pub fn waybar_stdout_line(o: &WaybarOutput, err_log: &mut dyn std::io::Write) ->
                 Ok(fallback) => fallback,
                 // Teoricamente impossível com strings estáticas; último recurso.
                 Err(_) => {
-                    r#"{"text":"err","tooltip":"agent-bar: serialize failed","class":"agent-bar-hidden"}"#
+                    r#"{"text":"err","tooltip":"agent-bar: serialize failed","class":"agent-bar disconnected"}"#
                         .to_string()
                 }
             }
@@ -389,7 +391,7 @@ mod tests {
         );
         assert_eq!(
             v.get("class").and_then(|c| c.as_str()),
-            Some(APP_HIDDEN_CLASS)
+            Some("agent-bar disconnected")
         );
         assert!(
             v.get("tooltip")

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -43,8 +43,9 @@ impl ColorToken {
             ColorToken::Green => "#98c379",
             ColorToken::Yellow => "#e5c07b",
             ColorToken::Orange => "#d19a66",
-            ColorToken::Red => "#e06c75",
-            ColorToken::Comment => "#6a7485",
+            // Contraste ≥4.5:1 sobre Bg #282c34 (trilha B / WCAG AA body).
+            ColorToken::Red => "#e88b93",
+            ColorToken::Comment => "#8b95a5",
             ColorToken::Text => "#c0c9d4",
             ColorToken::TextBright => "#e2e8f0",
             ColorToken::Muted => "#97a1ae",
@@ -57,12 +58,12 @@ impl ColorToken {
             ColorToken::ChipBg => "#262d3a",
             ColorToken::EmptyTrack => "#343b49",
             ColorToken::GreenHi => "#b5e890",
-            ColorToken::Series1 => "#3f8fd6",
-            ColorToken::Series2 => "#cb7e30",
-            ColorToken::Series3 => "#b562d6",
-            ColorToken::Series4 => "#55a34a",
-            ColorToken::Series5 => "#2ba3b4",
-            ColorToken::Series6 => "#af8f2c",
+            ColorToken::Series1 => "#4a9ae0",
+            ColorToken::Series2 => "#d4924a",
+            ColorToken::Series3 => "#c47ae0",
+            ColorToken::Series4 => "#63b358",
+            ColorToken::Series5 => "#3ab3c4",
+            ColorToken::Series6 => "#c2a23a",
             ColorToken::Bg => "#282c34",
         }
     }
@@ -127,8 +128,8 @@ mod tests {
     #[test]
     fn hex_values_match_one_dark() {
         assert_eq!(ColorToken::Green.hex(), "#98c379");
-        assert_eq!(ColorToken::Red.hex(), "#e06c75");
-        assert_eq!(ColorToken::Comment.hex(), "#6a7485");
+        assert_eq!(ColorToken::Red.hex(), "#e88b93");
+        assert_eq!(ColorToken::Comment.hex(), "#8b95a5");
         assert_eq!(ColorToken::BrightBlue.hex(), "#528bff");
         assert_eq!(ColorToken::TextBright.hex(), "#e2e8f0");
     }
@@ -137,7 +138,7 @@ mod tests {
     fn ansi_truecolor_format() {
         // #98c379 → 152;195;121
         assert_eq!(ColorToken::Green.ansi(), "\x1b[38;2;152;195;121m");
-        assert_eq!(ansi_truecolor("#e06c75"), "\x1b[38;2;224;108;117m");
+        assert_eq!(ansi_truecolor("#e88b93"), "\x1b[38;2;232;139;147m");
     }
 
     #[test]
@@ -179,12 +180,12 @@ mod tests {
 
     #[test]
     fn series_tokens_hex() {
-        assert_eq!(ColorToken::Series1.hex(), "#3f8fd6");
-        assert_eq!(ColorToken::Series2.hex(), "#cb7e30");
-        assert_eq!(ColorToken::Series3.hex(), "#b562d6");
-        assert_eq!(ColorToken::Series4.hex(), "#55a34a");
-        assert_eq!(ColorToken::Series5.hex(), "#2ba3b4");
-        assert_eq!(ColorToken::Series6.hex(), "#af8f2c");
+        assert_eq!(ColorToken::Series1.hex(), "#4a9ae0");
+        assert_eq!(ColorToken::Series2.hex(), "#d4924a");
+        assert_eq!(ColorToken::Series3.hex(), "#c47ae0");
+        assert_eq!(ColorToken::Series4.hex(), "#63b358");
+        assert_eq!(ColorToken::Series5.hex(), "#3ab3c4");
+        assert_eq!(ColorToken::Series6.hex(), "#c2a23a");
         assert_eq!(ColorToken::Bg.hex(), "#282c34");
     }
 

--- a/src/tui/render/detail/format.rs
+++ b/src/tui/render/detail/format.rs
@@ -51,11 +51,6 @@ pub(super) fn model_tokens(mu: &ModelUsage) -> u64 {
     mu.input + mu.output + mu.cache_read + mu.cache_write
 }
 
-/// Tokens totais de um `ProviderUsage` (mesma convenção de `model_tokens`).
-pub(super) fn provider_usage_tokens(pu: &ProviderUsage) -> u64 {
-    pu.total_input + pu.total_output + pu.total_cache_read + pu.total_cache_write
-}
-
 /// Encontra um ModelUsage cujo nome contem `quota_name` (case-insensitive).
 /// Necessario porque o nome no quota (ex "Opus") e curto, enquanto o nome no
 /// usage engine e completo (ex "claude-opus-4-8").

--- a/src/tui/render/detail/models.rs
+++ b/src/tui/render/detail/models.rs
@@ -22,9 +22,10 @@ fn model_usage_line(
     brand: Color,
     content_width: u16,
 ) -> Line<'static> {
-    let tokens = model_tokens(mu);
+    // Gauge = tokens totais (io+cache) p/ alinhar com o chart; rótulo = io.
+    let tokens_all = model_tokens(mu);
     let pct = if max_tokens > 0 {
-        (tokens as f64 / max_tokens as f64 * 100.0).clamp(0.0, 100.0)
+        (tokens_all as f64 / max_tokens as f64 * 100.0).clamp(0.0, 100.0)
     } else {
         0.0
     };
@@ -43,8 +44,12 @@ fn model_usage_line(
         derive_bar_width(content_width, MODEL_SUFFIX_W),
         brand,
     ));
+    // Rótulo = input+output (coluna fixa 8). Cache não cabe no suffix aqui;
+    // dual completo vive nos totais (trilha B). Gauge permanece em tokens
+    // totais p/ alinhar com o chart.
+    let io = mu.input + mu.output;
     spans.push(Span::styled(
-        format!(" {:>8}", fmt_tokens_short(tokens)),
+        format!(" {:>8}", fmt_tokens_short(io)),
         Style::default().fg(to_ratatui(ColorToken::Muted)),
     ));
     spans.push(Span::styled(

--- a/src/tui/render/detail/totals.rs
+++ b/src/tui/render/detail/totals.rs
@@ -6,15 +6,17 @@ use ratatui::text::{Line, Span};
 use crate::theme::ColorToken;
 use crate::tui::state::AppState;
 use crate::tui::theme_bridge::to_ratatui;
-use crate::tui::widgets::column_chart::fmt_tokens_short;
+use crate::tui::widgets::column_chart::fmt_tokens_dual;
 use crate::usage::pricing::cost_usd_of;
 use crate::usage::{ProviderUsage, UsageRecord};
 
-use super::format::{fmt_cost_generic, provider_usage_tokens};
+use super::format::fmt_cost_generic;
 
 /// Linha de totais: "hoje" vem de `state.usage` (já agregado pelo engine);
 /// "7 dias" soma `state.history` filtrado por provider (records brutos —
 /// `state.usage` não cobre a janela de 7d).
+///
+/// Rótulos usam dual io/cache (trilha B): principal = input+output.
 pub(super) fn totals_line(
     state: &AppState,
     provider_usage: Option<&ProviderUsage>,
@@ -28,15 +30,15 @@ pub(super) fn totals_line(
     let today_str = if state.usage.is_none() {
         "coletando\u{2026}".to_string()
     } else {
-        let (today_tokens, today_cost) = match provider_usage {
-            Some(pu) => (provider_usage_tokens(pu), fmt_cost_generic(pu)),
-            None => (0, "-".to_string()),
+        let (today_label, today_cost) = match provider_usage {
+            Some(pu) => {
+                let io = pu.total_input + pu.total_output;
+                let cache = pu.total_cache_read + pu.total_cache_write;
+                (fmt_tokens_dual(io, cache), fmt_cost_generic(pu))
+            }
+            None => ("0".to_string(), "-".to_string()),
         };
-        format!(
-            "{} tok \u{b7} {}",
-            fmt_tokens_short(today_tokens),
-            today_cost
-        )
+        format!("{today_label} tok \u{b7} {today_cost}")
     };
 
     if state.history.is_none() {
@@ -53,9 +55,10 @@ pub(super) fn totals_line(
         .iter()
         .filter(|r| r.provider == provider)
         .collect();
-    let week_tokens: u64 = week_records
+    let week_io: u64 = week_records.iter().map(|r| r.input + r.output).sum();
+    let week_cache: u64 = week_records
         .iter()
-        .map(|r| r.input + r.output + r.cache_read + r.cache_write)
+        .map(|r| r.cache_read + r.cache_write)
         .sum();
     let week_cost: Option<f64> = week_records
         .iter()
@@ -71,7 +74,7 @@ pub(super) fn totals_line(
         format!(
             " hoje {}    7 dias {} tok \u{b7} {}",
             today_str,
-            fmt_tokens_short(week_tokens),
+            fmt_tokens_dual(week_io, week_cache),
             week_cost_str
         ),
         Style::default().fg(to_ratatui(ColorToken::TextBright)),

--- a/src/tui/widgets/column_chart.rs
+++ b/src/tui/widgets/column_chart.rs
@@ -493,8 +493,10 @@ pub fn column_chart_lines_bucketed(
 
     // Legenda. Guard de largura (espelha o guard dos labels X): para de
     // acrescentar séries assim que a próxima entrada não couber em `width`.
+    // Séries omitidas → sufixo ` …+N` se ainda couber (trilha B).
     let mut legend: Vec<Span<'static>> = Vec::new();
     let mut legend_w = 0usize;
+    let mut shown = 0usize;
     for s in series {
         let marker = "  ● ".to_string();
         let text = format!("{} {}", s.label, fmt_tokens_short(s.total));
@@ -503,6 +505,7 @@ pub fn column_chart_lines_bucketed(
             break;
         }
         legend_w += entry_w;
+        shown += 1;
         legend.push(Span::styled(
             marker,
             Style::default().fg(to_ratatui(series_token(s.slot))),
@@ -511,6 +514,16 @@ pub fn column_chart_lines_bucketed(
             text,
             Style::default().fg(to_ratatui(ColorToken::Text)),
         ));
+    }
+    let omitted = series.len().saturating_sub(shown);
+    if omitted > 0 {
+        let more = format!(" \u{2026}+{omitted}");
+        if legend_w + more.chars().count() <= width {
+            legend.push(Span::styled(
+                more,
+                Style::default().fg(to_ratatui(ColorToken::Comment)),
+            ));
+        }
     }
     out.push(Line::from(legend));
 
@@ -533,6 +546,21 @@ pub fn fmt_tokens_short(t: u64) -> String {
         format!("{:.0}k", f / 1e3)
     } else {
         format!("{t}")
+    }
+}
+
+/// Rótulo de tokens com dual opcional: principal = input+output; sufixo de
+/// cache quando `cache > 0`. Charts/gauges de intensidade continuam
+/// cache-inclusive no plot — só o texto do rótulo usa este helper
+/// (spec confianca + trilha B).
+///
+/// Exemplos: `9,9M` · `9,9M (+1,4B cache)`.
+pub fn fmt_tokens_dual(io: u64, cache: u64) -> String {
+    let main = fmt_tokens_short(io);
+    if cache == 0 {
+        main
+    } else {
+        format!("{main} (+{} cache)", fmt_tokens_short(cache))
     }
 }
 
@@ -562,6 +590,33 @@ mod tests {
                     .collect::<String>()
             })
             .collect()
+    }
+
+    #[test]
+    fn fmt_tokens_dual_omits_cache_when_zero() {
+        assert_eq!(fmt_tokens_dual(1_200_000, 0), "1,2M");
+        assert_eq!(fmt_tokens_dual(1_200_000, 1_400_000_000), "1,2M (+1,4B cache)");
+    }
+
+    #[test]
+    fn legend_shows_omitted_count_when_narrow() {
+        // Muitas séries com labels longos → só cabem poucas em width=40;
+        // o sufixo …+N deve aparecer.
+        let s: Vec<_> = (0..6u8)
+            .map(|i| {
+                series(
+                    &format!("ModelNameVeryLong{i}"),
+                    i,
+                    vec![1000; 24],
+                )
+            })
+            .collect();
+        let lines = column_chart_lines(&s, 40, 10, datetime!(2026-07-10 12:00:00 UTC), time::UtcOffset::UTC);
+        let legend = plain(&lines).last().cloned().unwrap_or_default();
+        assert!(
+            legend.contains('\u{2026}') || legend.contains("…"),
+            "legenda estreita deveria indicar omissões: {legend:?}"
+        );
     }
 
     #[test]

--- a/src/usage/pricing.rs
+++ b/src/usage/pricing.rs
@@ -2,7 +2,7 @@
 //! família (os nomes exatos variam por versão). Modelo desconhecido → None
 //! (nunca chutar custo).
 //!
-//! Atualizado: 2026-07-10. Fontes oficiais (verificadas + cross-check adversarial):
+//! Atualizado: 2026-07-17. Fontes oficiais (revalidadas na trilha B):
 //! - Anthropic: <https://platform.claude.com/docs/en/about-claude/pricing>
 //!   (Fable/Mythos, Sonnet 5 introdutório com virada em 2026-09-01, Opus 4.5–4.8,
 //!   Opus legado ≤4.1, Sonnet ≤4.6, Haiku; cache_read = 0.1×input,

--- a/tests/golden.rs
+++ b/tests/golden.rs
@@ -748,12 +748,12 @@ fn waybar_claude_healthy_tooltip() {
 <span foreground='#d19a66'>┏━</span> <span foreground='#d19a66' weight='bold'>Claude · Pro</span> <span foreground='#d19a66'>━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span>
 <span foreground='#d19a66'>┃</span>
 <span foreground='#d19a66'>┣━</span> <span foreground='#d19a66' weight='bold'>◆ 5-hour limit (shared)</span>
-<span foreground='#d19a66'>┃</span>  <span foreground='#98c379'>●</span> <span foreground='#e2e8f0'>All Models          </span> <span foreground='#98c379'>███████████████</span><span foreground='#6a7485'>░░░░░</span> <span foreground='#98c379'> 75%</span> <span foreground='#56b6c2'>→ __HM__ (__:__)</span>
+<span foreground='#d19a66'>┃</span>  <span foreground='#98c379'>●</span> <span foreground='#e2e8f0'>All Models          </span> <span foreground='#98c379'>███████████████</span><span foreground='#8b95a5'>░░░░░</span> <span foreground='#98c379'> 75%</span> <span foreground='#56b6c2'>→ __HM__ (__:__)</span>
 <span foreground='#d19a66'>┃</span>
 <span foreground='#d19a66'>┣━</span> <span foreground='#d19a66' weight='bold'>◆ Weekly limit (shared)</span>
-<span foreground='#d19a66'>┃</span>  <span foreground='#98c379'>●</span> <span foreground='#e2e8f0'>All Models          </span> <span foreground='#98c379'>██████████████████</span><span foreground='#6a7485'>░░</span> <span foreground='#98c379'> 90%</span> <span foreground='#56b6c2'>→ __HM__ (__:__)</span>
+<span foreground='#d19a66'>┃</span>  <span foreground='#98c379'>●</span> <span foreground='#e2e8f0'>All Models          </span> <span foreground='#98c379'>██████████████████</span><span foreground='#8b95a5'>░░</span> <span foreground='#98c379'> 90%</span> <span foreground='#56b6c2'>→ __HM__ (__:__)</span>
 <span foreground='#d19a66'>┃</span>
-<span foreground='#d19a66'>┗━━━━━━━━━━━━━━━━━━</span><span foreground='#6a7485'> cached · __AGO__ </span><span foreground='#d19a66'>━━━━━━━━━━━━━━━━━━</span>");
+<span foreground='#d19a66'>┗━━━━━━━━━━━━━━━━━━</span><span foreground='#8b95a5'> cached · __AGO__ </span><span foreground='#d19a66'>━━━━━━━━━━━━━━━━━━</span>");
     });
 }
 
@@ -777,7 +777,7 @@ fn waybar_claude_error_text() {
             &settings(),
             DisplayMode::Remaining,
         );
-        insta::assert_snapshot!(out.text, @"<span foreground='#6a7485'>No Providers</span>");
+        insta::assert_snapshot!(out.text, @"<span foreground='#8b95a5'>No Providers</span>");
     });
 }
 
@@ -793,9 +793,9 @@ fn waybar_claude_error_tooltip() {
         insta::assert_snapshot!(out.tooltip, @r"
 <span foreground='#d19a66'>┏━</span> <span foreground='#d19a66' weight='bold'>Claude</span> <span foreground='#d19a66'>━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span>
 <span foreground='#d19a66'>┃</span>
-<span foreground='#d19a66'>┃</span>  <span foreground='#e06c75'>⚠️ Token expired. Open `agent-bar menu` and choose Provider login.</span>
+<span foreground='#d19a66'>┃</span>  <span foreground='#e88b93'>⚠️ Token expired. Open `agent-bar menu` and choose Provider login.</span>
 <span foreground='#d19a66'>┃</span>
-<span foreground='#d19a66'>┗━━━━━━━━━━━━━━━━━━</span><span foreground='#6a7485'> cached · __AGO__ </span><span foreground='#d19a66'>━━━━━━━━━━━━━━━━━━</span>");
+<span foreground='#d19a66'>┗━━━━━━━━━━━━━━━━━━</span><span foreground='#8b95a5'> cached · __AGO__ </span><span foreground='#d19a66'>━━━━━━━━━━━━━━━━━━</span>");
     });
 }
 
@@ -837,12 +837,12 @@ fn waybar_codex_healthy_tooltip() {
 <span foreground='#98c379'>┃</span>
 <span foreground='#98c379'>┃</span>
 <span foreground='#98c379'>┣━</span> <span foreground='#98c379' weight='bold'>◆ 5-hour limit</span>
-<span foreground='#98c379'>┃</span>  <span foreground='#98c379'>●</span> <span foreground='#e2e8f0'>Codex               </span> <span foreground='#98c379'>████████████</span><span foreground='#6a7485'>░░░░░░░░</span> <span foreground='#98c379'> 60%</span> <span foreground='#56b6c2'>→ __HM__ (__:__)</span>
+<span foreground='#98c379'>┃</span>  <span foreground='#98c379'>●</span> <span foreground='#e2e8f0'>Codex               </span> <span foreground='#98c379'>████████████</span><span foreground='#8b95a5'>░░░░░░░░</span> <span foreground='#98c379'> 60%</span> <span foreground='#56b6c2'>→ __HM__ (__:__)</span>
 <span foreground='#98c379'>┃</span>
 <span foreground='#98c379'>┣━</span> <span foreground='#98c379' weight='bold'>◆ 7-day limit</span>
-<span foreground='#98c379'>┃</span>  <span foreground='#98c379'>●</span> <span foreground='#e2e8f0'>Codex               </span> <span foreground='#98c379'>█████████████████</span><span foreground='#6a7485'>░░░</span> <span foreground='#98c379'> 85%</span> <span foreground='#56b6c2'>→ __HM__ (__:__)</span>
+<span foreground='#98c379'>┃</span>  <span foreground='#98c379'>●</span> <span foreground='#e2e8f0'>Codex               </span> <span foreground='#98c379'>█████████████████</span><span foreground='#8b95a5'>░░░</span> <span foreground='#98c379'> 85%</span> <span foreground='#56b6c2'>→ __HM__ (__:__)</span>
 <span foreground='#98c379'>┃</span>
-<span foreground='#98c379'>┗━━━━━━━━━━━━━━━━━━</span><span foreground='#6a7485'> cached · __AGO__ </span><span foreground='#98c379'>━━━━━━━━━━━━━━━━━━</span>");
+<span foreground='#98c379'>┗━━━━━━━━━━━━━━━━━━</span><span foreground='#8b95a5'> cached · __AGO__ </span><span foreground='#98c379'>━━━━━━━━━━━━━━━━━━</span>");
     });
 }
 
@@ -883,10 +883,10 @@ fn waybar_amp_healthy_tooltip() {
 <span foreground='#c678dd'>┏━</span> <span foreground='#c678dd' weight='bold'>Amp</span> <span foreground='#c678dd'>━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span>
 <span foreground='#c678dd'>┃</span>
 <span foreground='#c678dd'>┣━</span> <span foreground='#c678dd' weight='bold'>◆ Free Tier</span>
-<span foreground='#c678dd'>┃</span>  <span foreground='#98c379'>●</span> <span foreground='#98c379'>██████████████</span><span foreground='#6a7485'>░░░░░░</span> <span foreground='#98c379'> 70%</span>  <span foreground='#56b6c2'>→ Full in __HM__ (__:__)</span>
-<span foreground='#c678dd'>┃</span>  <span foreground='#6a7485'>○</span> <span foreground='#56b6c2'>+$0.25/hr</span><span foreground='#6a7485'>  |  </span><span foreground='#c0c9d4'>$3.50 / $5.00</span>
+<span foreground='#c678dd'>┃</span>  <span foreground='#98c379'>●</span> <span foreground='#98c379'>██████████████</span><span foreground='#8b95a5'>░░░░░░</span> <span foreground='#98c379'> 70%</span>  <span foreground='#56b6c2'>→ Full in __HM__ (__:__)</span>
+<span foreground='#c678dd'>┃</span>  <span foreground='#8b95a5'>○</span> <span foreground='#56b6c2'>+$0.25/hr</span><span foreground='#8b95a5'>  |  </span><span foreground='#c0c9d4'>$3.50 / $5.00</span>
 <span foreground='#c678dd'>┃</span>
-<span foreground='#c678dd'>┗━━━━━━━━━━━━━━━━━━</span><span foreground='#6a7485'> cached · __AGO__ </span><span foreground='#c678dd'>━━━━━━━━━━━━━━━━━━</span>");
+<span foreground='#c678dd'>┗━━━━━━━━━━━━━━━━━━</span><span foreground='#8b95a5'> cached · __AGO__ </span><span foreground='#c678dd'>━━━━━━━━━━━━━━━━━━</span>");
     });
 }
 
@@ -910,7 +910,7 @@ fn waybar_all_combined_text() {
             &settings(),
             DisplayMode::Remaining,
         );
-        insta::assert_snapshot!(out.text, @"<span foreground='#98c379'>75%</span> <span foreground='#6a7485'>│</span> <span foreground='#98c379'>60%</span> <span foreground='#6a7485'>│</span> <span foreground='#98c379'>70%</span>");
+        insta::assert_snapshot!(out.text, @"<span foreground='#98c379'>75%</span> <span foreground='#8b95a5'>│</span> <span foreground='#98c379'>60%</span> <span foreground='#8b95a5'>│</span> <span foreground='#98c379'>70%</span>");
     });
 }
 
@@ -927,31 +927,31 @@ fn waybar_all_combined_tooltip() {
 <span foreground='#d19a66'>┏━</span> <span foreground='#d19a66' weight='bold'>Claude · Pro</span> <span foreground='#d19a66'>━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span>
 <span foreground='#d19a66'>┃</span>
 <span foreground='#d19a66'>┣━</span> <span foreground='#d19a66' weight='bold'>◆ 5-hour limit (shared)</span>
-<span foreground='#d19a66'>┃</span>  <span foreground='#98c379'>●</span> <span foreground='#e2e8f0'>All Models          </span> <span foreground='#98c379'>███████████████</span><span foreground='#6a7485'>░░░░░</span> <span foreground='#98c379'> 75%</span> <span foreground='#56b6c2'>→ __HM__ (__:__)</span>
+<span foreground='#d19a66'>┃</span>  <span foreground='#98c379'>●</span> <span foreground='#e2e8f0'>All Models          </span> <span foreground='#98c379'>███████████████</span><span foreground='#8b95a5'>░░░░░</span> <span foreground='#98c379'> 75%</span> <span foreground='#56b6c2'>→ __HM__ (__:__)</span>
 <span foreground='#d19a66'>┃</span>
 <span foreground='#d19a66'>┣━</span> <span foreground='#d19a66' weight='bold'>◆ Weekly limit (shared)</span>
-<span foreground='#d19a66'>┃</span>  <span foreground='#98c379'>●</span> <span foreground='#e2e8f0'>All Models          </span> <span foreground='#98c379'>██████████████████</span><span foreground='#6a7485'>░░</span> <span foreground='#98c379'> 90%</span> <span foreground='#56b6c2'>→ __HM__ (__:__)</span>
+<span foreground='#d19a66'>┃</span>  <span foreground='#98c379'>●</span> <span foreground='#e2e8f0'>All Models          </span> <span foreground='#98c379'>██████████████████</span><span foreground='#8b95a5'>░░</span> <span foreground='#98c379'> 90%</span> <span foreground='#56b6c2'>→ __HM__ (__:__)</span>
 <span foreground='#d19a66'>┃</span>
-<span foreground='#d19a66'>┗━━━━━━━━━━━━━━━━━━</span><span foreground='#6a7485'> cached · __AGO__ </span><span foreground='#d19a66'>━━━━━━━━━━━━━━━━━━</span>
+<span foreground='#d19a66'>┗━━━━━━━━━━━━━━━━━━</span><span foreground='#8b95a5'> cached · __AGO__ </span><span foreground='#d19a66'>━━━━━━━━━━━━━━━━━━</span>
 
 <span foreground='#98c379'>┏━</span> <span foreground='#98c379' weight='bold'>Codex · Pro</span> <span foreground='#98c379'>━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span>
 <span foreground='#98c379'>┃</span>
 <span foreground='#98c379'>┃</span>
 <span foreground='#98c379'>┣━</span> <span foreground='#98c379' weight='bold'>◆ 5-hour limit</span>
-<span foreground='#98c379'>┃</span>  <span foreground='#98c379'>●</span> <span foreground='#e2e8f0'>Codex               </span> <span foreground='#98c379'>████████████</span><span foreground='#6a7485'>░░░░░░░░</span> <span foreground='#98c379'> 60%</span> <span foreground='#56b6c2'>→ __HM__ (__:__)</span>
+<span foreground='#98c379'>┃</span>  <span foreground='#98c379'>●</span> <span foreground='#e2e8f0'>Codex               </span> <span foreground='#98c379'>████████████</span><span foreground='#8b95a5'>░░░░░░░░</span> <span foreground='#98c379'> 60%</span> <span foreground='#56b6c2'>→ __HM__ (__:__)</span>
 <span foreground='#98c379'>┃</span>
 <span foreground='#98c379'>┣━</span> <span foreground='#98c379' weight='bold'>◆ 7-day limit</span>
-<span foreground='#98c379'>┃</span>  <span foreground='#98c379'>●</span> <span foreground='#e2e8f0'>Codex               </span> <span foreground='#98c379'>█████████████████</span><span foreground='#6a7485'>░░░</span> <span foreground='#98c379'> 85%</span> <span foreground='#56b6c2'>→ __HM__ (__:__)</span>
+<span foreground='#98c379'>┃</span>  <span foreground='#98c379'>●</span> <span foreground='#e2e8f0'>Codex               </span> <span foreground='#98c379'>█████████████████</span><span foreground='#8b95a5'>░░░</span> <span foreground='#98c379'> 85%</span> <span foreground='#56b6c2'>→ __HM__ (__:__)</span>
 <span foreground='#98c379'>┃</span>
-<span foreground='#98c379'>┗━━━━━━━━━━━━━━━━━━</span><span foreground='#6a7485'> cached · __AGO__ </span><span foreground='#98c379'>━━━━━━━━━━━━━━━━━━</span>
+<span foreground='#98c379'>┗━━━━━━━━━━━━━━━━━━</span><span foreground='#8b95a5'> cached · __AGO__ </span><span foreground='#98c379'>━━━━━━━━━━━━━━━━━━</span>
 
 <span foreground='#c678dd'>┏━</span> <span foreground='#c678dd' weight='bold'>Amp</span> <span foreground='#c678dd'>━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span>
 <span foreground='#c678dd'>┃</span>
 <span foreground='#c678dd'>┣━</span> <span foreground='#c678dd' weight='bold'>◆ Free Tier</span>
-<span foreground='#c678dd'>┃</span>  <span foreground='#98c379'>●</span> <span foreground='#98c379'>██████████████</span><span foreground='#6a7485'>░░░░░░</span> <span foreground='#98c379'> 70%</span>  <span foreground='#56b6c2'>→ Full in __HM__ (__:__)</span>
-<span foreground='#c678dd'>┃</span>  <span foreground='#6a7485'>○</span> <span foreground='#56b6c2'>+$0.25/hr</span><span foreground='#6a7485'>  |  </span><span foreground='#c0c9d4'>$3.50 / $5.00</span>
+<span foreground='#c678dd'>┃</span>  <span foreground='#98c379'>●</span> <span foreground='#98c379'>██████████████</span><span foreground='#8b95a5'>░░░░░░</span> <span foreground='#98c379'> 70%</span>  <span foreground='#56b6c2'>→ Full in __HM__ (__:__)</span>
+<span foreground='#c678dd'>┃</span>  <span foreground='#8b95a5'>○</span> <span foreground='#56b6c2'>+$0.25/hr</span><span foreground='#8b95a5'>  |  </span><span foreground='#c0c9d4'>$3.50 / $5.00</span>
 <span foreground='#c678dd'>┃</span>
-<span foreground='#c678dd'>┗━━━━━━━━━━━━━━━━━━</span><span foreground='#6a7485'> cached · __AGO__ </span><span foreground='#c678dd'>━━━━━━━━━━━━━━━━━━</span>");
+<span foreground='#c678dd'>┗━━━━━━━━━━━━━━━━━━</span><span foreground='#8b95a5'> cached · __AGO__ </span><span foreground='#c678dd'>━━━━━━━━━━━━━━━━━━</span>");
     });
 }
 
@@ -970,7 +970,7 @@ fn waybar_all_combined_class() {
 fn waybar_empty_text() {
     with_filters(|| {
         let out = format_for_waybar(&clk(), &wrap(vec![]), &settings(), DisplayMode::Remaining);
-        insta::assert_snapshot!(out.text, @"<span foreground='#6a7485'>No Providers</span>");
+        insta::assert_snapshot!(out.text, @"<span foreground='#8b95a5'>No Providers</span>");
     });
 }
 
@@ -1018,12 +1018,12 @@ fn waybar_claude_healthy_used_tooltip() {
 <span foreground='#d19a66'>┏━</span> <span foreground='#d19a66' weight='bold'>Claude · Pro</span> <span foreground='#d19a66'>━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span>
 <span foreground='#d19a66'>┃</span>
 <span foreground='#d19a66'>┣━</span> <span foreground='#d19a66' weight='bold'>◆ 5-hour limit (shared)</span>
-<span foreground='#d19a66'>┃</span>  <span foreground='#98c379'>●</span> <span foreground='#e2e8f0'>All Models          </span> <span foreground='#98c379'>█████</span><span foreground='#6a7485'>░░░░░░░░░░░░░░░</span> <span foreground='#98c379'> 25%</span> <span foreground='#56b6c2'>→ __HM__ (__:__)</span>
+<span foreground='#d19a66'>┃</span>  <span foreground='#98c379'>●</span> <span foreground='#e2e8f0'>All Models          </span> <span foreground='#98c379'>█████</span><span foreground='#8b95a5'>░░░░░░░░░░░░░░░</span> <span foreground='#98c379'> 25%</span> <span foreground='#56b6c2'>→ __HM__ (__:__)</span>
 <span foreground='#d19a66'>┃</span>
 <span foreground='#d19a66'>┣━</span> <span foreground='#d19a66' weight='bold'>◆ Weekly limit (shared)</span>
-<span foreground='#d19a66'>┃</span>  <span foreground='#98c379'>●</span> <span foreground='#e2e8f0'>All Models          </span> <span foreground='#98c379'>██</span><span foreground='#6a7485'>░░░░░░░░░░░░░░░░░░</span> <span foreground='#98c379'> 10%</span> <span foreground='#56b6c2'>→ __HM__ (__:__)</span>
+<span foreground='#d19a66'>┃</span>  <span foreground='#98c379'>●</span> <span foreground='#e2e8f0'>All Models          </span> <span foreground='#98c379'>██</span><span foreground='#8b95a5'>░░░░░░░░░░░░░░░░░░</span> <span foreground='#98c379'> 10%</span> <span foreground='#56b6c2'>→ __HM__ (__:__)</span>
 <span foreground='#d19a66'>┃</span>
-<span foreground='#d19a66'>┗━━━━━━━━━━━━━━━━━━</span><span foreground='#6a7485'> cached · __AGO__ </span><span foreground='#d19a66'>━━━━━━━━━━━━━━━━━━</span>");
+<span foreground='#d19a66'>┗━━━━━━━━━━━━━━━━━━</span><span foreground='#8b95a5'> cached · __AGO__ </span><span foreground='#d19a66'>━━━━━━━━━━━━━━━━━━</span>");
     });
 }
 
@@ -1065,12 +1065,12 @@ fn waybar_codex_healthy_used_tooltip() {
 <span foreground='#98c379'>┃</span>
 <span foreground='#98c379'>┃</span>
 <span foreground='#98c379'>┣━</span> <span foreground='#98c379' weight='bold'>◆ 5-hour limit</span>
-<span foreground='#98c379'>┃</span>  <span foreground='#98c379'>●</span> <span foreground='#e2e8f0'>Codex               </span> <span foreground='#98c379'>████████</span><span foreground='#6a7485'>░░░░░░░░░░░░</span> <span foreground='#98c379'> 40%</span> <span foreground='#56b6c2'>→ __HM__ (__:__)</span>
+<span foreground='#98c379'>┃</span>  <span foreground='#98c379'>●</span> <span foreground='#e2e8f0'>Codex               </span> <span foreground='#98c379'>████████</span><span foreground='#8b95a5'>░░░░░░░░░░░░</span> <span foreground='#98c379'> 40%</span> <span foreground='#56b6c2'>→ __HM__ (__:__)</span>
 <span foreground='#98c379'>┃</span>
 <span foreground='#98c379'>┣━</span> <span foreground='#98c379' weight='bold'>◆ 7-day limit</span>
-<span foreground='#98c379'>┃</span>  <span foreground='#98c379'>●</span> <span foreground='#e2e8f0'>Codex               </span> <span foreground='#98c379'>███</span><span foreground='#6a7485'>░░░░░░░░░░░░░░░░░</span> <span foreground='#98c379'> 15%</span> <span foreground='#56b6c2'>→ __HM__ (__:__)</span>
+<span foreground='#98c379'>┃</span>  <span foreground='#98c379'>●</span> <span foreground='#e2e8f0'>Codex               </span> <span foreground='#98c379'>███</span><span foreground='#8b95a5'>░░░░░░░░░░░░░░░░░</span> <span foreground='#98c379'> 15%</span> <span foreground='#56b6c2'>→ __HM__ (__:__)</span>
 <span foreground='#98c379'>┃</span>
-<span foreground='#98c379'>┗━━━━━━━━━━━━━━━━━━</span><span foreground='#6a7485'> cached · __AGO__ </span><span foreground='#98c379'>━━━━━━━━━━━━━━━━━━</span>");
+<span foreground='#98c379'>┗━━━━━━━━━━━━━━━━━━</span><span foreground='#8b95a5'> cached · __AGO__ </span><span foreground='#98c379'>━━━━━━━━━━━━━━━━━━</span>");
     });
 }
 
@@ -1111,10 +1111,10 @@ fn waybar_amp_healthy_used_tooltip() {
 <span foreground='#c678dd'>┏━</span> <span foreground='#c678dd' weight='bold'>Amp</span> <span foreground='#c678dd'>━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span>
 <span foreground='#c678dd'>┃</span>
 <span foreground='#c678dd'>┣━</span> <span foreground='#c678dd' weight='bold'>◆ Free Tier</span>
-<span foreground='#c678dd'>┃</span>  <span foreground='#98c379'>●</span> <span foreground='#98c379'>██████</span><span foreground='#6a7485'>░░░░░░░░░░░░░░</span> <span foreground='#98c379'> 30%</span>  <span foreground='#56b6c2'>→ Resets in __HM__ (__:__)</span>
-<span foreground='#c678dd'>┃</span>  <span foreground='#6a7485'>○</span> <span foreground='#56b6c2'>+$0.25/hr</span><span foreground='#6a7485'>  |  </span><span foreground='#c0c9d4'>$3.50 / $5.00</span>
+<span foreground='#c678dd'>┃</span>  <span foreground='#98c379'>●</span> <span foreground='#98c379'>██████</span><span foreground='#8b95a5'>░░░░░░░░░░░░░░</span> <span foreground='#98c379'> 30%</span>  <span foreground='#56b6c2'>→ Resets in __HM__ (__:__)</span>
+<span foreground='#c678dd'>┃</span>  <span foreground='#8b95a5'>○</span> <span foreground='#56b6c2'>+$0.25/hr</span><span foreground='#8b95a5'>  |  </span><span foreground='#c0c9d4'>$3.50 / $5.00</span>
 <span foreground='#c678dd'>┃</span>
-<span foreground='#c678dd'>┗━━━━━━━━━━━━━━━━━━</span><span foreground='#6a7485'> cached · __AGO__ </span><span foreground='#c678dd'>━━━━━━━━━━━━━━━━━━</span>");
+<span foreground='#c678dd'>┗━━━━━━━━━━━━━━━━━━</span><span foreground='#8b95a5'> cached · __AGO__ </span><span foreground='#c678dd'>━━━━━━━━━━━━━━━━━━</span>");
     });
 }
 
@@ -1149,10 +1149,10 @@ fn per_provider_claude_healthy_tooltip() {
 <span foreground='#d19a66'>┏━</span> <span foreground='#d19a66' weight='bold'>Claude · Pro</span> <span foreground='#d19a66'>━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span>
 <span foreground='#d19a66'>┃</span>
 <span foreground='#d19a66'>┣━</span> <span foreground='#d19a66' weight='bold'>◆ 5-hour limit (shared)</span>
-<span foreground='#d19a66'>┃</span>  <span foreground='#98c379'>●</span> <span foreground='#e2e8f0'>All Models          </span> <span foreground='#98c379'>███████████████</span><span foreground='#6a7485'>░░░░░</span> <span foreground='#98c379'> 75%</span> <span foreground='#56b6c2'>→ __HM__ (__:__)</span>
+<span foreground='#d19a66'>┃</span>  <span foreground='#98c379'>●</span> <span foreground='#e2e8f0'>All Models          </span> <span foreground='#98c379'>███████████████</span><span foreground='#8b95a5'>░░░░░</span> <span foreground='#98c379'> 75%</span> <span foreground='#56b6c2'>→ __HM__ (__:__)</span>
 <span foreground='#d19a66'>┃</span>
 <span foreground='#d19a66'>┣━</span> <span foreground='#d19a66' weight='bold'>◆ Weekly limit (shared)</span>
-<span foreground='#d19a66'>┃</span>  <span foreground='#98c379'>●</span> <span foreground='#e2e8f0'>All Models          </span> <span foreground='#98c379'>██████████████████</span><span foreground='#6a7485'>░░</span> <span foreground='#98c379'> 90%</span> <span foreground='#56b6c2'>→ __HM__ (__:__)</span>
+<span foreground='#d19a66'>┃</span>  <span foreground='#98c379'>●</span> <span foreground='#e2e8f0'>All Models          </span> <span foreground='#98c379'>██████████████████</span><span foreground='#8b95a5'>░░</span> <span foreground='#98c379'> 90%</span> <span foreground='#56b6c2'>→ __HM__ (__:__)</span>
 <span foreground='#d19a66'>┃</span>
 <span foreground='#d19a66'>┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span>");
     });
@@ -1179,7 +1179,7 @@ fn per_provider_claude_disconnected_text() {
             DisplayMode::Remaining,
         );
         // Glyph nerd-font U+F1616
-        insta::assert_snapshot!(out.text, @"<span foreground='#e06c75'>\u{f1616}</span>");
+        insta::assert_snapshot!(out.text, @"<span foreground='#e88b93'>\u{f1616}</span>");
     });
 }
 
@@ -1195,7 +1195,7 @@ fn per_provider_claude_disconnected_tooltip() {
         insta::assert_snapshot!(out.tooltip, @r"
 <span foreground='#d19a66'>┏━</span> <span foreground='#d19a66' weight='bold'>Claude</span> <span foreground='#d19a66'>━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span>
 <span foreground='#d19a66'>┃</span>
-<span foreground='#d19a66'>┃</span>  <span foreground='#e06c75'>⚠️ Token expired. Open `agent-bar menu` and choose Provider login.</span>
+<span foreground='#d19a66'>┃</span>  <span foreground='#e88b93'>⚠️ Token expired. Open `agent-bar menu` and choose Provider login.</span>
 <span foreground='#d19a66'>┃</span>
 <span foreground='#d19a66'>┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span>");
     });
@@ -1235,10 +1235,10 @@ fn per_provider_codex_healthy_tooltip() {
 <span foreground='#98c379'>┃</span>
 <span foreground='#98c379'>┃</span>
 <span foreground='#98c379'>┣━</span> <span foreground='#98c379' weight='bold'>◆ 5-hour limit</span>
-<span foreground='#98c379'>┃</span>  <span foreground='#98c379'>●</span> <span foreground='#e2e8f0'>Codex               </span> <span foreground='#98c379'>████████████</span><span foreground='#6a7485'>░░░░░░░░</span> <span foreground='#98c379'> 60%</span> <span foreground='#56b6c2'>→ __HM__ (__:__)</span>
+<span foreground='#98c379'>┃</span>  <span foreground='#98c379'>●</span> <span foreground='#e2e8f0'>Codex               </span> <span foreground='#98c379'>████████████</span><span foreground='#8b95a5'>░░░░░░░░</span> <span foreground='#98c379'> 60%</span> <span foreground='#56b6c2'>→ __HM__ (__:__)</span>
 <span foreground='#98c379'>┃</span>
 <span foreground='#98c379'>┣━</span> <span foreground='#98c379' weight='bold'>◆ 7-day limit</span>
-<span foreground='#98c379'>┃</span>  <span foreground='#98c379'>●</span> <span foreground='#e2e8f0'>Codex               </span> <span foreground='#98c379'>█████████████████</span><span foreground='#6a7485'>░░░</span> <span foreground='#98c379'> 85%</span> <span foreground='#56b6c2'>→ __HM__ (__:__)</span>
+<span foreground='#98c379'>┃</span>  <span foreground='#98c379'>●</span> <span foreground='#e2e8f0'>Codex               </span> <span foreground='#98c379'>█████████████████</span><span foreground='#8b95a5'>░░░</span> <span foreground='#98c379'> 85%</span> <span foreground='#56b6c2'>→ __HM__ (__:__)</span>
 <span foreground='#98c379'>┃</span>
 <span foreground='#98c379'>┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span>");
     });
@@ -1273,8 +1273,8 @@ fn per_provider_amp_healthy_tooltip() {
 <span foreground='#c678dd'>┏━</span> <span foreground='#c678dd' weight='bold'>Amp</span> <span foreground='#c678dd'>━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span>
 <span foreground='#c678dd'>┃</span>
 <span foreground='#c678dd'>┣━</span> <span foreground='#c678dd' weight='bold'>◆ Free Tier</span>
-<span foreground='#c678dd'>┃</span>  <span foreground='#98c379'>●</span> <span foreground='#98c379'>██████████████</span><span foreground='#6a7485'>░░░░░░</span> <span foreground='#98c379'> 70%</span>  <span foreground='#56b6c2'>→ Full in __HM__ (__:__)</span>
-<span foreground='#c678dd'>┃</span>  <span foreground='#6a7485'>○</span> <span foreground='#56b6c2'>+$0.25/hr</span><span foreground='#6a7485'>  |  </span><span foreground='#c0c9d4'>$3.50 / $5.00</span>
+<span foreground='#c678dd'>┃</span>  <span foreground='#98c379'>●</span> <span foreground='#98c379'>██████████████</span><span foreground='#8b95a5'>░░░░░░</span> <span foreground='#98c379'> 70%</span>  <span foreground='#56b6c2'>→ Full in __HM__ (__:__)</span>
+<span foreground='#c678dd'>┃</span>  <span foreground='#8b95a5'>○</span> <span foreground='#56b6c2'>+$0.25/hr</span><span foreground='#8b95a5'>  |  </span><span foreground='#c0c9d4'>$3.50 / $5.00</span>
 <span foreground='#c678dd'>┃</span>
 <span foreground='#c678dd'>┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span>");
     });
@@ -1317,10 +1317,10 @@ fn waybar_amp_with_account_tooltip() {
 <span foreground='#c678dd'>┏━</span> <span foreground='#c678dd' weight='bold'>Amp · user@example.com</span> <span foreground='#c678dd'>━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span>
 <span foreground='#c678dd'>┃</span>
 <span foreground='#c678dd'>┣━</span> <span foreground='#c678dd' weight='bold'>◆ Free Tier</span>
-<span foreground='#c678dd'>┃</span>  <span foreground='#98c379'>●</span> <span foreground='#98c379'>██████████████</span><span foreground='#6a7485'>░░░░░░</span> <span foreground='#98c379'> 70%</span>  <span foreground='#56b6c2'>→ Full in __HM__ (__:__)</span>
-<span foreground='#c678dd'>┃</span>  <span foreground='#6a7485'>○</span> <span foreground='#56b6c2'>+$0.25/hr</span><span foreground='#6a7485'>  |  </span><span foreground='#c0c9d4'>$3.50 / $5.00</span>
+<span foreground='#c678dd'>┃</span>  <span foreground='#98c379'>●</span> <span foreground='#98c379'>██████████████</span><span foreground='#8b95a5'>░░░░░░</span> <span foreground='#98c379'> 70%</span>  <span foreground='#56b6c2'>→ Full in __HM__ (__:__)</span>
+<span foreground='#c678dd'>┃</span>  <span foreground='#8b95a5'>○</span> <span foreground='#56b6c2'>+$0.25/hr</span><span foreground='#8b95a5'>  |  </span><span foreground='#c0c9d4'>$3.50 / $5.00</span>
 <span foreground='#c678dd'>┃</span>
-<span foreground='#c678dd'>┗━━━━━━━━━━━━━━━━━━</span><span foreground='#6a7485'> cached · __AGO__ </span><span foreground='#c678dd'>━━━━━━━━━━━━━━━━━━</span>");
+<span foreground='#c678dd'>┗━━━━━━━━━━━━━━━━━━</span><span foreground='#8b95a5'> cached · __AGO__ </span><span foreground='#c678dd'>━━━━━━━━━━━━━━━━━━</span>");
     });
 }
 
@@ -1361,8 +1361,8 @@ fn per_provider_amp_with_account_tooltip() {
 <span foreground='#c678dd'>┏━</span> <span foreground='#c678dd' weight='bold'>Amp · user@example.com</span> <span foreground='#c678dd'>━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span>
 <span foreground='#c678dd'>┃</span>
 <span foreground='#c678dd'>┣━</span> <span foreground='#c678dd' weight='bold'>◆ Free Tier</span>
-<span foreground='#c678dd'>┃</span>  <span foreground='#98c379'>●</span> <span foreground='#98c379'>██████████████</span><span foreground='#6a7485'>░░░░░░</span> <span foreground='#98c379'> 70%</span>  <span foreground='#56b6c2'>→ Full in __HM__ (__:__)</span>
-<span foreground='#c678dd'>┃</span>  <span foreground='#6a7485'>○</span> <span foreground='#56b6c2'>+$0.25/hr</span><span foreground='#6a7485'>  |  </span><span foreground='#c0c9d4'>$3.50 / $5.00</span>
+<span foreground='#c678dd'>┃</span>  <span foreground='#98c379'>●</span> <span foreground='#98c379'>██████████████</span><span foreground='#8b95a5'>░░░░░░</span> <span foreground='#98c379'> 70%</span>  <span foreground='#56b6c2'>→ Full in __HM__ (__:__)</span>
+<span foreground='#c678dd'>┃</span>  <span foreground='#8b95a5'>○</span> <span foreground='#56b6c2'>+$0.25/hr</span><span foreground='#8b95a5'>  |  </span><span foreground='#c0c9d4'>$3.50 / $5.00</span>
 <span foreground='#c678dd'>┃</span>
 <span foreground='#c678dd'>┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span>");
     });
@@ -1409,19 +1409,19 @@ fn waybar_claude_with_extras_tooltip() {
 <span foreground='#d19a66'>┏━</span> <span foreground='#d19a66' weight='bold'>Claude · Pro</span> <span foreground='#d19a66'>━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span>
 <span foreground='#d19a66'>┃</span>
 <span foreground='#d19a66'>┣━</span> <span foreground='#d19a66' weight='bold'>◆ 5-hour limit (shared)</span>
-<span foreground='#d19a66'>┃</span>  <span foreground='#98c379'>●</span> <span foreground='#e2e8f0'>All Models          </span> <span foreground='#98c379'>████████████</span><span foreground='#6a7485'>░░░░░░░░</span> <span foreground='#98c379'> 60%</span> <span foreground='#56b6c2'>→ __HM__ (__:__)</span>
+<span foreground='#d19a66'>┃</span>  <span foreground='#98c379'>●</span> <span foreground='#e2e8f0'>All Models          </span> <span foreground='#98c379'>████████████</span><span foreground='#8b95a5'>░░░░░░░░</span> <span foreground='#98c379'> 60%</span> <span foreground='#56b6c2'>→ __HM__ (__:__)</span>
 <span foreground='#d19a66'>┃</span>
 <span foreground='#d19a66'>┣━</span> <span foreground='#d19a66' weight='bold'>◆ Weekly per model</span>
-<span foreground='#d19a66'>┃</span>  <span foreground='#e5c07b'>●</span> <span foreground='#e2e8f0'>claude-opus-4-5     </span> <span foreground='#e5c07b'>████████</span><span foreground='#6a7485'>░░░░░░░░░░░░</span> <span foreground='#e5c07b'> 40%</span> <span foreground='#56b6c2'>→ __HM__ (__:__)</span>
-<span foreground='#d19a66'>┃</span>  <span foreground='#98c379'>●</span> <span foreground='#e2e8f0'>claude-sonnet-4-5   </span> <span foreground='#98c379'>█████████████</span><span foreground='#6a7485'>░░░░░░░</span> <span foreground='#98c379'> 65%</span> <span foreground='#56b6c2'>→ __HM__ (__:__)</span>
+<span foreground='#d19a66'>┃</span>  <span foreground='#e5c07b'>●</span> <span foreground='#e2e8f0'>claude-opus-4-5     </span> <span foreground='#e5c07b'>████████</span><span foreground='#8b95a5'>░░░░░░░░░░░░</span> <span foreground='#e5c07b'> 40%</span> <span foreground='#56b6c2'>→ __HM__ (__:__)</span>
+<span foreground='#d19a66'>┃</span>  <span foreground='#98c379'>●</span> <span foreground='#e2e8f0'>claude-sonnet-4-5   </span> <span foreground='#98c379'>█████████████</span><span foreground='#8b95a5'>░░░░░░░</span> <span foreground='#98c379'> 65%</span> <span foreground='#56b6c2'>→ __HM__ (__:__)</span>
 <span foreground='#d19a66'>┃</span>
 <span foreground='#d19a66'>┣━</span> <span foreground='#d19a66' weight='bold'>◆ Weekly limit (shared)</span>
-<span foreground='#d19a66'>┃</span>  <span foreground='#e5c07b'>●</span> <span foreground='#e2e8f0'>All Models          </span> <span foreground='#e5c07b'>██████████</span><span foreground='#6a7485'>░░░░░░░░░░</span> <span foreground='#e5c07b'> 50%</span> <span foreground='#56b6c2'>→ __HM__ (__:__)</span>
+<span foreground='#d19a66'>┃</span>  <span foreground='#e5c07b'>●</span> <span foreground='#e2e8f0'>All Models          </span> <span foreground='#e5c07b'>██████████</span><span foreground='#8b95a5'>░░░░░░░░░░</span> <span foreground='#e5c07b'> 50%</span> <span foreground='#56b6c2'>→ __HM__ (__:__)</span>
 <span foreground='#d19a66'>┃</span>
 <span foreground='#d19a66'>┣━</span> <span foreground='#d19a66' weight='bold'>◆ Extra Usage</span>
-<span foreground='#d19a66'>┃</span>  <span foreground='#e5c07b'>●</span> <span foreground='#e2e8f0'>Budget              </span> <span foreground='#e5c07b'>███████████</span><span foreground='#6a7485'>░░░░░░░░░</span> <span foreground='#e5c07b'> 55%</span> <span foreground='#56b6c2'>$22.50/$50.00</span>
+<span foreground='#d19a66'>┃</span>  <span foreground='#e5c07b'>●</span> <span foreground='#e2e8f0'>Budget              </span> <span foreground='#e5c07b'>███████████</span><span foreground='#8b95a5'>░░░░░░░░░</span> <span foreground='#e5c07b'> 55%</span> <span foreground='#56b6c2'>$22.50/$50.00</span>
 <span foreground='#d19a66'>┃</span>
-<span foreground='#d19a66'>┗━━━━━━━━━━━━━━━━━━</span><span foreground='#6a7485'> cached · __AGO__ </span><span foreground='#d19a66'>━━━━━━━━━━━━━━━━━━</span>");
+<span foreground='#d19a66'>┗━━━━━━━━━━━━━━━━━━</span><span foreground='#8b95a5'> cached · __AGO__ </span><span foreground='#d19a66'>━━━━━━━━━━━━━━━━━━</span>");
     });
 }
 
@@ -1462,13 +1462,13 @@ fn waybar_amp_with_credits_tooltip() {
 <span foreground='#c678dd'>┏━</span> <span foreground='#c678dd' weight='bold'>Amp</span> <span foreground='#c678dd'>━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span>
 <span foreground='#c678dd'>┃</span>
 <span foreground='#c678dd'>┣━</span> <span foreground='#c678dd' weight='bold'>◆ Free Tier</span>
-<span foreground='#c678dd'>┃</span>  <span foreground='#e5c07b'>●</span> <span foreground='#e5c07b'>██████</span><span foreground='#6a7485'>░░░░░░░░░░░░░░</span> <span foreground='#e5c07b'> 30%</span>  <span foreground='#56b6c2'>→ Full in __HM__ (__:__)</span>
-<span foreground='#c678dd'>┃</span>  <span foreground='#6a7485'>○</span> <span foreground='#56b6c2'>+$0.25/hr</span><span foreground='#6a7485'>  |  </span><span foreground='#c0c9d4'>$1.50 / $5.00</span>
+<span foreground='#c678dd'>┃</span>  <span foreground='#e5c07b'>●</span> <span foreground='#e5c07b'>██████</span><span foreground='#8b95a5'>░░░░░░░░░░░░░░</span> <span foreground='#e5c07b'> 30%</span>  <span foreground='#56b6c2'>→ Full in __HM__ (__:__)</span>
+<span foreground='#c678dd'>┃</span>  <span foreground='#8b95a5'>○</span> <span foreground='#56b6c2'>+$0.25/hr</span><span foreground='#8b95a5'>  |  </span><span foreground='#c0c9d4'>$1.50 / $5.00</span>
 <span foreground='#c678dd'>┃</span>
 <span foreground='#c678dd'>┣━</span> <span foreground='#c678dd' weight='bold'>◆ Credits</span>
 <span foreground='#c678dd'>┃</span>  <span foreground='#98c379'>●</span> <span foreground='#98c379'>$7.50 remaining</span>
 <span foreground='#c678dd'>┃</span>
-<span foreground='#c678dd'>┗━━━━━━━━━━━━━━━━━━</span><span foreground='#6a7485'> cached · __AGO__ </span><span foreground='#c678dd'>━━━━━━━━━━━━━━━━━━</span>");
+<span foreground='#c678dd'>┗━━━━━━━━━━━━━━━━━━</span><span foreground='#8b95a5'> cached · __AGO__ </span><span foreground='#c678dd'>━━━━━━━━━━━━━━━━━━</span>");
     });
 }
 
@@ -1509,10 +1509,10 @@ fn waybar_amp_unknown_models_tooltip() {
 <span foreground='#c678dd'>┏━</span> <span foreground='#c678dd' weight='bold'>Amp</span> <span foreground='#c678dd'>━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span>
 <span foreground='#c678dd'>┃</span>
 <span foreground='#c678dd'>┣━</span> <span foreground='#c678dd' weight='bold'>◆ Usage</span>
-<span foreground='#c678dd'>┃</span>  <span foreground='#e5c07b'>●</span> <span foreground='#e2e8f0'>Custom Plan A       </span> <span foreground='#e5c07b'>█████████</span><span foreground='#6a7485'>░░░░░░░░░░░</span> <span foreground='#e5c07b'> 45%</span>
-<span foreground='#c678dd'>┃</span>  <span foreground='#98c379'>●</span> <span foreground='#e2e8f0'>Custom Plan B       </span> <span foreground='#98c379'>████████████████</span><span foreground='#6a7485'>░░░░</span> <span foreground='#98c379'> 80%</span>
+<span foreground='#c678dd'>┃</span>  <span foreground='#e5c07b'>●</span> <span foreground='#e2e8f0'>Custom Plan A       </span> <span foreground='#e5c07b'>█████████</span><span foreground='#8b95a5'>░░░░░░░░░░░</span> <span foreground='#e5c07b'> 45%</span>
+<span foreground='#c678dd'>┃</span>  <span foreground='#98c379'>●</span> <span foreground='#e2e8f0'>Custom Plan B       </span> <span foreground='#98c379'>████████████████</span><span foreground='#8b95a5'>░░░░</span> <span foreground='#98c379'> 80%</span>
 <span foreground='#c678dd'>┃</span>
-<span foreground='#c678dd'>┗━━━━━━━━━━━━━━━━━━</span><span foreground='#6a7485'> cached · __AGO__ </span><span foreground='#c678dd'>━━━━━━━━━━━━━━━━━━</span>");
+<span foreground='#c678dd'>┗━━━━━━━━━━━━━━━━━━</span><span foreground='#8b95a5'> cached · __AGO__ </span><span foreground='#c678dd'>━━━━━━━━━━━━━━━━━━</span>");
     });
 }
 
@@ -1557,17 +1557,17 @@ fn per_provider_claude_with_extras_tooltip() {
 <span foreground='#d19a66'>┏━</span> <span foreground='#d19a66' weight='bold'>Claude · Pro</span> <span foreground='#d19a66'>━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span>
 <span foreground='#d19a66'>┃</span>
 <span foreground='#d19a66'>┣━</span> <span foreground='#d19a66' weight='bold'>◆ 5-hour limit (shared)</span>
-<span foreground='#d19a66'>┃</span>  <span foreground='#98c379'>●</span> <span foreground='#e2e8f0'>All Models          </span> <span foreground='#98c379'>████████████</span><span foreground='#6a7485'>░░░░░░░░</span> <span foreground='#98c379'> 60%</span> <span foreground='#56b6c2'>→ __HM__ (__:__)</span>
+<span foreground='#d19a66'>┃</span>  <span foreground='#98c379'>●</span> <span foreground='#e2e8f0'>All Models          </span> <span foreground='#98c379'>████████████</span><span foreground='#8b95a5'>░░░░░░░░</span> <span foreground='#98c379'> 60%</span> <span foreground='#56b6c2'>→ __HM__ (__:__)</span>
 <span foreground='#d19a66'>┃</span>
 <span foreground='#d19a66'>┣━</span> <span foreground='#d19a66' weight='bold'>◆ Weekly per model</span>
-<span foreground='#d19a66'>┃</span>  <span foreground='#e5c07b'>●</span> <span foreground='#e2e8f0'>claude-opus-4-5     </span> <span foreground='#e5c07b'>████████</span><span foreground='#6a7485'>░░░░░░░░░░░░</span> <span foreground='#e5c07b'> 40%</span> <span foreground='#56b6c2'>→ __HM__ (__:__)</span>
-<span foreground='#d19a66'>┃</span>  <span foreground='#98c379'>●</span> <span foreground='#e2e8f0'>claude-sonnet-4-5   </span> <span foreground='#98c379'>█████████████</span><span foreground='#6a7485'>░░░░░░░</span> <span foreground='#98c379'> 65%</span> <span foreground='#56b6c2'>→ __HM__ (__:__)</span>
+<span foreground='#d19a66'>┃</span>  <span foreground='#e5c07b'>●</span> <span foreground='#e2e8f0'>claude-opus-4-5     </span> <span foreground='#e5c07b'>████████</span><span foreground='#8b95a5'>░░░░░░░░░░░░</span> <span foreground='#e5c07b'> 40%</span> <span foreground='#56b6c2'>→ __HM__ (__:__)</span>
+<span foreground='#d19a66'>┃</span>  <span foreground='#98c379'>●</span> <span foreground='#e2e8f0'>claude-sonnet-4-5   </span> <span foreground='#98c379'>█████████████</span><span foreground='#8b95a5'>░░░░░░░</span> <span foreground='#98c379'> 65%</span> <span foreground='#56b6c2'>→ __HM__ (__:__)</span>
 <span foreground='#d19a66'>┃</span>
 <span foreground='#d19a66'>┣━</span> <span foreground='#d19a66' weight='bold'>◆ Weekly limit (shared)</span>
-<span foreground='#d19a66'>┃</span>  <span foreground='#e5c07b'>●</span> <span foreground='#e2e8f0'>All Models          </span> <span foreground='#e5c07b'>██████████</span><span foreground='#6a7485'>░░░░░░░░░░</span> <span foreground='#e5c07b'> 50%</span> <span foreground='#56b6c2'>→ __HM__ (__:__)</span>
+<span foreground='#d19a66'>┃</span>  <span foreground='#e5c07b'>●</span> <span foreground='#e2e8f0'>All Models          </span> <span foreground='#e5c07b'>██████████</span><span foreground='#8b95a5'>░░░░░░░░░░</span> <span foreground='#e5c07b'> 50%</span> <span foreground='#56b6c2'>→ __HM__ (__:__)</span>
 <span foreground='#d19a66'>┃</span>
 <span foreground='#d19a66'>┣━</span> <span foreground='#d19a66' weight='bold'>◆ Extra Usage</span>
-<span foreground='#d19a66'>┃</span>  <span foreground='#e5c07b'>●</span> <span foreground='#e2e8f0'>Budget              </span> <span foreground='#e5c07b'>███████████</span><span foreground='#6a7485'>░░░░░░░░░</span> <span foreground='#e5c07b'> 55%</span> <span foreground='#56b6c2'>$22.50/$50.00</span>
+<span foreground='#d19a66'>┃</span>  <span foreground='#e5c07b'>●</span> <span foreground='#e2e8f0'>Budget              </span> <span foreground='#e5c07b'>███████████</span><span foreground='#8b95a5'>░░░░░░░░░</span> <span foreground='#e5c07b'> 55%</span> <span foreground='#56b6c2'>$22.50/$50.00</span>
 <span foreground='#d19a66'>┃</span>
 <span foreground='#d19a66'>┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span>");
     });
@@ -1610,8 +1610,8 @@ fn per_provider_amp_with_credits_tooltip() {
 <span foreground='#c678dd'>┏━</span> <span foreground='#c678dd' weight='bold'>Amp</span> <span foreground='#c678dd'>━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span>
 <span foreground='#c678dd'>┃</span>
 <span foreground='#c678dd'>┣━</span> <span foreground='#c678dd' weight='bold'>◆ Free Tier</span>
-<span foreground='#c678dd'>┃</span>  <span foreground='#e5c07b'>●</span> <span foreground='#e5c07b'>██████</span><span foreground='#6a7485'>░░░░░░░░░░░░░░</span> <span foreground='#e5c07b'> 30%</span>  <span foreground='#56b6c2'>→ Full in __HM__ (__:__)</span>
-<span foreground='#c678dd'>┃</span>  <span foreground='#6a7485'>○</span> <span foreground='#56b6c2'>+$0.25/hr</span><span foreground='#6a7485'>  |  </span><span foreground='#c0c9d4'>$1.50 / $5.00</span>
+<span foreground='#c678dd'>┃</span>  <span foreground='#e5c07b'>●</span> <span foreground='#e5c07b'>██████</span><span foreground='#8b95a5'>░░░░░░░░░░░░░░</span> <span foreground='#e5c07b'> 30%</span>  <span foreground='#56b6c2'>→ Full in __HM__ (__:__)</span>
+<span foreground='#c678dd'>┃</span>  <span foreground='#8b95a5'>○</span> <span foreground='#56b6c2'>+$0.25/hr</span><span foreground='#8b95a5'>  |  </span><span foreground='#c0c9d4'>$1.50 / $5.00</span>
 <span foreground='#c678dd'>┃</span>
 <span foreground='#c678dd'>┣━</span> <span foreground='#c678dd' weight='bold'>◆ Credits</span>
 <span foreground='#c678dd'>┃</span>  <span foreground='#98c379'>●</span> <span foreground='#98c379'>$7.50 remaining</span>
@@ -1657,8 +1657,8 @@ fn per_provider_amp_unknown_models_tooltip() {
 <span foreground='#c678dd'>┏━</span> <span foreground='#c678dd' weight='bold'>Amp</span> <span foreground='#c678dd'>━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span>
 <span foreground='#c678dd'>┃</span>
 <span foreground='#c678dd'>┣━</span> <span foreground='#c678dd' weight='bold'>◆ Usage</span>
-<span foreground='#c678dd'>┃</span>  <span foreground='#e5c07b'>●</span> <span foreground='#e2e8f0'>Custom Plan A       </span> <span foreground='#e5c07b'>█████████</span><span foreground='#6a7485'>░░░░░░░░░░░</span> <span foreground='#e5c07b'> 45%</span>
-<span foreground='#c678dd'>┃</span>  <span foreground='#98c379'>●</span> <span foreground='#e2e8f0'>Custom Plan B       </span> <span foreground='#98c379'>████████████████</span><span foreground='#6a7485'>░░░░</span> <span foreground='#98c379'> 80%</span>
+<span foreground='#c678dd'>┃</span>  <span foreground='#e5c07b'>●</span> <span foreground='#e2e8f0'>Custom Plan A       </span> <span foreground='#e5c07b'>█████████</span><span foreground='#8b95a5'>░░░░░░░░░░░</span> <span foreground='#e5c07b'> 45%</span>
+<span foreground='#c678dd'>┃</span>  <span foreground='#98c379'>●</span> <span foreground='#e2e8f0'>Custom Plan B       </span> <span foreground='#98c379'>████████████████</span><span foreground='#8b95a5'>░░░░</span> <span foreground='#98c379'> 80%</span>
 <span foreground='#c678dd'>┃</span>
 <span foreground='#c678dd'>┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span>");
     });


### PR DESCRIPTION
## Summary

Trilha B (spec `docs/superpowers/specs/2026-07-17-hardening-produto-design.md`): legibilidade e confiança dos números/estados, sem redesign de layout.

- **Contraste AA** sobre `#282c34`: `Comment`, `Red`, `Series1..6` (≥4.5:1); golden Waybar atualizado
- **Rótulos dual** `fmt_tokens_dual`: principal = input+output; sufixo `(+N cache)` nos totais do Detail; MODELOS HOJE mostra io na coluna fixa (gauge/chart seguem cache-inclusive)
- **Legenda do chart**: séries que não cabem → `…+N`
- **Waybar serialize fail**: `class: agent-bar disconnected` (visível, não `agent-bar-hidden`)
- **Pricing**: revalidado em 2026-07-17 contra a tabela oficial Anthropic (sem mudança de números)

## Test plan

- [x] `cargo test` (711 testes)
- [x] `cargo clippy --all-targets -- -D warnings`
- [ ] Smoke visual: TUI Detail totais com cache alto; chart estreito com muitas séries; módulo Waybar com erro de serialize (raro)