### PR TITLE
fix: falso disconnected com usuário logado

### DIFF
--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -56,6 +56,7 @@ agent-bar --watch --interval 30            # custom poll floor
 | `models` | map of `Window` | Optional per-model/bucket windows. |
 | `extra` | object | **Unstable** — see below. |
 | `error` | string | Present only on failure (key omitted when OK — check `'error' in p`). |
+| `staleReason` | string | Present only when the data was served from an expired cache after a transient fetch error (timeout, expired token). The quota fields are the last known good values; the string is the user-facing reason. Omitted for fresh data. |
 
 `Window`: `{ remaining: number, used?: number|null, resetsAt: string|null, windowMinutes?: number|null }`.
 `remaining`/`used` are percentages (0-100). `used` is only present when a provider

--- a/docs/superpowers/plans/2026-07-20-false-disconnected.md
+++ b/docs/superpowers/plans/2026-07-20-false-disconnected.md
@@ -1,0 +1,746 @@
+# Falso "disconnected" — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Parar de mostrar "disconnected" na Waybar quando o usuário está logado — token expirado renovável e erro transitório não são logout.
+
+**Architecture:** Três frentes: (1) Grok considera logado quem tem `key` no auth.json (o provider é zero-rede e nem usa o token; o access token de 6h é renovado pelo Grok CLI via refresh_token); (2) infra de stale-cache — `cache::get_stale` ignora TTL, `ProviderQuota.stale_reason` marca dado servido de cache vencido, `ProviderError::is_transient()` classifica erros; `base_get_quota` e o fluxo inline do Claude servem stale em erro transitório em vez de erro; (3) timeout do `amp usage` vira `AmpError::Timeout` (transitório) em vez de `NotLoggedIn`. O tooltip ganha linha "⚠️ Cached data — {reason}"; o render do módulo fica normal (percentuais) porque quota stale tem `error=None` — `disconnected` sobra só para logout real ou erro sem cache algum.
+
+**Tech Stack:** Rust, tokio, serde, insta (snapshots), tempfile.
+
+## Global Constraints
+
+- Rust/cargo only; sem rede/CLIs vivas em teste; mocks via seams.
+- Nunca `unwrap()`/`expect()` em código de produção (testes podem).
+- Error strings são contrato — testes assertam verbatim (`src/providers/error.rs`).
+- stdout limpo (logs via `log::` → stderr).
+- Identificadores/UI em inglês; commits em PT, Conventional Commits, subject ≤50 chars.
+- `ClaudeProvider` implementa `Provider` direto (cache inline); Codex/Amp/Grok usam `base_get_quota`.
+- XML-escape só em `render_pango.rs` — builders nunca escapam.
+- Rodar `cargo fmt` antes de cada commit; clippy `-D warnings` no fim.
+- **Gotcha RTK:** hook reformata output do cargo; usar no máximo um filtro posicional por invocação de `cargo test`.
+
+---
+
+### Task 1: Grok — logado por presença de `key`, não por `expires_at`
+
+Contexto: `~/.grok/auth.json` tem access token de 6h renovado só quando o Grok CLI roda. `parse_auth_entries` hoje faz `logged_in = expires_at > now` → usuário logado (com refresh_token válido) aparece "Not logged in" na barra. O provider é zero-rede (lê só `sessions/**/signals.json`) — a expiração é irrelevante.
+
+**Files:**
+- Modify: `src/providers/grok.rs` (fn `parse_auth_entries`, ~linhas 83-130; testes `parse_auth_expired` ~529, `not_logged_in_expired` ~627)
+
+**Interfaces:**
+- Produces: `parse_auth_entries(bytes, _now) -> Result<AuthView, GrokError>` — `logged_in = true` sse existe entry com `key` não vazio. Assinatura inalterada (param `now` vira `_now`).
+
+- [ ] **Step 1: Ajustar testes existentes para a nova semântica (failing)**
+
+Em `src/providers/grok.rs`, trocar os dois testes:
+
+```rust
+#[test]
+fn parse_auth_expired_token_still_logged_in() {
+    let now = datetime!(2026-07-17 12:00:00 UTC);
+    let view = parse_auth_entries(&fixture_bytes("auth-expired.json"), now).unwrap();
+    // Access token vencido ≠ logout: o Grok CLI renova via refresh_token.
+    assert!(view.logged_in);
+    assert_eq!(view.account.as_deref(), Some("Test User"));
+}
+
+#[test]
+fn parse_auth_empty_key_not_logged_in() {
+    let now = datetime!(2026-07-17 12:00:00 UTC);
+    let json = br#"{"https://auth.x.ai::c": {"key": "", "first_name": "X"}}"#;
+    let view = parse_auth_entries(json, now).unwrap();
+    assert!(!view.logged_in);
+    assert!(view.account.is_none());
+}
+```
+
+E substituir o teste `not_logged_in_expired` (~linha 627) por:
+
+```rust
+#[tokio::test]
+async fn expired_access_token_still_serves_quota() {
+    let dir = tempdir().unwrap();
+    write_auth(dir.path(), "auth-expired.json");
+    write_signals(
+        dir.path(),
+        "proj/sid/signals.json",
+        &fixture_str("signals-recent.json"),
+    );
+    let s = settings();
+    let client = reqwest::Client::new();
+    let ctx = ctx_for(dir.path(), &s, &client, 1_720_000_000_000);
+    let q = GrokProvider.get_quota(&ctx).await;
+    assert!(q.available, "err={:?}", q.error);
+    assert_eq!(q.account.as_deref(), Some("Test User"));
+    assert_eq!(q.primary.as_ref().unwrap().remaining, 90.0);
+}
+```
+
+- [ ] **Step 2: Rodar e ver falhar**
+
+Run: `cargo test providers::grok`
+Expected: FAIL em `parse_auth_expired_token_still_logged_in` e `expired_access_token_still_serves_quota` (logged_in=false hoje).
+
+- [ ] **Step 3: Implementar**
+
+Substituir o corpo de `parse_auth_entries` (o doc-comment também):
+
+```rust
+/// Parse de `auth.json`. JSON inválido → `InvalidCredentials`.
+/// Logado = existe entry com `key` não vazio. `expires_at` NÃO desloga:
+/// o access token (6h) é renovado pelo Grok CLI via refresh_token, e este
+/// provider é zero-rede — nem usa o token, só lê signals.json.
+pub(crate) fn parse_auth_entries(
+    bytes: &[u8],
+    _now: OffsetDateTime,
+) -> Result<AuthView, GrokError> {
+    let map: HashMap<String, AuthEntry> =
+        serde_json::from_slice(bytes).map_err(|_| GrokError::InvalidCredentials)?;
+
+    // Entre entries com key não vazio, preferir a de expires_at mais distante
+    // (desempate estável quando o CLI mantém múltiplas entradas).
+    let mut best: Option<(OffsetDateTime, AuthEntry)> = None;
+    for (_k, entry) in map {
+        let key = entry.key.as_deref().unwrap_or("").trim();
+        if key.is_empty() {
+            continue;
+        }
+        let exp = entry
+            .expires_at
+            .as_deref()
+            .and_then(parse_expires_at)
+            .unwrap_or(OffsetDateTime::UNIX_EPOCH);
+        match &best {
+            Some((prev_exp, _)) if exp <= *prev_exp => {}
+            _ => best = Some((exp, entry)),
+        }
+    }
+
+    let Some((_exp, entry)) = best else {
+        return Ok(AuthView {
+            account: None,
+            logged_in: false,
+        });
+    };
+
+    Ok(AuthView {
+        account: Some(account_label(&entry)),
+        logged_in: true,
+    })
+}
+```
+
+Nota: a flag `any_with_key` some (o `best` já cobre); o caminho `logged_in=false` em `build_quota` (grok.rs:374) continua existindo para key vazio/ausente — não tocar.
+
+- [ ] **Step 4: Rodar e ver passar**
+
+Run: `cargo test providers::grok`
+Expected: PASS (todos).
+
+- [ ] **Step 5: fmt + commit**
+
+```bash
+cargo fmt
+git add src/providers/grok.rs
+git commit -m "fix: grok logado por key, não por expires_at"
+```
+
+---
+
+### Task 2: Infra stale — `cache::get_stale`, `stale_reason`, `is_transient`
+
+**Files:**
+- Modify: `src/cache.rs` (nova fn `get_stale` + teste)
+- Modify: `src/providers/types.rs` (`ProviderQuota.stale_reason` + teste)
+- Modify: `src/providers/error.rs` (`ProviderError::is_transient` + variante `AmpError::Timeout` + testes verbatim)
+- Modify: `src/providers/base.rs` (`quota_base` ganha o campo)
+
+**Interfaces:**
+- Produces: `cache::get_stale<T: DeserializeOwned>(cache_dir: &Path, key: &str) -> Option<T>` — lê ignorando TTL.
+- Produces: `ProviderQuota.stale_reason: Option<String>` — `#[serde(skip_serializing_if = "Option::is_none")]`, camelCase `staleReason`.
+- Produces: `ProviderError::is_transient(&self) -> bool`.
+- Produces: `AmpError::Timeout` com string verbatim `"Request timeout"`.
+
+- [ ] **Step 1: Testes failing**
+
+Em `src/cache.rs` (mod tests):
+
+```rust
+#[test]
+fn get_stale_ignores_expiry() {
+    let dir = tempdir().unwrap();
+    set(dir.path(), "k", &"v".to_string(), 5_000, 1_000).unwrap();
+    // now (10_000) > expires_at (6_000): get normal → None, stale → Some
+    let fresh: Option<String> = get(dir.path(), "k", 10_000);
+    assert_eq!(fresh, None);
+    let stale: Option<String> = get_stale(dir.path(), "k");
+    assert_eq!(stale, Some("v".to_string()));
+}
+
+#[test]
+fn get_stale_none_on_missing_or_corrupt() {
+    let dir = tempdir().unwrap();
+    let missing: Option<String> = get_stale(dir.path(), "nope");
+    assert_eq!(missing, None);
+    std::fs::write(dir.path().join("bad.json"), b"{ not json").unwrap();
+    let corrupt: Option<String> = get_stale(dir.path(), "bad");
+    assert_eq!(corrupt, None);
+}
+```
+
+Em `src/providers/types.rs` (mod tests):
+
+```rust
+#[test]
+fn stale_reason_omitted_when_none_present_when_some() {
+    let mut q = ProviderQuota {
+        provider: "amp".into(),
+        display_name: "Amp".into(),
+        available: true,
+        account: None,
+        plan: None,
+        plan_type: None,
+        primary: None,
+        secondary: None,
+        models: None,
+        extra: None,
+        error: None,
+        stale_reason: None,
+    };
+    let j = serde_json::to_value(&q).unwrap();
+    assert!(j.get("staleReason").is_none());
+    q.stale_reason = Some("Request timeout".into());
+    let j = serde_json::to_value(&q).unwrap();
+    assert_eq!(j["staleReason"], "Request timeout");
+}
+```
+
+Em `src/providers/error.rs` (mod tests):
+
+```rust
+#[test]
+fn amp_timeout_string_verbatim() {
+    assert_eq!(AmpError::Timeout.to_string(), "Request timeout");
+}
+
+#[test]
+fn transient_classification() {
+    assert!(ProviderError::from(ClaudeError::Timeout).is_transient());
+    assert!(ProviderError::from(ClaudeError::Api(500)).is_transient());
+    assert!(ProviderError::from(ClaudeError::Generic).is_transient());
+    assert!(!ProviderError::from(ClaudeError::NotLoggedIn).is_transient());
+    assert!(!ProviderError::from(ClaudeError::TokenExpired).is_transient());
+    assert!(ProviderError::from(AmpError::Timeout).is_transient());
+    assert!(ProviderError::from(AmpError::Generic).is_transient());
+    assert!(ProviderError::from(AmpError::ParseFailed).is_transient());
+    assert!(!ProviderError::from(AmpError::NotLoggedIn).is_transient());
+    assert!(!ProviderError::from(AmpError::NotInstalled).is_transient());
+    assert!(ProviderError::from(CodexError::Generic).is_transient());
+    assert!(!ProviderError::from(CodexError::NotLoggedIn).is_transient());
+    assert!(!ProviderError::from(CodexError::NoRateLimitData).is_transient());
+    assert!(!ProviderError::from(GrokError::NotLoggedIn).is_transient());
+}
+```
+
+- [ ] **Step 2: Rodar e ver falhar (erro de compilação = fail esperado)**
+
+Run: `cargo test cache`
+Expected: FAIL — `get_stale` não existe; depois `cargo test settings` nem rodará até o structs compilar.
+
+- [ ] **Step 3: Implementar**
+
+`src/cache.rs` — após `get`:
+
+```rust
+/// Lê o cache IGNORANDO o TTL (`None` só em miss/corrompido/key inválida).
+/// Para fallback em erro transitório: dado velho identificado no tooltip
+/// é mais honesto que ícone de desconectado quando o usuário está logado.
+pub fn get_stale<T: DeserializeOwned>(cache_dir: &Path, key: &str) -> Option<T> {
+    let path = cache_path(cache_dir, key).ok()?;
+    let bytes = std::fs::read(&path).ok()?;
+    let entry: CacheEntryOwned<T> = serde_json::from_slice(&bytes).ok()?;
+    Some(entry.data)
+}
+```
+
+`src/providers/types.rs` — em `ProviderQuota`, após `error`:
+
+```rust
+    /// Motivo de dado stale: erro transitório respondido com cache vencido.
+    /// `None` = dado fresco (ou erro real em `error`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stale_reason: Option<String>,
+```
+
+`src/providers/error.rs` — variante em `AmpError` (antes de `ParseFailed`):
+
+```rust
+    #[error("Request timeout")]
+    Timeout,
+```
+
+e o impl no fim do bloco de enums (antes de `#[cfg(test)]`):
+
+```rust
+impl ProviderError {
+    /// Transitório = falha de infra (rede/CLI/parse) que não significa
+    /// logout; o caller pode servir cache stale. Credencial/logout → false.
+    pub fn is_transient(&self) -> bool {
+        match self {
+            ProviderError::Claude(e) => matches!(
+                e,
+                ClaudeError::Timeout | ClaudeError::Api(_) | ClaudeError::Generic
+            ),
+            ProviderError::Codex(e) => matches!(e, CodexError::Generic),
+            ProviderError::Amp(e) => matches!(
+                e,
+                AmpError::Timeout | AmpError::Generic | AmpError::ParseFailed
+            ),
+            ProviderError::Grok(_) => false,
+        }
+    }
+}
+```
+
+`src/providers/base.rs` — `quota_base` ganha `stale_reason: None`. Depois, deixar o compilador guiar: `cargo build` aponta todo struct literal completo de `ProviderQuota` (produção e testes, ex.: `shared.rs` tests, `types.rs` tests, `formatters/*` tests) — adicionar `stale_reason: None` em cada um. NÃO tocar em construções via `..base`/`..q`.
+
+- [ ] **Step 4: Rodar e ver passar**
+
+Run: `cargo test cache` — Expected: PASS.
+Run: `cargo test providers` — Expected: PASS (compila tudo; erros verbatim ok).
+
+- [ ] **Step 5: fmt + commit**
+
+```bash
+cargo fmt
+git add -A src/
+git commit -m "feat: cache stale + stale_reason na quota"
+```
+
+---
+
+### Task 3: `base_get_quota` — fallback stale em erro transitório
+
+**Files:**
+- Modify: `src/providers/base.rs` (match final de `base_get_quota`, linhas 87-99; testes)
+
+**Interfaces:**
+- Consumes: `cache::get_stale`, `ProviderError::is_transient`, `ProviderQuota.stale_reason` (Task 2).
+- Produces: contrato — erro transitório + cache (mesmo vencido) presente ⇒ quota construída normal com `stale_reason = Some(user_facing_error)`; sem cache ⇒ comportamento atual (quota de erro).
+
+- [ ] **Step 1: Teste failing**
+
+No mod tests de `base.rs` (o `Fake` com `fail: true` retorna `AmpError::ParseFailed`, que é transitório):
+
+```rust
+#[tokio::test]
+async fn transient_error_with_stale_cache_serves_stale() {
+    let dir = tempdir().unwrap();
+    let calls = Cell::new(0);
+    let settings = crate::providers::test_support::settings();
+    let client = reqwest::Client::new();
+    let f = Fake {
+        available: true,
+        fail: true,
+        calls: &calls,
+    };
+    // Cache vencido: escrito em t=0 com ttl=1ms; ctx roda em t=1_000.
+    crate::cache::set(dir.path(), "fake-key", &"OLD".to_string(), 1, 0).unwrap();
+    let ctx = ctx_for(dir.path(), &settings, &client, 1_000);
+    let q = base_get_quota(&f, &ctx).await;
+    assert!(q.available, "stale deve construir quota normal");
+    assert_eq!(q.account.as_deref(), Some("OLD"));
+    assert_eq!(q.error, None);
+    assert_eq!(q.stale_reason.as_deref(), Some("Failed to parse usage"));
+}
+```
+
+Atenção: `ctx_for(dir.path(), ...)` precisa apontar `cache_dir` para `dir.path()` — conferir em `src/providers/test_support.rs` como `cache_dir` é derivado do home de teste e escrever o cache::set no path certo (se `cache_dir = home.join(...)`, usar esse join no teste).
+
+- [ ] **Step 2: Rodar e ver falhar**
+
+Run: `cargo test providers::base`
+Expected: FAIL — hoje retorna quota de erro (`available=false`).
+
+- [ ] **Step 3: Implementar**
+
+Substituir o braço `Err(e)` de `base_get_quota`:
+
+```rust
+        Err(e) => {
+            log::error!(
+                "Provider quota fetch error: provider={} error={e}",
+                source.id()
+            );
+            // Erro transitório não é logout: servir cache mesmo vencido,
+            // marcado como stale, em vez de derrubar pra "disconnected".
+            if e.is_transient() {
+                if let Some(raw) =
+                    cache::get_stale::<S::Raw>(&ctx.paths.cache_dir, source.cache_key())
+                {
+                    let mut q = source.build_quota(raw, base.clone(), ctx);
+                    q.stale_reason = Some(source.to_user_facing_error(&e));
+                    return q;
+                }
+            }
+            ProviderQuota {
+                error: Some(source.to_user_facing_error(&e)),
+                ..base
+            }
+        }
+```
+
+(`base` passa a precisar de `.clone()` — `ProviderQuota` já deriva `Clone`.)
+
+- [ ] **Step 4: Rodar e ver passar**
+
+Run: `cargo test providers::base`
+Expected: PASS (incluindo `error_is_not_cached_and_maps_message`, que não tem cache seedado e segue no caminho de erro).
+
+- [ ] **Step 5: fmt + commit**
+
+```bash
+cargo fmt
+git add src/providers/base.rs
+git commit -m "feat: fallback stale em erro transitório"
+```
+
+---
+
+### Task 4: Claude — token expirado/timeout servem cache stale
+
+Contexto: `claude.rs` tem fluxo inline (não usa `base_get_quota`). Hoje `expiresAt <= now` → short-circuit `TokenExpired` → disconnected, mesmo com `refreshToken` no arquivo (Claude Code renova sozinho na próxima execução) e mesmo com cache utilizável no disco.
+
+**Files:**
+- Modify: `src/providers/claude.rs` (get_quota, linhas ~348-398 + extração do bloco usage→quota ~400-520; testes)
+
+**Interfaces:**
+- Consumes: `cache::get`, `cache::get_stale` (Task 2).
+- Produces: `fn quota_from_usage(usage: <tipo do fetch>, plan: String, base: ProviderQuota, stale_reason: Option<String>) -> ProviderQuota` — função privada do módulo; contém TODO o bloco atual pós-fetch (do check `usage.error == token_expired` até o `ProviderQuota` final, movido verbatim), com o literal final recebendo `stale_reason`.
+
+- [ ] **Step 1: Testes failing**
+
+Seguir o padrão dos testes existentes do módulo (ver `missing_credentials_yields_not_logged_in` e o helper que escreve `.credentials.json` com `expiresAt`). Adicionar:
+
+```rust
+#[tokio::test]
+async fn token_expired_with_stale_cache_serves_stale() {
+    // credentials com expiresAt no passado + cache claude-usage vencido no disco
+    // → quota disponível, stale_reason = TokenExpired, error = None.
+    // Montagem: escrever credentials como nos testes vizinhos (expiresAt: 5000,
+    // now_ms do ctx > 5000); escrever cache com cache::set(cache_dir,
+    // "claude-usage", &usage_json_fixture, ttl_ms=1, now_ms=0).
+    // Asserts:
+    //   assert!(q.available);
+    //   assert_eq!(q.error, None);
+    //   assert_eq!(
+    //       q.stale_reason.as_deref(),
+    //       Some("Token expired. Open `agent-bar menu` and choose Provider login.")
+    //   );
+    //   assert!(q.primary.is_some());
+}
+
+#[tokio::test]
+async fn token_expired_without_cache_keeps_error() {
+    // credentials expiradas, sem cache → comportamento atual:
+    //   q.error == Some(TokenExpired verbatim), available=false.
+}
+```
+
+O corpo exato segue os helpers do módulo (fixture de usage: reutilizar o JSON dos testes de sucesso existentes do claude.rs — há fixture/`json!` com `five_hour`/`limits`). O tipo cacheado é o mesmo `T` que `get_or_fetch` já roundtripa hoje (o retorno de `fetch_usage`).
+
+- [ ] **Step 2: Rodar e ver falhar**
+
+Run: `cargo test providers::claude`
+Expected: FAIL no primeiro teste novo (hoje retorna erro TokenExpired direto).
+
+- [ ] **Step 3: Extrair `quota_from_usage` e implementar fallback**
+
+1. Extrair de `get_quota` o bloco inteiro que começa em `// Check pós-cache: body 200 pode trazer token_expired.` (linha ~400) até o `ProviderQuota` final da função, para:
+
+```rust
+fn quota_from_usage(
+    usage: ClaudeUsageResponse,
+    plan: String,
+    base: ProviderQuota,
+    stale_reason: Option<String>,
+) -> ProviderQuota {
+    // [bloco movido verbatim: check token_expired no body, limits/legado,
+    //  extra_usage, models/extra…]
+    // No literal final, acrescentar:
+    //     stale_reason,
+    // (as saídas de erro internas — ex. token_expired no body — mantêm
+    //  `..base`, que já tem stale_reason: None do quota_base)
+}
+```
+
+(Se o nome do tipo de usage for outro, usar o tipo real do retorno de `fetch_usage`.)
+
+2. No caminho de sucesso atual, substituir o bloco movido por:
+
+```rust
+        quota_from_usage(usage, plan, base, None)
+```
+
+3. Substituir o short-circuit de token expirado (linhas ~348-357) por:
+
+```rust
+        // Token expirado: sem rede (o refresh é do Claude Code, não nosso).
+        // Cache válido → serve normal; cache vencido → serve como stale;
+        // sem cache → erro (disconnected honesto).
+        if let Some(exp) = oauth.as_ref().and_then(|o| o.expires_at) {
+            if exp <= ctx.now_ms as f64 {
+                if let Some(usage) = cache::get::<ClaudeUsageResponse>(
+                    &ctx.paths.cache_dir,
+                    self.cache_key(),
+                    ctx.now_ms,
+                ) {
+                    return quota_from_usage(usage, plan, base, None);
+                }
+                if let Some(usage) = cache::get_stale::<ClaudeUsageResponse>(
+                    &ctx.paths.cache_dir,
+                    self.cache_key(),
+                ) {
+                    return quota_from_usage(
+                        usage,
+                        plan,
+                        base,
+                        Some(ClaudeError::TokenExpired.to_string()),
+                    );
+                }
+                return ProviderQuota {
+                    plan: Some(plan),
+                    error: Some(ClaudeError::TokenExpired.to_string()),
+                    ..base
+                };
+            }
+        }
+```
+
+4. Nos braços de erro do fetch (`Timeout`, `Api`, `Generic`, linhas ~374-397), antes de retornar o erro, tentar stale:
+
+```rust
+            Err(e) => {
+                log::warn!("Claude API error: {e}");
+                if let Some(usage) = cache::get_stale::<ClaudeUsageResponse>(
+                    &ctx.paths.cache_dir,
+                    self.cache_key(),
+                ) {
+                    return quota_from_usage(usage, plan, base, Some(e.to_string()));
+                }
+                return ProviderQuota {
+                    plan: Some(plan),
+                    error: Some(e.to_string()),
+                    ..base
+                };
+            }
+```
+
+Consolidar os três braços num só como acima SÓ se as mensagens resultantes ficarem idênticas às atuais (`ClaudeError::Timeout/Api/Generic` têm `Display` próprio; o braço atual de `Generic` loga com `log::error!` e converte `e` → manter os níveis de log atuais por braço se divergirem).
+
+- [ ] **Step 4: Rodar e ver passar**
+
+Run: `cargo test providers::claude`
+Expected: PASS (novos + existentes — nenhuma string de erro mudou).
+
+- [ ] **Step 5: fmt + commit**
+
+```bash
+cargo fmt
+git add src/providers/claude.rs
+git commit -m "feat: claude serve cache stale sem rede"
+```
+
+---
+
+### Task 5: Amp — timeout não é logout
+
+**Files:**
+- Modify: `src/providers/amp.rs` (linha ~199 + comentário; `to_user_facing_error` ~249; testes do módulo)
+- Modify: `src/action_right.rs` (teste novo)
+
+**Interfaces:**
+- Consumes: `AmpError::Timeout` (Task 2).
+- Produces: timeout do `amp usage` → `AmpError::Timeout` (transitório ⇒ Task 3 serve stale automaticamente).
+
+- [ ] **Step 1: Testes failing**
+
+Em `src/action_right.rs` (mod tests, junto dos vizinhos):
+
+```rust
+#[test]
+fn request_timeout_is_not_disconnected_for_amp() {
+    assert!(!looks_disconnected("amp", Some("Request timeout")));
+}
+```
+
+Em `src/providers/amp.rs`: localizar o teste que cobre timeout→NotLoggedIn (rg por `NotLoggedIn` no mod tests) e atualizar a expectativa para `"Request timeout"`. Se não existir teste direto de timeout (o seam pode não simular timeout), garantir pelo menos o mapeamento:
+
+```rust
+#[test]
+fn timeout_maps_to_own_message() {
+    let e: ProviderError = AmpError::Timeout.into();
+    assert_eq!(AmpProvider.to_user_facing_error(&e), "Request timeout");
+}
+```
+
+- [ ] **Step 2: Rodar e ver falhar**
+
+Run: `cargo test providers::amp`
+Expected: FAIL (mapeamento ainda cai no braço default/NotLoggedIn).
+
+- [ ] **Step 3: Implementar**
+
+Em `amp.rs` linha ~198-199, trocar:
+
+```rust
+        // timeout: CLI viva demais não é logout — erro transitório; a base
+        // serve cache stale. (Divergência consciente do TS, que deslogava.)
+        Err(_) => return Err(AmpError::Timeout.into()),
+```
+
+Em `to_user_facing_error` (~249), garantir que `AmpError::Timeout` passa a própria mensagem (`e.to_string()` no braço `ProviderError::Amp(e)`), preservando as strings atuais dos demais casos.
+
+- [ ] **Step 4: Rodar e ver passar**
+
+Run: `cargo test providers::amp`
+Expected: PASS.
+Run: `cargo test action_right`
+Expected: PASS.
+
+- [ ] **Step 5: fmt + commit**
+
+```bash
+cargo fmt
+git add src/providers/amp.rs src/action_right.rs
+git commit -m "fix: timeout do amp não é logout"
+```
+
+---
+
+### Task 6: Tooltip — aviso "Cached data" para quota stale
+
+Contexto: quota stale tem `available=true, error=None` ⇒ o módulo Waybar já renderiza percentuais normais (nenhuma mudança de classe CSS). Falta o aviso no tooltip para o dado velho ser identificável.
+
+**Files:**
+- Modify: `src/formatters/builders/shared.rs` (nova `stale_line`)
+- Modify: `src/formatters/builders/{generic,claude,codex,amp,grok}.rs` (chamada após o header)
+- Test: teste unitário em `generic.rs` + teste de integração em `src/formatters/waybar.rs`
+
+**Interfaces:**
+- Consumes: `ProviderQuota.stale_reason` (Task 2).
+- Produces: `pub fn stale_line(p: &ProviderQuota) -> Option<Line>` em `builders/shared.rs`; linha `⚠️ Cached data — {reason}` em `ColorToken::Yellow` logo após o header de cada builder.
+
+- [ ] **Step 1: Testes failing**
+
+Em `src/formatters/builders/generic.rs` (mod tests, seguindo o padrão de `error_branch_replaces_primary`):
+
+```rust
+#[test]
+fn stale_reason_adds_warning_line() {
+    let mut q = quota();
+    q.stale_reason = Some("Request timeout".into());
+    let lines = build_generic(&clk(), &q, &opts());
+    // header + stale + primary + footer
+    assert_eq!(lines.len(), 4);
+    let rendered = render_pango(&lines);
+    assert!(rendered.contains("Cached data — Request timeout"));
+}
+```
+
+Em `src/formatters/waybar.rs` (mod tests, seguindo `per_provider_disconnected`):
+
+```rust
+#[test]
+fn per_provider_stale_renders_normal_with_warning() {
+    let mut q = quota_ok(); // usar o helper existente dos testes vizinhos
+    q.stale_reason = Some("Request timeout".into());
+    let out = format_provider_for_waybar(&clk(), &q, &settings(), DisplayMode::Remaining);
+    assert!(!out.class.contains("disconnected"));
+    assert!(out.tooltip.contains("Cached data — Request timeout"));
+}
+```
+
+(Adaptar nomes de helpers `quota_ok`/`clk`/`settings` aos que o mod tests de waybar.rs realmente tem.)
+
+- [ ] **Step 2: Rodar e ver falhar**
+
+Run: `cargo test formatters`
+Expected: FAIL nos dois novos.
+
+- [ ] **Step 3: Implementar**
+
+Em `src/formatters/builders/shared.rs`:
+
+```rust
+/// Linha de aviso quando a quota veio de cache vencido (erro transitório).
+/// Builders nunca escapam — o escape é do render_pango.
+pub fn stale_line(p: &ProviderQuota) -> Option<Line> {
+    let reason = p.stale_reason.as_deref()?;
+    Some(vec![
+        Segment::new(box_chars::V, ColorToken::Text),
+        Segment::raw_text("  "),
+        Segment::new(format!("⚠️ Cached data — {reason}"), ColorToken::Yellow),
+    ])
+}
+```
+
+(Ajustar imports do arquivo: `Line`, `Segment`, `box_chars`, `ColorToken`, `ProviderQuota` — mesmos usados em `generic.rs`.)
+
+Em cada builder (`generic.rs`, `claude.rs`, `codex.rs`, `amp.rs`, `grok.rs`), logo após o push do `header_line(...)`:
+
+```rust
+    if let Some(l) = stale_line(p) {
+        lines.push(l);
+    }
+```
+
+(Em builders cujo parâmetro não se chama `p`, usar o nome local. Import de `stale_line` junto dos demais de `super::shared`.)
+
+- [ ] **Step 4: Rodar e ver passar + snapshots**
+
+Run: `cargo test formatters`
+Expected: PASS. Snapshots insta existentes NÃO devem mudar (stale_reason=None em todos os fixtures atuais) — se algum snapshot mudar, é regressão: investigar, não aceitar.
+
+Run: `cargo test --test golden`
+Expected: PASS sem mudanças.
+
+- [ ] **Step 5: fmt + commit**
+
+```bash
+cargo fmt
+git add src/formatters/
+git commit -m "feat: aviso de dado em cache no tooltip"
+```
+
+---
+
+### Task 7: Gate final
+
+- [ ] **Step 1: Suíte completa + clippy**
+
+Run: `cargo test`
+Expected: PASS.
+Run: `cargo clippy --all-targets -- -D warnings`
+Expected: sem warnings.
+
+- [ ] **Step 2: Smoke real (read-only)**
+
+Run: `cargo run -- --provider grok` (stdout JSON)
+Expected: com o auth.json real do usuário (access token vencido de 19/07, key presente), `"class":"agent-bar-grok ..."` SEM `disconnected`, tooltip com dados de sessão.
+
+- [ ] **Step 3: Commit final se houver sobras (fmt/docs)**
+
+```bash
+git status
+```
+
+Somente arquivos do plano; nada de commit espontâneo além dos previstos.
+
+## Limitações aceitas (documentar no PR)
+
+- Erro transitório SEM nenhum cache no disco continua renderizando `disconnected` (primeira execução offline). Estado neutro novo exigiria mudança no contrato CSS do Waybar — fora de escopo.
+- `CodexError::NoRateLimitData` segue não-transitório: no Codex esse erro costuma significar auth quebrada (o `action_right` o trata como desconexão); reclassificar exigiria evidência de falso positivo.
+- O check de `token_expired` no body 200 do Claude (dentro de `quota_from_usage`) mantém o comportamento atual (erro), pois o dado que chegou junto não é confiável.

--- a/src/action_right.rs
+++ b/src/action_right.rs
@@ -149,6 +149,11 @@ mod tests {
     }
 
     #[test]
+    fn request_timeout_is_not_disconnected_for_amp() {
+        assert!(!looks_disconnected("amp", Some("Request timeout")));
+    }
+
+    #[test]
     fn none_error_is_not_disconnected() {
         assert!(!looks_disconnected("claude", None));
     }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -80,6 +80,16 @@ pub fn set<T: Serialize>(
     Ok(())
 }
 
+/// Lê o cache IGNORANDO o TTL (`None` só em miss/corrompido/key inválida).
+/// Para fallback em erro transitório: dado velho identificado no tooltip
+/// é mais honesto que ícone de desconectado quando o usuário está logado.
+pub fn get_stale<T: DeserializeOwned>(cache_dir: &Path, key: &str) -> Option<T> {
+    let path = cache_path(cache_dir, key).ok()?;
+    let bytes = std::fs::read(&path).ok()?;
+    let entry: CacheEntryOwned<T> = serde_json::from_slice(&bytes).ok()?;
+    Some(entry.data)
+}
+
 /// Remove a entrada (no-op se ausente ou key inválida).
 pub fn invalidate(cache_dir: &Path, key: &str) {
     if let Ok(path) = cache_path(cache_dir, key) {
@@ -140,5 +150,26 @@ mod tests {
         invalidate(dir.path(), "k");
         let got: Option<u32> = get(dir.path(), "k", 0);
         assert_eq!(got, None);
+    }
+
+    #[test]
+    fn get_stale_ignores_expiry() {
+        let dir = tempdir().unwrap();
+        set(dir.path(), "k", &"v".to_string(), 5_000, 1_000).unwrap();
+        // now (10_000) > expires_at (6_000): get normal → None, stale → Some
+        let fresh: Option<String> = get(dir.path(), "k", 10_000);
+        assert_eq!(fresh, None);
+        let stale: Option<String> = get_stale(dir.path(), "k");
+        assert_eq!(stale, Some("v".to_string()));
+    }
+
+    #[test]
+    fn get_stale_none_on_missing_or_corrupt() {
+        let dir = tempdir().unwrap();
+        let missing: Option<String> = get_stale(dir.path(), "nope");
+        assert_eq!(missing, None);
+        std::fs::write(dir.path().join("bad.json"), b"{ not json").unwrap();
+        let corrupt: Option<String> = get_stale(dir.path(), "bad");
+        assert_eq!(corrupt, None);
     }
 }

--- a/src/formatters/builders/amp.rs
+++ b/src/formatters/builders/amp.rs
@@ -15,7 +15,9 @@ use crate::providers::types::ProviderQuota;
 use crate::settings::DisplayMode;
 use crate::theme::{box_chars, ColorToken};
 
-use super::shared::{build_footer_line, header_line, label_line, vline, AmpLayout, BuildOptions};
+use super::shared::{
+    build_footer_line, header_line, label_line, stale_line, vline, AmpLayout, BuildOptions,
+};
 
 /// Valor de meta com semântica truthy do JS: Some só se presente E não-vazio.
 fn meta_get<'a>(m: &'a BTreeMap<String, String>, k: &str) -> Option<&'a str> {
@@ -95,6 +97,11 @@ pub fn build_amp(clock: &Clock, p: &ProviderQuota, options: &BuildOptions) -> Ve
         options.header_width,
         ColorToken::Magenta,
     ));
+
+    if let Some(l) = stale_line(p) {
+        lines.push(l);
+    }
+
     lines.push(vline(ColorToken::Magenta));
 
     if let Some(err) = p.error.as_deref() {

--- a/src/formatters/builders/amp.rs
+++ b/src/formatters/builders/amp.rs
@@ -421,6 +421,7 @@ mod tests {
             models: Some(models),
             extra: Some(ProviderExtra::Amp(AmpQuotaExtra { meta: Some(meta) })),
             error: None,
+            stale_reason: None,
         }
     }
 
@@ -516,6 +517,7 @@ mod tests {
             models: Some(IndexMap::new()),
             extra: Some(ProviderExtra::Amp(AmpQuotaExtra { meta: Some(meta) })),
             error: None,
+            stale_reason: None,
         };
         for layout in [AmpLayout::Inline, AmpLayout::Generic] {
             let out = render_pango(&build_amp(&clk(), &q, &opts(layout)));

--- a/src/formatters/builders/amp.rs
+++ b/src/formatters/builders/amp.rs
@@ -22,6 +22,14 @@ fn meta_get<'a>(m: &'a BTreeMap<String, String>, k: &str) -> Option<&'a str> {
     m.get(k).map(|s| s.as_str()).filter(|s| !s.is_empty())
 }
 
+/// Linhas cruas `Label: valor` preservadas pelo parser quando o formato do
+/// servidor não é reconhecido (preparo p/ assinatura megawatt/gigawatt).
+fn raw_lines(m: &BTreeMap<String, String>) -> Vec<&str> {
+    (0..4)
+        .filter_map(|i| meta_get(m, &format!("raw{i}")))
+        .collect()
+}
+
 /// Junta freeRemaining/freeTotal (truthy) com " / ".
 fn dollars(m: &BTreeMap<String, String>) -> String {
     [meta_get(m, "freeRemaining"), meta_get(m, "freeTotal")]
@@ -98,11 +106,24 @@ pub fn build_amp(clock: &Clock, p: &ProviderQuota, options: &BuildOptions) -> Ve
     } else if layout == AmpLayout::Generic {
         // TUI: loop genérico, sem special-casing de Free Tier/Credits.
         match p.models.as_ref().filter(|mm| !mm.is_empty()) {
-            None => lines.push(vec![
-                Segment::new(box_chars::V, ColorToken::Magenta),
-                Segment::raw_text("  "),
-                Segment::new("No usage data", ColorToken::Muted),
-            ]),
+            None => {
+                let raws = raw_lines(m);
+                if raws.is_empty() {
+                    lines.push(vec![
+                        Segment::new(box_chars::V, ColorToken::Magenta),
+                        Segment::raw_text("  "),
+                        Segment::new("No usage data", ColorToken::Muted),
+                    ]);
+                } else {
+                    for raw in raws {
+                        lines.push(vec![
+                            Segment::new(box_chars::V, ColorToken::Magenta),
+                            Segment::raw_text("  "),
+                            Segment::new(raw.to_string(), ColorToken::Text),
+                        ]);
+                    }
+                }
+            }
             Some(models) => {
                 let max_len = models
                     .keys()
@@ -128,8 +149,13 @@ pub fn build_amp(clock: &Clock, p: &ProviderQuota, options: &BuildOptions) -> Ve
         if let Some(free) = free {
             let rem = free.remaining;
             let disp = to_display(Some(rem), mode);
+            let free_label = if meta_get(m, "freeCadence") == Some("daily") {
+                "Free Tier · daily"
+            } else {
+                "Free Tier"
+            };
             lines.push(label_line(
-                "Free Tier",
+                free_label,
                 options.label_color,
                 ColorToken::Magenta,
             ));
@@ -262,6 +288,10 @@ pub fn build_amp(clock: &Clock, p: &ProviderQuota, options: &BuildOptions) -> Ve
             line.extend(indicator_segments(credit_disp, mode));
             line.push(Segment::raw_text(" "));
             line.push(Segment::new(balance_text, credit_color));
+            if meta_get(m, "creditsReplenish").is_some() {
+                line.push(Segment::raw_text("  "));
+                line.push(Segment::new("↻ auto-replenish", ColorToken::Comment));
+            }
             lines.push(line);
         }
 
@@ -282,6 +312,24 @@ pub fn build_amp(clock: &Clock, p: &ProviderQuota, options: &BuildOptions) -> Ve
                 for (name, window) in models {
                     let disp = to_display(Some(window.remaining), mode);
                     lines.push(generic_model_line(name, max_len, disp, mode));
+                }
+            } else {
+                // Formato de servidor não reconhecido: mostra as linhas cruas
+                // em vez de um card vazio (ex.: assinatura nova do Amp).
+                let raws = raw_lines(m);
+                if !raws.is_empty() {
+                    lines.push(label_line(
+                        "Usage",
+                        options.label_color,
+                        ColorToken::Magenta,
+                    ));
+                    for raw in raws {
+                        lines.push(vec![
+                            Segment::new(box_chars::V, ColorToken::Magenta),
+                            Segment::raw_text("  "),
+                            Segment::new(raw.to_string(), ColorToken::Text),
+                        ]);
+                    }
                 }
             }
         }
@@ -422,6 +470,59 @@ mod tests {
         o.account_in_header = true;
         let out = render_pango(&build_amp(&clk(), &amp_with_free_and_credits(), &o));
         assert!(!out.contains("Account:"));
+    }
+
+    #[test]
+    fn daily_cadence_label_and_replenish_hint() {
+        let mut q = amp_with_free_and_credits();
+        if let Some(ProviderExtra::Amp(a)) = q.extra.as_mut() {
+            let m = a.meta.as_mut().unwrap();
+            m.insert("freeCadence".to_string(), "daily".to_string());
+            m.insert("creditsReplenish".to_string(), "auto".to_string());
+        }
+        let out = render_pango(&build_amp(&clk(), &q, &opts(AmpLayout::Inline)));
+        assert!(out.contains("Free Tier · daily"));
+        assert!(out.contains("↻ auto-replenish"));
+    }
+
+    #[test]
+    fn no_cadence_keeps_plain_labels() {
+        let out = render_pango(&build_amp(
+            &clk(),
+            &amp_with_free_and_credits(),
+            &opts(AmpLayout::Inline),
+        ));
+        assert!(!out.contains("Free Tier · daily"));
+        assert!(!out.contains("auto-replenish"));
+    }
+
+    #[test]
+    fn raw_lines_fallback_when_no_known_models() {
+        let mut meta = BTreeMap::new();
+        meta.insert(
+            "raw0".to_string(),
+            "Subscription (Gigawatt): $12.00 of $200.00 used".to_string(),
+        );
+        meta.insert("raw1".to_string(), "Orb usage: 3% used".to_string());
+        let q = ProviderQuota {
+            provider: "amp".into(),
+            display_name: "Amp".into(),
+            available: true,
+            account: Some("me@x.com".into()),
+            plan: None,
+            plan_type: None,
+            primary: None,
+            secondary: None,
+            models: Some(IndexMap::new()),
+            extra: Some(ProviderExtra::Amp(AmpQuotaExtra { meta: Some(meta) })),
+            error: None,
+        };
+        for layout in [AmpLayout::Inline, AmpLayout::Generic] {
+            let out = render_pango(&build_amp(&clk(), &q, &opts(layout)));
+            assert!(out.contains("Subscription (Gigawatt): $12.00 of $200.00 used"));
+            assert!(out.contains("Orb usage: 3% used"));
+            assert!(!out.contains("No usage data"));
+        }
     }
 
     #[test]

--- a/src/formatters/builders/amp.rs
+++ b/src/formatters/builders/amp.rs
@@ -98,7 +98,7 @@ pub fn build_amp(clock: &Clock, p: &ProviderQuota, options: &BuildOptions) -> Ve
         ColorToken::Magenta,
     ));
 
-    if let Some(l) = stale_line(p) {
+    if let Some(l) = stale_line(p, ColorToken::Magenta) {
         lines.push(l);
     }
 

--- a/src/formatters/builders/claude.rs
+++ b/src/formatters/builders/claude.rs
@@ -11,7 +11,9 @@ use crate::providers::types::ProviderQuota;
 use crate::settings::DisplayMode;
 use crate::theme::{box_chars, ColorToken};
 
-use super::shared::{build_footer_line, header_line, label_line, model_line, vline, BuildOptions};
+use super::shared::{
+    build_footer_line, header_line, label_line, model_line, stale_line, vline, BuildOptions,
+};
 
 /// Linha de Extra Usage: indicador + nome + barra + pct + texto `$used/$limit`.
 fn extra_usage_line(
@@ -52,6 +54,11 @@ pub fn build_claude(clock: &Clock, p: &ProviderQuota, options: &BuildOptions) ->
         options.header_width,
         ColorToken::Orange,
     ));
+
+    if let Some(l) = stale_line(p) {
+        lines.push(l);
+    }
+
     lines.push(vline(ColorToken::Orange));
 
     if let Some(err) = p.error.as_deref() {

--- a/src/formatters/builders/claude.rs
+++ b/src/formatters/builders/claude.rs
@@ -55,7 +55,7 @@ pub fn build_claude(clock: &Clock, p: &ProviderQuota, options: &BuildOptions) ->
         ColorToken::Orange,
     ));
 
-    if let Some(l) = stale_line(p) {
+    if let Some(l) = stale_line(p, ColorToken::Orange) {
         lines.push(l);
     }
 
@@ -253,6 +253,20 @@ mod tests {
         let out = render_pango(&build_claude(&clk(), &q, &opts()));
         assert!(out.contains("⚠️ token expired"));
         assert!(!out.contains("5-hour limit"));
+    }
+
+    #[test]
+    fn stale_reason_uses_brand_vline_color() {
+        let mut q = base();
+        q.stale_reason = Some("Request timeout".into());
+        let lines = build_claude(&clk(), &q, &opts());
+        // header + stale + ...
+        let stale = &lines[1];
+        assert_eq!(stale[0].text, "┃");
+        assert_eq!(stale[0].color, ColorToken::Orange); // brand color, não Text
+        assert_eq!(stale[2].color, ColorToken::Yellow);
+        let rendered = render_pango(&lines);
+        assert!(rendered.contains("Cached data — Request timeout"));
     }
 
     #[test]

--- a/src/formatters/builders/claude.rs
+++ b/src/formatters/builders/claude.rs
@@ -207,6 +207,7 @@ mod tests {
             models: None,
             extra: None,
             error: None,
+            stale_reason: None,
         }
     }
 

--- a/src/formatters/builders/codex.rs
+++ b/src/formatters/builders/codex.rs
@@ -31,7 +31,7 @@ pub fn build_codex(
         ColorToken::Green,
     ));
 
-    if let Some(l) = stale_line(p) {
+    if let Some(l) = stale_line(p, ColorToken::Green) {
         lines.push(l);
     }
 

--- a/src/formatters/builders/codex.rs
+++ b/src/formatters/builders/codex.rs
@@ -12,7 +12,9 @@ use crate::providers::types::ProviderQuota;
 use crate::settings::WindowPolicy;
 use crate::theme::{box_chars, ColorToken};
 
-use super::shared::{build_footer_line, header_line, label_line, model_line, vline, BuildOptions};
+use super::shared::{
+    build_footer_line, header_line, label_line, model_line, stale_line, vline, BuildOptions,
+};
 
 pub fn build_codex(
     clock: &Clock,
@@ -28,6 +30,11 @@ pub fn build_codex(
         options.header_width,
         ColorToken::Green,
     ));
+
+    if let Some(l) = stale_line(p) {
+        lines.push(l);
+    }
+
     lines.push(vline(ColorToken::Green));
 
     if let Some(err) = p.error.as_deref() {

--- a/src/formatters/builders/codex.rs
+++ b/src/formatters/builders/codex.rs
@@ -204,6 +204,7 @@ mod tests {
             models: None,
             extra: None,
             error: None,
+            stale_reason: None,
         }
     }
 

--- a/src/formatters/builders/generic.rs
+++ b/src/formatters/builders/generic.rs
@@ -103,6 +103,7 @@ mod tests {
             models: None,
             extra: None,
             error: None,
+            stale_reason: None,
         }
     }
 

--- a/src/formatters/builders/generic.rs
+++ b/src/formatters/builders/generic.rs
@@ -21,7 +21,7 @@ pub fn build_generic(clock: &Clock, p: &ProviderQuota, options: &BuildOptions) -
         ColorToken::Text,
     ));
 
-    if let Some(l) = stale_line(p) {
+    if let Some(l) = stale_line(p, ColorToken::Text) {
         lines.push(l);
     }
 
@@ -146,6 +146,10 @@ mod tests {
         let lines = build_generic(&clk(), &q, &opts());
         // header + stale + primary + footer
         assert_eq!(lines.len(), 4);
+        let stale = &lines[1];
+        assert_eq!(stale[0].text, "┃");
+        assert_eq!(stale[0].color, ColorToken::Text); // generic: mesma cor dos demais vline
+        assert_eq!(stale[2].color, ColorToken::Yellow);
         let rendered = render_pango(&lines);
         assert!(rendered.contains("Cached data — Request timeout"));
     }

--- a/src/formatters/builders/generic.rs
+++ b/src/formatters/builders/generic.rs
@@ -10,7 +10,7 @@ use crate::formatters::shared::{format_percent, to_display};
 use crate::providers::types::ProviderQuota;
 use crate::theme::{box_chars, ColorToken};
 
-use super::shared::{build_footer_line, header_line, BuildOptions};
+use super::shared::{build_footer_line, header_line, stale_line, BuildOptions};
 
 pub fn build_generic(clock: &Clock, p: &ProviderQuota, options: &BuildOptions) -> Vec<Line> {
     let mut lines: Vec<Line> = Vec::new();
@@ -20,6 +20,10 @@ pub fn build_generic(clock: &Clock, p: &ProviderQuota, options: &BuildOptions) -
         options.header_width,
         ColorToken::Text,
     ));
+
+    if let Some(l) = stale_line(p) {
+        lines.push(l);
+    }
 
     if let Some(err) = p.error.as_deref() {
         lines.push(vec![
@@ -133,5 +137,16 @@ mod tests {
         q.primary = None;
         let lines = build_generic(&clk(), &q, &opts());
         assert_eq!(lines.len(), 2); // header + footer
+    }
+
+    #[test]
+    fn stale_reason_adds_warning_line() {
+        let mut q = quota();
+        q.stale_reason = Some("Request timeout".into());
+        let lines = build_generic(&clk(), &q, &opts());
+        // header + stale + primary + footer
+        assert_eq!(lines.len(), 4);
+        let rendered = render_pango(&lines);
+        assert!(rendered.contains("Cached data — Request timeout"));
     }
 }

--- a/src/formatters/builders/grok.rs
+++ b/src/formatters/builders/grok.rs
@@ -182,6 +182,7 @@ mod tests {
                 recent_model: Some("grok-4.5".into()),
             })),
             error: None,
+            stale_reason: None,
         }
     }
 

--- a/src/formatters/builders/grok.rs
+++ b/src/formatters/builders/grok.rs
@@ -29,10 +29,7 @@ fn fmt_tokens_compact(n: u64) -> String {
 
 /// Linha da barra de contexto: `┃  ● contexto ████  87%`.
 fn contexto_bar_line(disp: Option<f64>, mode: crate::settings::DisplayMode) -> Line {
-    let mut line: Line = vec![
-        Segment::new(box_chars::V, BRAND),
-        Segment::raw_text("  "),
-    ];
+    let mut line: Line = vec![Segment::new(box_chars::V, BRAND), Segment::raw_text("  ")];
     line.extend(indicator_segments(disp, mode));
     line.push(Segment::raw_text(" "));
     line.push(Segment::new("contexto", ColorToken::TextBright));
@@ -191,7 +188,10 @@ mod tests {
     #[test]
     fn builder_mentions_context_not_plan_quota() {
         let out = render_pango(&build_grok(&clk(), &quota_with_primary(), &opts()));
-        assert!(out.contains("contexto"), "must name session context, got:\n{out}");
+        assert!(
+            out.contains("contexto"),
+            "must name session context, got:\n{out}"
+        );
         assert!(!out.to_lowercase().contains("plano"));
         assert!(!out.to_lowercase().contains("quota de plano"));
         assert!(out.contains("87%"));

--- a/src/formatters/builders/grok.rs
+++ b/src/formatters/builders/grok.rs
@@ -53,7 +53,7 @@ pub fn build_grok(clock: &Clock, p: &ProviderQuota, options: &BuildOptions) -> V
         BRAND,
     ));
 
-    if let Some(l) = stale_line(p) {
+    if let Some(l) = stale_line(p, BRAND) {
         lines.push(l);
     }
 

--- a/src/formatters/builders/grok.rs
+++ b/src/formatters/builders/grok.rs
@@ -10,7 +10,7 @@ use crate::providers::extras::get_grok_extra;
 use crate::providers::types::ProviderQuota;
 use crate::theme::{box_chars, ColorToken};
 
-use super::shared::{build_footer_line, header_line, vline, BuildOptions};
+use super::shared::{build_footer_line, header_line, stale_line, vline, BuildOptions};
 
 const BRAND: ColorToken = ColorToken::Cyan;
 
@@ -52,6 +52,11 @@ pub fn build_grok(clock: &Clock, p: &ProviderQuota, options: &BuildOptions) -> V
         options.header_width,
         BRAND,
     ));
+
+    if let Some(l) = stale_line(p) {
+        lines.push(l);
+    }
+
     lines.push(vline(BRAND));
 
     if let Some(err) = p.error.as_deref() {

--- a/src/formatters/builders/shared.rs
+++ b/src/formatters/builders/shared.rs
@@ -64,11 +64,12 @@ pub fn header_line(title: &str, header_width: usize, color: ColorToken) -> Line 
 }
 
 /// Linha de aviso quando a quota veio de cache vencido (erro transitório).
+/// `vline_color` deve casar com a cor usada pelos demais `┃` do builder chamador.
 /// Builders nunca escapam — o escape é do render_pango.
-pub fn stale_line(p: &ProviderQuota) -> Option<Line> {
+pub fn stale_line(p: &ProviderQuota, vline_color: ColorToken) -> Option<Line> {
     let reason = p.stale_reason.as_deref()?;
     Some(vec![
-        Segment::new(box_chars::V, ColorToken::Text),
+        Segment::new(box_chars::V, vline_color),
         Segment::raw_text("  "),
         Segment::new(format!("⚠️ Cached data — {reason}"), ColorToken::Yellow),
     ])

--- a/src/formatters/builders/shared.rs
+++ b/src/formatters/builders/shared.rs
@@ -8,7 +8,7 @@ use crate::formatters::segments::{
 use crate::formatters::shared::{
     format_ago, format_eta, format_percent, format_reset_time, to_window_display,
 };
-use crate::providers::types::QuotaWindow;
+use crate::providers::types::{ProviderQuota, QuotaWindow};
 use crate::settings::DisplayMode;
 use crate::theme::{box_chars, ColorToken};
 
@@ -61,6 +61,17 @@ pub fn header_line(title: &str, header_width: usize, color: ColorToken) -> Line 
         Segment::raw_text(" "),
         Segment::new(box_chars::H.repeat(fill), color),
     ]
+}
+
+/// Linha de aviso quando a quota veio de cache vencido (erro transitório).
+/// Builders nunca escapam — o escape é do render_pango.
+pub fn stale_line(p: &ProviderQuota) -> Option<Line> {
+    let reason = p.stale_reason.as_deref()?;
+    Some(vec![
+        Segment::new(box_chars::V, ColorToken::Text),
+        Segment::raw_text("  "),
+        Segment::new(format!("⚠️ Cached data — {reason}"), ColorToken::Yellow),
+    ])
 }
 
 /// `┗━…[ cached · {ago} ]…` sempre com 56 chars de largura total.

--- a/src/formatters/codex_helpers.rs
+++ b/src/formatters/codex_helpers.rs
@@ -131,6 +131,7 @@ mod tests {
             models: Some(models),
             extra: None,
             error: None,
+            stale_reason: None,
         }
     }
 

--- a/src/formatters/json.rs
+++ b/src/formatters/json.rs
@@ -52,6 +52,7 @@ mod tests {
                 models: None,
                 extra: None,
                 error: None,
+                stale_reason: None,
             }],
         }
     }

--- a/src/formatters/shared.rs
+++ b/src/formatters/shared.rs
@@ -159,6 +159,7 @@ mod helper_tests {
             models: None,
             extra: None,
             error: None,
+            stale_reason: None,
         };
         assert_eq!(normalize_plan_label(&q), "Pro");
         q.plan = None;

--- a/src/formatters/terminal.rs
+++ b/src/formatters/terminal.rs
@@ -196,6 +196,7 @@ mod tests {
             models: None,
             extra: None,
             error: None,
+            stale_reason: None,
         }
     }
 

--- a/src/formatters/view_model.rs
+++ b/src/formatters/view_model.rs
@@ -73,6 +73,7 @@ mod tests {
             models: Some(m),
             extra: None,
             error: None,
+            stale_reason: None,
         }
     }
 

--- a/src/formatters/waybar.rs
+++ b/src/formatters/waybar.rs
@@ -339,6 +339,7 @@ mod tests {
             models: None,
             extra: None,
             error: None,
+            stale_reason: None,
         }
     }
 

--- a/src/formatters/waybar.rs
+++ b/src/formatters/waybar.rs
@@ -377,6 +377,15 @@ mod tests {
     }
 
     #[test]
+    fn per_provider_stale_renders_normal_with_warning() {
+        let mut q = claude(75.0);
+        q.stale_reason = Some("Request timeout".into());
+        let out = format_provider_for_waybar(&clk(), &q, &settings(), DisplayMode::Remaining);
+        assert!(!out.class.contains("disconnected"));
+        assert!(out.tooltip.contains("Cached data — Request timeout"));
+    }
+
+    #[test]
     fn aggregate_empty_text() {
         let q = AllQuotas {
             providers: vec![],

--- a/src/formatters/waybar.rs
+++ b/src/formatters/waybar.rs
@@ -409,17 +409,18 @@ mod tests {
         assert!(!s.is_empty());
         let v: serde_json::Value = serde_json::from_str(&s).unwrap();
         assert_eq!(
-            v.get("text").and_then(|t| t.as_str()).map(|t| !t.is_empty()),
+            v.get("text")
+                .and_then(|t| t.as_str())
+                .map(|t| !t.is_empty()),
             Some(true)
         );
         assert_eq!(
             v.get("class").and_then(|c| c.as_str()),
             Some("agent-bar disconnected")
         );
-        assert!(
-            v.get("tooltip")
-                .and_then(|t| t.as_str())
-                .is_some_and(|t| t.contains("boom"))
-        );
+        assert!(v
+            .get("tooltip")
+            .and_then(|t| t.as_str())
+            .is_some_and(|t| t.contains("boom")));
     }
 }

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -288,6 +288,7 @@ mod tests {
             models: None,
             extra: None,
             error: None,
+            stale_reason: None,
         }
     }
 
@@ -426,6 +427,7 @@ mod tests {
             models: None,
             extra: None,
             error: Some("x".into()),
+            stale_reason: None,
         };
         let plan = plan_notifications(&wrap(vec![p]), &HashMap::new());
         assert_eq!(plan.fires.len(), 0);
@@ -452,6 +454,7 @@ mod tests {
             models: Some(models),
             extra: None,
             error: None,
+            stale_reason: None,
         };
         let plan = plan_notifications(&wrap(vec![amp]), &HashMap::new());
         assert_eq!(plan.fires.len(), 1);
@@ -478,6 +481,7 @@ mod tests {
                 extra_usage: None,
             })),
             error: None,
+            stale_reason: None,
         };
         let plan = plan_notifications(&wrap(vec![c]), &HashMap::new());
         assert!(plan

--- a/src/providers/amp.rs
+++ b/src/providers/amp.rs
@@ -35,6 +35,8 @@ fn dollars(n: f64) -> String {
     format!("${n}")
 }
 
+const MS_PER_DAY: u64 = 86_400_000;
+
 /// Parse do stdout de `amp usage` para `ProviderQuota`. `now_ms` é o relógio
 /// atual (o `fullAt` recalcula a cada chamada, inclusive em cache hit).
 pub fn parse_usage(stdout: &str, base: ProviderQuota, now_ms: u64) -> ProviderQuota {
@@ -77,11 +79,21 @@ pub fn parse_usage(stdout: &str, base: ProviderQuota, now_ms: u64) -> ProviderQu
     let mut primary: Option<QuotaWindow> = None;
 
     if let Some(pct_str) = free_pct.as_deref() {
-        // Percentual já vem pronto; reset é diário mas sem horário → sem ETA.
+        // Percentual já vem pronto. Reset diário à meia-noite UTC — regra do
+        // frontend oficial (nextAmpFreeResetDate em ampcode.com/settings:
+        // `Date.UTC(y, m, d+1)`). Só afirmamos o horário quando o texto do
+        // CLI ainda diz "resets daily"; se o servidor mudar a cadência, o
+        // ETA some em vez de mentir.
         let pct: f64 = pct_str.parse().unwrap_or(0.0);
+        let resets_at = if stdout.contains("resets daily") {
+            meta.insert("freeCadence".to_string(), "daily".to_string());
+            Some(iso_from_ms((now_ms / MS_PER_DAY + 1) * MS_PER_DAY))
+        } else {
+            None
+        };
         let window = QuotaWindow {
             remaining: pct,
-            resets_at: None,
+            resets_at,
             window_minutes: None,
             used: None,
             severity: None,
@@ -157,6 +169,29 @@ pub fn parse_usage(stdout: &str, base: ProviderQuota, now_ms: u64) -> ProviderQu
             },
         );
         meta.insert("creditsBalance".to_string(), dollars(balance));
+        if stdout.contains("replenishes automatically") {
+            meta.insert("creditsReplenish".to_string(), "auto".to_string());
+        }
+    }
+
+    // Fallback p/ formatos futuros do servidor (o texto de `amp usage` é
+    // renderizado server-side e já mudou sem update do CLI — ex.: linhas de
+    // assinatura megawatt/gigawatt). Sem Free Tier nem Credits reconhecidos,
+    // preserva as linhas `Label: valor` cruas p/ o tooltip não ficar vazio.
+    if primary.is_none() && !stdout.is_empty() && models.is_empty() {
+        let line_re = lazy_re!(RE_RAW_LINE, r"(?m)^([A-Z][A-Za-z0-9 /()&-]{1,39}):\s*(.+)$");
+        if let Some(r) = line_re {
+            for (i, caps) in r.captures_iter(stdout).take(4).enumerate() {
+                let label = caps.get(1).map(|m| m.as_str()).unwrap_or_default();
+                if label.starts_with("Signed in") {
+                    continue;
+                }
+                let value = caps.get(2).map(|m| m.as_str()).unwrap_or_default();
+                // Corta o sufixo " - https://..." que o CLI anexa.
+                let value = value.split(" - http").next().unwrap_or(value).trim();
+                meta.insert(format!("raw{i}"), format!("{label}: {value}"));
+            }
+        }
     }
 
     let extra = if meta.is_empty() {
@@ -373,15 +408,51 @@ mod tests {
         assert!(q.available);
         assert_eq!(q.account.as_deref(), Some("user@email.com"));
         assert_eq!(q.primary.as_ref().unwrap().remaining, 97.0);
-        assert!(q.primary.as_ref().unwrap().resets_at.is_none());
+        // "resets daily" → próxima meia-noite UTC após NOW.
+        let expected_reset = iso_from_ms((NOW / MS_PER_DAY + 1) * MS_PER_DAY);
+        assert_eq!(
+            q.primary.as_ref().unwrap().resets_at.as_deref(),
+            Some(expected_reset.as_str())
+        );
         let models = q.models.as_ref().unwrap();
         assert_eq!(models["Free Tier"].remaining, 97.0);
         assert_eq!(models["Credits"].remaining, 100.0);
         let m = meta_of(&q);
         assert_eq!(m.get("freePct").map(String::as_str), Some("97%"));
+        assert_eq!(m.get("freeCadence").map(String::as_str), Some("daily"));
         assert_eq!(m.get("creditsBalance").map(String::as_str), Some("$4.19"));
+        assert_eq!(m.get("creditsReplenish").map(String::as_str), Some("auto"));
         assert!(m.get("freeRemaining").is_none());
         assert!(m.get("freeTotal").is_none());
+    }
+
+    #[test]
+    fn free_pct_without_resets_daily_has_no_eta() {
+        let out = "Signed in as user@email.com\nAmp Free: 42% remaining this period\nIndividual credits: $1.00 remaining";
+        let q = parse_usage(out, base(), NOW);
+        assert_eq!(q.primary.as_ref().unwrap().remaining, 42.0);
+        assert!(q.primary.as_ref().unwrap().resets_at.is_none());
+        let m = meta_of(&q);
+        assert!(m.get("freeCadence").is_none());
+        assert!(m.get("creditsReplenish").is_none());
+    }
+
+    #[test]
+    fn unknown_server_format_preserves_raw_lines() {
+        let out = "Signed in as user@email.com (nick)\nSubscription (Gigawatt): $12.00 of $200.00 used - https://ampcode.com/settings\nOrb usage: 3% used this period";
+        let q = parse_usage(out, base(), NOW);
+        assert!(q.available);
+        assert!(q.primary.is_none());
+        assert!(q.models.as_ref().unwrap().is_empty());
+        let m = meta_of(&q);
+        assert_eq!(
+            m.get("raw0").map(String::as_str),
+            Some("Subscription (Gigawatt): $12.00 of $200.00 used")
+        );
+        assert_eq!(
+            m.get("raw1").map(String::as_str),
+            Some("Orb usage: 3% used this period")
+        );
     }
 
     #[test]

--- a/src/providers/amp.rs
+++ b/src/providers/amp.rs
@@ -233,8 +233,9 @@ async fn run_amp_usage(bin: &Path) -> Result<String, ProviderError> {
     {
         Ok(Ok(o)) => o,
         Ok(Err(_)) => return Err(AmpError::Generic.into()),
-        // timeout: kill_on_drop mata o filho; espelha o TS (kill→exit≠0→não-logado).
-        Err(_) => return Err(AmpError::NotLoggedIn.into()),
+        // timeout: CLI viva demais não é logout — erro transitório; a base
+        // serve cache stale. (Divergência consciente do TS, que deslogava.)
+        Err(_) => return Err(AmpError::Timeout.into()),
     };
 
     let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
@@ -284,7 +285,7 @@ impl QuotaSource for AmpProvider {
 
     fn to_user_facing_error(&self, error: &ProviderError) -> String {
         match error {
-            ProviderError::Amp(AmpError::NotLoggedIn) => AmpError::NotLoggedIn.to_string(),
+            ProviderError::Amp(e) => e.to_string(),
             _ => AmpError::Generic.to_string(),
         }
     }
@@ -573,6 +574,12 @@ mod tests {
             err.to_string(),
             "Not logged in. Open `agent-bar menu` and choose Provider login."
         );
+    }
+
+    #[test]
+    fn timeout_maps_to_own_message() {
+        let e: ProviderError = AmpError::Timeout.into();
+        assert_eq!(AmpProvider.to_user_facing_error(&e), "Request timeout");
     }
 
     #[tokio::test]

--- a/src/providers/amp.rs
+++ b/src/providers/amp.rs
@@ -332,6 +332,7 @@ mod tests {
             models: None,
             extra: None,
             error: None,
+            stale_reason: None,
         }
     }
 

--- a/src/providers/amp.rs
+++ b/src/providers/amp.rs
@@ -46,7 +46,10 @@ pub fn parse_usage(stdout: &str, base: ProviderQuota, now_ms: u64) -> ProviderQu
     let account = cap1(lazy_re!(RE_SIGNED, r"Signed in as (\S+)"), 1);
 
     // Formato novo (CLI ≥ 2026-07-11): `Amp Free: 97% remaining today (resets daily)`.
-    let free_pct = cap1(lazy_re!(RE_FREE_PCT, r"Amp Free:\s*([0-9.]+)%\s*remaining"), 1);
+    let free_pct = cap1(
+        lazy_re!(RE_FREE_PCT, r"Amp Free:\s*([0-9.]+)%\s*remaining"),
+        1,
+    );
 
     // Formato antigo: `Amp Free: $3.50/$5.00 remaining` + replenish/bonus.
     let free_re = lazy_re!(RE_FREE, r"Amp Free:\s*\$([0-9.]+)/\$([0-9.]+)\s*remaining");

--- a/src/providers/base.rs
+++ b/src/providers/base.rs
@@ -92,6 +92,17 @@ pub async fn base_get_quota<S: QuotaSource>(source: &S, ctx: &Ctx<'_>) -> Provid
                 "Provider quota fetch error: provider={} error={e}",
                 source.id()
             );
+            // Erro transitório não é logout: servir cache mesmo vencido,
+            // marcado como stale, em vez de derrubar pra "disconnected".
+            if e.is_transient() {
+                if let Some(raw) =
+                    cache::get_stale::<S::Raw>(&ctx.paths.cache_dir, source.cache_key())
+                {
+                    let mut q = source.build_quota(raw, base.clone(), ctx);
+                    q.stale_reason = Some(source.to_user_facing_error(&e));
+                    return q;
+                }
+            }
             ProviderQuota {
                 error: Some(source.to_user_facing_error(&e)),
                 ..base
@@ -194,6 +205,34 @@ mod tests {
         // segunda chamada: serve do cache, sem novo fetch.
         let _ = base_get_quota(&f, &ctx).await;
         assert_eq!(calls.get(), 1, "fetch só uma vez (cache hit no 2º)");
+    }
+
+    #[tokio::test]
+    async fn transient_error_with_stale_cache_serves_stale() {
+        let dir = tempdir().unwrap();
+        let calls = Cell::new(0);
+        let settings = crate::providers::test_support::settings();
+        let client = reqwest::Client::new();
+        let f = Fake {
+            available: true,
+            fail: true,
+            calls: &calls,
+        };
+        // Cache vencido: escrito em t=0 com ttl=1ms; ctx roda em t=1_000.
+        crate::cache::set(
+            &dir.path().join("cache"),
+            "fake-key",
+            &"OLD".to_string(),
+            1,
+            0,
+        )
+        .unwrap();
+        let ctx = ctx_for(dir.path(), &settings, &client, 1_000);
+        let q = base_get_quota(&f, &ctx).await;
+        assert!(q.available, "stale deve construir quota normal");
+        assert_eq!(q.account.as_deref(), Some("OLD"));
+        assert_eq!(q.error, None);
+        assert_eq!(q.stale_reason.as_deref(), Some("Failed to parse usage"));
     }
 
     #[tokio::test]

--- a/src/providers/base.rs
+++ b/src/providers/base.rs
@@ -99,8 +99,13 @@ pub async fn base_get_quota<S: QuotaSource>(source: &S, ctx: &Ctx<'_>) -> Provid
                     cache::get_stale::<S::Raw>(&ctx.paths.cache_dir, source.cache_key())
                 {
                     let mut q = source.build_quota(raw, base.clone(), ctx);
-                    q.stale_reason = Some(source.to_user_facing_error(&e));
-                    return q;
+                    // Raw degenerado (ex. sem janelas) constrói quota de erro:
+                    // stale só serve se renderiza saudável; senão cai no erro
+                    // transitório normal.
+                    if q.available && q.error.is_none() {
+                        q.stale_reason = Some(source.to_user_facing_error(&e));
+                        return q;
+                    }
                 }
             }
             ProviderQuota {
@@ -150,6 +155,14 @@ mod tests {
             }
         }
         fn build_quota(&self, raw: String, base: ProviderQuota, _ctx: &Ctx<'_>) -> ProviderQuota {
+            // Raw degenerado simula ex. Codex sem janelas de quota: constrói
+            // quota de erro em vez de saudável.
+            if raw == "BAD" {
+                return ProviderQuota {
+                    error: Some("degenerate".to_string()),
+                    ..base
+                };
+            }
             ProviderQuota {
                 available: true,
                 account: Some(raw),
@@ -233,6 +246,40 @@ mod tests {
         assert_eq!(q.account.as_deref(), Some("OLD"));
         assert_eq!(q.error, None);
         assert_eq!(q.stale_reason.as_deref(), Some("Failed to parse usage"));
+    }
+
+    #[tokio::test]
+    async fn stale_cache_with_degenerate_raw_falls_through_to_transient_error() {
+        let dir = tempdir().unwrap();
+        let calls = Cell::new(0);
+        let settings = crate::providers::test_support::settings();
+        let client = reqwest::Client::new();
+        let f = Fake {
+            available: true,
+            fail: true,
+            calls: &calls,
+        };
+        // Cache vencido com raw degenerado: build_quota("BAD") produz uma
+        // quota já com `error` setado — não deve ser servida como "stale".
+        crate::cache::set(
+            &dir.path().join("cache"),
+            "fake-key",
+            &"BAD".to_string(),
+            1,
+            0,
+        )
+        .unwrap();
+        let ctx = ctx_for(dir.path(), &settings, &client, 1_000);
+        let q = base_get_quota(&f, &ctx).await;
+        assert!(
+            !q.available,
+            "stale degenerado não deve ser servido como saudável"
+        );
+        assert_eq!(q.error.as_deref(), Some("Failed to parse usage"));
+        assert_eq!(
+            q.stale_reason, None,
+            "sem stale_reason: cai no erro transitório normal"
+        );
     }
 
     #[tokio::test]

--- a/src/providers/base.rs
+++ b/src/providers/base.rs
@@ -26,6 +26,7 @@ pub fn quota_base(id: &str, name: &str) -> ProviderQuota {
         models: None,
         extra: None,
         error: None,
+        stale_reason: None,
     }
 }
 

--- a/src/providers/claude.rs
+++ b/src/providers/claude.rs
@@ -13,6 +13,7 @@ use super::base::{get_or_fetch, quota_base};
 use super::error::ClaudeError;
 use super::types::{ClaudeQuotaExtra, ExtraUsage, ProviderExtra, ProviderQuota, QuotaWindow};
 use super::{Ctx, Provider};
+use crate::cache;
 
 /// Resolve o plano de exibição a partir de `subscriptionType` + `rateLimitTier`
 /// (o tier carrega o multiplicador, ex. `default_claude_max_5x` → `Max 5x`).
@@ -345,9 +346,30 @@ impl Provider for ClaudeProvider {
             oauth.as_ref().and_then(|o| o.rate_limit_tier.as_deref()),
         );
 
-        // Short-circuit pré-request: token já expirado → sem rede, sem cache.
+        // Token expirado: sem rede (o refresh é do Claude Code, não nosso).
+        // Cache válido → serve normal; cache vencido → serve como stale;
+        // sem cache nenhum → erro (disconnected honesto).
         if let Some(exp) = oauth.as_ref().and_then(|o| o.expires_at) {
             if exp <= ctx.now_ms as f64 {
+                if let Some(usage) = cache::get::<ClaudeUsageResponse>(
+                    &ctx.paths.cache_dir,
+                    self.cache_key(),
+                    ctx.now_ms,
+                ) {
+                    return quota_from_usage(usage, plan, base, None);
+                }
+                if let Some(usage) =
+                    cache::get_stale::<ClaudeUsageResponse>(&ctx.paths.cache_dir, self.cache_key())
+                {
+                    if let Some(q) = healthy_stale_quota(
+                        usage,
+                        plan.clone(),
+                        base.clone(),
+                        ClaudeError::TokenExpired.to_string(),
+                    ) {
+                        return q;
+                    }
+                }
                 return ProviderQuota {
                     plan: Some(plan),
                     error: Some(ClaudeError::TokenExpired.to_string()),
@@ -373,108 +395,159 @@ impl Provider for ClaudeProvider {
             Ok(u) => u,
             Err(ClaudeError::Timeout) => {
                 log::warn!("Claude API timeout");
-                return ProviderQuota {
-                    plan: Some(plan),
-                    error: Some(ClaudeError::Timeout.to_string()),
-                    ..base
-                };
+                return stale_or_error(
+                    ctx,
+                    self.cache_key(),
+                    plan,
+                    base,
+                    ClaudeError::Timeout.to_string(),
+                );
             }
             Err(e @ ClaudeError::Api(_)) => {
                 log::warn!("Claude API error: {e}");
-                return ProviderQuota {
-                    plan: Some(plan),
-                    error: Some(e.to_string()),
-                    ..base
-                };
+                return stale_or_error(ctx, self.cache_key(), plan, base, e.to_string());
             }
             Err(e) => {
                 log::error!("Claude API fetch error: {e}");
-                return ProviderQuota {
-                    plan: Some(plan),
-                    error: Some(ClaudeError::Generic.to_string()),
-                    ..base
-                };
+                return stale_or_error(
+                    ctx,
+                    self.cache_key(),
+                    plan,
+                    base,
+                    ClaudeError::Generic.to_string(),
+                );
             }
         };
 
-        // Check pós-cache: body 200 pode trazer token_expired.
-        if usage.error.as_ref().map(|e| e.error_code.as_str()) == Some("token_expired") {
-            return ProviderQuota {
-                plan: Some(plan),
-                error: Some(ClaudeError::TokenExpired.to_string()),
-                ..base
-            };
-        }
+        quota_from_usage(usage, plan, base, None)
+    }
+}
 
-        // limits[] (novo shape) tem precedência; five_hour/seven_day* legado é
-        // o fallback para contas que ainda não recebem o bloco novo.
-        let (primary, secondary, weekly) = match quota_from_limits(&usage) {
-            Some(t) => t,
-            None => {
-                let primary = usage.five_hour.as_ref().map(window_from);
-                let secondary = usage.seven_day.as_ref().map(window_from);
-                let mut weekly: IndexMap<String, QuotaWindow> = IndexMap::new();
-                if let Some(w) = usage.seven_day_opus.as_ref() {
-                    weekly.insert("Opus".to_string(), window_from(w));
-                }
-                if let Some(w) = usage.seven_day_sonnet.as_ref() {
-                    weekly.insert("Sonnet".to_string(), window_from(w));
-                }
-                if let Some(w) = usage.seven_day_cowork.as_ref() {
-                    weekly.insert("Cowork".to_string(), window_from(w));
-                }
-                (primary, secondary, weekly)
-            }
-        };
-
-        // extra_usage: spend novo tem precedência; legado como fallback.
-        let extra_usage = match usage.spend.as_ref() {
-            Some(s) => Some(extra_usage_from_spend(s)),
-            None => usage
-                .extra_usage
-                .as_ref()
-                .filter(|e| e.is_enabled)
-                .and_then(|e| {
-                    // A API nova pode mandar is_enabled=true com os 3 campos null
-                    // (crédito migrou p/ `spend`). Só montamos ExtraUsage se houver
-                    // dados reais — senão omitimos (não inventar 0%/$0).
-                    Some(ExtraUsage {
-                        enabled: true,
-                        remaining: (100.0 - e.utilization?).round(),
-                        limit: e.monthly_limit?,
-                        used: e.used_credits?.round(),
-                    })
-                }),
-        };
-
-        let models = if weekly.is_empty() {
-            None
-        } else {
-            Some(weekly.clone())
-        };
-
-        let extra = if !weekly.is_empty() || extra_usage.is_some() {
-            Some(ProviderExtra::Claude(ClaudeQuotaExtra {
-                weekly_models: if weekly.is_empty() {
-                    None
-                } else {
-                    Some(weekly)
-                },
-                extra_usage,
-            }))
-        } else {
-            None
-        };
-
-        ProviderQuota {
-            available: true,
+/// Bloco pós-fetch/pós-cache: body 200 pode trazer `token_expired`; senão
+/// monta janelas (limits[] novo ou five_hour/seven_day* legado) + extra_usage.
+/// `stale_reason` rotula o quota quando `usage` vem de cache vencido; as
+/// saídas de erro internas (ex. token_expired no corpo) mantêm `..base`
+/// (que já carrega `stale_reason: None` de `quota_base`) — um corpo cacheado
+/// doente nunca deve ser rotulado como stale saudável.
+fn quota_from_usage(
+    usage: ClaudeUsageResponse,
+    plan: String,
+    base: ProviderQuota,
+    stale_reason: Option<String>,
+) -> ProviderQuota {
+    // Check pós-cache: body 200 pode trazer token_expired.
+    if usage.error.as_ref().map(|e| e.error_code.as_str()) == Some("token_expired") {
+        return ProviderQuota {
             plan: Some(plan),
-            primary,
-            secondary,
-            models,
-            extra,
+            error: Some(ClaudeError::TokenExpired.to_string()),
             ..base
+        };
+    }
+
+    // limits[] (novo shape) tem precedência; five_hour/seven_day* legado é
+    // o fallback para contas que ainda não recebem o bloco novo.
+    let (primary, secondary, weekly) = match quota_from_limits(&usage) {
+        Some(t) => t,
+        None => {
+            let primary = usage.five_hour.as_ref().map(window_from);
+            let secondary = usage.seven_day.as_ref().map(window_from);
+            let mut weekly: IndexMap<String, QuotaWindow> = IndexMap::new();
+            if let Some(w) = usage.seven_day_opus.as_ref() {
+                weekly.insert("Opus".to_string(), window_from(w));
+            }
+            if let Some(w) = usage.seven_day_sonnet.as_ref() {
+                weekly.insert("Sonnet".to_string(), window_from(w));
+            }
+            if let Some(w) = usage.seven_day_cowork.as_ref() {
+                weekly.insert("Cowork".to_string(), window_from(w));
+            }
+            (primary, secondary, weekly)
         }
+    };
+
+    // extra_usage: spend novo tem precedência; legado como fallback.
+    let extra_usage = match usage.spend.as_ref() {
+        Some(s) => Some(extra_usage_from_spend(s)),
+        None => usage
+            .extra_usage
+            .as_ref()
+            .filter(|e| e.is_enabled)
+            .and_then(|e| {
+                // A API nova pode mandar is_enabled=true com os 3 campos null
+                // (crédito migrou p/ `spend`). Só montamos ExtraUsage se houver
+                // dados reais — senão omitimos (não inventar 0%/$0).
+                Some(ExtraUsage {
+                    enabled: true,
+                    remaining: (100.0 - e.utilization?).round(),
+                    limit: e.monthly_limit?,
+                    used: e.used_credits?.round(),
+                })
+            }),
+    };
+
+    let models = if weekly.is_empty() {
+        None
+    } else {
+        Some(weekly.clone())
+    };
+
+    let extra = if !weekly.is_empty() || extra_usage.is_some() {
+        Some(ProviderExtra::Claude(ClaudeQuotaExtra {
+            weekly_models: if weekly.is_empty() {
+                None
+            } else {
+                Some(weekly)
+            },
+            extra_usage,
+        }))
+    } else {
+        None
+    };
+
+    ProviderQuota {
+        available: true,
+        plan: Some(plan),
+        primary,
+        secondary,
+        models,
+        extra,
+        stale_reason,
+        ..base
+    }
+}
+
+/// Constrói o quota a partir de cache stale e só o devolve se saudável
+/// (`available` e sem erro embutido no corpo cacheado, ex. token_expired).
+/// Doente → `None`: quem chama cai no erro puro em vez de expor um "stale"
+/// que já nasce quebrado.
+fn healthy_stale_quota(
+    usage: ClaudeUsageResponse,
+    plan: String,
+    base: ProviderQuota,
+    stale_reason: String,
+) -> Option<ProviderQuota> {
+    let q = quota_from_usage(usage, plan, base, Some(stale_reason));
+    (q.available && q.error.is_none()).then_some(q)
+}
+
+/// Erro de fetch (timeout/API/decode): tenta servir cache stale saudável
+/// antes do erro puro; sem stale utilizável, retorna o erro corrente.
+fn stale_or_error(
+    ctx: &Ctx<'_>,
+    cache_key: &str,
+    plan: String,
+    base: ProviderQuota,
+    err_msg: String,
+) -> ProviderQuota {
+    if let Some(usage) = cache::get_stale::<ClaudeUsageResponse>(&ctx.paths.cache_dir, cache_key) {
+        if let Some(q) = healthy_stale_quota(usage, plan.clone(), base.clone(), err_msg.clone()) {
+            return q;
+        }
+    }
+    ProviderQuota {
+        plan: Some(plan),
+        error: Some(err_msg),
+        ..base
     }
 }
 
@@ -553,6 +626,148 @@ mod tests {
             q.error.as_deref(),
             Some("Token expired. Open `agent-bar menu` and choose Provider login.")
         );
+    }
+
+    /// Fixture de usage compartilhada entre os testes de cache stale.
+    fn usage_fixture() -> ClaudeUsageResponse {
+        serde_json::from_value(json!({
+            "five_hour": {"utilization": 25.0, "resets_at": "2026-03-28T14:00:00Z"},
+            "seven_day": {"utilization": 40.0, "resets_at": "2026-04-01T00:00:00Z"}
+        }))
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn token_expired_with_stale_cache_serves_stale() {
+        let dir = tempdir().unwrap();
+        let s = settings();
+        let client = reqwest::Client::new();
+        let ctx = ctx_for(dir.path(), &s, &client, 10_000);
+        write_creds(
+            &ctx.paths.claude_credentials,
+            json!({"claudeAiOauth":{"accessToken":"t","subscriptionType":"Pro","expiresAt":5000}}),
+        );
+        // Cache já vencido (ttl=1ms escrito em now_ms=0, lido em now_ms=10_000).
+        cache::set(&ctx.paths.cache_dir, "claude-usage", &usage_fixture(), 1, 0).unwrap();
+
+        let q = ClaudeProvider.get_quota(&ctx).await;
+        assert!(q.available);
+        assert_eq!(q.error, None);
+        assert_eq!(
+            q.stale_reason.as_deref(),
+            Some("Token expired. Open `agent-bar menu` and choose Provider login.")
+        );
+        assert!(q.primary.is_some());
+    }
+
+    #[tokio::test]
+    async fn token_expired_without_cache_keeps_error() {
+        let dir = tempdir().unwrap();
+        let s = settings();
+        let client = reqwest::Client::new();
+        let ctx = ctx_for(dir.path(), &s, &client, 10_000);
+        write_creds(
+            &ctx.paths.claude_credentials,
+            json!({"claudeAiOauth":{"accessToken":"t","subscriptionType":"Pro","expiresAt":5000}}),
+        );
+        // sem cache no disco.
+        let q = ClaudeProvider.get_quota(&ctx).await;
+        assert!(!q.available);
+        assert_eq!(
+            q.error.as_deref(),
+            Some("Token expired. Open `agent-bar menu` and choose Provider login.")
+        );
+        assert_eq!(q.stale_reason, None);
+    }
+
+    /// Guard-rail (revisão da Task 3): servir stale só se o resultado for
+    /// saudável. Corpo cacheado que já traz `token_expired` embutido não pode
+    /// virar um "stale" que na verdade está quebrado — cai no erro puro.
+    #[tokio::test]
+    async fn token_expired_stale_cache_itself_unhealthy_falls_through_to_error() {
+        let dir = tempdir().unwrap();
+        let s = settings();
+        let client = reqwest::Client::new();
+        let ctx = ctx_for(dir.path(), &s, &client, 10_000);
+        write_creds(
+            &ctx.paths.claude_credentials,
+            json!({"claudeAiOauth":{"accessToken":"t","subscriptionType":"Pro","expiresAt":5000}}),
+        );
+        let unhealthy: ClaudeUsageResponse = serde_json::from_value(json!({
+            "error": {"error_code": "token_expired", "message": "expired"}
+        }))
+        .unwrap();
+        cache::set(&ctx.paths.cache_dir, "claude-usage", &unhealthy, 1, 0).unwrap();
+
+        let q = ClaudeProvider.get_quota(&ctx).await;
+        assert!(!q.available);
+        assert_eq!(
+            q.error.as_deref(),
+            Some("Token expired. Open `agent-bar menu` and choose Provider login.")
+        );
+        assert_eq!(q.stale_reason, None, "não deve rotular um stale doente");
+    }
+
+    /// Mesmo guard-rail, agora no braço de erro de fetch (429): stale doente
+    /// no disco não pode mascarar o erro real com um "stale" quebrado.
+    #[tokio::test]
+    async fn fetch_error_stale_cache_itself_unhealthy_falls_through_to_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/oauth/usage"))
+            .respond_with(ResponseTemplate::new(429))
+            .mount(&server)
+            .await;
+        let dir = tempdir().unwrap();
+        let s = settings();
+        let client = reqwest::Client::new();
+        let url = format!("{}/api/oauth/usage", server.uri());
+        let ctx = ctx_with_url(&dir, &s, &client, url, 1_000);
+        write_creds(
+            &ctx.paths.claude_credentials,
+            json!({"claudeAiOauth":{"accessToken":"tok","subscriptionType":"Pro"}}),
+        );
+        let unhealthy: ClaudeUsageResponse = serde_json::from_value(json!({
+            "error": {"error_code": "token_expired", "message": "expired"}
+        }))
+        .unwrap();
+        cache::set(&ctx.paths.cache_dir, "claude-usage", &unhealthy, 1, 0).unwrap();
+
+        let q = ClaudeProvider.get_quota(&ctx).await;
+        assert!(!q.available);
+        assert_eq!(q.error.as_deref(), Some("Claude API error: 429"));
+        assert_eq!(q.stale_reason, None, "não deve rotular um stale doente");
+    }
+
+    /// Braço de erro de fetch com stale SAUDÁVEL disponível: serve o cache
+    /// vencido rotulado com o erro transitório, em vez de "disconnected".
+    #[tokio::test]
+    async fn fetch_timeout_with_healthy_stale_cache_serves_stale() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/oauth/usage"))
+            .respond_with(ResponseTemplate::new(200).set_delay(std::time::Duration::from_secs(5)))
+            .mount(&server)
+            .await;
+        let dir = tempdir().unwrap();
+        let s = settings();
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_millis(50))
+            .build()
+            .unwrap();
+        let url = format!("{}/api/oauth/usage", server.uri());
+        let ctx = ctx_with_url(&dir, &s, &client, url, 1_000);
+        write_creds(
+            &ctx.paths.claude_credentials,
+            json!({"claudeAiOauth":{"accessToken":"tok","subscriptionType":"Pro"}}),
+        );
+        cache::set(&ctx.paths.cache_dir, "claude-usage", &usage_fixture(), 1, 0).unwrap();
+
+        let q = ClaudeProvider.get_quota(&ctx).await;
+        assert!(q.available);
+        assert_eq!(q.error, None);
+        assert_eq!(q.stale_reason.as_deref(), Some("Request timeout"));
+        assert!(q.primary.is_some());
     }
 
     #[tokio::test]

--- a/src/providers/codex/mod.rs
+++ b/src/providers/codex/mod.rs
@@ -124,6 +124,7 @@ mod tests {
             models: None,
             extra: None,
             error: None,
+            stale_reason: None,
         }
     }
 

--- a/src/providers/codex/mod.rs
+++ b/src/providers/codex/mod.rs
@@ -103,12 +103,11 @@ impl Provider for CodexProvider {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
-    use super::*;
     use super::super::iso_from_ms;
     use super::super::types::{CodexQuotaExtra, ProviderExtra, ProviderQuota};
+    use super::*;
     use indexmap::IndexMap;
     use time::UtcOffset;
 

--- a/src/providers/error.rs
+++ b/src/providers/error.rs
@@ -42,6 +42,8 @@ pub enum AmpError {
     NotInstalled,
     #[error("Not logged in. Open `agent-bar menu` and choose Provider login.")]
     NotLoggedIn,
+    #[error("Request timeout")]
+    Timeout,
     #[error("Failed to parse usage")]
     ParseFailed,
     #[error("Failed to fetch Amp usage")]
@@ -68,6 +70,25 @@ pub enum ProviderError {
     Amp(#[from] AmpError),
     #[error(transparent)]
     Grok(#[from] GrokError),
+}
+
+impl ProviderError {
+    /// Transitório = falha de infra (rede/CLI/parse) que não significa
+    /// logout; o caller pode servir cache stale. Credencial/logout → false.
+    pub fn is_transient(&self) -> bool {
+        match self {
+            ProviderError::Claude(e) => matches!(
+                e,
+                ClaudeError::Timeout | ClaudeError::Api(_) | ClaudeError::Generic
+            ),
+            ProviderError::Codex(e) => matches!(e, CodexError::Generic),
+            ProviderError::Amp(e) => matches!(
+                e,
+                AmpError::Timeout | AmpError::Generic | AmpError::ParseFailed
+            ),
+            ProviderError::Grok(_) => false,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -156,5 +177,28 @@ mod tests {
     fn provider_error_wraps_transparently() {
         let e: ProviderError = ClaudeError::NoAccessToken.into();
         assert_eq!(e.to_string(), "No access token");
+    }
+
+    #[test]
+    fn amp_timeout_string_verbatim() {
+        assert_eq!(AmpError::Timeout.to_string(), "Request timeout");
+    }
+
+    #[test]
+    fn transient_classification() {
+        assert!(ProviderError::from(ClaudeError::Timeout).is_transient());
+        assert!(ProviderError::from(ClaudeError::Api(500)).is_transient());
+        assert!(ProviderError::from(ClaudeError::Generic).is_transient());
+        assert!(!ProviderError::from(ClaudeError::NotLoggedIn).is_transient());
+        assert!(!ProviderError::from(ClaudeError::TokenExpired).is_transient());
+        assert!(ProviderError::from(AmpError::Timeout).is_transient());
+        assert!(ProviderError::from(AmpError::Generic).is_transient());
+        assert!(ProviderError::from(AmpError::ParseFailed).is_transient());
+        assert!(!ProviderError::from(AmpError::NotLoggedIn).is_transient());
+        assert!(!ProviderError::from(AmpError::NotInstalled).is_transient());
+        assert!(ProviderError::from(CodexError::Generic).is_transient());
+        assert!(!ProviderError::from(CodexError::NotLoggedIn).is_transient());
+        assert!(!ProviderError::from(CodexError::NoRateLimitData).is_transient());
+        assert!(!ProviderError::from(GrokError::NotLoggedIn).is_transient());
     }
 }

--- a/src/providers/extras.rs
+++ b/src/providers/extras.rs
@@ -101,10 +101,7 @@ mod tests {
 
     #[test]
     fn grok_getter_returns_payload() {
-        let q = base(
-            "grok",
-            Some(ProviderExtra::Grok(GrokQuotaExtra::default())),
-        );
+        let q = base("grok", Some(ProviderExtra::Grok(GrokQuotaExtra::default())));
         assert!(get_grok_extra(&q).is_some());
         assert!(get_claude_extra(&q).is_none());
         assert!(get_codex_extra(&q).is_none());
@@ -114,10 +111,7 @@ mod tests {
     #[test]
     fn grok_getter_gated_by_provider_string() {
         // provider diz "amp" mas o payload é Grok → None.
-        let q = base(
-            "amp",
-            Some(ProviderExtra::Grok(GrokQuotaExtra::default())),
-        );
+        let q = base("amp", Some(ProviderExtra::Grok(GrokQuotaExtra::default())));
         assert!(get_grok_extra(&q).is_none());
         assert!(get_amp_extra(&q).is_none());
     }

--- a/src/providers/extras.rs
+++ b/src/providers/extras.rs
@@ -58,6 +58,7 @@ mod tests {
             models: None,
             extra,
             error: None,
+            stale_reason: None,
         }
     }
 

--- a/src/providers/grok.rs
+++ b/src/providers/grok.rs
@@ -81,21 +81,24 @@ pub(crate) fn context_remaining_pct(used: u64, window: u64) -> Option<f64> {
 }
 
 /// Parse de `auth.json`. JSON inválido → `InvalidCredentials`.
-/// Sem entry com `key` não vazio, ou todas expiradas → `logged_in = false`.
-pub(crate) fn parse_auth_entries(bytes: &[u8], now: OffsetDateTime) -> Result<AuthView, GrokError> {
+/// Logado = existe entry com `key` não vazio. `expires_at` NÃO desloga:
+/// o access token (6h) é renovado pelo Grok CLI via refresh_token, e este
+/// provider é zero-rede — nem usa o token, só lê signals.json.
+pub(crate) fn parse_auth_entries(
+    bytes: &[u8],
+    _now: OffsetDateTime,
+) -> Result<AuthView, GrokError> {
     let map: HashMap<String, AuthEntry> =
         serde_json::from_slice(bytes).map_err(|_| GrokError::InvalidCredentials)?;
 
-    // Entre entries com key não vazio, preferir a de expires_at mais distante.
+    // Entre entries com key não vazio, preferir a de expires_at mais distante
+    // (desempate estável quando o CLI mantém múltiplas entradas).
     let mut best: Option<(OffsetDateTime, AuthEntry)> = None;
-    let mut any_with_key = false;
-
     for (_k, entry) in map {
         let key = entry.key.as_deref().unwrap_or("").trim();
         if key.is_empty() {
             continue;
         }
-        any_with_key = true;
         let exp = entry
             .expires_at
             .as_deref()
@@ -107,25 +110,16 @@ pub(crate) fn parse_auth_entries(bytes: &[u8], now: OffsetDateTime) -> Result<Au
         }
     }
 
-    if !any_with_key {
-        return Ok(AuthView {
-            account: None,
-            logged_in: false,
-        });
-    }
-
-    let Some((exp, entry)) = best else {
+    let Some((_exp, entry)) = best else {
         return Ok(AuthView {
             account: None,
             logged_in: false,
         });
     };
 
-    let account = account_label(&entry);
-    let logged_in = exp > now;
     Ok(AuthView {
-        account: Some(account),
-        logged_in,
+        account: Some(account_label(&entry)),
+        logged_in: true,
     })
 }
 
@@ -526,11 +520,21 @@ mod tests {
     }
 
     #[test]
-    fn parse_auth_expired() {
+    fn parse_auth_expired_token_still_logged_in() {
         let now = datetime!(2026-07-17 12:00:00 UTC);
         let view = parse_auth_entries(&fixture_bytes("auth-expired.json"), now).unwrap();
-        assert!(!view.logged_in);
+        // Access token vencido ≠ logout: o Grok CLI renova via refresh_token.
+        assert!(view.logged_in);
         assert_eq!(view.account.as_deref(), Some("Test User"));
+    }
+
+    #[test]
+    fn parse_auth_empty_key_not_logged_in() {
+        let now = datetime!(2026-07-17 12:00:00 UTC);
+        let json = br#"{"https://auth.x.ai::c": {"key": "", "first_name": "X"}}"#;
+        let view = parse_auth_entries(json, now).unwrap();
+        assert!(!view.logged_in);
+        assert!(view.account.is_none());
     }
 
     #[test]
@@ -624,19 +628,21 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn not_logged_in_expired() {
+    async fn expired_access_token_still_serves_quota() {
         let dir = tempdir().unwrap();
         write_auth(dir.path(), "auth-expired.json");
+        write_signals(
+            dir.path(),
+            "proj/sid/signals.json",
+            &fixture_str("signals-recent.json"),
+        );
         let s = settings();
         let client = reqwest::Client::new();
         let ctx = ctx_for(dir.path(), &s, &client, 1_720_000_000_000);
         let q = GrokProvider.get_quota(&ctx).await;
-        assert!(!q.available);
-        assert_eq!(
-            q.error.as_deref(),
-            Some("Not logged in. Open `agent-bar menu` and choose Provider login.")
-        );
+        assert!(q.available, "err={:?}", q.error);
         assert_eq!(q.account.as_deref(), Some("Test User"));
+        assert_eq!(q.primary.as_ref().unwrap().remaining, 90.0);
     }
 
     #[tokio::test]

--- a/src/providers/grok_cli.rs
+++ b/src/providers/grok_cli.rs
@@ -38,9 +38,12 @@ pub fn find_grok_bin_with(
 /// Locator de produção: `which_in_path` + `Path::is_file`.
 /// `grok_home` (ex. `paths.grok_home` / `GROK_HOME`) vira candidato logo após o PATH.
 pub fn find_grok_bin(home: &str, grok_home: Option<&Path>) -> Option<PathBuf> {
-    find_grok_bin_with(home, grok_home, crate::providers::amp_cli::which_in_path, |p| {
-        p.is_file()
-    })
+    find_grok_bin_with(
+        home,
+        grok_home,
+        crate::providers::amp_cli::which_in_path,
+        |p| p.is_file(),
+    )
 }
 
 #[cfg(test)]
@@ -87,10 +90,7 @@ mod tests {
             |_| None,
             |p| p == Path::new("/custom/grok-home/bin/grok"),
         );
-        assert_eq!(
-            found,
-            Some(PathBuf::from("/custom/grok-home/bin/grok"))
-        );
+        assert_eq!(found, Some(PathBuf::from("/custom/grok-home/bin/grok")));
     }
 
     #[test]

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -174,6 +174,7 @@ pub(crate) async fn fetch_one(provider: &dyn Provider, ctx: &Ctx<'_>) -> Provide
                     models: None,
                     extra: None,
                     error: Some(msg),
+                    stale_reason: None,
                 };
             }
         }
@@ -315,6 +316,7 @@ mod tests {
                 models: None,
                 extra: None,
                 error: None,
+                stale_reason: None,
             }
         }
     }

--- a/src/providers/types.rs
+++ b/src/providers/types.rs
@@ -117,6 +117,10 @@ pub struct ProviderQuota {
     pub extra: Option<ProviderExtra>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+    /// Motivo de dado stale: erro transitório respondido com cache vencido.
+    /// `None` = dado fresco (ou erro real em `error`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stale_reason: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
@@ -185,6 +189,7 @@ mod tests {
             models: None,
             extra: None,
             error: None,
+            stale_reason: None,
         };
         let j = serde_json::to_value(q).unwrap();
         assert_eq!(j["provider"], "claude");
@@ -199,6 +204,7 @@ mod tests {
             "models",
             "extra",
             "error",
+            "staleReason",
         ] {
             assert!(
                 j.get(absent).is_none(),
@@ -230,5 +236,28 @@ mod tests {
         let j = serde_json::to_value(aq).unwrap();
         assert_eq!(j["fetchedAt"], "2026-06-19T14:00:00Z");
         assert!(j["providers"].is_array());
+    }
+
+    #[test]
+    fn stale_reason_omitted_when_none_present_when_some() {
+        let mut q = ProviderQuota {
+            provider: "amp".into(),
+            display_name: "Amp".into(),
+            available: true,
+            account: None,
+            plan: None,
+            plan_type: None,
+            primary: None,
+            secondary: None,
+            models: None,
+            extra: None,
+            error: None,
+            stale_reason: None,
+        };
+        let j = serde_json::to_value(&q).unwrap();
+        assert!(j.get("staleReason").is_none());
+        q.stale_reason = Some("Request timeout".into());
+        let j = serde_json::to_value(&q).unwrap();
+        assert_eq!(j["staleReason"], "Request timeout");
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -389,10 +389,7 @@ mod tests {
         let dir = tempdir().unwrap();
         let s = load(&paths_in(dir.path()));
         assert_eq!(s.version, 2);
-        assert_eq!(
-            s.waybar.providers,
-            vec!["claude", "codex", "amp", "grok"]
-        );
+        assert_eq!(s.waybar.providers, vec!["claude", "codex", "amp", "grok"]);
         assert_eq!(s.waybar.separators, SeparatorStyle::Gap);
         assert_eq!(s.waybar.display_mode, DisplayMode::Remaining);
         assert_eq!(s.waybar.interval, 60);

--- a/src/tui/login_state.rs
+++ b/src/tui/login_state.rs
@@ -53,6 +53,7 @@ mod tests {
             models: None,
             extra: None,
             error: error.map(|s| s.to_string()),
+            stale_reason: None,
         }
     }
 

--- a/src/tui/render/detail/mod.rs
+++ b/src/tui/render/detail/mod.rs
@@ -356,6 +356,7 @@ mod tests {
             models: None,
             extra: None,
             error: None,
+            stale_reason: None,
         }
     }
 
@@ -478,6 +479,7 @@ mod tests {
                 }),
             })),
             error: None,
+            stale_reason: None,
         })
     }
 
@@ -498,6 +500,7 @@ mod tests {
             models: Some(models),
             extra: Some(ProviderExtra::Amp(AmpQuotaExtra { meta: None })),
             error: None,
+            stale_reason: None,
         })
     }
 
@@ -516,6 +519,7 @@ mod tests {
             error: Some(
                 "Not logged in. Open `agent-bar menu` and choose Provider login.".to_string(),
             ),
+            stale_reason: None,
         })
     }
 
@@ -914,6 +918,7 @@ mod tests {
             models: None,
             extra: None,
             error: Some("Failed to fetch Codex usage".to_string()),
+            stale_reason: None,
         });
 
         let backend = ratatui::backend::TestBackend::new(100, 32);

--- a/src/tui/render/login.rs
+++ b/src/tui/render/login.rs
@@ -242,6 +242,7 @@ mod tests {
             models: None,
             extra: None,
             error: error.map(|s| s.to_string()),
+            stale_reason: None,
         }
     }
 

--- a/src/tui/render/mod.rs
+++ b/src/tui/render/mod.rs
@@ -341,6 +341,7 @@ mod tests {
             models: None,
             extra: None,
             error: None,
+            stale_reason: None,
         }
     }
 

--- a/src/tui/render/sidebar.rs
+++ b/src/tui/render/sidebar.rs
@@ -212,6 +212,7 @@ mod tests {
             models: None,
             extra: None,
             error: None,
+            stale_reason: None,
         })
     }
 

--- a/src/tui/update/config.rs
+++ b/src/tui/update/config.rs
@@ -122,7 +122,10 @@ pub(super) fn apply_field_edit(
     }
 }
 
-pub(super) fn init_config(state: &mut AppState, settings: crate::settings::Settings) -> Vec<Action> {
+pub(super) fn init_config(
+    state: &mut AppState,
+    settings: crate::settings::Settings,
+) -> Vec<Action> {
     // So inicializa se ainda nao existe (preserva edicoes em andamento).
     if state.config_state.is_none() {
         state.config_state = Some(ConfigState::new(&settings));
@@ -210,10 +213,7 @@ pub(super) fn save_config(state: &mut AppState) -> Vec<Action> {
     vec![]
 }
 
-pub(super) fn config_save_result(
-    state: &mut AppState,
-    result: Result<(), String>,
-) -> Vec<Action> {
+pub(super) fn config_save_result(state: &mut AppState, result: Result<(), String>) -> Vec<Action> {
     if let Some(cs) = state.config_state.as_mut() {
         cs.status_msg = Some(match result {
             Ok(()) => "Configuracao salva e Waybar recarregado.".to_string(),

--- a/src/tui/update/fetch.rs
+++ b/src/tui/update/fetch.rs
@@ -100,11 +100,9 @@ pub(super) fn fetch_completed(
     // Mesmo parse de timestamp usado pelo antigo DataFetched, mas
     // nunca regride: fica o mais recente entre o atual e o parseado
     // (ondas sobrepostas podem terminar fora de ordem).
-    let parsed = time::OffsetDateTime::parse(
-        &fetched_at,
-        &time::format_description::well_known::Rfc3339,
-    )
-    .ok();
+    let parsed =
+        time::OffsetDateTime::parse(&fetched_at, &time::format_description::well_known::Rfc3339)
+            .ok();
     if let Some(new) = parsed {
         state.last_update = Some(state.last_update.map_or(new, |cur| cur.max(new)));
     }

--- a/src/tui/update/mod.rs
+++ b/src/tui/update/mod.rs
@@ -96,6 +96,7 @@ mod tests {
             models: None,
             extra: None,
             error: None,
+            stale_reason: None,
         }
     }
 

--- a/src/tui/update/navigation.rs
+++ b/src/tui/update/navigation.rs
@@ -337,9 +337,7 @@ pub(super) fn click(state: &mut AppState, target: MouseTarget) -> Vec<Action> {
         MouseTarget::Chip(ChipKind::ToggleRange) => {
             super::update(state, Action::ToggleHistoryRange)
         }
-        MouseTarget::Chip(ChipKind::ExpandDay) => {
-            super::update(state, Action::HistoryToggleDay)
-        }
+        MouseTarget::Chip(ChipKind::ExpandDay) => super::update(state, Action::HistoryToggleDay),
         // Chip "iniciar login" da tela Login: dispara a MESMA action que
         // o Enter dispara lá (Action::LoginRequested pro provider
         // selecionado) — nunca Activate(Login), que seria no-op (a
@@ -348,9 +346,7 @@ pub(super) fn click(state: &mut AppState, target: MouseTarget) -> Vec<Action> {
             state,
             Action::LoginRequested(login_selected_id(state.login_selected).to_string()),
         ),
-        MouseTarget::Chip(ChipKind::EnterEdit) => {
-            super::update(state, Action::ConfigEnterEdit)
-        }
+        MouseTarget::Chip(ChipKind::EnterEdit) => super::update(state, Action::ConfigEnterEdit),
         MouseTarget::Chip(ChipKind::SaveConfig) => super::update(state, Action::SaveConfig),
     }
 }

--- a/src/tui/widgets/column_chart.rs
+++ b/src/tui/widgets/column_chart.rs
@@ -595,7 +595,10 @@ mod tests {
     #[test]
     fn fmt_tokens_dual_omits_cache_when_zero() {
         assert_eq!(fmt_tokens_dual(1_200_000, 0), "1,2M");
-        assert_eq!(fmt_tokens_dual(1_200_000, 1_400_000_000), "1,2M (+1,4B cache)");
+        assert_eq!(
+            fmt_tokens_dual(1_200_000, 1_400_000_000),
+            "1,2M (+1,4B cache)"
+        );
     }
 
     #[test]
@@ -603,15 +606,15 @@ mod tests {
         // Muitas séries com labels longos → só cabem poucas em width=40;
         // o sufixo …+N deve aparecer.
         let s: Vec<_> = (0..6u8)
-            .map(|i| {
-                series(
-                    &format!("ModelNameVeryLong{i}"),
-                    i,
-                    vec![1000; 24],
-                )
-            })
+            .map(|i| series(&format!("ModelNameVeryLong{i}"), i, vec![1000; 24]))
             .collect();
-        let lines = column_chart_lines(&s, 40, 10, datetime!(2026-07-10 12:00:00 UTC), time::UtcOffset::UTC);
+        let lines = column_chart_lines(
+            &s,
+            40,
+            10,
+            datetime!(2026-07-10 12:00:00 UTC),
+            time::UtcOffset::UTC,
+        );
         let legend = plain(&lines).last().cloned().unwrap_or_default();
         assert!(
             legend.contains('\u{2026}') || legend.contains("…"),

--- a/src/waybar_integration.rs
+++ b/src/waybar_integration.rs
@@ -835,12 +835,9 @@ mod orchestration_tests {
         let mr = parsed["modules-right"].as_array().unwrap();
         assert!(mr.iter().any(|v| v == "clock"));
         assert!(mr.iter().any(|v| v == "battery"));
-        for id in get_app_module_ids(&[
-            "claude".into(),
-            "codex".into(),
-            "amp".into(),
-            "grok".into(),
-        ]) {
+        for id in
+            get_app_module_ids(&["claude".into(), "codex".into(), "amp".into(), "grok".into()])
+        {
             assert!(mr.iter().any(|v| v.as_str() == Some(&id)), "missing {id}");
         }
         let inc = parsed["include"].as_array().unwrap();
@@ -903,12 +900,9 @@ mod orchestration_tests {
         ))
         .unwrap();
         let mr = final_cfg["modules-right"].as_array().unwrap();
-        for id in get_app_module_ids(&[
-            "claude".into(),
-            "codex".into(),
-            "amp".into(),
-            "grok".into(),
-        ]) {
+        for id in
+            get_app_module_ids(&["claude".into(), "codex".into(), "amp".into(), "grok".into()])
+        {
             assert!(!mr.iter().any(|v| v.as_str() == Some(&id)));
         }
         assert!(mr.iter().any(|v| v == "clock"));
@@ -940,12 +934,9 @@ mod orchestration_tests {
         assert_eq!(cfg["layer"], "top");
         assert_eq!(cfg["position"], "top");
         let mr = cfg["modules-right"].as_array().unwrap();
-        for id in get_app_module_ids(&[
-            "claude".into(),
-            "codex".into(),
-            "amp".into(),
-            "grok".into(),
-        ]) {
+        for id in
+            get_app_module_ids(&["claude".into(), "codex".into(), "amp".into(), "grok".into()])
+        {
             assert!(mr.iter().any(|v| v.as_str() == Some(&id)), "missing {id}");
         }
         let inc = cfg["include"].as_array().unwrap();

--- a/tests/golden.rs
+++ b/tests/golden.rs
@@ -111,6 +111,7 @@ fn claude_healthy() -> ProviderQuota {
         models: None,
         extra: None,
         error: None,
+        stale_reason: None,
     }
 }
 
@@ -127,6 +128,7 @@ fn claude_error() -> ProviderQuota {
         models: None,
         extra: None,
         error: Some("Token expired. Open `agent-bar menu` and choose Provider login.".into()),
+        stale_reason: None,
     }
 }
 
@@ -158,6 +160,7 @@ fn codex_healthy() -> ProviderQuota {
             extra_usage: None,
         })),
         error: None,
+        stale_reason: None,
     }
 }
 
@@ -174,6 +177,7 @@ fn codex_error() -> ProviderQuota {
         models: None,
         extra: None,
         error: Some("No session data found".into()),
+        stale_reason: None,
     }
 }
 
@@ -198,6 +202,7 @@ fn amp_healthy() -> ProviderQuota {
         models: Some(models),
         extra: Some(ProviderExtra::Amp(AmpQuotaExtra { meta: Some(meta) })),
         error: None,
+        stale_reason: None,
     }
 }
 
@@ -214,6 +219,7 @@ fn amp_error() -> ProviderQuota {
         models: None,
         extra: None,
         error: Some("Amp CLI not installed. Right-click to install and log in.".into()),
+        stale_reason: None,
     }
 }
 
@@ -254,6 +260,7 @@ fn claude_with_extras() -> ProviderQuota {
             }),
         })),
         error: None,
+        stale_reason: None,
     }
 }
 
@@ -280,6 +287,7 @@ fn amp_with_credits() -> ProviderQuota {
         models: Some(models),
         extra: Some(ProviderExtra::Amp(AmpQuotaExtra { meta: Some(meta) })),
         error: None,
+        stale_reason: None,
     }
 }
 
@@ -302,6 +310,7 @@ fn amp_unknown_models() -> ProviderQuota {
             meta: Some(BTreeMap::new()),
         })),
         error: None,
+        stale_reason: None,
     }
 }
 


### PR DESCRIPTION
## Problema

Providers logados apareciam como desconectados (ícone de corrente quebrada) na Waybar.

**Causa raiz:** o access token do Grok dura 6h e só é renovado quando o Grok CLI roda; o agent-bar tratava `expires_at <= now` como logout, mesmo com `refresh_token` válido no `auth.json` — num provider zero-rede que nem usa o token. Claude, Codex e Amp tinham o mesmo padrão: token expirado overnight ou timeout de rede viravam `disconnected`, porque o formatter renderiza qualquer `error` como corrente quebrada.

## Mudanças

- **Grok:** logado = existe entry com `key` não vazio no `auth.json`; `expires_at` não desloga mais.
- **Infra stale:** `cache::get_stale` (ignora TTL), `ProviderQuota.stale_reason`, `ProviderError::is_transient()`, novo `AmpError::Timeout`.
- **`base_get_quota`:** erro transitório + cache (mesmo vencido) que constrói quota saudável → serve com `stale_reason`; raw degenerado ou sem cache → comportamento de erro atual.
- **Claude (fluxo inline):** token expirado → cache válido serve normal, cache vencido serve como stale, sem cache mantém o erro; nunca chama a API com token vencido. Erros de fetch (timeout/API) também tentam stale primeiro.
- **Amp:** timeout do `amp usage` vira `AmpError::Timeout` (transitório), não `NotLoggedIn`.
- **Tooltip:** linha `⚠️ Cached data — {reason}` (amarelo, vline na cor de marca) nos 5 builders quando a quota é stale. Sem classe CSS nova; snapshots golden/insta intactos.
- **Docs:** `staleReason` documentado em `docs/json-output.md`.

Também incluído (commit `feat: reset diário e fallback raw no amp`): WIP pré-existente da working tree — ETA de reset diário à meia-noite UTC, flag auto-replenish e fallback de linhas cruas pro tooltip do Amp. Revisado à parte; provavelmente substitui a branch `feat/amp-tooltip-reset-diario`.

## Verificação

- `cargo test`: 764 passed, 0 failed.
- `cargo clippy --all-targets -- -D warnings`: limpo.
- Smoke com credenciais reais: grok `ok` (após `--refresh`; o cache pré-upgrade se autocorrige em ≤90s de TTL), claude `ok`, amp `ok`, codex `critical` (estado legítimo de quota).

## Limitações aceitas

- Erro transitório sem nenhum cache no disco ainda renderiza `disconnected` (primeira execução offline) — estado neutro exigiria mudança no contrato CSS.
- `CodexError::NoRateLimitData` segue não-transitório (costuma significar auth quebrada).
- Minors deferidos: truncation/sanitização dos raw values do Amp e teste de escape dedicado; `_exp` cosmético no grok.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Quota data can remain available during transient provider failures by using cached results.
  * Displays a clear “Cached data” warning when results are stale, including in Waybar.
  * Added richer AMP usage details, daily reset labels, auto-replenishment hints, and fallback usage lines.
  * Added support for exposing an optional `staleReason` field in JSON output.

* **Bug Fixes**
  * Prevents provider timeouts from being incorrectly reported as disconnected.
  * Improves logged-in detection when Grok tokens are expired but credentials remain available.

* **Documentation**
  * Documented stale-data indicators and JSON output behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->