### PR TITLE
feat: provider Grok (Grok Build CLI)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - **Provider Grok (Grok Build CLI)** — OAuth em `~/.grok/auth.json` e
   `signals.json` das sessões; o % da barra é contexto restante da sessão
   recente (não cota de plano xAI). Login via `grok login` na TUI.
+  **Novos installs** listam `grok` por default; **settings existentes**
+  precisam habilitar em Config (não há auto-inserção).
 
 ## [8.1.0] - 2026-07-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- **Provider Grok (Grok Build CLI)** — OAuth em `~/.grok/auth.json` e
+  `signals.json` das sessões; o % da barra é contexto restante da sessão
+  recente (não cota de plano xAI). Login via `grok login` na TUI.
+
 ## [8.1.0] - 2026-07-17
 
 Fundações de código, hardening de legibilidade e polish da TUI

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <img src="docs/assets/agent-bar-banner.png" alt="Banner do Agent Bar">
 </p>
 
-Monitor de quota de Claude Code, OpenAI Codex e Amp na Waybar. Quota de agente é aquele recurso que você só descobre que acabou quando acabou; aqui ela fica visível na barra o tempo todo. Um binário em Rust, sem daemon: a Waybar chama, ele imprime JSON e vai embora.
+Monitor de quota de Claude Code, OpenAI Codex, Amp e Grok Build na Waybar. Quota de agente é aquele recurso que você só descobre que acabou quando acabou; aqui ela fica visível na barra o tempo todo. Um binário em Rust, sem daemon: a Waybar chama, ele imprime JSON e vai embora.
 
 ## O que ele mostra
 
@@ -15,8 +15,10 @@ De onde vem o dado, por provider:
 - **Claude Code** — token OAuth de `~/.claude/.credentials.json` + endpoint de usage da Anthropic. Janela de sessão (5 h), semanal (7 d), limites semanais por modelo e o gasto extra do plano, quando existe.
 - **Codex** — fala JSON-RPC com `codex app-server`; se não der, cai pro parse do session log em `~/.codex/sessions`.
 - **Amp** — roda `amp usage` e parseia o texto com regex, porque `--json` não existe. É o que tem.
+- **Grok Build** — OAuth em `~/.grok/auth.json` + `signals.json` das sessões.
+  O % da barra é **contexto restante da sessão recente**, não cota de plano xAI.
 
-Tudo passa por um cache em disco (`~/.cache/agent-bar/`): 5 minutos pro Claude, 90 segundos pra Codex e Amp. A barra consulta a cada 2 minutos e ninguém martela API.
+Tudo passa por um cache em disco (`~/.cache/agent-bar/`): 5 minutos pro Claude, 90 segundos pra Codex, Amp e Grok. A barra consulta a cada 2 minutos e ninguém martela API.
 
 ## Requisitos
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -170,7 +170,7 @@ injection bug, so all Pango output goes through it.
 | `src/cache.rs` | File-based quota cache (5 min, cross-process, atomic writes). |
 | `src/providers/mod.rs` | Registration, parallel fan-out, timeout/retry. |
 | `src/providers/base.rs` | `BaseProvider` `get_quota()` orchestration. |
-| `src/providers/{claude,codex,amp}.rs` | Concrete providers. Claude is direct; others extend `BaseProvider`. |
+| `src/providers/{claude,codex,amp,grok}.rs` | Concrete providers. Claude is direct; others extend `BaseProvider`. |
 | `src/providers/types.rs` | `ProviderQuota`, `QuotaWindow`, `Provider`, `AllQuotas`. |
 | `src/formatters/waybar.rs` | Waybar JSON assembly ({text,tooltip,class}). |
 | `src/formatters/render_pango.rs` | Single XML-escape boundary for Pango. |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -97,7 +97,7 @@ These are mostly for tests, packagers, and manual integration.
 
 | Flag | Purpose |
 | --- | --- |
-| `-p`, `--provider <id>` | Limit output to `claude`, `codex`, or `amp`. |
+| `-p`, `--provider <id>` | Limit output to `claude`, `codex`, `amp`, or `grok`. |
 | `-r`, `--refresh` | Ignore cache and fetch fresh provider data. |
 | `-t`, `--terminal` | Force terminal output mode. |
 | `--format <waybar\|json>` | Output format. Default `waybar`. `json` emits the versioned contract (see below). |

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -47,8 +47,8 @@ agent-bar --watch --interval 30            # custom poll floor
 | --- | --- | --- |
 | `schemaVersion` | number | Contract version. See stability below. |
 | `fetchedAt` | string (ISO) | When agent-bar produced the snapshot — **not** the network fetch time. On a cache hit the underlying data can be up to the cache TTL (~5min) older. |
-| `providers[]` | array | One entry per provider. Order is registry order (currently `amp`, `claude`, `codex`) and is **not** part of the contract — key on the `provider` field, never on array index. |
-| `provider` | string | `claude` / `codex` / `amp`. |
+| `providers[]` | array | One entry per provider. Order is registry order (currently includes `claude`, `codex`, `amp`, `grok`) and is **not** part of the contract — key on the `provider` field, never on array index. |
+| `provider` | string | `claude` / `codex` / `amp` / `grok`. |
 | `displayName` | string | Human label. |
 | `available` | boolean | Authenticated and fetched OK. |
 | `account` / `plan` / `planType` | string | Optional; omitted when absent. |

--- a/docs/new-provider.md
+++ b/docs/new-provider.md
@@ -69,6 +69,7 @@ panicking. Keep messages stable; tests assert exact strings in several places.
 | Claude | reads Claude Code OAuth credentials and fetches Anthropic usage API |
 | Codex | prefers `codex app-server`, falls back to recent session `.jsonl` rate-limit events |
 | Amp | runs `amp usage` and parses stdout |
+| Grok | local-only: `~/.grok/auth.json` + walk of `sessions/**/signals.json`; primary = remaining session context % (not plan quota) |
 
 ## Standard Not Logged In Message
 

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -46,8 +46,8 @@ Settings schema version: `2`.
 
 Defaults:
 
-- providers: `claude`, `codex`, `amp`
-- provider order: `claude`, `codex`, `amp`
+- providers: `claude`, `codex`, `amp`, `grok`
+- provider order: `claude`, `codex`, `amp`, `grok`
 - separator style: `gap`
 - display mode: `remaining`
 - show percentage: `true`

--- a/docs/superpowers/plans/2026-07-17-grok-provider.md
+++ b/docs/superpowers/plans/2026-07-17-grok-provider.md
@@ -1,0 +1,565 @@
+# Provider Grok (Grok Build CLI) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Adicionar o provider `grok` ao agent-bar: status do Grok Build CLI a partir de `~/.grok` (auth + `signals.json`), com `%` de **contexto restante da sessão recente** na barra — conforme `docs/superpowers/specs/2026-07-17-grok-provider-design.md`.
+
+**Architecture:** `GrokProvider` estende `QuotaSource`/`base_get_quota` (zero rede). `find_grok_bin` espelha `amp_cli`. Scan limitado de `sessions/**/signals.json`. `GrokQuotaExtra` para contagens do tooltip. Integração completa: registry, Waybar, TUI login, builder, ícone, docs. Settings existentes **não** auto-habilitam grok; defaults de install novo incluem via `KNOWN_PROVIDER_IDS`.
+
+**Tech Stack:** Rust 2021, serde/serde_json, time (RFC3339), tokio tests, insta/golden existentes. Sem crates novas (walk com `std` recursivo).
+
+## Global Constraints
+
+- Spec canônica: `docs/superpowers/specs/2026-07-17-grok-provider-design.md` (ler §0–§14).
+- **% = contexto de sessão, NÃO cota de plano** — copy de tooltip/README deve dizer “contexto”.
+- **Zero rede** na v1. **Zero refresh OAuth.**
+- Error strings **verbatim** (spec §4).
+- `unwrap`/`expect` proibidos em produção (`deny` no crate).
+- stdout limpo Waybar; logs stderr.
+- Não mutar `~/.config/waybar` ao vivo; testes com temp dirs + paths injetados.
+- Conventional Commits PT, subject ≤ 50 chars; zero atribuição AI.
+- Gotcha RTK: um filtro posicional por `cargo test`.
+- Implementers: Read antes de Edit; re-Read se Edit falhar; após outro agente, re-Read.
+- Fixtures **nunca** com JWT real do dev.
+
+## File map (estado final)
+
+```text
+src/providers/grok_cli.rs          # find_grok_bin
+src/providers/grok.rs              # QuotaSource + parse auth/signals + walk
+src/providers/error.rs             # GrokError
+src/providers/types.rs             # GrokQuotaExtra + ProviderExtra::Grok
+src/providers/extras.rs            # get_grok_extra
+src/providers/mod.rs               # mod + registry
+src/config.rs                      # KNOWN_PROVIDER_IDS + Paths.grok_*
+src/theme.rs                       # provider_hex("grok") → Cyan
+src/formatters/builders/grok.rs    # build_grok
+src/formatters/builders/mod.rs
+src/formatters/waybar.rs           # match "grok"
+src/formatters/terminal.rs         # match "grok"
+src/waybar_contract.rs             # WAYBAR_PROVIDERS + CSS icon
+src/tui/login_spawn.rs             # grok login
+src/tui/render/login.rs            # PROVIDERS list
+icons/grok-icon.svg
+tests/fixtures/grok/auth-valid.json
+tests/fixtures/grok/auth-expired.json
+tests/fixtures/grok/signals-recent.json
+tests/fixtures/grok/signals-full.json
+docs/new-provider.md, README.md
+```
+
+## Ordem
+
+```text
+T1 foundation (ids/paths/error/theme/types/extra)
+  → T2 grok_cli
+  → T3 provider core + fixtures + unit tests
+  → T4 builder + waybar/terminal dispatch
+  → T5 waybar_contract + icon
+  → T6 login TUI
+  → T7 docs + hardcode sweep + gate
+```
+
+---
+
+### Task 1: Foundation — IDs, Paths, Error, Types, Theme
+
+**Files:**
+- Modify: `src/config.rs` (`KNOWN_PROVIDER_IDS`, `default_ttl_secs`, `Paths`)
+- Modify: `src/providers/error.rs`
+- Modify: `src/providers/types.rs` (`GrokQuotaExtra`, `ProviderExtra::Grok`)
+- Modify: `src/providers/extras.rs` (`get_grok_extra` + testes)
+- Modify: `src/theme.rs` (`provider_hex("grok")` + teste)
+
+**Interfaces:**
+- Produces:
+  - `KNOWN_PROVIDER_IDS = ["claude","codex","amp","grok"]`
+  - `default_ttl_secs("grok") -> 90`
+  - `Paths { grok_home, grok_auth, … }`
+  - `GrokError::{NotInstalled, NotLoggedIn, InvalidCredentials}` com strings da spec §4
+  - `ProviderError::Grok(#[from] GrokError)`
+  - ```rust
+    #[derive(Debug, Clone, PartialEq, Serialize, Default)]
+    #[serde(rename_all = "camelCase")]
+    pub struct GrokQuotaExtra {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub sessions_today: Option<u32>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub turns_today: Option<u32>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub context_tokens_used: Option<u64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub context_window_tokens: Option<u64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub recent_model: Option<String>,
+    }
+    ```
+  - `ProviderExtra::Grok(GrokQuotaExtra)`
+  - `get_grok_extra(q) -> Option<&GrokQuotaExtra>`
+  - `provider_hex("grok") == ColorToken::Cyan.hex()` (`#56b6c2`)
+
+- [ ] **Step 1: Error strings + testes**
+
+Em `error.rs`, adicionar (mensagens **exatas**):
+
+```rust
+#[derive(Error, Debug)]
+pub enum GrokError {
+    #[error("Grok CLI not installed. Install from https://x.ai/cli or ensure ~/.grok/bin/grok is on PATH.")]
+    NotInstalled,
+    #[error("Not logged in. Open `agent-bar menu` and choose Provider login.")]
+    NotLoggedIn,
+    #[error("Failed to read Grok credentials.")]
+    InvalidCredentials,
+}
+```
+
+E `ProviderError::Grok(#[from] GrokError)`.
+
+Teste `grok_strings_are_verbatim` no módulo de testes de `error.rs`.
+
+- [ ] **Step 2: KNOWN_PROVIDER_IDS + Paths**
+
+```rust
+pub const KNOWN_PROVIDER_IDS: [&str; 4] = ["claude", "codex", "amp", "grok"];
+```
+
+Em `default_ttl_secs`:
+
+```rust
+"codex" | "amp" | "grok" => 90,
+```
+
+`Paths`:
+
+```rust
+pub grok_home: PathBuf,
+pub grok_auth: PathBuf,
+```
+
+Em `from_env`:
+
+```rust
+let grok_home = env::var_os("GROK_HOME")
+    .filter(|v| !v.is_empty())
+    .map(PathBuf::from)
+    .unwrap_or_else(|| home.join(".grok"));
+// ...
+grok_home: grok_home.clone(),
+grok_auth: grok_home.join("auth.json"),
+```
+
+Atualizar **todos** os construtores de `Paths` em testes do crate (`PathBuf::new()` para os novos campos) — grep `amp_threads:` e complete.
+
+- [ ] **Step 3: types + extras + theme**
+
+Adicionar `GrokQuotaExtra` e variante. `get_grok_extra` espelhando `get_amp_extra`. Theme + assert.
+
+- [ ] **Step 4: Verificar**
+
+```bash
+cargo test providers::error
+cargo test providers::extras
+cargo test theme
+cargo test settings
+cargo clippy --all-targets -- -D warnings
+```
+
+Expected: PASS (settings default agora tem 4 providers — atualizar asserts que esperam exatamente `["claude","codex","amp"]`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat: base do provider grok (ids/paths/extra)
+
+EOF
+)"
+```
+
+---
+
+### Task 2: `grok_cli` locator
+
+**Files:**
+- Create: `src/providers/grok_cli.rs`
+- Modify: `src/providers/mod.rs` (`pub mod grok_cli;`)
+
+**Interfaces:**
+- Produces:
+  - `pub fn grok_candidate_paths(home: &str) -> Vec<PathBuf>`
+  - `pub fn find_grok_bin_with(home, which, exists) -> Option<PathBuf>`
+  - `pub fn find_grok_bin(home: &str) -> Option<PathBuf>`
+  - Candidatos (ordem): `{home}/.grok/bin/grok`, `{home}/.local/bin/grok`
+  - PATH (`which("grok")`) **primeiro**, depois candidatos
+
+Espelhar testes de `amp_cli.rs` (prefer_path, fallback, none, empty_home).
+
+- [ ] **Step 1: Implement + testes no mesmo arquivo**
+
+- [ ] **Step 2: Verificar**
+
+```bash
+cargo test providers::grok_cli
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat: locator do binário grok
+
+EOF
+)"
+```
+
+---
+
+### Task 3: Provider core (auth + signals + BaseProvider)
+
+**Files:**
+- Create: `src/providers/grok.rs`
+- Create: `tests/fixtures/grok/auth-valid.json`
+- Create: `tests/fixtures/grok/auth-expired.json`
+- Create: `tests/fixtures/grok/signals-recent.json`
+- Create: `tests/fixtures/grok/signals-full.json`
+- Modify: `src/providers/mod.rs` (`pub mod grok;` + registry)
+
+**Interfaces:**
+- Produces:
+  - `pub struct GrokProvider;`
+  - `impl QuotaSource for GrokProvider` com `Raw = GrokRaw`
+  - `impl Provider for GrokProvider` delegando `base_get_quota`
+  - Funções puras testáveis:
+    - `pub(crate) fn parse_auth_entries(bytes: &[u8], now: OffsetDateTime) -> Result<AuthView, GrokError>`
+    - `pub(crate) fn context_remaining_pct(used: u64, window: u64) -> Option<f64>`
+    - `pub(crate) fn collect_signals(sessions_dir: &Path, now_local_date: Date, offset: UtcOffset) -> Vec<SessionSnap>`
+  - `GrokRaw` **sem** JWT:
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct GrokRaw {
+    account: Option<String>,
+    logged_in: bool,
+    sessions: Vec<SessionSnap>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct SessionSnap {
+    mtime_ms: u64,
+    context_tokens_used: Option<u64>,
+    context_window_tokens: Option<u64>,
+    primary_model_id: Option<String>,
+    turn_count: u32,
+}
+```
+
+**Fórmula primary (spec §3.4):**
+
+```rust
+pub(crate) fn context_remaining_pct(used: u64, window: u64) -> Option<f64> {
+    if window == 0 {
+        return None;
+    }
+    let used_pct = 100.0 * (used as f64) / (window as f64);
+    Some((100.0 - used_pct).clamp(0.0, 100.0))
+}
+```
+
+**Walk (spec §3.3):** recursivo std, depth max 16, max 2000 visits, só arquivos cujo `file_name() == "signals.json"`.
+
+**Auth fixtures (sem secrets reais):**
+
+`auth-valid.json`:
+```json
+{
+  "https://auth.x.ai::test-client": {
+    "key": "test-access-token",
+    "refresh_token": "test-refresh",
+    "expires_at": "2099-01-01T00:00:00Z",
+    "first_name": "Test User",
+    "user_id": "00000000-0000-0000-0000-000000000001",
+    "auth_mode": "oidc"
+  }
+}
+```
+
+`auth-expired.json`: mesmo com `"expires_at": "2020-01-01T00:00:00Z"`.
+
+`signals-recent.json`:
+```json
+{
+  "contextTokensUsed": 50000,
+  "contextWindowTokens": 500000,
+  "contextWindowUsage": 10,
+  "primaryModelId": "grok-4.5",
+  "turnCount": 3
+}
+```
+→ remaining = 90.0
+
+`signals-full.json`: used=500000 window=500000 → remaining = 0.0
+
+**Layout de fixture home em teste:**
+
+```text
+tmp/
+  auth.json
+  bin/grok          # arquivo vazio basta p/ is_file (ou só auth)
+  sessions/proj/sid/signals.json
+```
+
+**`is_available`:** `paths.grok_auth.is_file()` OR `find_grok_bin(home).is_some()`.
+
+**`fetch_raw`:** lê auth; se fail → Err; monta sessions; Ok(GrokRaw).
+
+**`build_quota`:** se !logged_in → error NotLoggedIn; senão available=true, primary da sessão max mtime, extra com sessions_today/turns_today.
+
+**Registry:**
+
+```rust
+vec![
+    Box::new(claude::ClaudeProvider),
+    Box::new(amp::AmpProvider),
+    Box::new(codex::CodexProvider),
+    Box::new(grok::GrokProvider),
+]
+```
+
+- [ ] **Step 1: Testes unitários RED** (funções puras + async get_quota com tempdir)
+
+Cobrir no mínimo:
+- `context_remaining_pct(50000, 500000) == Some(90.0)`
+- `context_remaining_pct(0, 0) == None`
+- not installed / not logged in / expired / happy path remaining / picks recent / corrupt ignored
+
+- [ ] **Step 2: Implementar até verde**
+
+- [ ] **Step 3: Verificar**
+
+```bash
+cargo test providers::grok
+cargo test providers::base
+cargo clippy --all-targets -- -D warnings
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat: provider grok (auth + signals)
+
+EOF
+)"
+```
+
+---
+
+### Task 4: Builder + dispatch formatters
+
+**Files:**
+- Create: `src/formatters/builders/grok.rs`
+- Modify: `src/formatters/builders/mod.rs`
+- Modify: `src/formatters/waybar.rs` (match `"grok"`)
+- Modify: `src/formatters/terminal.rs` (match `"grok"`)
+
+**Interfaces:**
+- Produces: `pub fn build_grok(clock: &Clock, p: &ProviderQuota, options: &BuildOptions) -> Vec<Line>`
+- Cor de marca: `ColorToken::Cyan`
+- Copy obrigatória em linha de contexto (texto do segment):
+  - label `"contexto"` (minúsculo ok) perto da barra de primary
+  - se error: mostrar error em Red
+  - se available sem primary: `"sem sessões locais ainda"` (Comment/Muted)
+  - footer com `build_footer_line` como outros builders
+  - se `get_grok_extra`: linha `hoje  N sessões · M turns` quando Some
+
+Espelhar estrutura de `build_generic` / header de Amp, mas com Cyan e labels de contexto.
+
+Teste: `build_grok` render_pango contém `"contexto"` e não contém `"plano"` / `"quota de plano"`.
+
+- [ ] **Step 1: Builder + testes**
+- [ ] **Step 2: Wire waybar + terminal**
+
+```rust
+"grok" => render_pango(&build_grok(...))  // waybar
+"grok" => render_ansi(&build_grok(...), no_color)  // terminal
+```
+
+- [ ] **Step 3: Verificar**
+
+```bash
+cargo test formatters::builders::grok
+cargo test formatters::waybar
+cargo test formatters::terminal
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat: builder e dispatch Waybar do Grok
+
+EOF
+)"
+```
+
+---
+
+### Task 5: Waybar contract + ícone
+
+**Files:**
+- Modify: `src/waybar_contract.rs` (`WAYBAR_PROVIDERS` length 4 + `"grok"`)
+- Create: `icons/grok-icon.svg` (SVG simples 24×24, fill atual `#c0c9d4` ou currentColor se o pipeline usar mask; copiar estrutura de `icons/amp-icon.svg` se existir)
+- Atualizar `export_waybar_css` se lista de ícones for explícita
+- Fix testes em `waybar_contract.rs` / `waybar_integration.rs` que listam só 3 providers
+
+**Ícone mínimo SVG:**
+
+```svg
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#c0c9d4">
+  <text x="12" y="17" text-anchor="middle" font-size="14" font-family="sans-serif" font-weight="700">G</text>
+</svg>
+```
+
+(Se o CSS espera PNG, seguir o padrão dos outros providers no `export_waybar_css` / install assets.)
+
+- [ ] **Step 1: WAYBAR_PROVIDERS + testes contract**
+- [ ] **Step 2: Ícone + CSS path**
+- [ ] **Step 3: Verificar**
+
+```bash
+cargo test waybar_contract
+cargo test waybar_integration
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat: módulo Waybar e ícone do Grok
+
+EOF
+)"
+```
+
+---
+
+### Task 6: Login TUI
+
+**Files:**
+- Modify: `src/tui/login_spawn.rs` — braço `"grok"` com `find_grok_bin` + `arg("login")`
+- Modify: `src/tui/render/login.rs` — `PROVIDERS` length 4 + `("grok", "Grok")`
+- Modify: qualquer `login_selected_id` / índices que assumam 3 providers (grep `PROVIDERS` e `login_selected`)
+
+Login:
+
+```rust
+"grok" => {
+    let home = std::env::var("HOME").unwrap_or_default();
+    let bin = find_grok_bin(&home).ok_or_else(|| {
+        anyhow::anyhow!("Grok CLI não encontrado. Instale com: curl -fsSL https://x.ai/cli/install.sh | bash")
+    })?;
+    let status = Command::new(&bin)
+        .arg("login")
+        // ... inherit stdio
+        .status()?;
+    ...
+}
+```
+
+- [ ] **Step 1: Implement**
+- [ ] **Step 2: Verificar**
+
+```bash
+cargo test tui::render::login
+cargo test tui::update
+```
+
+Atualizar snapshots de login se necessário (`INSTA_UPDATE=1` só se o display mudou de propósito).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat: login TUI do Grok
+
+EOF
+)"
+```
+
+---
+
+### Task 7: Docs, hardcode sweep, gate
+
+**Files:**
+- Modify: `docs/new-provider.md` — tabela de padrões + Grok
+- Modify: `README.md` — bullet Grok Build CLI
+- Grep final de hardcodes 3-providers (spec §11.1)
+- `CHANGELOG.md` sob `[Unreleased]` (não cortar release neste plano)
+
+**README bullet (pt-BR, estilo existente):**
+
+```markdown
+- **Grok Build** — OAuth em `~/.grok/auth.json` + `signals.json` das sessões.
+  O % da barra é **contexto restante da sessão recente**, não cota de plano xAI.
+```
+
+- [ ] **Step 1: Docs**
+- [ ] **Step 2: Grep e corrigir leftovers**
+
+```bash
+rg -n 'KNOWN_PROVIDER_IDS: \[&str; 3\]|WAYBAR_PROVIDERS: \[&str; 3\]|"claude", "codex", "amp"\]' src tests
+```
+
+- [ ] **Step 3: Gate**
+
+```bash
+cargo test
+cargo clippy --all-targets -- -D warnings
+```
+
+Expected: all PASS.
+
+Smoke opcional (não mutar waybar):
+
+```bash
+GROK_HOME=/path/to/fixture cargo run -- status -p grok
+# ou com ~/.grok real do user
+cargo run -- status -p grok
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "$(cat <<'EOF'
+docs: Grok no README e new-provider
+
+EOF
+)"
+```
+
+---
+
+## Spec coverage (self-review do plano)
+
+| Spec | Task |
+| --- | --- |
+| §0 princípio contexto | T4 copy + T7 README |
+| D1–D9 | T1–T3 |
+| Paths / GROK_HOME | T1 |
+| Auth / expiry / no refresh | T3 |
+| signals walk + remaining formula | T3 |
+| GrokQuotaExtra | T1 + T3 build |
+| Error strings | T1 + T3 |
+| Builder / waybar / terminal | T4 |
+| Icon / WAYBAR_PROVIDERS | T5 |
+| Login | T6 |
+| Hardcode inventory §11.1 | T1, T5, T6, T7 |
+| Fora da v1 | não implementado |
+
+## Notas multi-agente
+
+- Worktree limpa a partir de `master` atual.
+- Um implementer por task; reviewer após cada uma.
+- T3 é a task mais crítica (parse + walk); não pular fixtures.
+- Settings default com 4 providers **quebra** testes que comparam lista exata de 3 — tratar em T1, não deixar para o gate.

--- a/docs/superpowers/specs/2026-07-17-grok-provider-design.md
+++ b/docs/superpowers/specs/2026-07-17-grok-provider-design.md
@@ -1,0 +1,390 @@
+# Spec — Provider Grok (Grok Build CLI)
+
+Data: 2026-07-17 · Status: aprovada pelo dono (brainstorming)  
+Origem: pedido de provider Grok; decisão de produto = **uso local do Grok Build
+CLI** (não API prepaid, não SuperGrok chat web).
+
+## 0. Princípio de produto (não negociar)
+
+O módulo **não** promete “cota de plano” estilo Claude (5h/semana). A xAI **não
+expõe** endpoint estável de quota restante para o OAuth do Grok Build CLI.
+
+O que o módulo responde, em um relance:
+
+> Estou logado no Grok Build? Quanto do **contexto da sessão recente** ainda
+> cabe? Qual modelo? Quanto mexi hoje (sessões/turns)?
+
+Qualquer copy de UI (tooltip, builder, docs) deve deixar explícito que o `%` é
+**contexto de sessão**, não billing nem limite de mensagens SuperGrok.
+
+## 1. Decisões fechadas
+
+| # | Decisão |
+| --- | --- |
+| D1 | Superfície: **Grok Build CLI** (`~/.grok`), não Management API / prepaid |
+| D2 | Padrão: **`BaseProvider` / `QuotaSource`** (como Amp/Codex) |
+| D3 | Rede: **zero** na v1 (só filesystem + existência de binário) |
+| D4 | `primary` = **% restante de contexto** da sessão mais recente com signals |
+| D5 | Settings **existentes** não ganham `grok` sozinhas; **defaults de install novo** incluem `grok` via `KNOWN_PROVIDER_IDS` |
+| D6 | Login TUI: `grok login` |
+| D7 | **Não** refresh de OAuth (mesmo princípio do Claude: não competir com o CLI no refresh token) |
+| D8 | Cache TTL default: **90s** (local, como codex/amp) |
+| D9 | ID estável: `grok` · display: `Grok` · cache key: `grok-usage` |
+
+## 2. Fontes de verdade (paths)
+
+Resolver home Grok:
+
+```text
+GROK_HOME env (não vazio) → PathBuf
+senão → $HOME/.grok
+```
+
+| Path | Uso |
+| --- | --- |
+| `{grok_home}/auth.json` | login, expiry, account label |
+| `{grok_home}/sessions/**/signals.json` | métricas de sessão |
+| `{grok_home}/bin/grok` e `PATH` | detecção de CLI / login spawn |
+
+Injetar em `Paths` (como claude/codex/amp):
+
+- `grok_home: PathBuf`
+- `grok_auth: PathBuf` (= `grok_home.join("auth.json")`)
+
+Testes: temp dir + override de paths (não ler o `~/.grok` real do dev).
+
+### 2.1 Shape de `auth.json` (observado 2026-07-17)
+
+Objeto mapa:
+
+```text
+"https://auth.x.ai::<client_id>" → {
+  auth_mode, key, refresh_token, expires_at,
+  first_name, user_id, team_id, principal_id, …
+}
+```
+
+- `expires_at`: RFC3339 com fração de segundo (ex. `2026-07-18T03:29:45.462038593Z`)
+- `key`: access JWT (nunca logar, nunca cachear em disco do agent-bar)
+- Pode haver **mais de uma** entrada; usar a de `expires_at` mais distante no futuro
+  entre as que tenham `key` não vazio; se todas expiradas → not logged in
+
+### 2.2 Shape de `signals.json` (observado 2026-07-17)
+
+Campos relevantes (outros ignorados com `#[serde(default)]`):
+
+| Campo | Tipo | Notas |
+| --- | --- | --- |
+| `contextTokensUsed` | number | tokens de contexto usados |
+| `contextWindowTokens` | number | janela (ex. 500000) |
+| `contextWindowUsage` | number | **% de uso** aproximado (arredondado; validar com used/total) |
+| `primaryModelId` | string | ex. `grok-4.5` |
+| `modelsUsed` | string[] | opcional |
+| `turnCount` | number | |
+| `sessionDurationSeconds` | number | opcional |
+
+**Recência da sessão:** mtime do arquivo `signals.json` (filesystem). Se no
+futuro aparecer `last_active_at` em `summary.json` irmão, preferir esse campo
+quando presente (YAGNI na v1: só mtime).
+
+**Prova de semântica de `contextWindowUsage`:** amostras reais mostraram
+`usage ≈ round(100 * used / total)` (ex. used=63533/500000 → calc 12.7%, campo 12).
+Portanto o campo é **% usado**, não restante.
+
+## 3. Algoritmo `get_quota`
+
+### 3.1 `is_available` (barato, sem rede)
+
+`true` se **qualquer** de:
+
+1. `grok_auth` existe e é arquivo legível (mesmo que JSON inválido — o parse
+   detalhado fica no fetch), **ou**
+2. `find_grok_bin(home)` retorna `Some` (PATH ou `{grok_home}/bin/grok` se
+   `is_file`)
+
+Se ambos falham → unavailable com `GrokError::NotInstalled`.
+
+### 3.2 Auth gate (dentro de `fetch_raw` / build)
+
+1. Ler e desserializar `auth.json`.
+2. Se arquivo ausente ou JSON inválido ou nenhuma entry com `key` →
+   `NotLoggedIn`.
+3. Parsear `expires_at` com `time` (RFC3339; tolerar nanos truncando para
+   precisão suportada). Se **todas** as entries com key estão com
+   `expires_at < now` → `NotLoggedIn` (**não** tentar refresh).
+4. Account label: `first_name` trim não vazio, senão `user_id` curto (8 chars),
+   senão `"Grok"`.
+
+### 3.3 Scan de signals
+
+1. Walk recursivo sob `{grok_home}/sessions` por arquivos nomeados
+   exatamente `signals.json` (não seguir symlinks para fora de `sessions`
+   se o walk permitir; `std::fs::read_dir` recursivo manual ou `walkdir` —
+   **preferir std only** se o crate ainda não tem walkdir: implementação
+   recursiva simples com profundidade máxima **16** e limite de **2000**
+   arquivos visitados para não travar o poll da barra).
+2. Para cada arquivo: `metadata.modified()` + parse JSON tolerante.
+3. Ordenar por mtime desc; **sessão mais recente** = first.
+4. Se lista vazia: `available=true`, `primary=None`, meta
+   `noSessions=true` (ou omitir primary — builder mostra “sem sessões”).
+
+### 3.4 Cálculo de `primary` (contexto restante)
+
+Da sessão mais recente com `contextWindowTokens > 0` e
+`contextTokensUsed` presente:
+
+```text
+used_pct = 100.0 * (contextTokensUsed as f64) / (contextWindowTokens as f64)
+remaining = (100.0 - used_pct).clamp(0.0, 100.0)
+// arredondar remaining para inteiro-ish como outros providers:
+// remaining.round() em f64 no QuotaWindow.remaining
+```
+
+**Não** usar só `contextWindowUsage` como fonte primária (é arredondado);
+usar a razão used/total. Se `contextWindowTokens == 0` ou missing → sem
+primary.
+
+`QuotaWindow`:
+
+```text
+remaining: <calculado>
+resets_at: None          // contexto não “reseta” com wall-clock
+window_minutes: None
+used: Some(used_pct.round())
+severity: None
+```
+
+### 3.5 Secondary e extras (v1 mínima)
+
+- **secondary:** `None` na v1 (evitar inventar segunda janela).  
+  Opcional no tooltip via **meta** / models, não via secondary, para não
+  poluir severidade da barra.
+- **models:** se `primaryModelId` presente, um entry
+  `IndexMap { model_display => mesma QuotaWindow do primary }` (nome
+  tratado: `grok-4.5` → `Grok 4.5` com helper local simples).
+- **plan:** `primaryModelId` tratado ou `"Grok Build"`.
+- **extra:** `ProviderExtra` — **não** criar variante nova se o generic
+  builder bastar. Preferir `extra: None` e meta no builder via campos
+  account/plan/models. Se precisar de meta string-only, usar padrão Amp
+  (`ProviderExtra::Amp` é errado semanticamente) — **melhor:** não usar
+  untagged Amp; colocar contagens só no **builder** lendo campos que
+  passamos via…  
+
+**Problema:** `ProviderQuota` não tem `meta` genérico fora de `ProviderExtra`.
+
+**Decisão minuciosa:**
+
+1. Adicionar `ProviderExtra::Grok(GrokQuotaExtra)` com:
+
+```text
+GrokQuotaExtra {
+  sessions_today: Option<u32>,
+  turns_today: Option<u32>,
+  context_tokens_used: Option<u64>,
+  context_window_tokens: Option<u64>,
+  recent_model: Option<String>,
+}
+```
+
+2. Serialização untagged como as outras variantes (serialize-only no quota).
+3. Builder `formatters/builders/grok.rs` consome `get_grok_extra`.
+4. Contagem “hoje”: mtime do signals em **data local** (`ctx.local_offset`)
+   igual a “hoje”; somar `turnCount` e contar arquivos.
+
+### 3.6 Cache
+
+- key: `grok-usage`
+- TTL: `ctx.ttl_ms("grok")` default 90s
+- Raw: struct com dados **já sanitizados** (sem access/refresh tokens):
+
+```text
+GrokRaw {
+  account: Option<String>,
+  logged_in: bool,
+  sessions: Vec<GrokSessionSnap>, // mtime_ms, used, window, usage_field, model, turns
+}
+```
+
+Auth revalidada a cada fetch_raw (barato); se raw veio do cache, o
+`build_quota` ainda confia no raw (TTL curto). **Não** colocar JWT no raw.
+
+## 4. Erros (contrato verbatim)
+
+```text
+Grok CLI not installed. Install from https://x.ai/cli or ensure ~/.grok/bin/grok is on PATH.
+Not logged in. Open `agent-bar menu` and choose Provider login.
+Failed to read Grok credentials.
+Failed to parse Grok session data.
+```
+
+- `NotInstalled` → `unavailable_error` quando `!is_available`  
+- `NotLoggedIn` → gate de auth / expiry  
+- `Failed to read…` → auth.json ilegível/JSON quebrado com arquivo presente  
+- `Failed to parse…` → walk ok mas **todas** as sessions falharam parse **e**
+  auth ok — raro; se auth ok e zero sessions válidas por parse, preferir
+  available sem primary + log debug, **não** error (degradação).  
+  `Failed to parse` só se auth ok e o walk estourou limite de segurança
+  sem conseguir ler nada útil **e** havia signals no caminho — na prática
+  YAGNI: **omitir** essa string na v1 se não houver caso claro; manter no
+  enum para futuro.
+
+**v1 strings que testes devem cobrir:** as três primeiras. A quarta só se
+implementada com caso de teste.
+
+## 5. Integração no crate (checklist)
+
+Espelhar `docs/new-provider.md` + esta lista (mais precisa):
+
+| # | Arquivo / local | Ação |
+| --- | --- | --- |
+| 1 | `src/providers/grok.rs` | Provider + parse + scan |
+| 2 | `src/providers/grok_cli.rs` | `find_grok_bin` (espelho amp_cli) |
+| 3 | `src/providers/mod.rs` | `mod grok`; `registry()` push `GrokProvider` |
+| 4 | `src/providers/error.rs` | `GrokError` + `From` em `ProviderError` |
+| 5 | `src/providers/types.rs` | `GrokQuotaExtra` + `ProviderExtra::Grok` |
+| 6 | `src/providers/extras.rs` | `get_grok_extra` |
+| 7 | `src/config.rs` | `KNOWN_PROVIDER_IDS` **4** ids; `default_ttl_secs("grok")→90`; `Paths` |
+| 8 | `src/theme.rs` | `provider_hex("grok")` → cor dedicada (ver §6) |
+| 9 | `src/waybar_contract.rs` | `WAYBAR_PROVIDERS` inclui `grok`; CSS/ícone |
+| 10 | `icons/grok-icon.svg` (ou png) | asset |
+| 11 | `src/formatters/builders/grok.rs` | tooltip |
+| 12 | `src/formatters/builders/mod.rs` | `pub mod grok` |
+| 13 | `src/formatters/waybar.rs` | match provider id |
+| 14 | `src/formatters/terminal.rs` | match provider id |
+| 15 | `src/tui/login_spawn.rs` | `"grok" => grok login` |
+| 16 | TUI login list / ids | incluir `grok` na ordem de providers de login |
+| 17 | `src/usage/model_names.rs` | opcional: `grok-*` display (se fácil) |
+| 18 | testes unitários + fixtures | `tests/fixtures/grok/` |
+| 19 | golden / waybar_contract tests | atualizar contagens de 3→4 providers onde fixo |
+| 20 | `docs/new-provider.md` | linha na tabela de padrões |
+| 21 | `README.md` | mencionar Grok Build na lista de providers |
+
+**Ordem no registry (display default):**  
+`claude`, `codex`, `amp`, `grok` — Grok por último para não reordenar a barra
+de quem já tem os três.
+
+**Settings existentes:** `normalize_provider_selection` só mantém ids
+presentes na lista do user; **não** injeta `grok`.  
+**Settings novas / default:** `default_providers()` itera
+`KNOWN_PROVIDER_IDS` → inclui `grok`. Documentar no CHANGELOG: “novos
+installs passam a listar grok; quem já tem settings precisa habilitar em
+Config”.
+
+## 6. Identidade visual
+
+| Token | Valor |
+| --- | --- |
+| Cor marca | `#56b6c2` (Cyan One Dark — distinto de Claude orange, Codex green, Amp magenta) |
+| Ícone Waybar | `icons/grok-icon.svg` — glifo simples “G” ou marca abstrata monocromática legível em 16–22px |
+| CSS | mesmo pipeline `export_waybar_css` / seletor `#custom-agent-bar-grok` |
+
+Severidade da barra: **só** pelo `primary` (contexto restante) via
+`status_for_percent` — contexto cheio (remaining baixo) = warn/critical,
+o que comunica “sessão inchada”, não “plano acabando”. Aceitável e
+documentado no tooltip.
+
+## 7. Builder / tooltip (conteúdo)
+
+Linhas sugeridas (Pango via segments, escape só no render_pango):
+
+```text
+Grok · <model>
+contexto  ████░░░░  87% restante
+39k / 500k tokens · sessão recente
+hoje  3 sessões · 12 turns
+account: <label>
+```
+
+Se deslogado: mensagem de erro + hint de login.  
+Se logado sem sessões: “sem sessões locais ainda”.
+
+## 8. Login
+
+```text
+find_grok_bin → Command::new(bin).arg("login")
+```
+
+stdio inherited; mesmo restore/reinit de terminal que Amp/Codex.
+
+## 9. Testes (mínimo obrigatório)
+
+| Teste | Assert |
+| --- | --- |
+| `not_installed` | sem home/bin → error string NotInstalled |
+| `not_logged_in_missing_auth` | home sem auth → NotLoggedIn |
+| `not_logged_in_expired` | expires_at no passado → NotLoggedIn |
+| `context_remaining_from_signals` | used=50k window=500k → remaining ≈ 90 |
+| `picks_most_recent_session` | dois signals, mtimes diferentes → usa o novo |
+| `ignores_corrupt_signals` | um JSON lixo + um ok → ainda available |
+| `find_grok_bin_prefers_path` | espelho amp_cli |
+| `builder_mentions_context_not_plan_quota` | tooltip contém “contexto” (ou string fixa da copy) |
+| golden/waybar_contract | contagens e listas de 4 providers onde hardcodado |
+
+Fixtures: **nunca** copiar JWT real do dev; auth de teste com
+`key: "test-token"`, `expires_at` futuro fixo, `first_name: "Test"`.
+
+## 10. Fora da v1 (backlog explícito)
+
+- Management API / prepaid balance  
+- Rate-limit tier da API  
+- Usage engine USD a partir de events (events atuais não trazem
+  `input_tokens` de billing de forma confiável)  
+- Refresh OAuth  
+- SuperGrok web message limits  
+- secondary window artificial  
+- Auto-inserir `grok` em settings.json já existente  
+
+## 11. Riscos e mitigações
+
+| Risco | Mitigação |
+| --- | --- |
+| `signals.json` muda de schema | serde defaults; testes de fixture; ignore unknown |
+| Walk lento com milhares de sessões | limite 2000 visits + depth 16; TTL 90s |
+| Confundir % contexto com cota | copy no tooltip + README |
+| `WAYBAR_PROVIDERS` length 3 hardcoded em testes | atualizar todos os `3` → `4` / slices |
+| Cor Cyan colide com UI accent | aceitável: marca de provider vs accent de foco; documentar |
+| docs/new-provider.md cita arquivos TUI antigos | ao editar, apontar paths reais (`login_spawn`, não `list_all`) |
+
+### 11.1 Inventário de hardcodes 3-providers (obrigatório no PR)
+
+Locais conhecidos em 2026-07-17 (grep ao implementar; pode haver mais):
+
+| Local | O que mudar |
+| --- | --- |
+| `src/config.rs` `KNOWN_PROVIDER_IDS: [&str; 3]` | `4` + `"grok"` |
+| `src/waybar_contract.rs` `WAYBAR_PROVIDERS: [&str; 3]` | `4` + `"grok"` |
+| `src/tui/render/login.rs` `PROVIDERS: [(&str,&str); 3]` | entrada `("grok","Grok")` |
+| `src/tui/login_spawn.rs` match login | braço `"grok"` |
+| `src/tui/theme_bridge.rs` loop ids | incluir `"grok"` |
+| `src/settings.rs` testes default providers | expect 4 ids se assertar lista completa |
+| `src/waybar_integration.rs` testes com `["claude","codex","amp"]` | incluir grok onde o teste for “todos” |
+| `src/waybar_contract.rs` testes `s(&["claude","codex","amp"])` | idem |
+| `src/formatters/waybar.rs` / `terminal.rs` match | braço `grok` → builder |
+| `src/tui/update` / `login_selected_id` se lista fixa | alinhar com PROVIDERS |
+
+Qualquer `assert_eq!(….len(), 3)` ligado a providers deve ser reavaliado.
+
+## 12. Critério de pronto (DoD)
+
+1. `cargo test providers::grok` verde  
+2. `cargo test waybar_contract` e `cargo test --test golden` verdes (ou
+   atualizados com intenção)  
+3. `cargo clippy --all-targets -- -D warnings` limpo  
+4. `agent-bar status -p grok` (com `GROK_HOME` de fixture ou real) mostra
+   % ou estado deslogado sem panic  
+5. README + new-provider.md atualizados  
+6. **Não** mutar `~/.config/waybar` ao vivo nos testes  
+
+## 13. Ordem de implementação sugerida (para o plano)
+
+1. Paths + KNOWN_PROVIDER_IDS + theme + error  
+2. `grok_cli` + parse auth/signals + provider + testes unitários  
+3. extras + builder + waybar/terminal dispatch  
+4. waybar_contract + icon + CSS  
+5. login_spawn + TUI login list  
+6. docs + golden adjustments + gate  
+
+## 14. Não-objetivos de escopo (repetir)
+
+Não é redesign de TUI, não é trilha A5, não é release acoplado (pode ir
+em minor 8.2.0 quando pronto).

--- a/icons/grok-icon.svg
+++ b/icons/grok-icon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#c0c9d4">
+  <text x="12" y="17" text-anchor="middle" font-size="14" font-family="sans-serif" font-weight="700">G</text>
+</svg>

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -2,7 +2,7 @@
 pkgname=agent-bar-bin
 pkgver=8.1.0
 pkgrel=1
-pkgdesc="LLM quota monitor for Waybar (Claude, Codex, Amp) — standalone binary"
+pkgdesc="LLM quota monitor for Waybar (Claude, Codex, Amp, Grok) — standalone binary"
 arch=('x86_64')
 url="https://github.com/othavi0/agent-bar"
 license=('MIT')
@@ -10,7 +10,7 @@ provides=('agent-bar') # futureproof for an eventual source-based agent-bar pack
 conflicts=('agent-bar')
 optdepends=('waybar: status bar integration'
             'libnotify: desktop low/critical quota notifications')
-# Provider CLIs (claude/codex/amp) are detected at runtime; no canonical AUR
+# Provider CLIs (claude/codex/amp/grok) are detected at runtime; no canonical AUR
 # package names verified, so they are not listed here (see .install).
 install="${pkgname}.install"
 source=("agent-bar-${pkgver}-x86_64.tar.gz::${url}/releases/download/v${pkgver}/agent-bar-${pkgver}-x86_64.tar.gz")

--- a/packaging/aur/agent-bar-bin.install
+++ b/packaging/aur/agent-bar-bin.install
@@ -1,6 +1,6 @@
 post_install() {
   echo "==> Run 'agent-bar setup' to integrate the modules into Waybar."
-  echo "==> Provider CLIs (claude/codex/amp) are detected at runtime if installed."
+  echo "==> Provider CLIs (claude/codex/amp/grok) are detected at runtime if installed."
 }
 
 post_upgrade() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,13 +17,13 @@ pub const PROVIDER_TIMEOUT_SECS: u64 = 10;
 /// Poll interval default do módulo Waybar (era 120s hardcoded; ver design §1).
 pub const DEFAULT_INTERVAL_SECS: u32 = 60;
 
-pub const KNOWN_PROVIDER_IDS: [&str; 3] = ["claude", "codex", "amp"];
+pub const KNOWN_PROVIDER_IDS: [&str; 4] = ["claude", "codex", "amp", "grok"];
 
 /// TTL default de cache por provider (segundos). Claude conservador (rate-limit);
-/// Codex/Amp são locais e podem ser mais frescos.
+/// Codex/Amp/Grok são locais e podem ser mais frescos.
 pub fn default_ttl_secs(provider: &str) -> u32 {
     match provider {
-        "codex" | "amp" => 90,
+        "codex" | "amp" | "grok" => 90,
         _ => 300,
     }
 }
@@ -110,6 +110,8 @@ pub struct Paths {
     pub codex_sessions: PathBuf,
     pub amp_settings: PathBuf,
     pub amp_threads: PathBuf,
+    pub grok_home: PathBuf,
+    pub grok_auth: PathBuf,
 }
 
 impl Paths {
@@ -130,6 +132,11 @@ impl Paths {
         let xdg_cache = xdg_dir("XDG_CACHE_HOME", ".cache");
         let xdg_config = xdg_dir("XDG_CONFIG_HOME", ".config");
 
+        let grok_home = env::var_os("GROK_HOME")
+            .filter(|v| !v.is_empty())
+            .map(PathBuf::from)
+            .unwrap_or_else(|| home.join(".grok"));
+
         Ok(Self {
             cache_dir: xdg_cache.join("agent-bar"),
             config_dir: xdg_config.join("agent-bar"),
@@ -142,6 +149,8 @@ impl Paths {
                 .join("share")
                 .join("amp")
                 .join("threads"),
+            grok_home: grok_home.clone(),
+            grok_auth: grok_home.join("auth.json"),
         })
     }
 
@@ -260,6 +269,7 @@ mod tests {
         assert_eq!(default_ttl_secs("claude"), 300);
         assert_eq!(default_ttl_secs("codex"), 90);
         assert_eq!(default_ttl_secs("amp"), 90);
+        assert_eq!(default_ttl_secs("grok"), 90);
         assert_eq!(default_ttl_secs("unknown"), 300);
     }
 

--- a/src/formatters/builders/grok.rs
+++ b/src/formatters/builders/grok.rs
@@ -1,0 +1,238 @@
+//! Builder do card Grok (Grok Build CLI). Cor de marca = Cyan.
+//! Copy deixa explícito que o % é **contexto de sessão**, não cota de plano.
+
+use crate::formatters::clock::Clock;
+use crate::formatters::segments::{
+    bar_segments, color_for_display, indicator_segments, Line, Segment,
+};
+use crate::formatters::shared::{format_percent, to_display};
+use crate::providers::extras::get_grok_extra;
+use crate::providers::types::ProviderQuota;
+use crate::theme::{box_chars, ColorToken};
+
+use super::shared::{build_footer_line, header_line, vline, BuildOptions};
+
+const BRAND: ColorToken = ColorToken::Cyan;
+
+/// Compacta tokens para tooltip: 39000 → "39k", 500000 → "500k".
+fn fmt_tokens_compact(n: u64) -> String {
+    if n >= 1_000_000 {
+        let m = (n as f64 / 1_000_000.0).round() as u64;
+        format!("{m}M")
+    } else if n >= 1_000 {
+        let k = (n as f64 / 1_000.0).round() as u64;
+        format!("{k}k")
+    } else {
+        format!("{n}")
+    }
+}
+
+/// Linha da barra de contexto: `┃  ● contexto ████  87%`.
+fn contexto_bar_line(disp: Option<f64>, mode: crate::settings::DisplayMode) -> Line {
+    let mut line: Line = vec![
+        Segment::new(box_chars::V, BRAND),
+        Segment::raw_text("  "),
+    ];
+    line.extend(indicator_segments(disp, mode));
+    line.push(Segment::raw_text(" "));
+    line.push(Segment::new("contexto", ColorToken::TextBright));
+    line.push(Segment::raw_text(" "));
+    line.extend(bar_segments(disp, mode));
+    line.push(Segment::raw_text(" "));
+    line.push(Segment::new(
+        format!("{:>4}", format_percent(disp)),
+        color_for_display(disp, mode),
+    ));
+    line
+}
+
+pub fn build_grok(clock: &Clock, p: &ProviderQuota, options: &BuildOptions) -> Vec<Line> {
+    let mode = options.mode;
+    let mut lines: Vec<Line> = Vec::new();
+
+    lines.push(header_line(
+        &options.header_title,
+        options.header_width,
+        BRAND,
+    ));
+    lines.push(vline(BRAND));
+
+    if let Some(err) = p.error.as_deref() {
+        lines.push(vec![
+            Segment::new(box_chars::V, BRAND),
+            Segment::raw_text("  "),
+            Segment::new(format!("⚠️ {err}"), ColorToken::Red),
+        ]);
+    } else if let Some(primary) = p.primary.as_ref() {
+        let disp = to_display(Some(primary.remaining), mode);
+        lines.push(contexto_bar_line(disp, mode));
+
+        // Tokens da sessão recente (quando o extra os traz).
+        if let Some(extra) = get_grok_extra(p) {
+            if let (Some(used), Some(window)) =
+                (extra.context_tokens_used, extra.context_window_tokens)
+            {
+                let text = format!(
+                    "{} / {} tokens · sessão recente",
+                    fmt_tokens_compact(used),
+                    fmt_tokens_compact(window)
+                );
+                lines.push(vec![
+                    Segment::new(box_chars::V, BRAND),
+                    Segment::raw_text("  "),
+                    Segment::new(text, ColorToken::Comment),
+                ]);
+            }
+        }
+    } else {
+        lines.push(vec![
+            Segment::new(box_chars::V, BRAND),
+            Segment::raw_text("  "),
+            Segment::new("sem sessões locais ainda", ColorToken::Muted),
+        ]);
+    }
+
+    // Contagem do dia: `hoje  N sessões · M turns`.
+    if p.error.is_none() {
+        if let Some(extra) = get_grok_extra(p) {
+            if extra.sessions_today.is_some() || extra.turns_today.is_some() {
+                let sessions = extra.sessions_today.unwrap_or(0);
+                let turns = extra.turns_today.unwrap_or(0);
+                let text = format!("hoje  {sessions} sessões · {turns} turns");
+                lines.push(vec![
+                    Segment::new(box_chars::V, BRAND),
+                    Segment::raw_text("  "),
+                    Segment::new(text, ColorToken::Comment),
+                ]);
+            }
+        }
+    }
+
+    if let Some(account) = p.account.as_deref().filter(|s| !s.is_empty()) {
+        if !options.account_in_header {
+            lines.push(vline(BRAND));
+            lines.push(vec![
+                Segment::new(box_chars::V, BRAND),
+                Segment::raw_text("  "),
+                Segment::new(format!("Account: {account}"), ColorToken::Comment),
+            ]);
+        }
+    }
+
+    lines.push(vline(BRAND));
+    lines.push(build_footer_line(
+        clock,
+        options.footer_fetched_at.as_deref(),
+        BRAND,
+    ));
+
+    lines
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::formatters::builders::shared::{AmpLayout, BuildOptions};
+    use crate::formatters::clock::Clock;
+    use crate::formatters::render_pango::render_pango;
+    use crate::providers::types::{GrokQuotaExtra, ProviderExtra, ProviderQuota, QuotaWindow};
+    use crate::settings::DisplayMode;
+    use crate::theme::ColorToken;
+    use time::macros::datetime;
+
+    fn clk() -> Clock {
+        Clock {
+            now: datetime!(2026-06-19 12:00:00 UTC),
+            local_offset: time::UtcOffset::UTC,
+        }
+    }
+
+    fn opts() -> BuildOptions {
+        BuildOptions {
+            mode: DisplayMode::Remaining,
+            header_title: "Grok · Grok 4.5".into(),
+            header_width: 52,
+            label_color: ColorToken::Cyan,
+            footer_fetched_at: None,
+            plan_label: None,
+            amp_free_tier_layout: AmpLayout::Inline,
+            account_in_header: false,
+        }
+    }
+
+    fn quota_with_primary() -> ProviderQuota {
+        ProviderQuota {
+            provider: "grok".into(),
+            display_name: "Grok".into(),
+            available: true,
+            account: Some("Test".into()),
+            plan: Some("Grok 4.5".into()),
+            plan_type: None,
+            primary: Some(QuotaWindow {
+                remaining: 87.0,
+                resets_at: None,
+                window_minutes: None,
+                used: Some(13.0),
+                severity: None,
+            }),
+            secondary: None,
+            models: None,
+            extra: Some(ProviderExtra::Grok(GrokQuotaExtra {
+                sessions_today: Some(3),
+                turns_today: Some(12),
+                context_tokens_used: Some(39_000),
+                context_window_tokens: Some(500_000),
+                recent_model: Some("grok-4.5".into()),
+            })),
+            error: None,
+        }
+    }
+
+    #[test]
+    fn builder_mentions_context_not_plan_quota() {
+        let out = render_pango(&build_grok(&clk(), &quota_with_primary(), &opts()));
+        assert!(out.contains("contexto"), "must name session context, got:\n{out}");
+        assert!(!out.to_lowercase().contains("plano"));
+        assert!(!out.to_lowercase().contains("quota de plano"));
+        assert!(out.contains("87%"));
+        assert!(out.contains("39k / 500k tokens"));
+        assert!(out.contains("hoje  3 sessões · 12 turns"));
+        assert!(out.contains("Account: Test"));
+    }
+
+    #[test]
+    fn error_branch_is_red_text() {
+        let mut q = quota_with_primary();
+        q.error = Some("Not logged in. Open `agent-bar menu` and choose Provider login.".into());
+        q.primary = None;
+        let out = render_pango(&build_grok(&clk(), &q, &opts()));
+        assert!(out.contains("Not logged in"));
+        assert!(!out.contains("contexto"));
+        assert!(!out.contains("sem sessões"));
+    }
+
+    #[test]
+    fn no_primary_shows_empty_sessions() {
+        let mut q = quota_with_primary();
+        q.primary = None;
+        q.extra = Some(ProviderExtra::Grok(GrokQuotaExtra {
+            sessions_today: Some(0),
+            turns_today: Some(0),
+            context_tokens_used: None,
+            context_window_tokens: None,
+            recent_model: None,
+        }));
+        let out = render_pango(&build_grok(&clk(), &q, &opts()));
+        assert!(out.contains("sem sessões locais ainda"));
+        assert!(out.contains("hoje  0 sessões · 0 turns"));
+    }
+
+    #[test]
+    fn fmt_tokens_compact_rounds_thousands() {
+        assert_eq!(fmt_tokens_compact(0), "0");
+        assert_eq!(fmt_tokens_compact(999), "999");
+        assert_eq!(fmt_tokens_compact(39_000), "39k");
+        assert_eq!(fmt_tokens_compact(500_000), "500k");
+        assert_eq!(fmt_tokens_compact(1_500_000), "2M");
+    }
+}

--- a/src/formatters/builders/mod.rs
+++ b/src/formatters/builders/mod.rs
@@ -2,4 +2,5 @@ pub mod amp;
 pub mod claude;
 pub mod codex;
 pub mod generic;
+pub mod grok;
 pub mod shared;

--- a/src/formatters/terminal.rs
+++ b/src/formatters/terminal.rs
@@ -6,6 +6,7 @@ use crate::formatters::builders::amp::build_amp;
 use crate::formatters::builders::claude::build_claude;
 use crate::formatters::builders::codex::build_codex;
 use crate::formatters::builders::generic::build_generic;
+use crate::formatters::builders::grok::build_grok;
 use crate::formatters::builders::shared::{AmpLayout, BuildOptions};
 use crate::formatters::clock::Clock;
 use crate::formatters::render_ansi::render_ansi;
@@ -73,6 +74,23 @@ fn terminal_section(
                     footer_fetched_at: None,
                     plan_label: None,
                     amp_free_tier_layout: AmpLayout::Sublines,
+                    account_in_header: false,
+                },
+            ),
+            no_color,
+        ),
+        "grok" => render_ansi(
+            &build_grok(
+                clock,
+                p,
+                &BuildOptions {
+                    mode,
+                    header_title: "Grok".into(),
+                    header_width: 56,
+                    label_color: ColorToken::Cyan,
+                    footer_fetched_at: None,
+                    plan_label: None,
+                    amp_free_tier_layout: AmpLayout::Inline,
                     account_in_header: false,
                 },
             ),

--- a/src/formatters/terminal.rs
+++ b/src/formatters/terminal.rs
@@ -154,6 +154,8 @@ mod tests {
             codex_sessions: PathBuf::new(),
             amp_settings: PathBuf::new(),
             amp_threads: PathBuf::new(),
+            grok_home: PathBuf::new(),
+            grok_auth: PathBuf::new(),
         })
     }
 

--- a/src/formatters/view_model.rs
+++ b/src/formatters/view_model.rs
@@ -44,6 +44,8 @@ mod tests {
             codex_sessions: PathBuf::new(),
             amp_settings: PathBuf::new(),
             amp_threads: PathBuf::new(),
+            grok_home: PathBuf::new(),
+            grok_auth: PathBuf::new(),
         }
     }
 

--- a/src/formatters/waybar.rs
+++ b/src/formatters/waybar.rs
@@ -295,6 +295,8 @@ mod tests {
             codex_sessions: PathBuf::new(),
             amp_settings: PathBuf::new(),
             amp_threads: PathBuf::new(),
+            grok_home: PathBuf::new(),
+            grok_auth: PathBuf::new(),
         })
     }
     fn claude(remaining: f64) -> ProviderQuota {

--- a/src/formatters/waybar.rs
+++ b/src/formatters/waybar.rs
@@ -11,6 +11,7 @@ use crate::formatters::builders::amp::build_amp;
 use crate::formatters::builders::claude::build_claude;
 use crate::formatters::builders::codex::build_codex;
 use crate::formatters::builders::generic::build_generic;
+use crate::formatters::builders::grok::build_grok;
 use crate::formatters::builders::shared::{AmpLayout, BuildOptions, TOOLTIP_BORDER};
 use crate::formatters::clock::Clock;
 use crate::formatters::render_pango::{render_pango, span};
@@ -149,6 +150,26 @@ fn provider_tooltip(
                     plan_label: None,
                     amp_free_tier_layout: AmpLayout::Inline,
                     account_in_header: true,
+                },
+            ))
+        }
+        "grok" => {
+            let title = match p.plan.as_deref().filter(|s| !s.is_empty()) {
+                Some(plan) => format!("Grok · {plan}"),
+                None => "Grok".to_string(),
+            };
+            render_pango(&build_grok(
+                clock,
+                p,
+                &BuildOptions {
+                    mode,
+                    header_title: title,
+                    header_width: header_width_waybar(),
+                    label_color: ColorToken::Cyan,
+                    footer_fetched_at: fetched,
+                    plan_label: None,
+                    amp_free_tier_layout: AmpLayout::Inline,
+                    account_in_header: false,
                 },
             ))
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -731,6 +731,8 @@ mod tests {
             codex_sessions: PathBuf::new(),
             amp_settings: PathBuf::new(),
             amp_threads: PathBuf::new(),
+            grok_home: PathBuf::new(),
+            grok_auth: PathBuf::new(),
         }
     }
 

--- a/src/providers/error.rs
+++ b/src/providers/error.rs
@@ -49,6 +49,16 @@ pub enum AmpError {
 }
 
 #[derive(Error, Debug)]
+pub enum GrokError {
+    #[error("Grok CLI not installed. Install from https://x.ai/cli or ensure ~/.grok/bin/grok is on PATH.")]
+    NotInstalled,
+    #[error("Not logged in. Open `agent-bar menu` and choose Provider login.")]
+    NotLoggedIn,
+    #[error("Failed to read Grok credentials.")]
+    InvalidCredentials,
+}
+
+#[derive(Error, Debug)]
 pub enum ProviderError {
     #[error(transparent)]
     Claude(#[from] ClaudeError),
@@ -56,6 +66,8 @@ pub enum ProviderError {
     Codex(#[from] CodexError),
     #[error(transparent)]
     Amp(#[from] AmpError),
+    #[error(transparent)]
+    Grok(#[from] GrokError),
 }
 
 #[cfg(test)]
@@ -122,6 +134,22 @@ mod tests {
         );
         assert_eq!(AmpError::ParseFailed.to_string(), "Failed to parse usage");
         assert_eq!(AmpError::Generic.to_string(), "Failed to fetch Amp usage");
+    }
+
+    #[test]
+    fn grok_strings_are_verbatim() {
+        assert_eq!(
+            GrokError::NotInstalled.to_string(),
+            "Grok CLI not installed. Install from https://x.ai/cli or ensure ~/.grok/bin/grok is on PATH."
+        );
+        assert_eq!(
+            GrokError::NotLoggedIn.to_string(),
+            format!("Not logged in. Open `{APP_NAME} menu` and choose Provider login.")
+        );
+        assert_eq!(
+            GrokError::InvalidCredentials.to_string(),
+            "Failed to read Grok credentials."
+        );
     }
 
     #[test]

--- a/src/providers/extras.rs
+++ b/src/providers/extras.rs
@@ -3,7 +3,7 @@
 //! para reproduzir exatamente o comportamento do TS (`q.provider === '...'`).
 
 use super::types::{
-    AmpQuotaExtra, ClaudeQuotaExtra, CodexQuotaExtra, ProviderExtra, ProviderQuota,
+    AmpQuotaExtra, ClaudeQuotaExtra, CodexQuotaExtra, GrokQuotaExtra, ProviderExtra, ProviderQuota,
 };
 
 /// Payload Claude-específico, ou None para outros providers.
@@ -30,11 +30,19 @@ pub fn get_amp_extra(q: &ProviderQuota) -> Option<&AmpQuotaExtra> {
     }
 }
 
+/// Payload Grok-específico, ou None para outros providers.
+pub fn get_grok_extra(q: &ProviderQuota) -> Option<&GrokQuotaExtra> {
+    match (q.provider == "grok", &q.extra) {
+        (true, Some(ProviderExtra::Grok(e))) => Some(e),
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::providers::types::{
-        ClaudeQuotaExtra, CodexQuotaExtra, ProviderExtra, ProviderQuota,
+        ClaudeQuotaExtra, CodexQuotaExtra, GrokQuotaExtra, ProviderExtra, ProviderQuota,
     };
 
     fn base(provider: &str, extra: Option<ProviderExtra>) -> ProviderQuota {
@@ -62,6 +70,7 @@ mod tests {
         assert!(get_claude_extra(&q).is_some());
         assert!(get_codex_extra(&q).is_none());
         assert!(get_amp_extra(&q).is_none());
+        assert!(get_grok_extra(&q).is_none());
     }
 
     #[test]
@@ -87,6 +96,29 @@ mod tests {
     #[test]
     fn none_extra_returns_none() {
         let q = base("amp", None);
+        assert!(get_amp_extra(&q).is_none());
+    }
+
+    #[test]
+    fn grok_getter_returns_payload() {
+        let q = base(
+            "grok",
+            Some(ProviderExtra::Grok(GrokQuotaExtra::default())),
+        );
+        assert!(get_grok_extra(&q).is_some());
+        assert!(get_claude_extra(&q).is_none());
+        assert!(get_codex_extra(&q).is_none());
+        assert!(get_amp_extra(&q).is_none());
+    }
+
+    #[test]
+    fn grok_getter_gated_by_provider_string() {
+        // provider diz "amp" mas o payload é Grok → None.
+        let q = base(
+            "amp",
+            Some(ProviderExtra::Grok(GrokQuotaExtra::default())),
+        );
+        assert!(get_grok_extra(&q).is_none());
         assert!(get_amp_extra(&q).is_none());
     }
 }

--- a/src/providers/grok.rs
+++ b/src/providers/grok.rs
@@ -346,7 +346,12 @@ impl QuotaSource for GrokProvider {
     }
 
     async fn is_available(&self, ctx: &Ctx<'_>) -> bool {
-        ctx.paths.grok_auth.is_file() || find_grok_bin(&ctx.home.to_string_lossy()).is_some()
+        ctx.paths.grok_auth.is_file()
+            || find_grok_bin(
+                &ctx.home.to_string_lossy(),
+                Some(ctx.paths.grok_home.as_path()),
+            )
+            .is_some()
     }
 
     async fn fetch_raw(&self, ctx: &Ctx<'_>) -> Result<GrokRaw, ProviderError> {

--- a/src/providers/grok.rs
+++ b/src/providers/grok.rs
@@ -1,0 +1,759 @@
+//! Grok Build CLI provider. Zero rede: auth.json + sessions/**/signals.json.
+//! Estende `QuotaSource` / `base_get_quota` (como Amp/Codex). Sem OAuth refresh.
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use async_trait::async_trait;
+use indexmap::IndexMap;
+use serde::{Deserialize, Serialize};
+use time::format_description::well_known::Rfc3339;
+use time::{Date, OffsetDateTime, UtcOffset};
+
+use super::base::{base_get_quota, QuotaSource};
+use super::error::{GrokError, ProviderError};
+use super::grok_cli::find_grok_bin;
+use super::types::{GrokQuotaExtra, ProviderExtra, ProviderQuota, QuotaWindow};
+use super::{Ctx, Provider};
+
+const MAX_WALK_DEPTH: u32 = 16;
+const MAX_WALK_VISITS: u32 = 2000;
+
+/// Snapshot de sessão (cacheável; sem tokens JWT).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SessionSnap {
+    pub mtime_ms: u64,
+    pub context_tokens_used: Option<u64>,
+    pub context_window_tokens: Option<u64>,
+    pub primary_model_id: Option<String>,
+    pub turn_count: u32,
+}
+
+/// Raw cacheável do Grok — **sem** access/refresh tokens.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct GrokRaw {
+    pub account: Option<String>,
+    pub logged_in: bool,
+    pub sessions: Vec<SessionSnap>,
+}
+
+/// Visão sanitizada do auth (sem JWT).
+#[derive(Debug, Clone, PartialEq)]
+pub struct AuthView {
+    pub account: Option<String>,
+    pub logged_in: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct AuthEntry {
+    #[serde(default)]
+    key: Option<String>,
+    #[serde(default)]
+    expires_at: Option<String>,
+    #[serde(default)]
+    first_name: Option<String>,
+    #[serde(default)]
+    user_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SignalsFile {
+    #[serde(default)]
+    context_tokens_used: Option<u64>,
+    #[serde(default)]
+    context_window_tokens: Option<u64>,
+    #[serde(default)]
+    primary_model_id: Option<String>,
+    #[serde(default)]
+    turn_count: Option<u32>,
+}
+
+/// % restante de contexto: `(100 - 100*used/window).clamp(0, 100)`.
+/// `None` se `window == 0`.
+pub(crate) fn context_remaining_pct(used: u64, window: u64) -> Option<f64> {
+    if window == 0 {
+        return None;
+    }
+    let used_pct = 100.0 * (used as f64) / (window as f64);
+    Some((100.0 - used_pct).clamp(0.0, 100.0))
+}
+
+/// Parse de `auth.json`. JSON inválido → `InvalidCredentials`.
+/// Sem entry com `key` não vazio, ou todas expiradas → `logged_in = false`.
+pub(crate) fn parse_auth_entries(bytes: &[u8], now: OffsetDateTime) -> Result<AuthView, GrokError> {
+    let map: HashMap<String, AuthEntry> =
+        serde_json::from_slice(bytes).map_err(|_| GrokError::InvalidCredentials)?;
+
+    // Entre entries com key não vazio, preferir a de expires_at mais distante.
+    let mut best: Option<(OffsetDateTime, AuthEntry)> = None;
+    let mut any_with_key = false;
+
+    for (_k, entry) in map {
+        let key = entry.key.as_deref().unwrap_or("").trim();
+        if key.is_empty() {
+            continue;
+        }
+        any_with_key = true;
+        let exp = entry
+            .expires_at
+            .as_deref()
+            .and_then(parse_expires_at)
+            .unwrap_or(OffsetDateTime::UNIX_EPOCH);
+        match &best {
+            Some((prev_exp, _)) if exp <= *prev_exp => {}
+            _ => best = Some((exp, entry)),
+        }
+    }
+
+    if !any_with_key {
+        return Ok(AuthView {
+            account: None,
+            logged_in: false,
+        });
+    }
+
+    let Some((exp, entry)) = best else {
+        return Ok(AuthView {
+            account: None,
+            logged_in: false,
+        });
+    };
+
+    let account = account_label(&entry);
+    let logged_in = exp > now;
+    Ok(AuthView {
+        account: Some(account),
+        logged_in,
+    })
+}
+
+fn account_label(entry: &AuthEntry) -> String {
+    if let Some(name) = entry
+        .first_name
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        return name.to_string();
+    }
+    if let Some(uid) = entry
+        .user_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        let short: String = uid.chars().take(8).collect();
+        return short;
+    }
+    "Grok".to_string()
+}
+
+/// RFC3339; tolerar fração de segundo com mais de 9 dígitos truncando.
+fn parse_expires_at(s: &str) -> Option<OffsetDateTime> {
+    if let Ok(dt) = OffsetDateTime::parse(s, &Rfc3339) {
+        return Some(dt);
+    }
+    // Truncar nanos excedentes: "2026-07-18T03:29:45.462038593Z" ok;
+    // se >9 dígitos fracionais, cortar.
+    let truncated = truncate_rfc3339_fraction(s)?;
+    OffsetDateTime::parse(&truncated, &Rfc3339).ok()
+}
+
+fn truncate_rfc3339_fraction(s: &str) -> Option<String> {
+    let dot = s.find('.')?;
+    let (head, frac_and_tz) = s.split_at(dot + 1);
+    // frac_and_tz = "462038593Z" ou "462038593+00:00"
+    let mut digits = 0usize;
+    for (i, c) in frac_and_tz.char_indices() {
+        if c.is_ascii_digit() {
+            digits += 1;
+            if digits > 9 {
+                // cortar a partir daqui; manter sufixo TZ
+                let tz = &frac_and_tz[i..];
+                let kept = &frac_and_tz[..i];
+                // kept tem 9 dígitos; se o original tinha mais, kept é os 9 primeiros
+                // na verdade i aponta pro 10º dígito, kept = 9 dígitos
+                return Some(format!("{head}{kept}{tz}"));
+            }
+        } else {
+            // TZ começa
+            if digits == 0 {
+                return None;
+            }
+            return Some(s.to_string());
+        }
+    }
+    Some(s.to_string())
+}
+
+/// Walk recursivo sob `sessions_dir` por arquivos `signals.json`.
+/// Depth max 16, max 2000 visits; não segue symlinks.
+/// `now_local_date` / `offset` reservados p/ contagem de “hoje” no build.
+pub(crate) fn collect_signals(
+    sessions_dir: &Path,
+    _now_local_date: Date,
+    _offset: UtcOffset,
+) -> Vec<SessionSnap> {
+    if !sessions_dir.is_dir() {
+        return Vec::new();
+    }
+    let mut out = Vec::new();
+    let mut visits = 0u32;
+    walk_signals(sessions_dir, 0, &mut visits, &mut out);
+    out.sort_by_key(|s| std::cmp::Reverse(s.mtime_ms));
+    out
+}
+
+fn walk_signals(dir: &Path, depth: u32, visits: &mut u32, out: &mut Vec<SessionSnap>) {
+    if depth > MAX_WALK_DEPTH || *visits >= MAX_WALK_VISITS {
+        return;
+    }
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        if *visits >= MAX_WALK_VISITS {
+            return;
+        }
+        *visits += 1;
+
+        let ft = match entry.file_type() {
+            Ok(ft) => ft,
+            Err(_) => continue,
+        };
+        // Não seguir symlinks (evita sair de sessions).
+        if ft.is_symlink() {
+            continue;
+        }
+        let path = entry.path();
+        if ft.is_dir() {
+            walk_signals(&path, depth + 1, visits, out);
+            continue;
+        }
+        if !ft.is_file() {
+            continue;
+        }
+        if entry.file_name() != "signals.json" {
+            continue;
+        }
+        if let Some(snap) = parse_signals_file(&path) {
+            out.push(snap);
+        }
+    }
+}
+
+fn parse_signals_file(path: &Path) -> Option<SessionSnap> {
+    let meta = std::fs::metadata(path).ok()?;
+    let mtime = meta.modified().ok()?;
+    let mtime_ms = system_time_to_ms(mtime);
+    let bytes = std::fs::read(path).ok()?;
+    let file: SignalsFile = serde_json::from_slice(&bytes).ok()?;
+    Some(SessionSnap {
+        mtime_ms,
+        context_tokens_used: file.context_tokens_used,
+        context_window_tokens: file.context_window_tokens,
+        primary_model_id: file.primary_model_id,
+        turn_count: file.turn_count.unwrap_or(0),
+    })
+}
+
+fn system_time_to_ms(t: SystemTime) -> u64 {
+    t.duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+fn ms_to_local_date(mtime_ms: u64, offset: UtcOffset) -> Option<Date> {
+    let dt = OffsetDateTime::from_unix_timestamp_nanos(i128::from(mtime_ms) * 1_000_000).ok()?;
+    Some(dt.to_offset(offset).date())
+}
+
+/// `grok-4.5` → `Grok 4.5`; ids sem prefixo ficam como estão.
+fn display_grok_model(id: &str) -> String {
+    if let Some(rest) = id.strip_prefix("grok-") {
+        if rest.is_empty() {
+            return "Grok".to_string();
+        }
+        return format!("Grok {rest}");
+    }
+    id.to_string()
+}
+
+fn now_from_ctx(ctx: &Ctx<'_>) -> OffsetDateTime {
+    OffsetDateTime::from_unix_timestamp_nanos(i128::from(ctx.now_ms) * 1_000_000)
+        .unwrap_or(OffsetDateTime::UNIX_EPOCH)
+}
+
+fn local_today(ctx: &Ctx<'_>) -> Date {
+    now_from_ctx(ctx).to_offset(ctx.local_offset).date()
+}
+
+fn pick_primary_session(sessions: &[SessionSnap]) -> Option<&SessionSnap> {
+    // Já ordenados por mtime desc; primeira com window>0 e used presente.
+    sessions
+        .iter()
+        .find(|s| s.context_tokens_used.is_some() && s.context_window_tokens.is_some_and(|w| w > 0))
+}
+
+fn build_primary_window(session: &SessionSnap) -> Option<QuotaWindow> {
+    let used = session.context_tokens_used?;
+    let window = session.context_window_tokens.filter(|w| *w > 0)?;
+    let remaining = context_remaining_pct(used, window)?;
+    let used_pct = 100.0 * (used as f64) / (window as f64);
+    Some(QuotaWindow {
+        remaining: remaining.round(),
+        resets_at: None,
+        window_minutes: None,
+        used: Some(used_pct.round()),
+        severity: None,
+    })
+}
+
+fn count_today(sessions: &[SessionSnap], today: Date, offset: UtcOffset) -> (u32, u32) {
+    let mut sessions_today = 0u32;
+    let mut turns_today = 0u32;
+    for s in sessions {
+        let Some(d) = ms_to_local_date(s.mtime_ms, offset) else {
+            continue;
+        };
+        if d == today {
+            sessions_today = sessions_today.saturating_add(1);
+            turns_today = turns_today.saturating_add(s.turn_count);
+        }
+    }
+    (sessions_today, turns_today)
+}
+
+pub struct GrokProvider;
+
+#[async_trait(?Send)]
+impl QuotaSource for GrokProvider {
+    type Raw = GrokRaw;
+
+    fn id(&self) -> &'static str {
+        "grok"
+    }
+
+    fn name(&self) -> &'static str {
+        "Grok"
+    }
+
+    fn cache_key(&self) -> &'static str {
+        "grok-usage"
+    }
+
+    async fn is_available(&self, ctx: &Ctx<'_>) -> bool {
+        ctx.paths.grok_auth.is_file() || find_grok_bin(&ctx.home.to_string_lossy()).is_some()
+    }
+
+    async fn fetch_raw(&self, ctx: &Ctx<'_>) -> Result<GrokRaw, ProviderError> {
+        let auth_path = &ctx.paths.grok_auth;
+        let bytes = match std::fs::read(auth_path) {
+            Ok(b) => b,
+            Err(_) => return Err(GrokError::NotLoggedIn.into()),
+        };
+        let auth = parse_auth_entries(&bytes, now_from_ctx(ctx))?;
+        let sessions_dir = ctx.paths.grok_home.join("sessions");
+        let sessions = collect_signals(&sessions_dir, local_today(ctx), ctx.local_offset);
+        Ok(GrokRaw {
+            account: auth.account,
+            logged_in: auth.logged_in,
+            sessions,
+        })
+    }
+
+    fn build_quota(&self, raw: GrokRaw, base: ProviderQuota, ctx: &Ctx<'_>) -> ProviderQuota {
+        if !raw.logged_in {
+            return ProviderQuota {
+                error: Some(GrokError::NotLoggedIn.to_string()),
+                account: raw.account,
+                ..base
+            };
+        }
+
+        let today = local_today(ctx);
+        let (sessions_today, turns_today) = count_today(&raw.sessions, today, ctx.local_offset);
+
+        let primary_session = pick_primary_session(&raw.sessions);
+        let primary = primary_session.and_then(build_primary_window);
+
+        let recent_model = primary_session
+            .and_then(|s| s.primary_model_id.clone())
+            .filter(|m| !m.is_empty());
+
+        let plan = recent_model
+            .as_deref()
+            .map(display_grok_model)
+            .or_else(|| Some("Grok Build".to_string()));
+
+        let models = match (primary.as_ref(), recent_model.as_deref()) {
+            (Some(w), Some(id)) => {
+                let mut m = IndexMap::new();
+                m.insert(display_grok_model(id), w.clone());
+                Some(m)
+            }
+            _ => None,
+        };
+
+        let extra = ProviderExtra::Grok(GrokQuotaExtra {
+            sessions_today: Some(sessions_today),
+            turns_today: Some(turns_today),
+            context_tokens_used: primary_session.and_then(|s| s.context_tokens_used),
+            context_window_tokens: primary_session.and_then(|s| s.context_window_tokens),
+            recent_model,
+        });
+
+        ProviderQuota {
+            available: true,
+            account: raw.account,
+            plan,
+            primary,
+            models,
+            extra: Some(extra),
+            ..base
+        }
+    }
+
+    fn unavailable_error(&self) -> String {
+        GrokError::NotInstalled.to_string()
+    }
+
+    fn to_user_facing_error(&self, error: &ProviderError) -> String {
+        match error {
+            ProviderError::Grok(e) => e.to_string(),
+            _ => GrokError::NotLoggedIn.to_string(),
+        }
+    }
+}
+
+#[async_trait(?Send)]
+impl Provider for GrokProvider {
+    fn id(&self) -> &'static str {
+        "grok"
+    }
+
+    fn name(&self) -> &'static str {
+        "Grok"
+    }
+
+    fn cache_key(&self) -> &'static str {
+        "grok-usage"
+    }
+
+    async fn is_available(&self, ctx: &Ctx<'_>) -> bool {
+        QuotaSource::is_available(self, ctx).await
+    }
+
+    async fn get_quota(&self, ctx: &Ctx<'_>) -> ProviderQuota {
+        base_get_quota(self, ctx).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::providers::test_support::{ctx_for, settings};
+    use std::path::PathBuf;
+    use tempfile::tempdir;
+    use time::macros::{date, datetime};
+
+    const FIXTURES: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/grok");
+
+    fn fixture_bytes(name: &str) -> Vec<u8> {
+        std::fs::read(PathBuf::from(FIXTURES).join(name))
+            .unwrap_or_else(|e| panic!("fixture {name}: {e}"))
+    }
+
+    fn fixture_str(name: &str) -> String {
+        String::from_utf8(fixture_bytes(name)).expect("utf8 fixture")
+    }
+
+    fn write_auth(dir: &Path, name: &str) {
+        let auth = dir.join("grok").join("auth.json");
+        if let Some(parent) = auth.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(&auth, fixture_bytes(name)).unwrap();
+    }
+
+    fn write_signals(dir: &Path, rel: &str, body: &str) -> PathBuf {
+        let path = dir.join("grok").join("sessions").join(rel);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(&path, body).unwrap();
+        path
+    }
+
+    fn touch_bin(home: &Path) {
+        let p = home.join(".grok").join("bin").join("grok");
+        std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+        std::fs::File::create(&p).unwrap();
+    }
+
+    #[test]
+    fn context_remaining_pct_happy() {
+        assert_eq!(context_remaining_pct(50_000, 500_000), Some(90.0));
+    }
+
+    #[test]
+    fn context_remaining_pct_none_on_zero_window() {
+        assert_eq!(context_remaining_pct(0, 0), None);
+        assert_eq!(context_remaining_pct(10, 0), None);
+    }
+
+    #[test]
+    fn context_remaining_pct_full_and_clamp() {
+        assert_eq!(context_remaining_pct(500_000, 500_000), Some(0.0));
+        // used > window → clamp a 0
+        assert_eq!(context_remaining_pct(600_000, 500_000), Some(0.0));
+    }
+
+    #[test]
+    fn parse_auth_valid() {
+        let now = datetime!(2026-07-17 12:00:00 UTC);
+        let view = parse_auth_entries(&fixture_bytes("auth-valid.json"), now).unwrap();
+        assert!(view.logged_in);
+        assert_eq!(view.account.as_deref(), Some("Test User"));
+    }
+
+    #[test]
+    fn parse_auth_expired() {
+        let now = datetime!(2026-07-17 12:00:00 UTC);
+        let view = parse_auth_entries(&fixture_bytes("auth-expired.json"), now).unwrap();
+        assert!(!view.logged_in);
+        assert_eq!(view.account.as_deref(), Some("Test User"));
+    }
+
+    #[test]
+    fn parse_auth_invalid_json() {
+        let now = datetime!(2026-07-17 12:00:00 UTC);
+        let err = parse_auth_entries(b"not-json", now).unwrap_err();
+        assert_eq!(err.to_string(), "Failed to read Grok credentials.");
+    }
+
+    #[test]
+    fn parse_auth_nanos_fraction() {
+        let now = datetime!(2026-07-17 12:00:00 UTC);
+        let json = br#"{
+          "https://auth.x.ai::c": {
+            "key": "tok",
+            "expires_at": "2099-07-18T03:29:45.462038593Z",
+            "first_name": "Nano"
+          }
+        }"#;
+        let view = parse_auth_entries(json, now).unwrap();
+        assert!(view.logged_in);
+        assert_eq!(view.account.as_deref(), Some("Nano"));
+    }
+
+    #[test]
+    fn display_grok_model_formats() {
+        assert_eq!(display_grok_model("grok-4.5"), "Grok 4.5");
+        assert_eq!(display_grok_model("other"), "other");
+    }
+
+    /// Isola `PATH` (host pode ter `grok` real). Mutex evita corrida entre testes.
+    static PATH_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    struct PathGuard {
+        old: Option<std::ffi::OsString>,
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl PathGuard {
+        fn clear() -> Self {
+            let lock = PATH_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+            let old = std::env::var_os("PATH");
+            // PATH vazio: `which` não encontra binários do host.
+            std::env::set_var("PATH", "");
+            Self { old, _lock: lock }
+        }
+    }
+
+    impl Drop for PathGuard {
+        fn drop(&mut self) {
+            match &self.old {
+                Some(p) => std::env::set_var("PATH", p),
+                None => std::env::remove_var("PATH"),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn not_installed() {
+        let _path = PathGuard::clear();
+        let dir = tempdir().unwrap();
+        let s = settings();
+        let client = reqwest::Client::new();
+        // now_ms irrelevante; sem auth e sem bin sob home de teste.
+        let ctx = ctx_for(dir.path(), &s, &client, 1_720_000_000_000);
+        let q = GrokProvider.get_quota(&ctx).await;
+        assert!(!q.available);
+        assert_eq!(
+            q.error.as_deref(),
+            Some(
+                "Grok CLI not installed. Install from https://x.ai/cli or ensure ~/.grok/bin/grok is on PATH."
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn not_logged_in_missing_auth() {
+        let _path = PathGuard::clear();
+        let dir = tempdir().unwrap();
+        // bin sob home de teste → available, mas sem auth → NotLoggedIn
+        touch_bin(dir.path());
+        let s = settings();
+        let client = reqwest::Client::new();
+        let ctx = ctx_for(dir.path(), &s, &client, 1_720_000_000_000);
+        let q = GrokProvider.get_quota(&ctx).await;
+        assert!(!q.available);
+        assert_eq!(
+            q.error.as_deref(),
+            Some("Not logged in. Open `agent-bar menu` and choose Provider login.")
+        );
+    }
+
+    #[tokio::test]
+    async fn not_logged_in_expired() {
+        let dir = tempdir().unwrap();
+        write_auth(dir.path(), "auth-expired.json");
+        let s = settings();
+        let client = reqwest::Client::new();
+        let ctx = ctx_for(dir.path(), &s, &client, 1_720_000_000_000);
+        let q = GrokProvider.get_quota(&ctx).await;
+        assert!(!q.available);
+        assert_eq!(
+            q.error.as_deref(),
+            Some("Not logged in. Open `agent-bar menu` and choose Provider login.")
+        );
+        assert_eq!(q.account.as_deref(), Some("Test User"));
+    }
+
+    #[tokio::test]
+    async fn happy_path_remaining_90() {
+        let dir = tempdir().unwrap();
+        write_auth(dir.path(), "auth-valid.json");
+        write_signals(
+            dir.path(),
+            "proj/sid/signals.json",
+            &fixture_str("signals-recent.json"),
+        );
+        let s = settings();
+        let client = reqwest::Client::new();
+        let ctx = ctx_for(dir.path(), &s, &client, 1_720_000_000_000);
+        let q = GrokProvider.get_quota(&ctx).await;
+        assert!(q.available, "err={:?}", q.error);
+        assert_eq!(q.account.as_deref(), Some("Test User"));
+        let primary = q.primary.as_ref().expect("primary");
+        assert_eq!(primary.remaining, 90.0);
+        assert!(primary.resets_at.is_none());
+        assert_eq!(primary.used, Some(10.0));
+        assert_eq!(q.plan.as_deref(), Some("Grok 4.5"));
+        match q.extra.as_ref() {
+            Some(ProviderExtra::Grok(e)) => {
+                assert_eq!(e.context_tokens_used, Some(50_000));
+                assert_eq!(e.context_window_tokens, Some(500_000));
+                assert_eq!(e.recent_model.as_deref(), Some("grok-4.5"));
+            }
+            other => panic!("expected Grok extra, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn picks_most_recent_session() {
+        let dir = tempdir().unwrap();
+        write_auth(dir.path(), "auth-valid.json");
+        let old = write_signals(
+            dir.path(),
+            "proj/old/signals.json",
+            &fixture_str("signals-full.json"),
+        );
+        let new = write_signals(
+            dir.path(),
+            "proj/new/signals.json",
+            &fixture_str("signals-recent.json"),
+        );
+        // mtimes: old no passado, new no futuro.
+        let past = SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1_000_000);
+        let future = SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(2_000_000);
+        filetime::set_file_mtime(&old, filetime::FileTime::from_system_time(past)).unwrap();
+        filetime::set_file_mtime(&new, filetime::FileTime::from_system_time(future)).unwrap();
+
+        let s = settings();
+        let client = reqwest::Client::new();
+        let ctx = ctx_for(dir.path(), &s, &client, 1_720_000_000_000);
+        let q = GrokProvider.get_quota(&ctx).await;
+        assert!(q.available, "err={:?}", q.error);
+        // recent = 90%, full = 0%
+        assert_eq!(q.primary.as_ref().unwrap().remaining, 90.0);
+        assert_eq!(
+            q.extra.as_ref().and_then(|e| match e {
+                ProviderExtra::Grok(g) => g.context_tokens_used,
+                _ => None,
+            }),
+            Some(50_000)
+        );
+    }
+
+    #[tokio::test]
+    async fn ignores_corrupt_signals() {
+        let dir = tempdir().unwrap();
+        write_auth(dir.path(), "auth-valid.json");
+        write_signals(dir.path(), "proj/bad/signals.json", "NOT JSON{{{");
+        write_signals(
+            dir.path(),
+            "proj/good/signals.json",
+            &fixture_str("signals-recent.json"),
+        );
+        let s = settings();
+        let client = reqwest::Client::new();
+        let ctx = ctx_for(dir.path(), &s, &client, 1_720_000_000_000);
+        let q = GrokProvider.get_quota(&ctx).await;
+        assert!(q.available, "err={:?}", q.error);
+        assert_eq!(q.primary.as_ref().unwrap().remaining, 90.0);
+    }
+
+    #[test]
+    fn collect_signals_sorts_and_parses() {
+        let dir = tempdir().unwrap();
+        let sessions = dir.path().join("sessions");
+        let a = sessions.join("a/signals.json");
+        let b = sessions.join("b/signals.json");
+        std::fs::create_dir_all(a.parent().unwrap()).unwrap();
+        std::fs::create_dir_all(b.parent().unwrap()).unwrap();
+        std::fs::write(&a, fixture_str("signals-recent.json")).unwrap();
+        std::fs::write(&b, fixture_str("signals-full.json")).unwrap();
+        let past = SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(100);
+        let future = SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(200);
+        filetime::set_file_mtime(&a, filetime::FileTime::from_system_time(past)).unwrap();
+        filetime::set_file_mtime(&b, filetime::FileTime::from_system_time(future)).unwrap();
+
+        let snaps = collect_signals(&sessions, date!(2026 - 07 - 17), UtcOffset::UTC);
+        assert_eq!(snaps.len(), 2);
+        assert_eq!(snaps[0].context_tokens_used, Some(500_000)); // b first (newer)
+        assert_eq!(snaps[1].context_tokens_used, Some(50_000));
+    }
+
+    #[test]
+    fn grok_raw_does_not_serialize_jwt_fields() {
+        let raw = GrokRaw {
+            account: Some("Test".into()),
+            logged_in: true,
+            sessions: vec![],
+        };
+        let j = serde_json::to_value(&raw).unwrap();
+        let s = j.to_string();
+        assert!(!s.contains("refresh"));
+        // snake_case default; sem campos de JWT
+        assert_eq!(j["logged_in"], true);
+        assert_eq!(j["account"], "Test");
+        assert!(j.get("key").is_none());
+        assert!(j.get("refresh_token").is_none());
+        let _ = s;
+    }
+}

--- a/src/providers/grok_cli.rs
+++ b/src/providers/grok_cli.rs
@@ -1,0 +1,93 @@
+//! Descoberta do binário `grok` (locator). Ordem: PATH (`which`), depois
+//! caminhos conhecidos sob `$HOME`.
+
+use std::path::{Path, PathBuf};
+
+/// Caminhos candidatos sob `$HOME`, na ordem de preferência. Vazio se `home` vazio.
+pub fn grok_candidate_paths(home: &str) -> Vec<PathBuf> {
+    if home.is_empty() {
+        return Vec::new();
+    }
+    let h = Path::new(home);
+    vec![
+        h.join(".grok").join("bin").join("grok"),
+        h.join(".local").join("bin").join("grok"),
+    ]
+}
+
+/// Locator com seams injetáveis (`which`/`exists`) para teste. PATH primeiro;
+/// depois o 1º candidato que existe; senão `None`.
+pub fn find_grok_bin_with(
+    home: &str,
+    which: impl Fn(&str) -> Option<PathBuf>,
+    exists: impl Fn(&Path) -> bool,
+) -> Option<PathBuf> {
+    if let Some(p) = which("grok") {
+        return Some(p);
+    }
+    grok_candidate_paths(home)
+        .into_iter()
+        .find(|p| exists(p))
+}
+
+/// Locator de produção: `which_in_path` + `Path::is_file`.
+pub fn find_grok_bin(home: &str) -> Option<PathBuf> {
+    find_grok_bin_with(home, crate::providers::amp_cli::which_in_path, |p| {
+        p.is_file()
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn candidate_paths_under_home() {
+        let paths = grok_candidate_paths("/tmp/agent-bar-home");
+        let got: Vec<String> = paths
+            .iter()
+            .map(|p| p.to_string_lossy().to_string())
+            .collect();
+        assert_eq!(
+            got,
+            vec![
+                "/tmp/agent-bar-home/.grok/bin/grok",
+                "/tmp/agent-bar-home/.local/bin/grok",
+            ]
+        );
+    }
+
+    #[test]
+    fn empty_home_yields_no_candidates() {
+        assert!(grok_candidate_paths("").is_empty());
+    }
+
+    #[test]
+    fn prefers_path_when_available() {
+        let found = find_grok_bin_with(
+            "/tmp/agent-bar-home",
+            |_| Some(PathBuf::from("/usr/local/bin/grok")),
+            |_| false,
+        );
+        assert_eq!(found, Some(PathBuf::from("/usr/local/bin/grok")));
+    }
+
+    #[test]
+    fn falls_back_to_known_locations() {
+        let found = find_grok_bin_with(
+            "/tmp/agent-bar-home",
+            |_| None,
+            |p| p == Path::new("/tmp/agent-bar-home/.grok/bin/grok"),
+        );
+        assert_eq!(
+            found,
+            Some(PathBuf::from("/tmp/agent-bar-home/.grok/bin/grok"))
+        );
+    }
+
+    #[test]
+    fn none_when_unavailable() {
+        let found = find_grok_bin_with("/tmp/agent-bar-home", |_| None, |_| false);
+        assert_eq!(found, None);
+    }
+}

--- a/src/providers/grok_cli.rs
+++ b/src/providers/grok_cli.rs
@@ -1,5 +1,6 @@
 //! Descoberta do binário `grok` (locator). Ordem: PATH (`which`), depois
-//! caminhos conhecidos sob `$HOME`.
+//! `{grok_home}/bin/grok` (quando `GROK_HOME`/paths.grok_home é conhecido),
+//! depois caminhos conhecidos sob `$HOME`.
 
 use std::path::{Path, PathBuf};
 
@@ -16,23 +17,28 @@ pub fn grok_candidate_paths(home: &str) -> Vec<PathBuf> {
 }
 
 /// Locator com seams injetáveis (`which`/`exists`) para teste. PATH primeiro;
-/// depois o 1º candidato que existe; senão `None`.
+/// em seguida `{grok_home}/bin/grok` se fornecido; depois candidatos sob `$HOME`.
 pub fn find_grok_bin_with(
     home: &str,
+    grok_home: Option<&Path>,
     which: impl Fn(&str) -> Option<PathBuf>,
     exists: impl Fn(&Path) -> bool,
 ) -> Option<PathBuf> {
     if let Some(p) = which("grok") {
         return Some(p);
     }
-    grok_candidate_paths(home)
-        .into_iter()
-        .find(|p| exists(p))
+    let mut candidates = Vec::new();
+    if let Some(gh) = grok_home {
+        candidates.push(gh.join("bin").join("grok"));
+    }
+    candidates.extend(grok_candidate_paths(home));
+    candidates.into_iter().find(|p| exists(p))
 }
 
 /// Locator de produção: `which_in_path` + `Path::is_file`.
-pub fn find_grok_bin(home: &str) -> Option<PathBuf> {
-    find_grok_bin_with(home, crate::providers::amp_cli::which_in_path, |p| {
+/// `grok_home` (ex. `paths.grok_home` / `GROK_HOME`) vira candidato logo após o PATH.
+pub fn find_grok_bin(home: &str, grok_home: Option<&Path>) -> Option<PathBuf> {
+    find_grok_bin_with(home, grok_home, crate::providers::amp_cli::which_in_path, |p| {
         p.is_file()
     })
 }
@@ -66,6 +72,7 @@ mod tests {
     fn prefers_path_when_available() {
         let found = find_grok_bin_with(
             "/tmp/agent-bar-home",
+            Some(Path::new("/custom/grok-home")),
             |_| Some(PathBuf::from("/usr/local/bin/grok")),
             |_| false,
         );
@@ -73,9 +80,24 @@ mod tests {
     }
 
     #[test]
+    fn prefers_grok_home_bin_before_home_candidates() {
+        let found = find_grok_bin_with(
+            "/tmp/agent-bar-home",
+            Some(Path::new("/custom/grok-home")),
+            |_| None,
+            |p| p == Path::new("/custom/grok-home/bin/grok"),
+        );
+        assert_eq!(
+            found,
+            Some(PathBuf::from("/custom/grok-home/bin/grok"))
+        );
+    }
+
+    #[test]
     fn falls_back_to_known_locations() {
         let found = find_grok_bin_with(
             "/tmp/agent-bar-home",
+            None,
             |_| None,
             |p| p == Path::new("/tmp/agent-bar-home/.grok/bin/grok"),
         );
@@ -87,7 +109,7 @@ mod tests {
 
     #[test]
     fn none_when_unavailable() {
-        let found = find_grok_bin_with("/tmp/agent-bar-home", |_| None, |_| false);
+        let found = find_grok_bin_with("/tmp/agent-bar-home", None, |_| None, |_| false);
         assert_eq!(found, None);
     }
 }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -5,6 +5,7 @@ pub mod claude;
 pub mod codex;
 pub mod error;
 pub mod extras;
+pub mod grok_cli;
 pub mod types;
 
 use std::time::Duration;

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -5,6 +5,7 @@ pub mod claude;
 pub mod codex;
 pub mod error;
 pub mod extras;
+pub mod grok;
 pub mod grok_cli;
 pub mod types;
 
@@ -111,12 +112,13 @@ pub trait Provider {
     async fn get_quota(&self, ctx: &Ctx<'_>) -> ProviderQuota;
 }
 
-/// Providers de produção. Cresce a cada plano (04a: Claude; 04b: Amp; 04c: Codex).
+/// Providers de produção. Cresce a cada plano (04a: Claude; 04b: Amp; 04c: Codex; grok).
 pub fn registry() -> Vec<Box<dyn Provider>> {
     vec![
         Box::new(claude::ClaudeProvider),
         Box::new(amp::AmpProvider),
         Box::new(codex::CodexProvider),
+        Box::new(grok::GrokProvider),
     ]
 }
 
@@ -184,7 +186,7 @@ pub fn get_provider(id: &str) -> Option<Box<dyn Provider>> {
 }
 
 /// Ids registrados na ordem do registry (espelha `getRegisteredProviderIds`).
-/// Retorna `["claude", "amp", "codex"]`.
+/// Retorna `["claude", "amp", "codex", "grok"]`.
 pub fn registered_provider_ids() -> Vec<&'static str> {
     registry().iter().map(|p| p.id()).collect()
 }
@@ -355,13 +357,13 @@ mod tests {
     }
 
     #[test]
-    fn registry_has_claude_amp_and_codex() {
+    fn registry_has_claude_amp_codex_grok() {
         let r = registry();
-        assert_eq!(r.len(), 3);
+        assert_eq!(r.len(), 4);
         assert_eq!(r[0].id(), "claude");
         assert_eq!(r[1].id(), "amp");
         assert_eq!(r[2].id(), "codex");
-        assert!(r.iter().any(|p| p.id() == "codex"));
+        assert_eq!(r[3].id(), "grok");
     }
 
     // --- Task 3: get_provider / registered_provider_ids / get_quota_for ---
@@ -371,6 +373,7 @@ mod tests {
         assert!(get_provider("claude").is_some());
         assert!(get_provider("amp").is_some());
         assert!(get_provider("codex").is_some());
+        assert!(get_provider("grok").is_some());
     }
 
     #[test]
@@ -380,7 +383,10 @@ mod tests {
 
     #[test]
     fn registered_provider_ids_matches_registry_order() {
-        assert_eq!(registered_provider_ids(), vec!["claude", "amp", "codex"]);
+        assert_eq!(
+            registered_provider_ids(),
+            vec!["claude", "amp", "codex", "grok"]
+        );
     }
 
     #[tokio::test]

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -220,6 +220,8 @@ pub(crate) mod test_support {
             codex_sessions: PathBuf::new(),
             amp_settings: PathBuf::new(),
             amp_threads: PathBuf::new(),
+            grok_home: PathBuf::new(),
+            grok_auth: PathBuf::new(),
         })
     }
 
@@ -232,6 +234,8 @@ pub(crate) mod test_support {
             codex_sessions: dir.join("codex-sessions"),
             amp_settings: dir.join("amp-settings.json"),
             amp_threads: dir.join("amp-threads"),
+            grok_home: dir.join("grok"),
+            grok_auth: dir.join("grok").join("auth.json"),
         }
     }
 

--- a/src/providers/types.rs
+++ b/src/providers/types.rs
@@ -69,6 +69,21 @@ pub struct AmpQuotaExtra {
     pub meta: Option<BTreeMap<String, String>>,
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct GrokQuotaExtra {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sessions_today: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub turns_today: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context_tokens_used: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context_window_tokens: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recent_model: Option<String>,
+}
+
 /// Untagged: serializa apenas o conteúdo do struct interno (sem chave de variante),
 /// reproduzindo a forma de `extra` do TS.
 #[derive(Debug, Clone, PartialEq, Serialize)]
@@ -77,6 +92,7 @@ pub enum ProviderExtra {
     Claude(ClaudeQuotaExtra),
     Codex(CodexQuotaExtra),
     Amp(AmpQuotaExtra),
+    Grok(GrokQuotaExtra),
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize)]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -379,6 +379,8 @@ mod tests {
             codex_sessions: PathBuf::new(),
             amp_settings: PathBuf::new(),
             amp_threads: PathBuf::new(),
+            grok_home: PathBuf::new(),
+            grok_auth: PathBuf::new(),
         }
     }
 
@@ -387,7 +389,10 @@ mod tests {
         let dir = tempdir().unwrap();
         let s = load(&paths_in(dir.path()));
         assert_eq!(s.version, 2);
-        assert_eq!(s.waybar.providers, vec!["claude", "codex", "amp"]);
+        assert_eq!(
+            s.waybar.providers,
+            vec!["claude", "codex", "amp", "grok"]
+        );
         assert_eq!(s.waybar.separators, SeparatorStyle::Gap);
         assert_eq!(s.waybar.display_mode, DisplayMode::Remaining);
         assert_eq!(s.waybar.interval, 60);
@@ -395,6 +400,7 @@ mod tests {
         assert!(s.notify.enabled);
         assert_eq!(s.cache.ttl.get("claude"), Some(&300));
         assert_eq!(s.cache.ttl.get("codex"), Some(&90));
+        assert_eq!(s.cache.ttl.get("grok"), Some(&90));
         assert_eq!(s.window_policy.get("codex"), Some(&WindowPolicy::Both));
     }
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -212,6 +212,8 @@ mod tests {
             codex_sessions: PathBuf::new(),
             amp_settings: PathBuf::new(),
             amp_threads: PathBuf::new(),
+            grok_home: PathBuf::new(),
+            grok_auth: PathBuf::new(),
         });
         let cfg = SetupConfig {
             asset_paths: Some(asset_paths),

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -93,6 +93,7 @@ pub fn provider_hex(id: &str) -> &'static str {
         "claude" => ColorToken::Orange.hex(),
         "codex" => ColorToken::Green.hex(),
         "amp" => ColorToken::Magenta.hex(),
+        "grok" => ColorToken::Cyan.hex(),
         _ => ColorToken::Text.hex(),
     }
 }
@@ -159,6 +160,7 @@ mod tests {
         assert_eq!(provider_hex("claude"), ColorToken::Orange.hex());
         assert_eq!(provider_hex("codex"), ColorToken::Green.hex());
         assert_eq!(provider_hex("amp"), ColorToken::Magenta.hex());
+        assert_eq!(provider_hex("grok"), ColorToken::Cyan.hex());
         assert_eq!(provider_hex("other"), ColorToken::Text.hex());
     }
 

--- a/src/tui/event_loop.rs
+++ b/src/tui/event_loop.rs
@@ -166,14 +166,16 @@ fn drain(
     }
 }
 
-/// Índice do provider na tela Login (0=claude, 1=codex, 2=amp) — mesma ordem
-/// de `render/login.rs::PROVIDERS` e `update.rs::login_selected_id`
-/// (inverso). Usado só no boot (`InitialFocus::Login`, Task 11); id
-/// desconhecido cai em 0 (claude) em vez de panicar.
+/// Índice do provider na tela Login (0=claude, 1=codex, 2=amp, 3=grok) —
+/// mesma ordem de `render/login.rs::PROVIDERS` e
+/// `update.rs::login_selected_id` (inverso). Usado só no boot
+/// (`InitialFocus::Login`, Task 11); id desconhecido cai em 0 (claude) em
+/// vez de panicar.
 fn login_index_of(id: &str) -> usize {
     match id {
         "codex" => 1,
         "amp" => 2,
+        "grok" => 3,
         _ => 0,
     }
 }

--- a/src/tui/login_spawn.rs
+++ b/src/tui/login_spawn.rs
@@ -124,7 +124,8 @@ fn run_login_cli(provider_id: &str) -> anyhow::Result<()> {
 
         "grok" => {
             let home = std::env::var("HOME").unwrap_or_default();
-            let bin = find_grok_bin(&home).ok_or_else(|| {
+            let grok_home = std::env::var_os("GROK_HOME").map(std::path::PathBuf::from);
+            let bin = find_grok_bin(&home, grok_home.as_deref()).ok_or_else(|| {
                 anyhow::anyhow!(
                     "Grok CLI não encontrado. Instale com: curl -fsSL https://x.ai/cli/install.sh | bash"
                 )

--- a/src/tui/login_spawn.rs
+++ b/src/tui/login_spawn.rs
@@ -11,6 +11,7 @@
 //!   - claude: `claude` (sem args; o usuario digita `/login` dentro da REPL)
 //!   - codex:  `codex login`
 //!   - amp:    `amp login`
+//!   - grok:   `grok login`
 
 use std::process::Command;
 
@@ -18,6 +19,7 @@ use anyhow::{bail, Context as _};
 
 use crate::install::ensure_command;
 use crate::providers::amp_cli::find_amp_bin;
+use crate::providers::grok_cli::find_grok_bin;
 
 /// Trait mockavel para testes unitarios do update/event_loop.
 pub trait ProviderLogin {
@@ -116,6 +118,26 @@ fn run_login_cli(provider_id: &str) -> anyhow::Result<()> {
                 .context("falha ao executar amp login")?;
             if !status.success() {
                 log::warn!("amp login encerrou com código {:?}", status.code());
+            }
+            Ok(())
+        }
+
+        "grok" => {
+            let home = std::env::var("HOME").unwrap_or_default();
+            let bin = find_grok_bin(&home).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Grok CLI não encontrado. Instale com: curl -fsSL https://x.ai/cli/install.sh | bash"
+                )
+            })?;
+            let status = Command::new(&bin)
+                .arg("login")
+                .stdin(std::process::Stdio::inherit())
+                .stdout(std::process::Stdio::inherit())
+                .stderr(std::process::Stdio::inherit())
+                .status()
+                .context("falha ao executar grok login")?;
+            if !status.success() {
+                log::warn!("grok login encerrou com código {:?}", status.code());
             }
             Ok(())
         }

--- a/src/tui/render/config.rs
+++ b/src/tui/render/config.rs
@@ -243,7 +243,7 @@ fn render_help_and_status(cs: &ConfigState, frame: &mut Frame, area: Rect, hits:
 fn field_hint(field: ConfigField) -> Option<&'static str> {
     match field {
         ConfigField::Providers => {
-            Some("Quais providers aparecem na barra. Ex: claude, codex, amp (providers)")
+            Some("Quais providers aparecem na barra. Ex: claude, codex, amp, grok (providers)")
         }
         ConfigField::ProviderOrder => {
             Some("Ordem dos módulos no Waybar. Ex: claude, codex (providerOrder)")

--- a/src/tui/render/login.rs
+++ b/src/tui/render/login.rs
@@ -1,4 +1,4 @@
-//! Aba Login: lista os 3 providers com status de autenticacao e acao de login.
+//! Aba Login: lista os 4 providers com status de autenticacao e acao de login.
 //! Sem emoji. Status vem do `LoginState` derivado do ULTIMO FETCH REAL (ver
 //! `crate::tui::login_state`) — nunca de path.exists() ou binario no PATH.
 
@@ -17,7 +17,12 @@ use crate::tui::widgets::chips::{chips_line, register_chip_hits};
 use crate::tui::widgets::icons::{glyph, Icon};
 
 /// Constantes dos providers da aba Login (id, nome de exibicao).
-const PROVIDERS: [(&str, &str); 3] = [("claude", "Claude"), ("codex", "Codex"), ("amp", "Amp")];
+const PROVIDERS: [(&str, &str); 4] = [
+    ("claude", "Claude"),
+    ("codex", "Codex"),
+    ("amp", "Amp"),
+    ("grok", "Grok"),
+];
 
 /// Renderiza a aba Login completa. O status de cada provider nao depende de
 /// paths de credencial — vem do `LoginState` (ultimo fetch real).
@@ -169,6 +174,7 @@ fn render_detail_panel(state: &AppState, frame: &mut Frame, area: Rect, hits: &m
         "claude" => "Abre a REPL do Claude. Digite /login e siga as instruções.",
         "codex" => "Executa `codex login` (fluxo OAuth no browser).",
         "amp" => "Executa `amp login` (autenticação no browser).",
+        "grok" => "Executa `grok login` (autenticação no browser).",
         _ => "",
     };
 

--- a/src/tui/render/snapshots/agent_bar__tui__render__login__tests__render_login_snapshot.snap
+++ b/src/tui/render/snapshots/agent_bar__tui__render__login__tests__render_login_snapshot.snap
@@ -6,7 +6,7 @@ expression: terminal.backend()
 "┃   ◆ Claude ✗ deslogado     ┃┃ Codex                          ┃"
 "┃ > ● Codex  ✗ deslogado     ┃┃                                ┃"
 "┃   ● Amp    ✗ deslogado     ┃┃ Executa `codex login` (fluxo OA┃"
-"┃                            ┃┃                                ┃"
+"┃   ● Grok   ✗ deslogado     ┃┃                                ┃"
 "┃                            ┃┃                                ┃"
 "┃                            ┃┃                                ┃"
 "┃                            ┃┃                                ┃"

--- a/src/tui/render/snapshots/agent_bar__tui__render__login__tests__render_login_snapshot_mixed_login_states.snap
+++ b/src/tui/render/snapshots/agent_bar__tui__render__login__tests__render_login_snapshot_mixed_login_states.snap
@@ -6,7 +6,7 @@ expression: terminal.backend()
 "┃ > ◆ Claude ✓ ok            ┃┃ Claude                         ┃"
 "┃   ● Codex  × sem token     ┃┃                                ┃"
 "┃   ● Amp    ! erro          ┃┃ Abre a REPL do Claude. Digite /┃"
-"┃                            ┃┃                                ┃"
+"┃   ● Grok   ✗ deslogado     ┃┃                                ┃"
 "┃                            ┃┃                                ┃"
 "┃                            ┃┃                                ┃"
 "┃                            ┃┃                                ┃"

--- a/src/tui/render/snapshots/agent_bar__tui__render__login__tests__render_login_snapshot_with_status.snap
+++ b/src/tui/render/snapshots/agent_bar__tui__render__login__tests__render_login_snapshot_with_status.snap
@@ -6,7 +6,7 @@ expression: terminal.backend()
 "┃ > ◆ Claude ✗ deslogado     ┃┃ Claude                         ┃"
 "┃   ● Codex  ✗ deslogado     ┃┃                                ┃"
 "┃   ● Amp    ✗ deslogado     ┃┃ Abre a REPL do Claude. Digite /┃"
-"┃                            ┃┃                                ┃"
+"┃   ● Grok   ✗ deslogado     ┃┃                                ┃"
 "┃                            ┃┃ Erro no login: claude nao encon┃"
 "┃                            ┃┃                                ┃"
 "┃                            ┃┃                                ┃"

--- a/src/tui/render/snapshots/agent_bar__tui__render__tests__help_overlay_clears_over_login_screen.snap
+++ b/src/tui/render/snapshots/agent_bar__tui__render__tests__help_overlay_clears_over_login_screen.snap
@@ -7,7 +7,7 @@ expression: terminal.backend()
 "│ MAIS            ┃ > ◆ Claude ✗ deslogado     ┃┃ Claude                                          ┃│"
 "│   Histórico     ┃   ● Codex  ✗ deslogado     ┃┃                                                 ┃│"
 "│   Login         ┃   ● Amp    ✗ deslogado     ┃┃ Abre a REPL do Claude. Digite /login e siga as i┃│"
-"│   Config        ┃                            ┃┃                                                 ┃│"
+"│   Config        ┃   ● Grok   ✗ deslogado     ┃┃                                                 ┃│"
 "│                 ┃                            ┃┃                                                 ┃│"
 "│                 ┃                            ┃┃                                                 ┃│"
 "│                 ┃                            ┃┃                                                 ┃│"

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -202,7 +202,7 @@ pub struct AppState {
     pub throbber: ThrobberAnim,
     /// Estado da aba Waybar config. None ate a aba ser aberta pela 1a vez.
     pub config_state: Option<ConfigState>,
-    /// Indice selecionado na aba Login (0=claude, 1=codex, 2=amp).
+    /// Indice selecionado na aba Login (0=claude, 1=codex, 2=amp, 3=grok).
     pub login_selected: usize,
     /// Mensagem de status da aba Login (feedback de erro ou instrucao).
     pub login_status: Option<String>,

--- a/src/tui/theme_bridge.rs
+++ b/src/tui/theme_bridge.rs
@@ -52,7 +52,7 @@ mod tests {
 
     #[test]
     fn provider_color_matches_theme_provider_hex() {
-        for id in ["claude", "codex", "amp", "other"] {
+        for id in ["claude", "codex", "amp", "grok", "other"] {
             let h = provider_hex(id).trim_start_matches('#');
             let want = Color::Rgb(
                 u8::from_str_radix(&h[0..2], 16).unwrap(),

--- a/src/tui/update/login.rs
+++ b/src/tui/update/login.rs
@@ -11,7 +11,8 @@ pub(super) fn login_selected_id(idx: usize) -> &'static str {
     match idx {
         0 => "claude",
         1 => "codex",
-        _ => "amp",
+        2 => "amp",
+        _ => "grok",
     }
 }
 
@@ -24,8 +25,8 @@ pub(super) fn login_up(state: &mut AppState) -> Vec<Action> {
 }
 
 pub(super) fn login_down(state: &mut AppState) -> Vec<Action> {
-    // 3 providers: indices 0, 1, 2.
-    if state.login_selected < 2 {
+    // 4 providers: indices 0..=3 (claude, codex, amp, grok).
+    if state.login_selected < 3 {
         state.login_selected += 1;
     }
     state.login_status = None;

--- a/src/tui/update/mod.rs
+++ b/src/tui/update/mod.rs
@@ -982,7 +982,7 @@ mod tests {
 
         assert_eq!(
             state.login_selected, 0,
-            "índice fora de faixa (só 3 providers) é ignorado"
+            "índice fora de faixa (só 4 providers) é ignorado"
         );
     }
 

--- a/src/tui/update/navigation.rs
+++ b/src/tui/update/navigation.rs
@@ -311,7 +311,8 @@ pub(super) fn click(state: &mut AppState, target: MouseTarget) -> Vec<Action> {
         // tela Login no primeiro clique, contrariando "click seleciona;
         // ativação continua pelo Enter/chip" (T14).
         MouseTarget::Card(i) if state.screen == Screen::Login => {
-            if i < 3 {
+            // 4 providers na lista Login (claude/codex/amp/grok).
+            if i < 4 {
                 state.login_selected = i;
                 state.login_status = None;
             }

--- a/src/waybar_contract.rs
+++ b/src/waybar_contract.rs
@@ -22,7 +22,7 @@ const SURFACE: &str = "#242a33";
 const SYSTEM_ASSET_DIR_PREFIX: &str = "/usr/share/";
 
 /// Providers Waybar na ordem canônica — espelha `WAYBAR_PROVIDERS` do TS.
-pub const WAYBAR_PROVIDERS: [&str; 3] = ["claude", "codex", "amp"];
+pub const WAYBAR_PROVIDERS: [&str; 4] = ["claude", "codex", "amp", "grok"];
 
 // ---------------------------------------------------------------------------
 // WaybarModuleConfig
@@ -275,6 +275,10 @@ pub fn export_waybar_css(
             "{WAYBAR_SELECTOR_PREFIX}amp {{ background-image: url(\"{}\"); }}",
             icon_ref("amp-icon.svg")
         ),
+        format!(
+            "{WAYBAR_SELECTOR_PREFIX}grok {{ background-image: url(\"{}\"); }}",
+            icon_ref("grok-icon.svg")
+        ),
         String::new(),
         format!(
             "{} {{ color: {}; }}",
@@ -513,7 +517,7 @@ mod tests {
             "$HOME/.local/bin/agent-bar",
             "$HOME/.config/waybar/scripts/agent-bar-open-terminal",
             None,
-            &s(&["claude", "codex", "amp"]),
+            &s(&["claude", "codex", "amp", "grok"]),
             120,
         );
         let claude = &e.modules["custom/agent-bar-claude"];
@@ -529,6 +533,8 @@ mod tests {
             amp.on_click_right,
             "$HOME/.config/waybar/scripts/agent-bar-open-terminal $HOME/.local/bin/agent-bar action-right amp"
         );
+        let grok = &e.modules["custom/agent-bar-grok"];
+        assert_eq!(grok.exec, "$HOME/.local/bin/agent-bar --provider grok");
     }
 
     #[test]
@@ -565,17 +571,23 @@ mod tests {
     fn css_has_base_styles_icons_states() {
         let css = export_waybar_css(
             "/home/user/.config/waybar/agent-bar/icons",
-            &s(&["claude", "codex", "amp"]),
+            &s(&["claude", "codex", "amp", "grok"]),
             SeparatorStyle::Gap,
         );
         for sel in [
             "#custom-agent-bar-claude",
             "#custom-agent-bar-codex",
             "#custom-agent-bar-amp",
+            "#custom-agent-bar-grok",
         ] {
             assert!(css.contains(sel), "missing {sel}");
         }
-        for icon in ["claude-code-icon.png", "codex-icon.png", "amp-icon.svg"] {
+        for icon in [
+            "claude-code-icon.png",
+            "codex-icon.png",
+            "amp-icon.svg",
+            "grok-icon.svg",
+        ] {
             assert!(css.contains(icon), "missing {icon}");
         }
         for st in [".ok", ".low", ".warn", ".critical", ".disconnected"] {

--- a/src/waybar_integration.rs
+++ b/src/waybar_integration.rs
@@ -835,7 +835,12 @@ mod orchestration_tests {
         let mr = parsed["modules-right"].as_array().unwrap();
         assert!(mr.iter().any(|v| v == "clock"));
         assert!(mr.iter().any(|v| v == "battery"));
-        for id in get_app_module_ids(&["claude".into(), "codex".into(), "amp".into()]) {
+        for id in get_app_module_ids(&[
+            "claude".into(),
+            "codex".into(),
+            "amp".into(),
+            "grok".into(),
+        ]) {
             assert!(mr.iter().any(|v| v.as_str() == Some(&id)), "missing {id}");
         }
         let inc = parsed["include"].as_array().unwrap();
@@ -898,7 +903,12 @@ mod orchestration_tests {
         ))
         .unwrap();
         let mr = final_cfg["modules-right"].as_array().unwrap();
-        for id in get_app_module_ids(&["claude".into(), "codex".into(), "amp".into()]) {
+        for id in get_app_module_ids(&[
+            "claude".into(),
+            "codex".into(),
+            "amp".into(),
+            "grok".into(),
+        ]) {
             assert!(!mr.iter().any(|v| v.as_str() == Some(&id)));
         }
         assert!(mr.iter().any(|v| v == "clock"));
@@ -930,7 +940,12 @@ mod orchestration_tests {
         assert_eq!(cfg["layer"], "top");
         assert_eq!(cfg["position"], "top");
         let mr = cfg["modules-right"].as_array().unwrap();
-        for id in get_app_module_ids(&["claude".into(), "codex".into(), "amp".into()]) {
+        for id in get_app_module_ids(&[
+            "claude".into(),
+            "codex".into(),
+            "amp".into(),
+            "grok".into(),
+        ]) {
             assert!(mr.iter().any(|v| v.as_str() == Some(&id)), "missing {id}");
         }
         let inc = cfg["include"].as_array().unwrap();

--- a/src/waybar_integration.rs
+++ b/src/waybar_integration.rs
@@ -804,6 +804,8 @@ mod orchestration_tests {
             codex_sessions: PathBuf::new(),
             amp_settings: PathBuf::new(),
             amp_threads: PathBuf::new(),
+            grok_home: PathBuf::new(),
+            grok_auth: PathBuf::new(),
         })
     }
 

--- a/tests/fixtures/grok/auth-expired.json
+++ b/tests/fixtures/grok/auth-expired.json
@@ -1,0 +1,10 @@
+{
+  "https://auth.x.ai::test-client": {
+    "key": "test-access-token",
+    "refresh_token": "test-refresh",
+    "expires_at": "2020-01-01T00:00:00Z",
+    "first_name": "Test User",
+    "user_id": "00000000-0000-0000-0000-000000000001",
+    "auth_mode": "oidc"
+  }
+}

--- a/tests/fixtures/grok/auth-valid.json
+++ b/tests/fixtures/grok/auth-valid.json
@@ -1,0 +1,10 @@
+{
+  "https://auth.x.ai::test-client": {
+    "key": "test-access-token",
+    "refresh_token": "test-refresh",
+    "expires_at": "2099-01-01T00:00:00Z",
+    "first_name": "Test User",
+    "user_id": "00000000-0000-0000-0000-000000000001",
+    "auth_mode": "oidc"
+  }
+}

--- a/tests/fixtures/grok/signals-full.json
+++ b/tests/fixtures/grok/signals-full.json
@@ -1,0 +1,7 @@
+{
+  "contextTokensUsed": 500000,
+  "contextWindowTokens": 500000,
+  "contextWindowUsage": 100,
+  "primaryModelId": "grok-4.5",
+  "turnCount": 10
+}

--- a/tests/fixtures/grok/signals-recent.json
+++ b/tests/fixtures/grok/signals-recent.json
@@ -1,0 +1,7 @@
+{
+  "contextTokensUsed": 50000,
+  "contextWindowTokens": 500000,
+  "contextWindowUsage": 10,
+  "primaryModelId": "grok-4.5",
+  "turnCount": 3
+}

--- a/tests/golden.rs
+++ b/tests/golden.rs
@@ -47,6 +47,8 @@ fn settings() -> Settings {
         codex_sessions: PathBuf::new(),
         amp_settings: PathBuf::new(),
         amp_threads: PathBuf::new(),
+        grok_home: PathBuf::new(),
+        grok_auth: PathBuf::new(),
     })
 }
 


### PR DESCRIPTION
## Summary

Provider **Grok** para o agent-bar, lendo o **Grok Build CLI** local (`~/.grok`).

- **Barra:** `%` de **contexto restante** da sessão mais recente (`signals.json`)
- **Auth:** `auth.json` OAuth (sem refresh; expirado = not logged in)
- **Sem rede** na v1; cache 90s; `BaseProvider`
- Login TUI: `grok login`
- Waybar module + ícone + builder (copy “contexto”)
- **Settings existentes não ganham grok sozinhas**; installs novos sim

Spec: `docs/superpowers/specs/2026-07-17-grok-provider-design.md`  
Plan: `docs/superpowers/plans/2026-07-17-grok-provider.md`

## Test plan

- [x] `cargo test` (740)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] Review multi-agente por task + review final de branch
- [ ] Habilitar `grok` em Config se settings já existir
- [ ] `agent-bar status -p grok` com `~/.grok` real
- [ ] `agent-bar setup` (só se quiser regenerar módulos Waybar)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Grok Build as a supported provider.
  * Displayed remaining session context, recent token usage, and daily session activity.
  * Added Grok login through the TUI using `grok login`.
  * Included Grok in default provider settings, terminal output, Waybar, JSON output, and provider selection.

* **Documentation**
  * Updated setup, command, runtime, architecture, and provider documentation with Grok details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->