### PR TITLE
feat: reset diário e ETA no tooltip do Amp

### DIFF
--- a/src/formatters/builders/amp.rs
+++ b/src/formatters/builders/amp.rs
@@ -22,6 +22,14 @@ fn meta_get<'a>(m: &'a BTreeMap<String, String>, k: &str) -> Option<&'a str> {
     m.get(k).map(|s| s.as_str()).filter(|s| !s.is_empty())
 }
 
+/// Linhas cruas `Label: valor` preservadas pelo parser quando o formato do
+/// servidor não é reconhecido (preparo p/ assinatura megawatt/gigawatt).
+fn raw_lines(m: &BTreeMap<String, String>) -> Vec<&str> {
+    (0..4)
+        .filter_map(|i| meta_get(m, &format!("raw{i}")))
+        .collect()
+}
+
 /// Junta freeRemaining/freeTotal (truthy) com " / ".
 fn dollars(m: &BTreeMap<String, String>) -> String {
     [meta_get(m, "freeRemaining"), meta_get(m, "freeTotal")]
@@ -98,11 +106,24 @@ pub fn build_amp(clock: &Clock, p: &ProviderQuota, options: &BuildOptions) -> Ve
     } else if layout == AmpLayout::Generic {
         // TUI: loop genérico, sem special-casing de Free Tier/Credits.
         match p.models.as_ref().filter(|mm| !mm.is_empty()) {
-            None => lines.push(vec![
-                Segment::new(box_chars::V, ColorToken::Magenta),
-                Segment::raw_text("  "),
-                Segment::new("No usage data", ColorToken::Muted),
-            ]),
+            None => {
+                let raws = raw_lines(m);
+                if raws.is_empty() {
+                    lines.push(vec![
+                        Segment::new(box_chars::V, ColorToken::Magenta),
+                        Segment::raw_text("  "),
+                        Segment::new("No usage data", ColorToken::Muted),
+                    ]);
+                } else {
+                    for raw in raws {
+                        lines.push(vec![
+                            Segment::new(box_chars::V, ColorToken::Magenta),
+                            Segment::raw_text("  "),
+                            Segment::new(raw.to_string(), ColorToken::Text),
+                        ]);
+                    }
+                }
+            }
             Some(models) => {
                 let max_len = models
                     .keys()
@@ -128,8 +149,13 @@ pub fn build_amp(clock: &Clock, p: &ProviderQuota, options: &BuildOptions) -> Ve
         if let Some(free) = free {
             let rem = free.remaining;
             let disp = to_display(Some(rem), mode);
+            let free_label = if meta_get(m, "freeCadence") == Some("daily") {
+                "Free Tier · daily"
+            } else {
+                "Free Tier"
+            };
             lines.push(label_line(
-                "Free Tier",
+                free_label,
                 options.label_color,
                 ColorToken::Magenta,
             ));
@@ -262,6 +288,10 @@ pub fn build_amp(clock: &Clock, p: &ProviderQuota, options: &BuildOptions) -> Ve
             line.extend(indicator_segments(credit_disp, mode));
             line.push(Segment::raw_text(" "));
             line.push(Segment::new(balance_text, credit_color));
+            if meta_get(m, "creditsReplenish").is_some() {
+                line.push(Segment::raw_text("  "));
+                line.push(Segment::new("↻ auto-replenish", ColorToken::Comment));
+            }
             lines.push(line);
         }
 
@@ -282,6 +312,24 @@ pub fn build_amp(clock: &Clock, p: &ProviderQuota, options: &BuildOptions) -> Ve
                 for (name, window) in models {
                     let disp = to_display(Some(window.remaining), mode);
                     lines.push(generic_model_line(name, max_len, disp, mode));
+                }
+            } else {
+                // Formato de servidor não reconhecido: mostra as linhas cruas
+                // em vez de um card vazio (ex.: assinatura nova do Amp).
+                let raws = raw_lines(m);
+                if !raws.is_empty() {
+                    lines.push(label_line(
+                        "Usage",
+                        options.label_color,
+                        ColorToken::Magenta,
+                    ));
+                    for raw in raws {
+                        lines.push(vec![
+                            Segment::new(box_chars::V, ColorToken::Magenta),
+                            Segment::raw_text("  "),
+                            Segment::new(raw.to_string(), ColorToken::Text),
+                        ]);
+                    }
                 }
             }
         }
@@ -422,6 +470,59 @@ mod tests {
         o.account_in_header = true;
         let out = render_pango(&build_amp(&clk(), &amp_with_free_and_credits(), &o));
         assert!(!out.contains("Account:"));
+    }
+
+    #[test]
+    fn daily_cadence_label_and_replenish_hint() {
+        let mut q = amp_with_free_and_credits();
+        if let Some(ProviderExtra::Amp(a)) = q.extra.as_mut() {
+            let m = a.meta.as_mut().unwrap();
+            m.insert("freeCadence".to_string(), "daily".to_string());
+            m.insert("creditsReplenish".to_string(), "auto".to_string());
+        }
+        let out = render_pango(&build_amp(&clk(), &q, &opts(AmpLayout::Inline)));
+        assert!(out.contains("Free Tier · daily"));
+        assert!(out.contains("↻ auto-replenish"));
+    }
+
+    #[test]
+    fn no_cadence_keeps_plain_labels() {
+        let out = render_pango(&build_amp(
+            &clk(),
+            &amp_with_free_and_credits(),
+            &opts(AmpLayout::Inline),
+        ));
+        assert!(!out.contains("Free Tier · daily"));
+        assert!(!out.contains("auto-replenish"));
+    }
+
+    #[test]
+    fn raw_lines_fallback_when_no_known_models() {
+        let mut meta = BTreeMap::new();
+        meta.insert(
+            "raw0".to_string(),
+            "Subscription (Gigawatt): $12.00 of $200.00 used".to_string(),
+        );
+        meta.insert("raw1".to_string(), "Orb usage: 3% used".to_string());
+        let q = ProviderQuota {
+            provider: "amp".into(),
+            display_name: "Amp".into(),
+            available: true,
+            account: Some("me@x.com".into()),
+            plan: None,
+            plan_type: None,
+            primary: None,
+            secondary: None,
+            models: Some(IndexMap::new()),
+            extra: Some(ProviderExtra::Amp(AmpQuotaExtra { meta: Some(meta) })),
+            error: None,
+        };
+        for layout in [AmpLayout::Inline, AmpLayout::Generic] {
+            let out = render_pango(&build_amp(&clk(), &q, &opts(layout)));
+            assert!(out.contains("Subscription (Gigawatt): $12.00 of $200.00 used"));
+            assert!(out.contains("Orb usage: 3% used"));
+            assert!(!out.contains("No usage data"));
+        }
     }
 
     #[test]

--- a/src/providers/amp.rs
+++ b/src/providers/amp.rs
@@ -35,6 +35,8 @@ fn dollars(n: f64) -> String {
     format!("${n}")
 }
 
+const MS_PER_DAY: u64 = 86_400_000;
+
 /// Parse do stdout de `amp usage` para `ProviderQuota`. `now_ms` é o relógio
 /// atual (o `fullAt` recalcula a cada chamada, inclusive em cache hit).
 pub fn parse_usage(stdout: &str, base: ProviderQuota, now_ms: u64) -> ProviderQuota {
@@ -46,7 +48,10 @@ pub fn parse_usage(stdout: &str, base: ProviderQuota, now_ms: u64) -> ProviderQu
     let account = cap1(lazy_re!(RE_SIGNED, r"Signed in as (\S+)"), 1);
 
     // Formato novo (CLI ≥ 2026-07-11): `Amp Free: 97% remaining today (resets daily)`.
-    let free_pct = cap1(lazy_re!(RE_FREE_PCT, r"Amp Free:\s*([0-9.]+)%\s*remaining"), 1);
+    let free_pct = cap1(
+        lazy_re!(RE_FREE_PCT, r"Amp Free:\s*([0-9.]+)%\s*remaining"),
+        1,
+    );
 
     // Formato antigo: `Amp Free: $3.50/$5.00 remaining` + replenish/bonus.
     let free_re = lazy_re!(RE_FREE, r"Amp Free:\s*\$([0-9.]+)/\$([0-9.]+)\s*remaining");
@@ -74,11 +79,21 @@ pub fn parse_usage(stdout: &str, base: ProviderQuota, now_ms: u64) -> ProviderQu
     let mut primary: Option<QuotaWindow> = None;
 
     if let Some(pct_str) = free_pct.as_deref() {
-        // Percentual já vem pronto; reset é diário mas sem horário → sem ETA.
+        // Percentual já vem pronto. Reset diário à meia-noite UTC — regra do
+        // frontend oficial (nextAmpFreeResetDate em ampcode.com/settings:
+        // `Date.UTC(y, m, d+1)`). Só afirmamos o horário quando o texto do
+        // CLI ainda diz "resets daily"; se o servidor mudar a cadência, o
+        // ETA some em vez de mentir.
         let pct: f64 = pct_str.parse().unwrap_or(0.0);
+        let resets_at = if stdout.contains("resets daily") {
+            meta.insert("freeCadence".to_string(), "daily".to_string());
+            Some(iso_from_ms((now_ms / MS_PER_DAY + 1) * MS_PER_DAY))
+        } else {
+            None
+        };
         let window = QuotaWindow {
             remaining: pct,
-            resets_at: None,
+            resets_at,
             window_minutes: None,
             used: None,
             severity: None,
@@ -154,6 +169,29 @@ pub fn parse_usage(stdout: &str, base: ProviderQuota, now_ms: u64) -> ProviderQu
             },
         );
         meta.insert("creditsBalance".to_string(), dollars(balance));
+        if stdout.contains("replenishes automatically") {
+            meta.insert("creditsReplenish".to_string(), "auto".to_string());
+        }
+    }
+
+    // Fallback p/ formatos futuros do servidor (o texto de `amp usage` é
+    // renderizado server-side e já mudou sem update do CLI — ex.: linhas de
+    // assinatura megawatt/gigawatt). Sem Free Tier nem Credits reconhecidos,
+    // preserva as linhas `Label: valor` cruas p/ o tooltip não ficar vazio.
+    if primary.is_none() && !stdout.is_empty() && models.is_empty() {
+        let line_re = lazy_re!(RE_RAW_LINE, r"(?m)^([A-Z][A-Za-z0-9 /()&-]{1,39}):\s*(.+)$");
+        if let Some(r) = line_re {
+            for (i, caps) in r.captures_iter(stdout).take(4).enumerate() {
+                let label = caps.get(1).map(|m| m.as_str()).unwrap_or_default();
+                if label.starts_with("Signed in") {
+                    continue;
+                }
+                let value = caps.get(2).map(|m| m.as_str()).unwrap_or_default();
+                // Corta o sufixo " - https://..." que o CLI anexa.
+                let value = value.split(" - http").next().unwrap_or(value).trim();
+                meta.insert(format!("raw{i}"), format!("{label}: {value}"));
+            }
+        }
     }
 
     let extra = if meta.is_empty() {
@@ -370,15 +408,51 @@ mod tests {
         assert!(q.available);
         assert_eq!(q.account.as_deref(), Some("user@email.com"));
         assert_eq!(q.primary.as_ref().unwrap().remaining, 97.0);
-        assert!(q.primary.as_ref().unwrap().resets_at.is_none());
+        // "resets daily" → próxima meia-noite UTC após NOW.
+        let expected_reset = iso_from_ms((NOW / MS_PER_DAY + 1) * MS_PER_DAY);
+        assert_eq!(
+            q.primary.as_ref().unwrap().resets_at.as_deref(),
+            Some(expected_reset.as_str())
+        );
         let models = q.models.as_ref().unwrap();
         assert_eq!(models["Free Tier"].remaining, 97.0);
         assert_eq!(models["Credits"].remaining, 100.0);
         let m = meta_of(&q);
         assert_eq!(m.get("freePct").map(String::as_str), Some("97%"));
+        assert_eq!(m.get("freeCadence").map(String::as_str), Some("daily"));
         assert_eq!(m.get("creditsBalance").map(String::as_str), Some("$4.19"));
+        assert_eq!(m.get("creditsReplenish").map(String::as_str), Some("auto"));
         assert!(m.get("freeRemaining").is_none());
         assert!(m.get("freeTotal").is_none());
+    }
+
+    #[test]
+    fn free_pct_without_resets_daily_has_no_eta() {
+        let out = "Signed in as user@email.com\nAmp Free: 42% remaining this period\nIndividual credits: $1.00 remaining";
+        let q = parse_usage(out, base(), NOW);
+        assert_eq!(q.primary.as_ref().unwrap().remaining, 42.0);
+        assert!(q.primary.as_ref().unwrap().resets_at.is_none());
+        let m = meta_of(&q);
+        assert!(m.get("freeCadence").is_none());
+        assert!(m.get("creditsReplenish").is_none());
+    }
+
+    #[test]
+    fn unknown_server_format_preserves_raw_lines() {
+        let out = "Signed in as user@email.com (nick)\nSubscription (Gigawatt): $12.00 of $200.00 used - https://ampcode.com/settings\nOrb usage: 3% used this period";
+        let q = parse_usage(out, base(), NOW);
+        assert!(q.available);
+        assert!(q.primary.is_none());
+        assert!(q.models.as_ref().unwrap().is_empty());
+        let m = meta_of(&q);
+        assert_eq!(
+            m.get("raw0").map(String::as_str),
+            Some("Subscription (Gigawatt): $12.00 of $200.00 used")
+        );
+        assert_eq!(
+            m.get("raw1").map(String::as_str),
+            Some("Orb usage: 3% used this period")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## O que muda

O hover do módulo Amp na Waybar mostrava só a barra de percentual e o saldo de créditos, sem contexto — diferente do Claude/Codex, que exibem janela nomeada + ETA de reset.

**Antes → depois:**

```
┣━ ◆ Free Tier                 ┣━ ◆ Free Tier · daily
┃  ● ██░░░░░░  10%             ┃  ● ██░░░░░░  10%  → Resets in 1h 29m (21:00)
┣━ ◆ Credits                   ┣━ ◆ Credits
┃  ● $4.19 remaining           ┃  ● $4.19 remaining  ↻ auto-replenish
```

## Por quê / fonte da regra

- O Amp Free reseta à **meia-noite UTC, diariamente**. Regra extraída do frontend de produção de `ampcode.com/settings` (`nextAmpFreeResetDate` = `Date.UTC(y, m, d+1)`) e **confirmada empiricamente** em 2026-07-20: 90% → 100% às 00:02 UTC.
- O parser só calcula `resets_at` quando o texto do CLI ainda diz "resets daily" — se o servidor mudar a cadência, a ETA some em vez de mentir.
- Captura `replenishes automatically` dos créditos → hint `↻ auto-replenish`.

## Robustez p/ formatos futuros

O texto de `amp usage` é renderizado no servidor (a RPC `userDisplayBalanceInfo` devolve só `displayText`) e já mudou sem update do CLI (2026-07-11). Formatos desconhecidos — ex.: assinaturas `megawatt`/`gigawatt` — caem num fallback que preserva as linhas `Label: valor` cruas no tooltip em vez de deixar o card vazio.

## Verificação

- `cargo test providers::amp` — 21 passed (novos: ETA da fixture pct, formato sem "resets daily", raw lines de formato desconhecido)
- `cargo test formatters` — 79 passed (novos: label daily, hint replenish, fallback raw nos layouts Inline/Generic)
- `cargo test --test golden` — 78 passed · `waybar_contract` — 19 passed
- `cargo clippy --all-targets -- -D warnings` — limpo
- Perceptual: tooltip renderizado com dados reais, ETA apontando 21:00 local
- Empírico: monitor observou o reset 90%→100% na virada UTC

Risco não-verificado: formato real do `usage` de conta com assinatura (sem acesso a uma) — coberto pelo fallback de linhas cruas.