### PR TITLE
feat: settings Omarchy e CLI simplify

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ Monitor de quota de Claude Code, OpenAI Codex, Amp e Grok Build na Waybar. Quota
 
 ## O que ele mostra
 
-Cada provider vira um módulo na barra com o percentual restante, colorido pelo estado: verde de 60% pra cima, amarelo entre 30 e 59, laranja entre 10 e 29, vermelho abaixo de 10. Passando o mouse, o tooltip abre as janelas de quota com horário de reset. Clique esquerdo abre a TUI num terminal à parte; clique direito força um refresh, ou o login se a sessão caiu.
+Cada provider vira um módulo na barra com o percentual restante, colorido pelo estado: verde de 60% pra cima, amarelo entre 30 e 59, laranja entre 10 e 29, vermelho abaixo de 10. Passando o mouse, o tooltip abre as janelas de quota com horário de reset.
+
+Na **Waybar**, clique esquerdo abre a TUI num terminal à parte; clique direito foca o provider (detail ou login se a sessão caiu). No **Omarchy 4** (omarchy-shell): esquerdo = popup de usage, direito = settings nativo no mesmo popup, meio = refresh. Dashboard completo (charts, histórico, login): `agent-bar menu` ou o link no rodapé do popup.
 
 De onde vem o dado, por provider:
 
@@ -80,20 +82,18 @@ Ele descobre como você instalou e age de acordo. Instalação pelo instalador: 
 | Comando | O que faz |
 | --- | --- |
 | `agent-bar` | Chamado pela Waybar (sem TTY), imprime o JSON do módulo. Num terminal, abre a TUI. |
-| `agent-bar status` | Quotas de todos os providers no terminal, sem TUI. Com `-r`, ignora o cache. |
-| `agent-bar menu` | A TUI: abre no detalhe do primeiro provider habilitado (gauges e sparklines), histórico de uso (24 h/7 d), login e Config. Mouse funciona. |
-| `agent-bar setup` | (Re)aplica a integração: assets, patches na config da Waybar, symlink, reload. Pergunta antes. |
+| `agent-bar status` | Quotas de todos os providers no terminal, sem TUI. Com `-r`, ignora o cache. `-t` / `--terminal` é alias. |
+| `agent-bar menu` | A TUI (dashboard): detalhe do primeiro provider habilitado, histórico, login e Config. |
+| `agent-bar config show` | Imprime o subset editável de settings (JSON). |
+| `agent-bar config apply` | Aplica patch JSON em settings (`--json` / `--file`). Não recarrega a Waybar. |
+| `agent-bar setup` | (Re)aplica a integração: assets, Waybar e/ou plugin Omarchy, symlink, reload. Pergunta antes. |
 | `agent-bar update` | Atualiza a instalação (detalhes acima). |
-| `agent-bar uninstall` | Remove binário, assets da Waybar, settings e cache, e reverte os patches na config. Pede confirmação. |
-| `agent-bar remove` | O mesmo, sem perguntar. |
-| `agent-bar doctor` | Caça sobras da era npm do projeto no `$HOME` (`package.json`, `node_modules`, lockfiles) e limpa. `--dry-run` só lista, `--yes` não pergunta. |
-| `agent-bar assets install` | Só copia ícones e helper, sem tocar na config. Aceita `--waybar-dir` e `--scripts-dir`. |
-| `agent-bar export waybar-modules` | Imprime o contrato JSON dos módulos, pra quem prefere fiação manual. |
-| `agent-bar export waybar-css` | O mesmo pro CSS. |
-| `agent-bar help` | Todos os comandos e flags. |
+| `agent-bar uninstall` | Remove binário, assets, settings e cache, e reverte patches. Pede confirmação. |
+| `agent-bar doctor` | Caça sobras da era npm no `$HOME` e limpa. `--dry-run` só lista, `--yes` não pergunta. |
+| `agent-bar help` | Comandos e flags públicos (internos de packager/Waybar ficam ocultos). |
 | `agent-bar --version` | Versão instalada. |
 
-Flags úteis no dia a dia: `--provider <id>` (`-p`) limita a um provider, `--refresh` (`-r`) invalida o cache antes de buscar, `--verbose` (`-v`) liga o debug no stderr sem sujar o stdout que a Waybar parseia.
+Flags úteis no dia a dia: `--provider <id>` (`-p`) limita a um provider, `--refresh` (`-r`) invalida o cache antes de buscar, `--verbose` (`-v`) liga o debug no stderr sem sujar o stdout que a Waybar parseia. Superfície completa em [docs/commands.md](docs/commands.md).
 
 ## Outras barras (Quickshell, Eww, Ironbar)
 
@@ -108,7 +108,7 @@ O schema é versionado (`schemaVersion: 1`) e está descrito, com exemplo de Qui
 
 ## Desinstalação
 
-`agent-bar uninstall` mostra a lista do que vai remover e pede confirmação; `agent-bar remove` faz o mesmo sem perguntar. Os dois revertem os patches na config da Waybar. Os backups `.agent-bar-backup` ficam, caso você queira comparar depois.
+`agent-bar uninstall` mostra a lista do que vai remover e pede confirmação; `agent-bar remove` é alias forçado (`uninstall --yes`). Os dois revertem os patches na config da Waybar e desregistram o plugin Omarchy quando existir. Os backups `.agent-bar-backup` ficam, caso você queira comparar depois.
 
 ## Stack
 
@@ -121,6 +121,7 @@ Rust 2021 (MSRV 1.88), tokio + reqwest/rustls no fetch, ratatui na TUI, serde no
 - [Comandos](docs/commands.md) — a versão longa da tabela acima
 - [Runtime](docs/runtime.md) — quais paths o agent-bar considera dele
 - [Integração com a Waybar](docs/integration.md)
+- [Omarchy shell](docs/omarchy-shell.md) — plugin, clicks, settings nativo
 - [Contrato Waybar](docs/waybar-contract.md) — module IDs, CSS, refresh por signal
 - [Saída JSON](docs/json-output.md)
 - [Troubleshooting](docs/troubleshooting.md)

--- a/assets/omarchy/Widget.qml
+++ b/assets/omarchy/Widget.qml
@@ -4,10 +4,11 @@ import Quickshell.Io
 import qs.Commons
 import qs.Ui
 
-// agent-bar — chips de quota por provider + popup nativo.
+// agent-bar — chips de quota por provider + popup nativo (usage + settings).
 // Fonte de dados: `agent-bar --format json` (envelope schemaVersion 1,
-// ver docs/json-output.md no repo do agent-bar). Este arquivo é escrito
-// pelo `agent-bar setup` e version-locked com o binário.
+// ver docs/json-output.md no repo do agent-bar). Settings editáveis via
+// `agent-bar config show|apply`. Este arquivo é escrito pelo
+// `agent-bar setup` e version-locked com o binário.
 BarWidget {
   id: root
   moduleName: "agent-bar.usage"
@@ -17,19 +18,37 @@ BarWidget {
   property bool stale: false
   property bool forceNext: false
 
+  property bool settingsMode: false
+  property var draftSettings: ({
+    providers: [],
+    providerOrder: [],
+    displayMode: "remaining",
+    notifyEnabled: true,
+    refreshIntervalSec: 60
+  })
+  // null = config show ainda não retornou → sem filtro (mostra todos)
+  property var enabledIds: null
+  property string displayMode: "remaining"
+  property string settingsStatusText: ""
+  property bool settingsBusy: false
+
   readonly property color fg: bar ? bar.foreground : Color.foreground
   readonly property color urgent: bar ? bar.urgent : Color.urgent
+  readonly property color dim: Qt.darker(fg, 1.45)
   readonly property string fontFamily: bar ? bar.fontFamily : "monospace"
   readonly property var providers: payload && Array.isArray(payload.providers) ? payload.providers : []
   // Clamp aos limites do schema do manifest (min 30 / max 3600) — o editor
   // do shell respeita o schema, mas shell.json editado à mão não.
   readonly property int refreshIntervalSec: Math.min(3600, Math.max(30, Number(setting("refreshIntervalSec", 60)) || 60))
+  readonly property var knownProviderIds: ["claude", "codex", "amp", "grok"]
 
   // Chamado pelo PopupCard no clique-fora (owner.close()). Sem isto o card
   // faz `open = false` imperativo, o que DESTRÓI o binding open:popupOpen —
   // o popup nunca mais abre. Resetar a fonte da verdade preserva o binding.
   function close() {
     popupOpen = false
+    settingsMode = false
+    settingsBusy = false
   }
 
   function pathFromUrl(url) { return String(url).replace(/^file:\/\//, "") }
@@ -67,10 +86,26 @@ BarWidget {
     return ""
   }
 
+  function providerLabel(id) {
+    if (id === "claude") return "Claude"
+    if (id === "codex") return "Codex"
+    if (id === "amp") return "Amp"
+    if (id === "grok") return "Grok"
+    return String(id || "")
+  }
+
   function chipLabel(p) {
     if (!p.available) return "–"
     var w = p.primary
-    if (!w || !isFinite(Number(w.remaining))) return ""
+    if (!w) return ""
+    if (root.displayMode === "used") {
+      var used = Number(w.used)
+      if (isFinite(used)) return Math.round(used) + "%"
+      var rem = Number(w.remaining)
+      if (isFinite(rem)) return Math.round(100 - rem) + "%"
+      return ""
+    }
+    if (!isFinite(Number(w.remaining))) return ""
     return Math.round(Number(w.remaining)) + "%"
   }
 
@@ -116,9 +151,183 @@ BarWidget {
     if (bar) bar.run(Util.shellQuote(root.helperPath) + " agent-bar menu")
   }
 
+  function applyConfigView(data) {
+    if (!data || data.schemaVersion !== 1) return false
+    enabledIds = Array.isArray(data.providerOrder) ? data.providerOrder.slice()
+              : (Array.isArray(data.providers) ? data.providers.slice() : [])
+    displayMode = data.displayMode === "used" ? "used" : "remaining"
+    return true
+  }
+
+  function onConfigShowFinished(text) {
+    try {
+      var data = JSON.parse(String(text || ""))
+      if (!applyConfigView(data)) throw new Error("bad config")
+      draftSettings = {
+        providers: (data.providers || []).slice(),
+        providerOrder: (data.providerOrder || data.providers || []).slice(),
+        displayMode: displayMode,
+        notifyEnabled: !!(data.notify && data.notify.enabled),
+        refreshIntervalSec: Math.min(3600, Math.max(30, Number(setting("refreshIntervalSec", 60)) || 60))
+      }
+      settingsStatusText = ""
+    } catch (e) {
+      settingsStatusText = "failed to load settings"
+    }
+  }
+
+  function openSettings() {
+    settingsMode = true
+    popupOpen = true
+    settingsStatusText = ""
+    if (!configShowProc.running) configShowProc.running = true
+  }
+
+  function showUsage() {
+    settingsMode = false
+    settingsStatusText = ""
+  }
+
+  function visibleProviders() {
+    var all = root.providers
+    if (!enabledIds || !enabledIds.length) return all
+    var out = []
+    for (var i = 0; i < enabledIds.length; i++) {
+      var id = enabledIds[i]
+      for (var j = 0; j < all.length; j++) {
+        if (all[j] && all[j].provider === id) { out.push(all[j]); break }
+      }
+    }
+    return out
+  }
+
+  // apply via tempfile: Process.write existe, mas fechar stdin (EOF) para
+  // `config apply --json -` não é API estável no Quickshell do Omarchy
+  // 4.0.0.alpha — mktemp + --file evita o problema.
+  function applyShellScript(blob) {
+    return "f=$(mktemp) && printf '%s' " + Util.shellQuote(String(blob || ""))
+      + " >\"$f\" && agent-bar config apply --file \"$f\"; e=$?; rm -f \"$f\"; exit $e"
+  }
+
+  function runConfigApply(blob) {
+    if (configApplyProc.running) return
+    configApplyProc.command = ["bash", "-lc", root.applyShellScript(blob)]
+    configApplyProc.running = true
+  }
+
+  function saveSettings() {
+    if (settingsBusy) return
+    var prov = draftSettings.providers || []
+    if (!prov.length) {
+      settingsStatusText = "Keep at least one provider"
+      return
+    }
+    settingsBusy = true
+    settingsStatusText = "Saving…"
+    var blob = JSON.stringify({
+      schemaVersion: 1,
+      providers: prov,
+      providerOrder: draftSettings.providerOrder || prov,
+      displayMode: draftSettings.displayMode === "used" ? "used" : "remaining",
+      notify: { enabled: !!draftSettings.notifyEnabled }
+    })
+    root.runConfigApply(blob)
+  }
+
+  function onConfigApplyFinished(text, exitCode) {
+    settingsBusy = false
+    if (exitCode !== 0) {
+      settingsStatusText = "apply failed"
+      return
+    }
+    try {
+      var data = JSON.parse(String(text || ""))
+      if (!applyConfigView(data)) throw new Error("bad apply result")
+    } catch (e) {
+      settingsStatusText = "apply failed"
+      return
+    }
+    // interval → shell.json (só se apply OK)
+    var interval = Math.min(3600, Math.max(30, Number(draftSettings.refreshIntervalSec) || 60))
+    if (bar && bar.shell && typeof bar.shell.updateEntryInline === "function") {
+      try {
+        var next = Object.assign({}, root.settings || {}, { refreshIntervalSec: interval })
+        bar.shell.updateEntryInline(root.moduleName, next)
+      } catch (e2) {
+        settingsStatusText = "settings saved; interval not persisted"
+        root.refresh(true)
+        return
+      }
+    }
+    settingsStatusText = "Saved"
+    root.refresh(true)
+  }
+
+  function setProviderEnabled(id, on) {
+    var p = (draftSettings.providers || []).slice()
+    var idx = p.indexOf(id)
+    if (on && idx < 0) p.push(id)
+    if (!on) {
+      if (p.length <= 1 && idx >= 0) {
+        settingsStatusText = "Keep at least one provider"
+        return
+      }
+      if (idx >= 0) p.splice(idx, 1)
+    }
+    var order = (draftSettings.providerOrder || []).filter(function(x) { return p.indexOf(x) >= 0 })
+    p.forEach(function(x) { if (order.indexOf(x) < 0) order.push(x) })
+    draftSettings = Object.assign({}, draftSettings, { providers: p, providerOrder: order })
+  }
+
+  function moveProvider(id, dir) {
+    var p = (draftSettings.providers || []).slice()
+    var idx = p.indexOf(id)
+    if (idx < 0) return
+    var j = idx + dir
+    if (j < 0 || j >= p.length) return
+    var tmp = p[idx]
+    p[idx] = p[j]
+    p[j] = tmp
+    draftSettings = Object.assign({}, draftSettings, { providers: p, providerOrder: p.slice() })
+  }
+
+  function setDisplayMode(mode) {
+    var m = mode === "used" ? "used" : "remaining"
+    draftSettings = Object.assign({}, draftSettings, { displayMode: m })
+  }
+
+  function setNotifyEnabled(on) {
+    draftSettings = Object.assign({}, draftSettings, { notifyEnabled: !!on })
+  }
+
+  function setRefreshInterval(sec) {
+    var n = Math.min(3600, Math.max(30, Number(sec) || 60))
+    draftSettings = Object.assign({}, draftSettings, { refreshIntervalSec: n })
+  }
+
+  // enabled first (draft order), then disabled known ids
+  function settingsProviderRows() {
+    var known = root.knownProviderIds
+    var enabled = draftSettings.providers || []
+    var rows = []
+    for (var i = 0; i < enabled.length; i++) {
+      if (known.indexOf(enabled[i]) >= 0)
+        rows.push({ id: enabled[i], on: true, index: i, count: enabled.length })
+    }
+    for (var j = 0; j < known.length; j++) {
+      if (enabled.indexOf(known[j]) < 0)
+        rows.push({ id: known[j], on: false, index: -1, count: enabled.length })
+    }
+    return rows
+  }
+
   implicitWidth: root.vertical ? root.barSize : chips.implicitWidth + 12
   implicitHeight: root.vertical ? chips.implicitHeight + 12 : root.barSize
   opacity: root.stale ? 0.55 : 1.0
+
+  Component.onCompleted: {
+    if (!configShowProc.running) configShowProc.running = true
+  }
 
   Process {
     id: fetchProc
@@ -129,6 +338,27 @@ BarWidget {
         root.applyPayload(text)
         root.forceNext = false
       }
+    }
+  }
+
+  Process {
+    id: configShowProc
+    command: ["bash", "-lc", "agent-bar config show --format json"]
+    stdout: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: root.onConfigShowFinished(text)
+    }
+  }
+
+  Process {
+    id: configApplyProc
+    command: ["bash", "-lc", "true"]
+    stdout: StdioCollector {
+      id: applyOut
+      waitForEnd: true
+    }
+    onExited: function(exitCode, exitStatus) {
+      root.onConfigApplyFinished(applyOut.text, exitCode)
     }
   }
 
@@ -143,12 +373,12 @@ BarWidget {
   Grid {
     id: chips
     anchors.centerIn: parent
-    columns: root.vertical ? 1 : Math.max(1, root.providers.length)
+    columns: root.vertical ? 1 : Math.max(1, root.visibleProviders().length)
     columnSpacing: 10
     rowSpacing: 6
 
     Repeater {
-      model: root.providers
+      model: root.visibleProviders()
 
       Item {
         id: chip
@@ -194,16 +424,19 @@ BarWidget {
           onEntered: if (root.bar) root.bar.showTooltip(chip, chip.modelData.displayName + (chip.label ? " · " + chip.label : "") + (chip.modelData.available ? "" : " · " + String(chip.modelData.error || "unavailable")))
           onExited: if (root.bar) root.bar.hideTooltip(chip)
           onClicked: function(mouse) {
-            if (mouse.button === Qt.RightButton) root.openTui()
+            if (mouse.button === Qt.RightButton) root.openSettings()
             else if (mouse.button === Qt.MiddleButton) root.refresh(true)
-            else root.popupOpen = !root.popupOpen
+            else {
+              root.showUsage()
+              root.popupOpen = !root.popupOpen
+            }
           }
         }
       }
     }
 
     Text {
-      visible: root.providers.length === 0
+      visible: root.visibleProviders().length === 0
       text: "agent-bar"
       color: root.fg
       font.family: root.fontFamily
@@ -217,8 +450,8 @@ BarWidget {
     owner: root
     bar: root.bar
     open: root.popupOpen
-    contentWidth: Style.space(300)
-    contentHeight: Math.min(popupCol.implicitHeight + Style.space(20), Style.space(480))
+    contentWidth: Style.space(370)
+    contentHeight: Math.min(popupCol.implicitHeight + Style.space(20), Style.space(560))
 
     Flickable {
       anchors.fill: parent
@@ -230,8 +463,56 @@ BarWidget {
         width: parent.width
         spacing: 10
 
+        // ── Settings header ──────────────────────────────────────────
+        RowLayout {
+          visible: root.settingsMode
+          Layout.fillWidth: true
+          spacing: 8
+
+          Button {
+            text: "← Usage"
+            foreground: root.fg
+            fontFamily: root.fontFamily
+            fontSize: 10
+            horizontalPadding: 8
+            verticalPadding: 4
+            onClicked: root.showUsage()
+          }
+
+          Text {
+            text: "Settings"
+            color: root.fg
+            font.family: root.fontFamily
+            font.pixelSize: 13
+            font.bold: true
+            Layout.fillWidth: true
+            Layout.alignment: Qt.AlignVCenter
+          }
+
+          Button {
+            text: root.settingsBusy ? "Saving…" : "Save"
+            foreground: root.fg
+            accent: Color.accent
+            fontFamily: root.fontFamily
+            fontSize: 10
+            horizontalPadding: 8
+            verticalPadding: 4
+            active: true
+            enabled: !root.settingsBusy
+            onClicked: root.saveSettings()
+          }
+        }
+
+        PanelSeparator {
+          visible: root.settingsMode
+          Layout.fillWidth: true
+          foreground: root.fg
+          strength: 0.18
+        }
+
+        // ── Usage sections ───────────────────────────────────────────
         Repeater {
-          model: root.providers
+          model: root.settingsMode ? [] : root.visibleProviders()
 
           ColumnLayout {
             id: section
@@ -260,7 +541,7 @@ BarWidget {
               Text {
                 Layout.fillWidth: true
                 text: String(section.modelData.plan || section.modelData.account || "")
-                color: Qt.darker(root.fg, 1.45)
+                color: root.dim
                 font.family: root.fontFamily
                 font.pixelSize: 11
                 elide: Text.ElideRight
@@ -294,18 +575,201 @@ BarWidget {
           }
         }
 
+        // ── Settings body ────────────────────────────────────────────
+        ColumnLayout {
+          visible: root.settingsMode
+          Layout.fillWidth: true
+          spacing: 12
+
+          PanelSectionHeader {
+            Layout.fillWidth: true
+            text: "Providers"
+            foreground: root.fg
+            fontFamily: root.fontFamily
+            fontSize: 11
+          }
+
+          Repeater {
+            model: root.settingsMode ? root.settingsProviderRows() : []
+
+            ColumnLayout {
+              id: provRow
+              required property var modelData
+              Layout.fillWidth: true
+              spacing: 4
+
+              Toggle {
+                Layout.fillWidth: true
+                label: root.providerLabel(provRow.modelData.id)
+                description: checked ? "Shown in bar chips" : "Hidden from the bar"
+                checked: provRow.modelData.on
+                foreground: root.fg
+                accent: Color.accent
+                fontFamily: root.fontFamily
+                onClicked: root.setProviderEnabled(provRow.modelData.id, !checked)
+              }
+
+              RowLayout {
+                visible: provRow.modelData.on
+                Layout.fillWidth: true
+                spacing: 6
+
+                Item { Layout.fillWidth: true }
+
+                Button {
+                  text: "↑"
+                  enabled: provRow.modelData.index > 0
+                  foreground: root.fg
+                  fontFamily: root.fontFamily
+                  fontSize: 11
+                  horizontalPadding: 8
+                  verticalPadding: 3
+                  onClicked: root.moveProvider(provRow.modelData.id, -1)
+                }
+                Button {
+                  text: "↓"
+                  enabled: provRow.modelData.index >= 0 && provRow.modelData.index < provRow.modelData.count - 1
+                  foreground: root.fg
+                  fontFamily: root.fontFamily
+                  fontSize: 11
+                  horizontalPadding: 8
+                  verticalPadding: 3
+                  onClicked: root.moveProvider(provRow.modelData.id, 1)
+                }
+              }
+            }
+          }
+
+          PanelSectionHeader {
+            Layout.fillWidth: true
+            text: "Display"
+            foreground: root.fg
+            fontFamily: root.fontFamily
+            fontSize: 11
+          }
+
+          RowLayout {
+            Layout.fillWidth: true
+            spacing: 6
+
+            Button {
+              text: "Remaining"
+              Layout.fillWidth: true
+              foreground: root.fg
+              accent: Color.accent
+              fontFamily: root.fontFamily
+              fontSize: 11
+              horizontalPadding: 8
+              verticalPadding: 5
+              active: (root.draftSettings.displayMode || "remaining") !== "used"
+              onClicked: root.setDisplayMode("remaining")
+            }
+            Button {
+              text: "Used"
+              Layout.fillWidth: true
+              foreground: root.fg
+              accent: Color.accent
+              fontFamily: root.fontFamily
+              fontSize: 11
+              horizontalPadding: 8
+              verticalPadding: 5
+              active: root.draftSettings.displayMode === "used"
+              onClicked: root.setDisplayMode("used")
+            }
+          }
+
+          PanelSectionHeader {
+            Layout.fillWidth: true
+            text: "Alerts"
+            foreground: root.fg
+            fontFamily: root.fontFamily
+            fontSize: 11
+          }
+
+          Toggle {
+            Layout.fillWidth: true
+            label: "Desktop notifications"
+            description: checked ? "notify-send on quota thresholds" : "Notifications off"
+            checked: !!root.draftSettings.notifyEnabled
+            foreground: root.fg
+            accent: Color.accent
+            fontFamily: root.fontFamily
+            onClicked: root.setNotifyEnabled(!checked)
+          }
+
+          PanelSectionHeader {
+            Layout.fillWidth: true
+            text: "Refresh"
+            foreground: root.fg
+            fontFamily: root.fontFamily
+            fontSize: 11
+          }
+
+          NumberField {
+            Layout.fillWidth: true
+            label: "Interval (seconds)"
+            value: Number(root.draftSettings.refreshIntervalSec || 60)
+            from: 30
+            to: 3600
+            stepSize: 30
+            fieldWidth: parent.width
+            foreground: root.fg
+            accent: Color.accent
+            fontFamily: root.fontFamily
+            onModified: function(value) { root.setRefreshInterval(value) }
+          }
+
+          Text {
+            visible: root.settingsStatusText !== ""
+            Layout.fillWidth: true
+            text: root.settingsStatusText
+            color: root.dim
+            font.family: root.fontFamily
+            font.pixelSize: 10
+            horizontalAlignment: Text.AlignHCenter
+            wrapMode: Text.WordWrap
+          }
+
+          Text {
+            Layout.fillWidth: true
+            text: "s saves · esc closes"
+            color: root.dim
+            font.family: root.fontFamily
+            font.pixelSize: 10
+            horizontalAlignment: Text.AlignHCenter
+          }
+        }
+
+        // ── Usage footer ─────────────────────────────────────────────
         Text {
+          visible: !root.settingsMode
           text: root.stale ? "stale — last fetch failed" : (root.payload ? "fetched " + root.fmtReset(root.payload.fetchedAt) : "loading…")
-          color: Qt.darker(root.fg, 1.45)
+          color: root.dim
           font.family: root.fontFamily
           font.pixelSize: 10
         }
 
         Text {
-          text: "right-click: TUI · middle-click: refresh"
+          visible: !root.settingsMode
+          text: "right-click: settings · middle: refresh"
           color: Qt.darker(root.fg, 1.6)
           font.family: root.fontFamily
           font.pixelSize: 10
+        }
+
+        Text {
+          visible: !root.settingsMode
+          text: "Abrir menu (TUI)"
+          color: Color.accent
+          font.family: root.fontFamily
+          font.pixelSize: 11
+          font.underline: true
+
+          MouseArea {
+            anchors.fill: parent
+            cursorShape: Qt.PointingHandCursor
+            onClicked: root.openTui()
+          }
         }
       }
     }

--- a/assets/omarchy/Widget.qml
+++ b/assets/omarchy/Widget.qml
@@ -220,6 +220,10 @@ BarWidget {
 
   function runConfigApply(blob) {
     if (configApplyProc.running) return
+    configApplyProc._haveStdout = false
+    configApplyProc._haveExit = false
+    configApplyProc._stdout = ""
+    configApplyProc._exitCode = 0
     configApplyProc.command = ["bash", "-lc", root.applyShellScript(blob)]
     configApplyProc.running = true
   }
@@ -363,13 +367,35 @@ BarWidget {
 
   Process {
     id: configApplyProc
+    // Barrier: onExited can race ahead of StdioCollector flush.
+    // Wait for both streamFinished and exited before parsing stdout.
+    property string _stdout: ""
+    property int _exitCode: 0
+    property bool _haveStdout: false
+    property bool _haveExit: false
     command: ["bash", "-lc", "true"]
     stdout: StdioCollector {
       id: applyOut
       waitForEnd: true
+      onStreamFinished: {
+        configApplyProc._stdout = text
+        configApplyProc._haveStdout = true
+        configApplyProc._tryFinishApply()
+      }
     }
     onExited: function(exitCode, exitStatus) {
-      root.onConfigApplyFinished(applyOut.text, exitCode)
+      configApplyProc._exitCode = exitCode
+      configApplyProc._haveExit = true
+      configApplyProc._tryFinishApply()
+    }
+    function _tryFinishApply() {
+      if (!_haveStdout || !_haveExit) return
+      var text = _stdout
+      var code = _exitCode
+      _haveStdout = false
+      _haveExit = false
+      _stdout = ""
+      root.onConfigApplyFinished(text, code)
     }
   }
 
@@ -438,8 +464,14 @@ BarWidget {
             if (mouse.button === Qt.RightButton) root.openSettings()
             else if (mouse.button === Qt.MiddleButton) root.refresh(true)
             else {
-              root.showUsage()
-              root.popupOpen = !root.popupOpen
+              // left: usage; toggle open only if already usage (or closed).
+              // From settings with popup open → switch to usage, keep open.
+              if (root.settingsMode && root.popupOpen) {
+                root.showUsage()
+              } else {
+                root.showUsage()
+                root.popupOpen = !root.popupOpen
+              }
             }
           }
         }

--- a/assets/omarchy/Widget.qml
+++ b/assets/omarchy/Widget.qml
@@ -51,6 +51,15 @@ BarWidget {
     settingsBusy = false
   }
 
+  // PopupCard (xdg-popup) não tem focusTarget como KeyboardPanel; forçamos
+  // o catcher quando o popup abre. Sem click no card o compositor pode ainda
+  // não entregar teclas — mesmo padrão do shell quando o surface não é Exclusive.
+  onPopupOpenChanged: {
+    if (popupOpen) Qt.callLater(function() {
+      if (root.popupOpen && keyCatcher) keyCatcher.forceActiveFocus()
+    })
+  }
+
   function pathFromUrl(url) { return String(url).replace(/^file:\/\//, "") }
   readonly property string helperPath: pathFromUrl(Qt.resolvedUrl("scripts/agent-bar-open-terminal"))
 
@@ -249,17 +258,19 @@ BarWidget {
     }
     // interval → shell.json (só se apply OK)
     var interval = Math.min(3600, Math.max(30, Number(draftSettings.refreshIntervalSec) || 60))
+    var intervalPersisted = false
     if (bar && bar.shell && typeof bar.shell.updateEntryInline === "function") {
       try {
         var next = Object.assign({}, root.settings || {}, { refreshIntervalSec: interval })
         bar.shell.updateEntryInline(root.moduleName, next)
+        intervalPersisted = true
       } catch (e2) {
-        settingsStatusText = "settings saved; interval not persisted"
-        root.refresh(true)
-        return
+        intervalPersisted = false
       }
     }
-    settingsStatusText = "Saved"
+    settingsStatusText = intervalPersisted
+      ? "Saved"
+      : "settings saved; interval not persisted"
     root.refresh(true)
   }
 
@@ -452,6 +463,19 @@ BarWidget {
     open: root.popupOpen
     contentWidth: Style.space(370)
     contentHeight: Math.min(popupCol.implicitHeight + Style.space(20), Style.space(560))
+
+    // PanelKeyCatcher (qs.Ui): esc → close, s/S → save ou openSettings.
+    // PopupCard não expõe focusTarget; ver onPopupOpenChanged no root.
+    PanelKeyCatcher {
+      id: keyCatcher
+      anchors.fill: parent
+      blocked: root.settingsMode && refreshIntervalField.field.activeFocus
+
+      onCloseRequested: root.close()
+      onTextKey: function(t) {
+        if (t === "s" || t === "S")
+          root.settingsMode ? root.saveSettings() : root.openSettings()
+      }
 
     Flickable {
       anchors.fill: parent
@@ -706,6 +730,7 @@ BarWidget {
           }
 
           NumberField {
+            id: refreshIntervalField
             Layout.fillWidth: true
             label: "Interval (seconds)"
             value: Number(root.draftSettings.refreshIntervalSec || 60)
@@ -773,6 +798,7 @@ BarWidget {
         }
       }
     }
+    } // PanelKeyCatcher
   }
 
   component QuotaRow: RowLayout {

--- a/assets/omarchy/manifest.json
+++ b/assets/omarchy/manifest.json
@@ -13,7 +13,7 @@
   },
   "barWidget": {
     "displayName": "agent-bar",
-    "description": "Quota chips per provider; left = popup, right = TUI, middle = refresh.",
+    "description": "Quota chips per provider; left = usage, right = settings, middle = refresh.",
     "category": "AI",
     "aliases": ["agent-bar"],
     "allowMultiple": false,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -45,12 +45,16 @@ goes to `stderr` via `logger`. Breaking that contract breaks the bar.
 
 `parse_args` (`src/cli.rs`) turns argv into `CliOptions`. `main()` dispatches:
 
-- **Subcommands** (`menu`, `setup`, `doctor`, `update`, `action-right`, …) are
-  dispatched by pattern match and handled, then the process exits.
+- **Subcommands** (`menu`, `setup`, `doctor`, `update`, `config show|apply`,
+  `action-right`, …) are dispatched by pattern match and handled, then the
+  process exits. `config show|apply` is implemented in `src/config_cmd.rs`
+  (editable settings subset only; no Waybar reload). `action-right` remains
+  the Waybar right-click path; Omarchy uses the native popup settings mode
+  instead (see [omarchy-shell.md](omarchy-shell.md)).
 - **`--watch`** hands off to `start_watch` (`src/watch.rs`) and streams NDJSON.
 - Otherwise it resolves quotas and prints a single payload. The default command
-  is `waybar`; `status`/`terminal` print the ANSI view; `--format json` prints
-  the versioned envelope.
+  is `waybar`; `status` (`-t`/`--terminal` alias) prints the ANSI view;
+  `--format json` prints the versioned envelope.
 
 Two Waybar render shapes share the formatter:
 
@@ -167,6 +171,7 @@ injection bug, so all Pango output goes through it.
 | `src/main.rs` | Entry point; dispatch by command/flags. |
 | `src/cli.rs` | argv → `CliOptions`; `--help` rendering; command suggestions. |
 | `src/config.rs` | Paths (XDG), cache TTL, API endpoints, color thresholds. |
+| `src/config_cmd.rs` | `config show` / `config apply` — editable settings subset (JSON). |
 | `src/cache.rs` | File-based quota cache (5 min, cross-process, atomic writes). |
 | `src/providers/mod.rs` | Registration, parallel fan-out, timeout/retry. |
 | `src/providers/base.rs` | `BaseProvider` `get_quota()` orchestration. |
@@ -178,12 +183,14 @@ injection bug, so all Pango output goes through it.
 | `src/formatters/json.rs` | Versioned JSON envelope (`schemaVersion`). |
 | `src/waybar_contract.rs` | Generated Waybar modules/CSS/asset install (the integration contract). |
 | `src/notify.rs` | Best-effort low/critical desktop notifications. |
-| `src/action_right.rs` | Right-click handler — resolves TUI focus (provider detail or Login) from connection state. |
+| `src/action_right.rs` | Waybar right-click handler — resolves TUI focus (provider detail or Login) from connection state. |
+| `src/omarchy_integration.rs` | Omarchy drop-in install/remove; embeds `Widget.qml` / manifest. |
 
 ## See Also
 
-- [Commands](commands.md) — public CLI surface, flags, and `action-right`.
+- [Commands](commands.md) — public CLI surface, `config`, flags, and internals.
 - [Runtime](runtime.md) — owned paths, settings, cache, credentials.
 - [Waybar contract](waybar-contract.md) — generated modules, classes, click actions.
+- [Omarchy shell](omarchy-shell.md) — plugin drop-in, settings popup, dual-write.
 - [JSON output](json-output.md) — `--format json` / `--watch` schema.
 - [New provider guide](new-provider.md) — implementing a provider on `BaseProvider`.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -28,8 +28,8 @@ agent-bar config apply --file <path>     # packager / QML / tests
 ```
 
 Stdout is JSON only (logs on stderr). Success stdout of `apply` is the same
-envelope as `show` (post-save state). Exit: `0` ok · `1` validation/IO ·
-`2` bad args.
+envelope as `show` (post-save state). Exit: `0` ok · `1` validation, usage
+(missing args), or IO — same as the rest of the CLI.
 
 Example envelope:
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,13 +1,147 @@
 # Commands
 
-## Primary Commands
+Public CLI surface grouped the way `--help` presents it. Internal commands
+remain parseable (Waybar modules, terminal helper, packagers) but are hidden
+from the human help listing.
+
+## Usage
 
 | Command | Purpose | Writes |
 | --- | --- | --- |
 | `agent-bar` | Print Waybar JSON for enabled providers. | Cache only when providers fetch fresh data |
 | `agent-bar status` | Print the quota view in a terminal. | Cache only |
-| `agent-bar menu` | Interactive TUI: boots on the first enabled provider's detail view, plus hourly/daily history, provider login, and the Config editor. | Settings and provider auth as requested |
-| `agent-bar update` | Update the install: managed `~/.agent-bar` checkout, or defers to system package manager. | `~/.agent-bar`, managed Waybar files |
+| `agent-bar menu` | Interactive TUI: first enabled provider detail, hourly/daily history, provider login, and the Config editor. | Settings and provider auth as requested |
+| `agent-bar config show` | Print the editable settings subset as JSON. | Nothing |
+| `agent-bar config apply` | Apply a JSON patch to the editable settings subset. | `~/.config/agent-bar/settings.json` |
+
+## `config show` / `config apply`
+
+Bridge for the Omarchy settings popup (and scripts). Schema of **this**
+command is independent of the quota JSON envelope (`schemaVersion` here is
+the config subset, currently `1`).
+
+```bash
+agent-bar config show
+agent-bar config apply --json '{"schemaVersion":1,"providers":["claude","codex"]}'
+agent-bar config apply --json -          # read blob from stdin
+agent-bar config apply --file <path>     # packager / QML / tests
+```
+
+Stdout is JSON only (logs on stderr). Success stdout of `apply` is the same
+envelope as `show` (post-save state). Exit: `0` ok · `1` validation/IO ·
+`2` bad args.
+
+Example envelope:
+
+```json
+{
+  "schemaVersion": 1,
+  "providers": ["claude", "codex", "amp", "grok"],
+  "providerOrder": ["claude", "codex", "amp", "grok"],
+  "displayMode": "remaining",
+  "notify": { "enabled": true }
+}
+```
+
+| Field | Notes |
+| --- | --- |
+| `schemaVersion` | Required on apply; must be `1`. |
+| `providers` | Enabled ids after normalize; apply with empty/unknown-only → error. |
+| `providerOrder` | Effective order; unknown ids dropped. |
+| `displayMode` | `"remaining"` or `"used"`. |
+| `notify.enabled` | Desktop low/critical notifications. |
+
+Omitted fields on apply are left unchanged. Not included: separators, Waybar
+signal/interval, menu font, cache, glyphs, `refreshIntervalSec` (Omarchy
+plugin setting — see [omarchy-shell.md](omarchy-shell.md)).
+
+**Side-effects of apply:** writes `settings.json` only. Does **not** reload
+Waybar, re-patch modules, or invalidate the quota cache.
+
+## Setup
+
+| Command | Purpose | Writes |
+| --- | --- | --- |
+| `agent-bar setup` | Install assets, create symlink, patch Waybar and/or Omarchy plugin, reload. | `~/.local/bin`, `~/.config/waybar`, Omarchy plugins dir |
+| `agent-bar update` | Update the install: managed `~/.agent-bar` checkout, or defers to system package manager. | `~/.agent-bar`, managed Waybar/Omarchy files |
+| `agent-bar uninstall` | Interactive removal of managed integration and owned files. | Removes managed files/entries |
+| `agent-bar doctor` | Detect and clean leftover agent-bar artifacts in `$HOME` from previous installs. | Optional cleanup under `$HOME` |
+
+```bash
+agent-bar doctor              # interactive
+agent-bar doctor --dry-run    # report without removing
+agent-bar doctor --yes        # non-interactive, remove without prompting
+```
+
+`remove` is a quiet alias of `uninstall --yes` (forced, non-interactive). It
+is not listed in `--help`; the primary removal command is `uninstall`.
+
+## Machine (JSON / flags)
+
+For Quickshell, Eww, Ironbar, or any consumer that renders natively and wants
+raw structured data instead of the Waybar Pango envelope.
+
+| Command | Purpose | Writes |
+| --- | --- | --- |
+| `agent-bar --format json` | One-shot versioned JSON envelope for all registered providers (Pango-free). | Cache only |
+| `agent-bar --format json --provider <id>` | Same, single provider. | Cache only |
+| `agent-bar --watch [--interval <s>]` | Stream NDJSON (one envelope per line) until killed. | Cache only |
+
+The schema, stability policy, and a Quickshell QML example live in
+[`docs/json-output.md`](json-output.md). Unlike the Waybar path, JSON output is
+**not** filtered by the `waybar.providers` setting — it emits all registered
+providers and the consumer decides what to show (Omarchy QML filters chips
+using `config show`).
+
+### Flags
+
+| Flag | Purpose |
+| --- | --- |
+| `-p`, `--provider <id>` | Limit output to `claude`, `codex`, `amp`, or `grok`. |
+| `-r`, `--refresh` | Ignore cache and fetch fresh provider data. |
+| `-t`, `--terminal` | Alias of `status` (terminal quota view). |
+| `--format <waybar\|json>` | Output format. Default `waybar`. `json` emits the versioned contract. |
+| `--watch` | Stream NDJSON (one envelope per line); implies `--format json`. |
+| `--interval <seconds>` | Watch poll floor (default 60). Only meaningful with `--watch`. |
+| `-v`, `--verbose` | Enable diagnostic logging (stderr). |
+| `-V`, `--version` | Print version and exit. |
+| `-h`, `--help` | Print CLI help. |
+
+## Internal (hidden from `--help`)
+
+Still parseable for Waybar modules, the terminal helper, tests, and
+packagers. Prefer the public commands above for interactive use.
+
+### Waybar-triggered
+
+Generated Waybar modules wire these to click actions (see
+[waybar-contract.md](waybar-contract.md)). Omarchy uses native popup
+settings instead of `action-right`.
+
+| Command | Trigger | Behavior |
+| --- | --- | --- |
+| `agent-bar menu` | Left click (Waybar) | Interactive TUI (also a primary command). |
+| `agent-bar action-right <provider>` | Right click (Waybar) | Opens the TUI already focused on one provider. Requires a provider arg. |
+
+`action-right` resolves whether the clicked provider looks connected, then opens
+the interactive TUI already focused there:
+
+- **Disconnected** — no credentials, or a quota error matching the base pattern
+  (`expired` / `not logged in` / `login again` / `please login`); for Codex,
+  additionally `no session data` / `no rate limit data` / `auth` / `token` →
+  boots straight into the Login screen with that provider preselected.
+- **Connected** — boots straight into that provider's detail view.
+
+It requires a provider argument — the CLI parser exits non-zero without one.
+
+### Helper / packaging
+
+| Command | Purpose |
+| --- | --- |
+| `agent-bar menu-font` | Prints `{fontFamily}\t{fontSize}` from `settings.menu` for `scripts/agent-bar-open-terminal`. |
+| `agent-bar assets install --waybar-dir <path> --scripts-dir <path>` | Copy icons and terminal helper into explicit paths. |
+| `agent-bar export waybar-modules --app-bin <path> --terminal-script <path>` | Print generated Waybar module JSON. |
+| `agent-bar export waybar-css --icons-dir <path>` | Print generated Waybar CSS JSON. |
 
 ## `menu` Navigation
 
@@ -23,89 +157,9 @@ a right-hand content pane.
 - **Mouse:** click selects (sidebar rows, provider cards, chips), the wheel
   scrolls, and `shift`+drag selects terminal text as usual (mouse capture is
   disabled for that gesture).
-- **`menu-font`:** hidden internal command (`agent-bar menu-font`, not shown
-  in `--help`) that prints `{fontFamily}\t{fontSize}` from
-  `settings.menu` for `scripts/agent-bar-open-terminal` to pass through to
-  terminals that support a font flag when launching the menu.
 
-## Internal Commands (Waybar-Triggered)
-
-You normally don't type these — generated Waybar modules wire them to click
-actions (see [waybar-contract.md](waybar-contract.md)).
-
-| Command | Trigger | Behavior |
-| --- | --- | --- |
-| `agent-bar menu` | Left click | Interactive TUI (also a primary command). |
-| `agent-bar action-right <provider>` | Right click | Opens the TUI already focused on one provider. Requires a provider arg. |
-
-`action-right` resolves whether the clicked provider looks connected, then opens
-the interactive TUI already focused there:
-
-- **Disconnected** — no credentials, or a quota error matching the base pattern
-  (`expired` / `not logged in` / `login again` / `please login`); for Codex,
-  additionally `no session data` / `no rate limit data` / `auth` / `token` →
-  boots straight into the Login screen with that provider preselected.
-- **Connected** — boots straight into that provider's detail view.
-
-It requires a provider argument — the CLI parser exits non-zero without one.
-
-## JSON Output (non-Waybar bars)
-
-For Quickshell, Eww, Ironbar, or any consumer that renders natively and wants
-raw structured data instead of the Waybar Pango envelope.
-
-| Command | Purpose | Writes |
-| --- | --- | --- |
-| `agent-bar --format json` | One-shot versioned JSON envelope for all registered providers (Pango-free). | Cache only |
-| `agent-bar --format json --provider <id>` | Same, single provider. | Cache only |
-| `agent-bar --watch [--interval <s>]` | Stream NDJSON (one envelope per line) until killed. | Cache only |
-
-The schema, stability policy, and a Quickshell QML example live in
-[`docs/json-output.md`](json-output.md). Unlike the Waybar path, JSON output is
-**not** filtered by the `waybar.providers` setting — it emits all registered
-providers and the consumer decides what to show.
-
-## Install And Removal
-
-| Command | Purpose | Writes |
-| --- | --- | --- |
-| `agent-bar setup` | Install assets, create symlink, patch Waybar, reload Waybar. | `~/.local/bin`, `~/.config/waybar` |
-| `agent-bar uninstall` | Interactive removal of managed integration and owned files. | Removes managed files/entries |
-| `agent-bar remove` | Non-interactive forced removal. | Same targets as uninstall |
-
-## `doctor`
-
-Detect and clean leftover agent-bar artifacts in `$HOME` from previous installs.
-
-```bash
-agent-bar doctor              # interactive
-agent-bar doctor --dry-run    # report without removing
-agent-bar doctor --yes        # non-interactive, remove without prompting
-```
-
-## Export And Assets
-
-These are mostly for tests, packagers, and manual integration.
-
-| Command | Purpose |
-| --- | --- |
-| `agent-bar assets install --waybar-dir <path> --scripts-dir <path>` | Copy icons and terminal helper into explicit paths. |
-| `agent-bar export waybar-modules --app-bin <path> --terminal-script <path>` | Print generated Waybar module JSON. |
-| `agent-bar export waybar-css --icons-dir <path>` | Print generated Waybar CSS JSON. |
-
-## Flags
-
-| Flag | Purpose |
-| --- | --- |
-| `-p`, `--provider <id>` | Limit output to `claude`, `codex`, `amp`, or `grok`. |
-| `-r`, `--refresh` | Ignore cache and fetch fresh provider data. |
-| `-t`, `--terminal` | Force terminal output mode. |
-| `--format <waybar\|json>` | Output format. Default `waybar`. `json` emits the versioned contract (see below). |
-| `--watch` | Stream NDJSON (one envelope per line); implies `--format json`. |
-| `--interval <seconds>` | Watch poll floor (default 60). Only meaningful with `--watch`. |
-| `-v`, `--verbose` | Enable diagnostic logging (stderr). |
-| `-V`, `--version` | Print version and exit. |
-| `-h`, `--help` | Print CLI help. |
+On Omarchy, daily use is the native popup; open the dashboard with
+`agent-bar menu` or the **Abrir menu (TUI)** link in the usage footer.
 
 ## Update Behavior
 

--- a/docs/omarchy-shell.md
+++ b/docs/omarchy-shell.md
@@ -24,20 +24,52 @@ If Waybar is also installed, the classic Waybar flow runs alongside.
 
 ## Widget
 
-- One chip per provider (icon + remaining % of the primary limit), shell
+- One chip per **enabled** provider (icon + % of the primary limit), shell
   theme colors, severity mirroring the TUI (≥60 ok / 30-59 / 10-29 / <10).
-- Left click: native popup (primary/secondary windows, per-model breakdown,
-  reset times, plan/account).
-- Right click: opens the TUI (`agent-bar menu`) in a floating terminal.
-- Middle click: forced refresh (`--refresh`).
-- `refreshIntervalSec` setting (default 60, min 30) via
-  `omarchy bar plugin set` or `shell.json`.
+  Enabled set and order come from `waybar.providers` /
+  `waybar.provider_order` in `~/.config/agent-bar/settings.json` (same
+  keys the TUI Config editor uses). The quota poll
+  (`agent-bar --format json`) still returns the full envelope; the QML
+  filters chips and usage sections client-side.
+- **Left click:** native usage popup (primary/secondary windows, per-model
+  breakdown, reset times, plan/account). Footer has a link
+  **Abrir menu (TUI)** that launches `agent-bar menu` via the terminal
+  helper.
+- **Right click:** same popup in **settings mode** (`settingsMode`) —
+  providers on/off and order, display remaining/used, desktop notify
+  toggle, refresh interval. Not the full TUI.
+- **Middle click:** forced refresh (`--refresh`).
+- `refreshIntervalSec` (default 60, min 30, max 3600) lives on the plugin
+  entry in Omarchy `shell.json`, not in agent-bar `settings.json`.
+
+### Settings save (dual-write)
+
+One Save button, two writers:
+
+| Field | Written by | Where |
+| --- | --- | --- |
+| `providers`, `providerOrder`, `displayMode`, `notify.enabled` | `agent-bar config apply` | `~/.config/agent-bar/settings.json` |
+| `refreshIntervalSec` | `bar.shell.updateEntryInline` | plugin entry in Omarchy `shell.json` |
+
+If `config apply` fails, the interval is **not** written. If apply succeeds
+but inline fails, settings are saved and the UI reports that the interval
+was not persisted.
+
+### `config apply` does not reload Waybar
+
+`agent-bar config apply` only patches and saves the settings subset. It does
+**not** call `apply_waybar_integration` or reload Waybar. On a mixed
+desktop (Waybar + Omarchy), enabled providers in `settings.json` stay
+aligned for both; Waybar module layout only updates on the next TUI Config
+save or `agent-bar setup`.
 
 ## Data
 
 The QML runs `agent-bar --format json` (contract in
-[`json-output.md`](json-output.md)). The QML files are embedded in the
-binary — version-locked with the schema. After `agent-bar update`, re-run
+[`json-output.md`](json-output.md)). Editable settings for the popup come
+from `agent-bar config show` / stdout of `config apply` (contract in
+[`commands.md`](commands.md)). The QML files are embedded in the binary —
+version-locked with the schema. After `agent-bar update`, re-run
 `agent-bar setup` to refresh the drop-in (the update prints this hint).
 
 ## Removal

--- a/docs/superpowers/plans/2026-07-21-omarchy-settings-and-cli-simplify.md
+++ b/docs/superpowers/plans/2026-07-21-omarchy-settings-and-cli-simplify.md
@@ -1,0 +1,1127 @@
+# Omarchy settings nativo + CLI simplify — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Right-click no plugin Omarchy abre settings nativo (mesmo popup); `config show`/`apply` como bridge para `settings.json`; help CLI limpo com internos escondidos e aliases — sem remover Waybar/TUI.
+
+**Architecture:** Mini-API Rust (`src/config_cmd.rs`) serializa/valida o subset editável e grava via `settings::load`/`save`. O `Widget.qml` ganha `settingsMode` (padrão `omarchy.model-usage`), filtra chips por `waybar.providers`, e no Save faz dual-write (CLI + `updateEntryInline` só pro interval). Help público deixa de listar `action-right`/`assets`/`export`/`remove` como primários; parse desses paths permanece onde a spec exige.
+
+**Tech Stack:** Rust (serde_json, tempfile, anyhow) + QML Quickshell (`Process`/`StdioCollector` já usados no widget; docs Quickshell Process+StdioCollector). Spec: `docs/superpowers/specs/2026-07-21-omarchy-settings-and-cli-simplify-design.md`.
+
+**Evidência de baseline (não chutar):**
+
+- `assets/omarchy/Widget.qml`: left popup, right `openTui()`, width `Style.space(300)`.
+- `model-usage` local: right → `openSettings()`, width `Style.space(370)`, `updateEntryInline`.
+- `settings::{load,save,normalize_provider_selection}` em `src/settings.rs`.
+- `Command` + `build_help` em `src/cli.rs`; dispatch em `src/main.rs`.
+- Plugin embutido: `include_str!("../assets/omarchy/Widget.qml")` em `omarchy_integration.rs`.
+
+## Global Constraints
+
+- **Rust/cargo only** — sem Node em runtime/teste.
+- **Nunca mutar desktop vivo em teste** — temp dirs, `XDG_*`, `--omarchy-plugins-dir`.
+- **stdout limpo** em poll/config show/apply sucesso = só JSON; logs em stderr.
+- **Nunca `unwrap()`/`expect()` em produção** (ok em `#[cfg(test)]`).
+- **TUI Config / `action_right.rs` / waybar modules: sem mudança funcional.**
+- **Envelope quota `schemaVersion: 1` inalterado** — não filtrar providers no JSON de poll.
+- **`config apply` NÃO chama `apply_waybar_integration`.**
+- Identidade: `OMARCHY_PLUGIN_ID` etc. de `app_identity.rs`.
+- Conventional Commits PT, subject ≤ 50 chars; zero atribuição de AI.
+- Gotcha RTK: um filtro posicional por `cargo test`.
+- Read arquivo antes de Edit; re-Read após outro agente.
+
+## File map
+
+| Path | Papel |
+| --- | --- |
+| `src/config_cmd.rs` | **Novo.** show envelope + apply patch/validate/save |
+| `src/lib.rs` | `pub mod config_cmd` |
+| `src/cli.rs` | `Command::ConfigShow` / `ConfigApply`; parse; help; aliases |
+| `src/main.rs` | dispatch config |
+| `assets/omarchy/Widget.qml` | settingsMode, filtro, largura, Save |
+| `assets/omarchy/manifest.json` | description dos clicks |
+| `docs/commands.md`, `omarchy-shell.md`, `architecture.md`, `README.md` | contrato |
+
+## Ordem
+
+```text
+T1 config_cmd ──► T2 CLI parse+dispatch ──► T3 help+aliases
+                                              │
+                                              ▼
+                                    T4 Widget.qml settings
+                                              │
+                                              ▼
+                                         T5 docs ──► T6 gate
+```
+
+---
+
+### Task 1: `config_cmd` — show / apply puros
+
+**Files:**
+- Create: `src/config_cmd.rs`
+- Modify: `src/lib.rs` (adicionar `pub mod config_cmd;`)
+
+**Interfaces:**
+- Produces:
+  - `pub const CONFIG_SCHEMA_VERSION: u32 = 1`
+  - `pub struct ConfigView { schema_version, providers, provider_order, display_mode, notify_enabled }` com `Serialize`
+  - `pub fn view_from_settings(s: &Settings) -> ConfigView`
+  - `pub fn show(paths: &Paths) -> ConfigView` (= load + view)
+  - `pub fn apply_json(paths: &Paths, raw: &str) -> Result<ConfigView, ApplyError>`
+  - `pub enum ApplyError { Validation(String), Io(String) }` com `Display`
+- Consumes: `settings::{load, save, normalize_provider_selection, DisplayMode, Settings}`, `config::Paths`
+
+- [ ] **Step 1: Criar módulo com testes que falham (API `todo!`)**
+
+```rust
+//! `agent-bar config show|apply` — subset editável do settings.json (spec
+//! 2026-07-21-omarchy-settings-and-cli-simplify).
+
+use serde::{Deserialize, Serialize};
+
+use crate::config::Paths;
+use crate::settings::{
+    normalize_provider_selection, DisplayMode, Settings,
+};
+
+pub const CONFIG_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConfigView {
+    pub schema_version: u32,
+    pub providers: Vec<String>,
+    pub provider_order: Vec<String>,
+    pub display_mode: DisplayMode,
+    pub notify: NotifyView,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct NotifyView {
+    pub enabled: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ApplyError {
+    Validation(String),
+    Io(String),
+}
+
+impl std::fmt::Display for ApplyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ApplyError::Validation(m) | ApplyError::Io(m) => write!(f, "{m}"),
+        }
+    }
+}
+
+pub fn view_from_settings(s: &Settings) -> ConfigView {
+    todo!("Task 1")
+}
+
+pub fn show(paths: &Paths) -> ConfigView {
+    todo!("Task 1")
+}
+
+pub fn apply_json(paths: &Paths, raw: &str) -> Result<ConfigView, ApplyError> {
+    todo!("Task 1")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Paths;
+    use crate::settings::{self, DisplayMode};
+    use std::path::PathBuf;
+    use tempfile::tempdir;
+
+    fn paths_in(dir: &std::path::Path) -> Paths {
+        Paths {
+            cache_dir: dir.join("cache"),
+            config_dir: dir.join("config"),
+            claude_credentials: PathBuf::new(),
+            codex_auth: PathBuf::new(),
+            codex_sessions: PathBuf::new(),
+            amp_settings: PathBuf::new(),
+            amp_threads: PathBuf::new(),
+            grok_home: PathBuf::new(),
+            grok_auth: PathBuf::new(),
+        }
+    }
+
+    #[test]
+    fn show_defaults_when_no_file() {
+        let dir = tempdir().unwrap();
+        let v = show(&paths_in(dir.path()));
+        assert_eq!(v.schema_version, 1);
+        assert_eq!(v.providers, vec!["claude", "codex", "amp", "grok"]);
+        assert_eq!(v.provider_order, v.providers);
+        assert_eq!(v.display_mode, DisplayMode::Remaining);
+        assert!(v.notify.enabled);
+    }
+
+    #[test]
+    fn apply_rejects_wrong_schema() {
+        let dir = tempdir().unwrap();
+        let p = paths_in(dir.path());
+        let err = apply_json(&p, r#"{"schemaVersion":2,"providers":["claude"]}"#).unwrap_err();
+        assert!(matches!(err, ApplyError::Validation(_)));
+    }
+
+    #[test]
+    fn apply_rejects_empty_providers() {
+        let dir = tempdir().unwrap();
+        let p = paths_in(dir.path());
+        let err = apply_json(&p, r#"{"schemaVersion":1,"providers":[]}"#).unwrap_err();
+        assert!(matches!(err, ApplyError::Validation(_)));
+    }
+
+    #[test]
+    fn apply_partial_preserves_omitted_fields() {
+        let dir = tempdir().unwrap();
+        let p = paths_in(dir.path());
+        // seed
+        let mut s = settings::load(&p);
+        s.waybar.display_mode = DisplayMode::Used;
+        s.notify.enabled = false;
+        settings::save(&p, &s).unwrap();
+
+        let v = apply_json(
+            &p,
+            r#"{"schemaVersion":1,"providers":["claude","codex"]}"#,
+        )
+        .unwrap();
+        assert_eq!(v.providers, vec!["claude", "codex"]);
+        assert_eq!(v.display_mode, DisplayMode::Used);
+        assert!(!v.notify.enabled);
+
+        let loaded = settings::load(&p);
+        assert_eq!(loaded.waybar.providers, vec!["claude", "codex"]);
+        assert_eq!(loaded.waybar.display_mode, DisplayMode::Used);
+        assert!(!loaded.notify.enabled);
+        // separators etc. intact
+        assert_eq!(loaded.waybar.separators, s.waybar.separators);
+    }
+
+    #[test]
+    fn apply_display_mode_and_notify() {
+        let dir = tempdir().unwrap();
+        let p = paths_in(dir.path());
+        let v = apply_json(
+            &p,
+            r#"{"schemaVersion":1,"displayMode":"used","notify":{"enabled":false}}"#,
+        )
+        .unwrap();
+        assert_eq!(v.display_mode, DisplayMode::Used);
+        assert!(!v.notify.enabled);
+    }
+
+    #[test]
+    fn apply_rejects_invalid_display_mode() {
+        let dir = tempdir().unwrap();
+        let p = paths_in(dir.path());
+        let err = apply_json(&p, r#"{"schemaVersion":1,"displayMode":"nope"}"#).unwrap_err();
+        assert!(matches!(err, ApplyError::Validation(_)));
+    }
+
+    #[test]
+    fn apply_drops_unknown_provider_ids() {
+        let dir = tempdir().unwrap();
+        let p = paths_in(dir.path());
+        let v = apply_json(
+            &p,
+            r#"{"schemaVersion":1,"providers":["claude","nope","codex"]}"#,
+        )
+        .unwrap();
+        assert_eq!(v.providers, vec!["claude", "codex"]);
+    }
+
+    #[test]
+    fn apply_all_unknown_providers_is_error() {
+        let dir = tempdir().unwrap();
+        let p = paths_in(dir.path());
+        let err =
+            apply_json(&p, r#"{"schemaVersion":1,"providers":["nope"]}"#).unwrap_err();
+        assert!(matches!(err, ApplyError::Validation(_)));
+    }
+}
+```
+
+Em `src/lib.rs`, após `pub mod config;`:
+
+```rust
+pub mod config_cmd;
+```
+
+- [ ] **Step 2: Rodar testes — devem falhar em `todo!`**
+
+Run: `cargo test config_cmd`
+
+Expected: FAIL / panic `not yet implemented` (ou compile error se DisplayMode não serializa camelCase — ver Step 3).
+
+- [ ] **Step 3: Implementar**
+
+Notas de serialização (evidência `settings.rs`):
+
+- `DisplayMode` já tem `#[serde(rename_all = "lowercase")]` no Serialize do settings — reusar o enum no `ConfigView` (precisa `Deserialize` para o patch). Se `DisplayMode` não implementa `Deserialize`, adicionar `#[derive(Deserialize)]` **só se já tiver Serialize** — checar e estender derives no enum existente sem mudar wire format.
+
+Implementação de referência:
+
+```rust
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ConfigPatch {
+    schema_version: Option<u32>,
+    providers: Option<Vec<String>>,
+    provider_order: Option<Vec<String>>,
+    display_mode: Option<String>,
+    notify: Option<NotifyPatch>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct NotifyPatch {
+    enabled: Option<bool>,
+}
+
+pub fn view_from_settings(s: &Settings) -> ConfigView {
+    ConfigView {
+        schema_version: CONFIG_SCHEMA_VERSION,
+        providers: s.waybar.providers.clone(),
+        provider_order: s.waybar.provider_order.clone(),
+        display_mode: s.waybar.display_mode,
+        notify: NotifyView {
+            enabled: s.notify.enabled,
+        },
+    }
+}
+
+pub fn show(paths: &Paths) -> ConfigView {
+    view_from_settings(&crate::settings::load(paths))
+}
+
+pub fn apply_json(paths: &Paths, raw: &str) -> Result<ConfigView, ApplyError> {
+    let patch: ConfigPatch = serde_json::from_str(raw).map_err(|e| {
+        ApplyError::Validation(format!("invalid JSON: {e}"))
+    })?;
+
+    match patch.schema_version {
+        Some(CONFIG_SCHEMA_VERSION) => {}
+        Some(v) => {
+            return Err(ApplyError::Validation(format!(
+                "unsupported schemaVersion: {v} (expected {CONFIG_SCHEMA_VERSION})"
+            )));
+        }
+        None => {
+            return Err(ApplyError::Validation(
+                "schemaVersion is required".into(),
+            ));
+        }
+    }
+
+    let mut s = crate::settings::load(paths);
+
+    if let Some(providers) = patch.providers {
+        let order_src = patch
+            .provider_order
+            .clone()
+            .unwrap_or_else(|| s.waybar.provider_order.clone());
+        let (providers, order) = normalize_provider_selection(&providers, &order_src);
+        if providers.is_empty() {
+            return Err(ApplyError::Validation(
+                "providers must contain at least one known id".into(),
+            ));
+        }
+        s.waybar.providers = providers;
+        s.waybar.provider_order = order;
+    } else if let Some(order) = patch.provider_order {
+        let (providers, order) =
+            normalize_provider_selection(&s.waybar.providers, &order);
+        s.waybar.providers = providers;
+        s.waybar.provider_order = order;
+    }
+
+    if let Some(mode) = patch.display_mode {
+        s.waybar.display_mode = match mode.as_str() {
+            "remaining" => DisplayMode::Remaining,
+            "used" => DisplayMode::Used,
+            other => {
+                return Err(ApplyError::Validation(format!(
+                    "invalid displayMode: '{other}' (remaining|used)"
+                )));
+            }
+        };
+    }
+
+    if let Some(n) = patch.notify {
+        if let Some(en) = n.enabled {
+            s.notify.enabled = en;
+        }
+    }
+
+    crate::settings::save(paths, &s).map_err(|e| ApplyError::Io(e.to_string()))?;
+    Ok(view_from_settings(&s))
+}
+```
+
+Se `DisplayMode` no Serialize do view emitir `Remaining` em vez de `remaining`, forçar:
+
+```rust
+// no ConfigView, em vez de DisplayMode cru:
+// display_mode: String  com "remaining"|"used"
+```
+
+**Preferência da spec:** JSON com `"displayMode":"remaining"`. Garantir com teste:
+
+```rust
+#[test]
+fn show_json_wire_format() {
+    let dir = tempdir().unwrap();
+    let v = show(&paths_in(dir.path()));
+    let j = serde_json::to_value(&v).unwrap();
+    assert_eq!(j["schemaVersion"], 1);
+    assert_eq!(j["displayMode"], "remaining");
+    assert_eq!(j["notify"]["enabled"], true);
+    assert!(j["providers"].is_array());
+}
+```
+
+Ajustar derives/`serialize_with` até o wire bater.
+
+- [ ] **Step 4: Testes verdes**
+
+Run: `cargo test config_cmd`
+
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/config_cmd.rs src/lib.rs src/settings.rs
+git commit -m "feat: config show/apply subset settings"
+```
+
+---
+
+### Task 2: CLI parse + dispatch `config`
+
+**Files:**
+- Modify: `src/cli.rs` (`Command`, `CliOptions`, `parse_args`, `KNOWN_COMMANDS`)
+- Modify: `src/main.rs` (dispatch antes do path de poll)
+
+**Interfaces:**
+- Produces: `Command::ConfigShow`, `Command::ConfigApply`; em `CliOptions`:
+  - `config_json: Option<String>` (literal ou conteúdo de `--file`)
+  - ou flag `config_json_stdin: bool`
+- Parse:
+  - `config show` → ConfigShow
+  - `config apply --json '...'` → ConfigApply
+  - `config apply --json -` → lê stdin no **main** (parse só marca stdin)
+  - `config apply --file path` → main lê file
+  - `config` / `config --help` / `config help` → help de config ou help geral com seção config
+
+- [ ] **Step 1: Testes de parse (em `cli.rs` mod tests)**
+
+```rust
+    #[test]
+    fn command_config_show() {
+        let opts = parse_args(&args(&["config", "show"])).unwrap();
+        assert_eq!(opts.command, Command::ConfigShow);
+    }
+
+    #[test]
+    fn command_config_apply_json() {
+        let opts = parse_args(&args(&[
+            "config",
+            "apply",
+            "--json",
+            r#"{"schemaVersion":1}"#,
+        ]))
+        .unwrap();
+        assert_eq!(opts.command, Command::ConfigApply);
+        assert_eq!(
+            opts.config_json.as_deref(),
+            Some(r#"{"schemaVersion":1}"#)
+        );
+    }
+
+    #[test]
+    fn command_config_apply_requires_payload() {
+        let err = parse_args(&args(&["config", "apply"])).unwrap_err();
+        assert!(err.message.contains("--json") || err.message.contains("--file"));
+    }
+```
+
+Adicionar em `CliOptions` / `Default`:
+
+```rust
+    /// Payload de `config apply --json` (None se `--json -` ou `--file`).
+    pub config_json: Option<String>,
+    pub config_json_stdin: bool,
+    pub config_file: Option<String>,
+```
+
+- [ ] **Step 2: Rodar — falha (Command inexistente)**
+
+Run: `cargo test cli command_config`
+
+Expected: compile error / FAIL.
+
+- [ ] **Step 3: Implementar parse + enum + main**
+
+Em `Command`:
+
+```rust
+    ConfigShow,
+    ConfigApply,
+```
+
+Em `parse_args`, ramo:
+
+```rust
+            "config" => {
+                match args.get(i + 1).map(|s| s.as_str()) {
+                    Some("show") => {
+                        opts.command = Command::ConfigShow;
+                        i += 1;
+                    }
+                    Some("apply") => {
+                        opts.command = Command::ConfigApply;
+                        i += 1;
+                        // consumir --json / --file no loop principal OU aqui
+                    }
+                    Some("--help" | "help" | "-h") | None => {
+                        opts.command = Command::Help; // ou help dedicado
+                        if args.get(i + 1).is_some() { i += 1; }
+                    }
+                    Some(other) => {
+                        return Err(CliError {
+                            message: format!(
+                                "Unknown subcommand for 'config': {other}. Use 'show' or 'apply'."
+                            ),
+                        });
+                    }
+                }
+            }
+```
+
+Para `--json` / `--file` **dentro de apply**, o loop atual já processa flags genéricas — estender:
+
+```rust
+            "--json" => {
+                let val = require_next_arg(args, i, "--json")?;
+                if val == "-" {
+                    opts.config_json_stdin = true;
+                } else {
+                    opts.config_json = Some(val.to_string());
+                }
+                i += 1;
+            }
+            "--file" => {
+                let val = require_next_arg(args, i, "--file")?;
+                opts.config_file = Some(val.to_string());
+                i += 1;
+            }
+```
+
+Validar no fim do parse se `ConfigApply` tem exatamente uma fonte (json literal | stdin | file).
+
+`KNOWN_COMMANDS`: incluir `"config"` (typo suggest).
+
+Em `main.rs`, no bloco de subcommands early-exit (junto de Setup/Doctor), **antes** do poll:
+
+```rust
+        Command::ConfigShow => {
+            let paths = Paths::from_env().unwrap_or_else(|e| {
+                log::error!("{e}");
+                std::process::exit(1);
+            });
+            let view = agent_bar::config_cmd::show(&paths);
+            match serde_json::to_string_pretty(&view) {
+                Ok(j) => {
+                    println!("{j}");
+                    std::process::exit(0);
+                }
+                Err(e) => {
+                    log::error!("{e}");
+                    std::process::exit(1);
+                }
+            }
+        }
+        Command::ConfigApply => {
+            let paths = Paths::from_env().unwrap_or_else(|e| {
+                log::error!("{e}");
+                std::process::exit(1);
+            });
+            let raw = if opts.config_json_stdin {
+                use std::io::Read;
+                let mut buf = String::new();
+                if let Err(e) = std::io::stdin().read_to_string(&mut buf) {
+                    log::error!("failed to read stdin: {e}");
+                    std::process::exit(2);
+                }
+                buf
+            } else if let Some(path) = &opts.config_file {
+                match std::fs::read_to_string(path) {
+                    Ok(s) => s,
+                    Err(e) => {
+                        log::error!("failed to read {path}: {e}");
+                        std::process::exit(1);
+                    }
+                }
+            } else if let Some(j) = &opts.config_json {
+                j.clone()
+            } else {
+                log::error!("config apply requires --json <blob>, --json -, or --file <path>");
+                std::process::exit(2);
+            };
+            match agent_bar::config_cmd::apply_json(&paths, &raw) {
+                Ok(view) => match serde_json::to_string_pretty(&view) {
+                    Ok(j) => {
+                        println!("{j}");
+                        std::process::exit(0);
+                    }
+                    Err(e) => {
+                        log::error!("{e}");
+                        std::process::exit(1);
+                    }
+                },
+                Err(agent_bar::config_cmd::ApplyError::Validation(m)) => {
+                    eprintln!("{m}");
+                    std::process::exit(1);
+                }
+                Err(agent_bar::config_cmd::ApplyError::Io(m)) => {
+                    eprintln!("{m}");
+                    std::process::exit(1);
+                }
+            }
+        }
+```
+
+(Usar `?`/match sem unwrap em prod.)
+
+Smoke manual (temp XDG):
+
+```bash
+XDG_CONFIG_HOME=/tmp/ab-cfg-test cargo run -- config show
+XDG_CONFIG_HOME=/tmp/ab-cfg-test cargo run -- config apply --json '{"schemaVersion":1,"providers":["claude"]}'
+```
+
+- [ ] **Step 4: Testes**
+
+Run: `cargo test cli`
+
+Expected: PASS (incluir novos testes).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cli.rs src/main.rs
+git commit -m "feat: CLI config show e apply"
+```
+
+---
+
+### Task 3: Help limpo + aliases (`-t`, `remove`)
+
+**Files:**
+- Modify: `src/cli.rs` (`build_help`, `parse_args`, `KNOWN_COMMANDS`, testes help)
+- Modify: `src/main.rs` só se `Command::Terminal` / `Remove` mudarem de semântica
+
+**Spec §4:**
+
+- Help lista: menu, status, config show|apply, setup, update, uninstall, doctor + flags machine.
+- **Não** lista: action-right, menu-font, assets, export, remove (remove vira alias).
+- `-t` / `--terminal` → `Command::Status` (não `Terminal`).
+- `remove` → `Command::Uninstall` + `yes = true` (force path). Preferir **não** manter `Command::Remove` no parse se main puder unificar; se `Remove` ainda existir no enum por testes, mapear parse de `remove` para Uninstall+yes e atualizar testes.
+
+- [ ] **Step 1: Testes**
+
+```rust
+    #[test]
+    fn terminal_flag_aliases_status() {
+        let opts = parse_args(&args(&["--terminal"])).unwrap();
+        assert_eq!(opts.command, Command::Status);
+        let opts = parse_args(&args(&["-t"])).unwrap();
+        assert_eq!(opts.command, Command::Status);
+    }
+
+    #[test]
+    fn remove_aliases_uninstall_yes() {
+        let opts = parse_args(&args(&["remove"])).unwrap();
+        assert_eq!(opts.command, Command::Uninstall);
+        assert!(opts.yes);
+    }
+
+    #[test]
+    fn build_help_hides_internals() {
+        let help = build_help(true);
+        assert!(help.contains("config"));
+        assert!(help.contains("menu"));
+        assert!(help.contains("status"));
+        assert!(!help.contains("action-right"));
+        assert!(!help.contains("assets install"));
+        assert!(!help.contains("export waybar-modules"));
+        assert!(!help.contains("menu-font"));
+        // remove não como comando de vitrine
+        assert!(
+            !help.lines().any(|l| l.contains("remove") && l.contains("Force")),
+            "remove não deve aparecer como comando primário"
+        );
+    }
+
+    #[test]
+    fn action_right_still_parses() {
+        let opts = parse_args(&args(&["action-right", "claude"])).unwrap();
+        assert_eq!(opts.command, Command::ActionRight);
+    }
+```
+
+Atualizar testes antigos que esperam `Command::Terminal` ou `Command::Remove` no parse.
+
+- [ ] **Step 2: FAIL nos asserts de help/alias**
+
+Run: `cargo test cli`
+
+- [ ] **Step 3: Reescrever `build_help` (grupos)**
+
+Estrutura alvo (texto; manter box-drawing existente):
+
+```text
+Commands
+  menu / status / config show / config apply / setup / update / uninstall / doctor
+
+Omarchy / Waybar (resumo curto)
+  default poll = Waybar JSON; --format json = shell
+  Omarchy: left usage, right settings, middle refresh
+  Waybar: left menu, right action-right (internal)
+
+Flags
+  --provider, --refresh, --format, --watch, --interval, --verbose, …
+```
+
+Remover `cmd_line` de assets/export/remove. Adicionar config. Ajustar seção Waybar desatualizada (“Right click Refresh/Login” → TUI focada / internos).
+
+Parse:
+
+```rust
+            "--terminal" | "-t" => opts.command = Command::Status,
+
+            "remove" => {
+                opts.command = Command::Uninstall;
+                opts.yes = true;
+            }
+```
+
+Main: se `Uninstall` + `yes`, chamar `run_uninstall(..., force=true)` — **ler** `uninstall::run_uninstall` e o branch atual de `Remove`/`Uninstall` para unificar. Hoje `Remove` passa `true` e `Uninstall` passa `false`. Se `opts.yes` no Uninstall interativo ainda não força, mapear: `force = opts.yes` no call de Uninstall e deletar branch `Command::Remove` **ou** manter Remove só no enum unused.
+
+`KNOWN_COMMANDS`: tirar `"assets"`, `"export"`, `"action-right"` da lista de typo **ou** manter action-right para suggest se user digitar mal — spec: internos parseáveis; typo suggest de action-right ainda útil. Manter `action-right` em KNOWN_COMMANDS; remover assets/export se quiser help mental limpo.
+
+- [ ] **Step 4: PASS**
+
+Run: `cargo test cli`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cli.rs src/main.rs
+git commit -m "refactor: help CLI e aliases remove/-t"
+```
+
+---
+
+### Task 4: Widget.qml — settingsMode + filtro + largura
+
+**Files:**
+- Modify: `assets/omarchy/Widget.qml` (fonte embutida; setup reescreve drop-in)
+- Modify: `assets/omarchy/manifest.json` (description dos clicks)
+- Modify: snapshot `src/snapshots/agent_bar__omarchy_integration__tests__omarchy_manifest.snap` via teste
+
+**Referência obrigatória (ler no disco antes de editar):**
+
+- `/usr/share/omarchy/shell/plugins/model-usage/Widget.qml` — `openSettings`, `saveSettings`, `settingsMode`, `SettingsContent`, `updateEntryInline`
+- Quickshell: `Process` + `StdioCollector` `onStreamFinished` (já no widget)
+
+**Não há cargo test de QML.** Verificação: asserts de string no `omarchy_integration` se existirem; senão smoke manual Task 6. Atualizar snapshot do manifest.
+
+- [ ] **Step 1: Atualizar manifest description**
+
+Em `assets/omarchy/manifest.json`:
+
+```json
+"description": "Quota chips per provider; left = usage, right = settings, middle = refresh.",
+```
+
+(e o campo `barWidget.description` igual.)
+
+- [ ] **Step 2: Rodar snapshot**
+
+Run: `cargo test omarchy_integration`
+
+Expected: snapshot fail se description mudou → `INSTA_UPDATE=auto cargo test omarchy_integration` **só** após conferir o snap.
+
+- [ ] **Step 3: Estado e helpers no root do Widget**
+
+Adicionar properties (junto das existentes):
+
+```qml
+  property bool settingsMode: false
+  property var draftSettings: ({
+    providers: [],
+    providerOrder: [],
+    displayMode: "remaining",
+    notifyEnabled: true,
+    refreshIntervalSec: 60
+  })
+  property var enabledIds: null          // null = sem filtro ainda
+  property string displayMode: "remaining"
+  property string settingsStatusText: ""
+  property bool settingsBusy: false
+```
+
+`close()`:
+
+```qml
+  function close() {
+    popupOpen = false
+    settingsMode = false
+    settingsBusy = false
+  }
+```
+
+Largura/altura popup:
+
+```qml
+    contentWidth: Style.space(370)
+    contentHeight: Math.min(popupCol.implicitHeight + Style.space(20), Style.space(560))
+```
+
+- [ ] **Step 4: Processes config show / apply**
+
+```qml
+  Process {
+    id: configShowProc
+    command: ["bash", "-lc", "agent-bar config show --format json"]
+    stdout: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: root.onConfigShowFinished(text)
+    }
+  }
+
+  Process {
+    id: configApplyProc
+    property string payload: ""
+    command: ["bash", "-lc", "agent-bar config apply --json " + Util.shellQuote(payload)]
+    stdout: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: root.onConfigApplyFinished(text)
+    }
+    // capturar falha: se Process expõe exit code no shell, preferir;
+    // senão parse JSON — se inválido, settingsStatusText = "apply failed"
+  }
+```
+
+**Nota:** passar JSON via argv com `shellQuote` é frágil se o blob tiver aspas. Preferir:
+
+```qml
+    command: ["bash", "-lc", "agent-bar config apply --json -"]
+    stdin: payload   // se Process do Quickshell suportar stdin
+```
+
+Se `stdin` não existir no Process do Omarchy 4.0.0.alpha, usar tempfile:
+
+```qml
+    command: ["bash", "-lc",
+      "f=$(mktemp) && cat >\"$f\" <<'AGENT_BAR_JSON'\n" + payload + "\nAGENT_BAR_JSON\nagent-bar config apply --file \"$f\"; e=$?; rm -f \"$f\"; exit $e"
+    ]
+```
+
+Validar no desktop (Task 6) qual caminho funciona; **preferir `--file` via mktemp** se stdin indisponível (evidenciar no commit message).
+
+Implementar:
+
+```qml
+  function applyConfigView(data) {
+    if (!data || data.schemaVersion !== 1) return false
+    enabledIds = Array.isArray(data.providerOrder) ? data.providerOrder.slice()
+              : (Array.isArray(data.providers) ? data.providers.slice() : [])
+    displayMode = data.displayMode === "used" ? "used" : "remaining"
+    return true
+  }
+
+  function onConfigShowFinished(text) {
+    try {
+      var data = JSON.parse(String(text || ""))
+      if (!applyConfigView(data)) throw new Error("bad config")
+      draftSettings = {
+        providers: (data.providers || []).slice(),
+        providerOrder: (data.providerOrder || data.providers || []).slice(),
+        displayMode: displayMode,
+        notifyEnabled: !!(data.notify && data.notify.enabled),
+        refreshIntervalSec: Math.min(3600, Math.max(30, Number(setting("refreshIntervalSec", 60)) || 60))
+      }
+      settingsStatusText = ""
+    } catch (e) {
+      settingsStatusText = "failed to load settings"
+    }
+  }
+
+  function openSettings() {
+    settingsMode = true
+    popupOpen = true
+    settingsStatusText = ""
+    if (!configShowProc.running) configShowProc.running = true
+  }
+
+  function showUsage() {
+    settingsMode = false
+    settingsStatusText = ""
+  }
+
+  function visibleProviders() {
+    var all = root.providers
+    if (!enabledIds || !enabledIds.length) return all
+    var out = []
+    for (var i = 0; i < enabledIds.length; i++) {
+      var id = enabledIds[i]
+      for (var j = 0; j < all.length; j++) {
+        if (all[j] && all[j].provider === id) { out.push(all[j]); break }
+      }
+    }
+    return out
+  }
+
+  function chipLabel(p) {
+    if (!p.available) return "–"
+    var w = p.primary
+    if (!w) return ""
+    if (root.displayMode === "used") {
+      var used = Number(w.used)
+      if (isFinite(used)) return Math.round(used) + "%"
+      var rem = Number(w.remaining)
+      if (isFinite(rem)) return Math.round(100 - rem) + "%"
+      return ""
+    }
+    if (!isFinite(Number(w.remaining))) return ""
+    return Math.round(Number(w.remaining)) + "%"
+  }
+
+  function saveSettings() {
+    if (settingsBusy) return
+    var prov = draftSettings.providers || []
+    if (!prov.length) {
+      settingsStatusText = "Keep at least one provider"
+      return
+    }
+    settingsBusy = true
+    settingsStatusText = "Saving…"
+    var blob = JSON.stringify({
+      schemaVersion: 1,
+      providers: prov,
+      providerOrder: draftSettings.providerOrder || prov,
+      displayMode: draftSettings.displayMode === "used" ? "used" : "remaining",
+      notify: { enabled: !!draftSettings.notifyEnabled }
+    })
+    // disparar apply (ver path file/json acima)
+    root._pendingApplyBlob = blob
+    root.runConfigApply(blob)
+  }
+
+  function onConfigApplyFinished(text) {
+    settingsBusy = false
+    try {
+      var data = JSON.parse(String(text || ""))
+      if (!applyConfigView(data)) throw new Error("bad apply result")
+    } catch (e) {
+      settingsStatusText = "apply failed"
+      return
+    }
+    // interval → shell.json
+    var interval = Math.min(3600, Math.max(30, Number(draftSettings.refreshIntervalSec) || 60))
+    if (bar && bar.shell && typeof bar.shell.updateEntryInline === "function") {
+      try {
+        var next = Object.assign({}, root.settings || {}, { refreshIntervalSec: interval })
+        bar.shell.updateEntryInline(root.moduleName, next)
+      } catch (e2) {
+        settingsStatusText = "settings saved; interval not persisted"
+        root.refresh(true)
+        return
+      }
+    }
+    settingsStatusText = "Saved"
+    root.refresh(true)
+  }
+
+  Component.onCompleted: {
+    if (!configShowProc.running) configShowProc.running = true
+  }
+```
+
+- [ ] **Step 5: Mouse + popup body**
+
+Right-click:
+
+```qml
+            if (mouse.button === Qt.RightButton) root.openSettings()
+            else if (mouse.button === Qt.MiddleButton) root.refresh(true)
+            else {
+              root.showUsage()
+              root.popupOpen = !root.popupOpen
+            }
+```
+
+Repeater de chips e seções usage: `model: root.visibleProviders()` (não `root.providers` cru).
+
+Popup column: se `settingsMode`, mostrar `SettingsHeader` + `SettingsContent`; senão usage atual + footer novo.
+
+Footer usage:
+
+```qml
+        Text {
+          visible: !root.settingsMode
+          text: "right-click: settings · middle: refresh"
+          // …
+        }
+        Text {
+          visible: !root.settingsMode
+          text: "Abrir menu (TUI)"
+          color: Color.accent
+          // MouseArea → root.openTui()
+        }
+```
+
+Settings UI (padrão model-usage, denso):
+
+- Header: `← Usage` | Settings | `Save`
+- Section Providers: 4 toggles + ↑↓
+- Display: Remaining | Used (dois botões, selected = accent)
+- Alerts: notify toggle
+- Refresh: stepper ±30 nos bounds
+- Status + hint `s saves · esc closes`
+
+Toggles: implementar `component Toggle` mínimo (label + switch visual com Rectangle) se `qs.Ui` não exportar o mesmo Toggle do model-usage — **copiar o pattern visual do model-usage**, não inventar glass.
+
+Ordem ↑↓: só entre ids em `draftSettings.providers`; disabled known ids aparecem off abaixo.
+
+Não desligar o último:
+
+```qml
+  function setProviderEnabled(id, on) {
+    var p = (draftSettings.providers || []).slice()
+    var idx = p.indexOf(id)
+    if (on && idx < 0) p.push(id)
+    if (!on) {
+      if (p.length <= 1 && idx >= 0) {
+        settingsStatusText = "Keep at least one provider"
+        return
+      }
+      if (idx >= 0) p.splice(idx, 1)
+    }
+    // rebuild providerOrder: enabled order first
+    var order = (draftSettings.providerOrder || []).filter(function(x) { return p.indexOf(x) >= 0 })
+    p.forEach(function(x) { if (order.indexOf(x) < 0) order.push(x) })
+    draftSettings = Object.assign({}, draftSettings, { providers: p, providerOrder: order })
+  }
+```
+
+- [ ] **Step 6: Commit assets**
+
+```bash
+git add assets/omarchy/Widget.qml assets/omarchy/manifest.json src/snapshots/
+git commit -m "feat: settings nativo no popup Omarchy"
+```
+
+---
+
+### Task 5: Docs
+
+**Files:**
+- Modify: `docs/commands.md`
+- Modify: `docs/omarchy-shell.md`
+- Modify: `docs/architecture.md` (dispatch `config`; action-right ainda Waybar)
+- Modify: `README.md` (tabela Omarchy clicks)
+
+**Não** editar `CHANGELOG.md` (só no release).
+
+- [ ] **Step 1: Reescrever seções**
+
+`docs/omarchy-shell.md` — substituir right-click TUI por settings; documentar dual-write; filtro `waybar.providers`; link TUI; trade-off apply ≠ Waybar reload.
+
+`docs/commands.md` — taxonomia Usage / Setup / Machine / Internal; `config show|apply` com schema; action-right/menu-font/assets/export em Internal; `remove` = alias uninstall -y; `-t` = status.
+
+`docs/architecture.md` — uma linha no module map para `config_cmd.rs`.
+
+`README.md` — Omarchy 4: left usage, right settings, middle refresh; `agent-bar menu` para dashboard.
+
+- [ ] **Step 2: `git diff --check`**
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/commands.md docs/omarchy-shell.md docs/architecture.md README.md
+git commit -m "docs: config Omarchy e CLI simplify"
+```
+
+---
+
+### Task 6: Gate de verificação
+
+**Files:** nenhum de produto (só prova).
+
+- [ ] **Step 1: Testes automatizados**
+
+```bash
+cargo test config_cmd
+cargo test cli
+cargo test settings
+cargo test omarchy_integration
+cargo clippy --all-targets -- -D warnings
+```
+
+Expected: PASS, clippy clean.
+
+- [ ] **Step 2: Smoke CLI com XDG temp**
+
+```bash
+export XDG_CONFIG_HOME=/tmp/agent-bar-gate-$$
+export XDG_CACHE_HOME=/tmp/agent-bar-gate-cache-$$
+mkdir -p "$XDG_CONFIG_HOME" "$XDG_CACHE_HOME"
+cargo run --quiet -- config show | head
+cargo run --quiet -- config apply --json '{"schemaVersion":1,"providers":["claude","codex"],"displayMode":"used","notify":{"enabled":false}}'
+cargo run --quiet -- config show
+# help não lista internos
+cargo run --quiet -- help | tee /tmp/ab-help.txt
+rg -n "action-right|assets install|export waybar" /tmp/ab-help.txt && exit 1 || true
+rg -n "config" /tmp/ab-help.txt
+```
+
+- [ ] **Step 3: Manual desktop Omarchy (3 provas)** — **pedir aprovação** antes de `agent-bar setup` se for reescrever plugin live.
+
+1. **Funcional:** right-click → settings; toggle provider; Save; chip some/volta; refresh interval; notify; link TUI abre menu.
+2. **Perceptual:** largura ~model-usage; settings denso; sem decoração.
+3. **Dados:** `config show` reflete toggles; `settings.json` coerente; `shell.json` entry com `refreshIntervalSec`.
+
+Após mudar QML embutido: `agent-bar setup` (com OK do user) ou copiar `Widget.qml` pro drop-in de teste.
+
+- [ ] **Step 4: Commit vazio não** — se só prova, sem commit. Se fix de bug do gate, commit focado.
+
+---
+
+## Spec coverage (self-review do plano)
+
+| Spec | Task |
+| --- | --- |
+| config show/apply schema + regras | T1–T2 |
+| apply sem Waybar reload | T1 (save only) |
+| Help + hide + aliases | T3 |
+| settingsMode, width 370, dual-write | T4 |
+| filtro chips + displayMode label | T4 |
+| link TUI, middle refresh | T4 |
+| TUI Config intocada | (nenhuma task toca `tui/`) |
+| action-right parse preservado | T3 teste |
+| Docs | T5 |
+| 3 provas manuais | T6 |
+
+**Placeholders:** nenhum TBD de requisito; path stdin vs mktemp do apply no QML tem fallback explícito a validar no desktop.
+
+**Tipos:** `ConfigView` / `ApplyError` / `Command::ConfigShow|ConfigApply` consistentes T1→T2→T4.

--- a/docs/superpowers/specs/2026-07-21-omarchy-settings-and-cli-simplify-design.md
+++ b/docs/superpowers/specs/2026-07-21-omarchy-settings-and-cli-simplify-design.md
@@ -111,7 +111,7 @@ agent-bar config apply --file <path>      # opcional (testes)
 agent-bar config --help
 ```
 
-Exit: `0` ok · `1` validação/IO · `2` uso (args).
+Exit: `0` ok · `1` validação, uso (args) ou IO (igual ao resto da CLI).
 
 ### `config show` — envelope
 

--- a/docs/superpowers/specs/2026-07-21-omarchy-settings-and-cli-simplify-design.md
+++ b/docs/superpowers/specs/2026-07-21-omarchy-settings-and-cli-simplify-design.md
@@ -1,0 +1,332 @@
+# Omarchy settings nativo + simplificação da CLI
+
+Data: 2026-07-21 · Status: aprovado em brainstorming
+
+## Contexto
+
+No Omarchy 4 (Quattro / PR basecamp/omarchy#6231) a barra é `omarchy-shell`
+(Quickshell). O plugin `agent-bar.usage` já entrega:
+
+| Clique | Hoje |
+| --- | --- |
+| Esquerdo | `PopupCard` nativo de quotas |
+| Direito | terminal flutuante → `agent-bar menu` (TUI inteira) |
+| Meio | refresh forçado |
+
+O first-party `omarchy.model-usage` usa outro idioma: right-click abre o
+**mesmo popup** em modo settings (toggles, numbers, save em `shell.json`).
+
+A TUI (~9k LOC) ainda tem valor real em Detail (charts), History e Login.
+A tela Config da TUI edita 7 campos, vários mortos no Omarchy (separators,
+signal) e o Save sempre chama `apply_waybar_integration`.
+
+Paralelo: a CLI pública mistura primários, internos de Waybar (`action-right`,
+`export`, `assets`) e aliases redundantes (`remove` vs `uninstall`, `-t` vs
+`status`), com help ainda Waybar-primary.
+
+## Objetivos
+
+1. **Omarchy only:** right-click → settings nativo no mesmo popup (estilo
+   model-usage); left = usage mais largo; middle = refresh.
+2. **Settings essenciais:** providers on/off, ordem, display remaining/used,
+   refresh interval, notify on/off.
+3. **CLI:** `config show` / `config apply` como bridge; help limpo; internos
+   escondidos; aliases; **sem** remover suporte Waybar.
+4. TUI continua via `agent-bar menu` + link no popup. TUI Config **intocada**.
+
+## Não-objetivos
+
+- Podar ou redesenhar Detail / History / Login / Config da TUI.
+- Port de charts/history para QML.
+- `--watch` como fonte do widget.
+- Bump `schemaVersion` do envelope de quota; filtrar providers no JSON de poll.
+- `config apply` recarregar Waybar.
+- Deletar `action-right`, path Waybar, ou default waybar JSON.
+- Drag-and-drop de ordem; login OAuth no popup.
+- Major “Omarchy-only binary”.
+
+## Decisões travadas
+
+| # | Decisão |
+| --- | --- |
+| 1 | Right-click settings **só no plugin Omarchy**; Waybar left/right iguais. |
+| 2 | Subset: providers, order, displayMode, refreshIntervalSec, notify. |
+| 3 | Persist: Rust `settings.json` via CLI; interval via `updateEntryInline`. |
+| 4 | Mesmo `PopupCard`, `settingsMode`; largura ~`Style.space(370)`. |
+| 5 | TUI: CLI + link “Abrir menu (TUI)” no popup. |
+| 6 | TUI Config sem mudanças neste trabalho. |
+| 7 | `waybar.providers` canônico; filtro de chips no QML; envelope quota intacto. |
+| 8 | `agent-bar config show` / `config apply`. |
+| 9 | CLI simplify A: help + hide internals + aliases (não hard-cut). |
+
+## §1 Arquitetura
+
+```text
+Widget.qml
+  left  → popupOpen, settingsMode=false   (usage)
+  right → openSettings()                  (show + settingsMode=true)
+  mid   → refresh(true)
+  Save  → config apply --json …  then  updateEntryInline(refreshIntervalSec)
+  link  → helper + agent-bar menu
+
+Binário
+  settings.json  ← load / normalize / save
+  config show    → subset editável
+  config apply   → patch + save (sem apply_waybar_integration)
+  --format json  → envelope quota INALTERADO
+```
+
+### Fonte de verdade
+
+| Dado | Casa | Writer |
+| --- | --- | --- |
+| providers, providerOrder, displayMode, notify.enabled | `~/.config/agent-bar/settings.json` | `config apply` |
+| refreshIntervalSec | entry do plugin em `shell.json` | `updateEntryInline` |
+| quotas | cache + APIs | poll `--format json` |
+
+### Filtro de chips
+
+1. Boot e pós-apply: `config show` (ou stdout do apply) → `enabledIds` + order.
+2. Poll de quota continua full-envelope.
+3. Chips e seções usage usam só providers em `enabledIds`, na `providerOrder`.
+4. Até o primeiro `show` retornar: **não filtrar** (evita flash vazio).
+
+### Save (um botão, dois writes)
+
+1. Normaliza draft no QML.
+2. `config apply --json` (subset Rust).
+3. Se exit ≠ 0 → status de erro; **não** grava interval.
+4. Se OK → `updateEntryInline` com `refreshIntervalSec` (merge settings do plugin).
+5. Atualiza `enabledIds`, status “Saved”, `refresh(true)`.
+6. Apply OK + inline falha → “settings saved; interval not persisted”.
+
+## §2 Contrato CLI — `config`
+
+### Superfície
+
+```bash
+agent-bar config show [--format json]     # default json
+agent-bar config apply --json '<blob>'    # ou --json - (stdin)
+agent-bar config apply --file <path>      # opcional (testes)
+agent-bar config --help
+```
+
+Exit: `0` ok · `1` validação/IO · `2` uso (args).
+
+### `config show` — envelope
+
+Stdout só JSON; logs em stderr.
+
+```json
+{
+  "schemaVersion": 1,
+  "providers": ["claude", "amp", "codex", "grok"],
+  "providerOrder": ["claude", "amp", "codex", "grok"],
+  "displayMode": "remaining",
+  "notify": { "enabled": true }
+}
+```
+
+| Campo | Tipo | Notas |
+| --- | --- | --- |
+| `schemaVersion` | number | Contrato **deste** comando (≠ quota schema). v1 = este subset. |
+| `providers` | string[] | Habilitados, pós-normalização. |
+| `providerOrder` | string[] | Ordem efetiva. |
+| `displayMode` | `"remaining"` \| `"used"` | |
+| `notify.enabled` | bool | |
+
+Valores = pós-`settings::load` + normalização. **Não** inclui separators,
+signal, interval Waybar, fxRate, menu, glyph, cache, windowPolicy,
+`refreshIntervalSec`.
+
+### `config apply` — input
+
+Mesmo shape; campos **omitidos** = não mudar.
+
+Regras:
+
+1. `schemaVersion` ausente ou ≠ 1 → erro.
+2. Campo presente → substitui (com normalização).
+3. `providers: []` ou vazio após normalize → **erro** (≥ 1 known id).
+4. Ids desconhecidos → drop (igual load); se sobrar vazio → erro.
+5. `providerOrder`: `normalize_provider_selection`.
+6. `displayMode` inválido → erro (fail loud no apply).
+7. Merge: load → patch → `save` atômico.
+
+Stdout de sucesso: **mesmo envelope do show** (estado pós-save), para o QML
+atualizar `enabledIds` sem segundo show.
+
+Stderr em erro: mensagem curta.
+
+### Side-effects do apply
+
+| Ação | Faz? |
+| --- | --- |
+| Gravar `settings.json` | Sim |
+| `apply_waybar_integration` / reload Waybar | **Não** |
+| Invalidar cache de quota | **Não** |
+| Tocar `shell.json` | **Não** |
+
+Desktop misto (Waybar + Omarchy): providers no `settings.json` alinham; módulos
+Waybar só na próxima TUI Config / `setup`. Documentar em `docs/omarchy-shell.md`.
+
+### Implementação
+
+- Dispatch em `cli.rs` / `main.rs`.
+- Módulo fino (`src/config_cmd.rs` ou equivalente); reusa
+  `settings::load` / `save` / `normalize_provider_selection`.
+- Sem UI.
+
+## §3 QML / UX
+
+Registro product: densidade, controles do shell, sem paleta própria.
+Referência: `/usr/share/omarchy/shell/plugins/model-usage/Widget.qml`.
+
+### Popup
+
+| Hoje | Alvo |
+| --- | --- |
+| `contentWidth: Style.space(300)` | `Style.space(370)` (paridade model-usage) |
+| max height ~480 | max `Style.space(560)` |
+
+- `close()` reseta `popupOpen` **e** `settingsMode`.
+- Cores: `bar.foreground`, `Color.accent`, `urgent`, dim via `Qt.darker`.
+
+### Gestos e teclado
+
+| Input | Comportamento |
+| --- | --- |
+| Left | usage; toggle open se já no mesmo modo |
+| Right | `openSettings()` |
+| Middle | `refresh(true)` |
+| Fora / Esc | fecha + sai de settings (descarta draft) |
+| `s` | usage → settings; settings → save |
+| Header “← Usage” | volta usage sem salvar |
+| Save | dual-write (§1) |
+
+### Usage (ajustes)
+
+- Largura nova.
+- Rodapé: timestamp; `right-click: settings · middle: refresh`; botão texto
+  **Abrir menu (TUI)** → `openTui()` (helper existente).
+
+### Settings — seções
+
+1. **Providers** — Toggle por known id (claude/codex/amp/grok); ↑↓ entre
+   enabled; não desligar o último (status de erro).
+2. **Display** — segmento Remaining | Used (`displayMode`).
+3. **Alerts** — Toggle desktop notifications (`notify.enabled`).
+4. **Refresh** — NumberField 30–3600 step 30 (`refreshIntervalSec`, só shell).
+
+Vocabulário: Toggle, NumberField/stepper, botões header — padrão model-usage.
+Sem TextField de lista `claude, codex`; sem drag-and-drop; sem modal extra.
+
+### displayMode nos chips
+
+Label do chip respeita o modo:
+
+- `remaining` → `Math.round(primary.remaining) + "%"` (hoje).
+- `used` → `used` do envelope se presente e finito; senão derivar
+  `100 - remaining` quando remaining for finito.
+
+Sem isso o setting é mentira visual no Omarchy.
+
+### Estado QML (resumo)
+
+```text
+popupOpen, settingsMode, settingsBusy, settingsStatusText
+draft: providers, providerOrder, displayMode, notifyEnabled, refreshIntervalSec
+enabledIds  // pós show/apply; filtra chips + usage
+```
+
+## §4 Simplificação da CLI (opção A)
+
+### Help humano (grupos)
+
+```text
+Usage
+  (default)              Waybar JSON snapshot (generated modules)
+  status                 Terminal quota view
+  menu                   Interactive TUI
+  config show | apply    Read/write editable settings (JSON)
+
+Setup
+  setup | update | uninstall | doctor
+
+Machine
+  --format json | --watch | -p | -r | …
+```
+
+### Esconder do help (parse **permanece**)
+
+- `action-right` — modules Waybar gerados continuam usando.
+- `menu-font` — helper Bash.
+- `assets install`, `export waybar-modules`, `export waybar-css` — packager/test;
+  docs de integração/packaging, não help de usuário.
+
+### Aliases
+
+- `--terminal` / `-t` → mesmo path que `status` (silencioso).
+- `remove` → equivalente a `uninstall --yes` (comportamento forçado preservado).
+
+### Não neste release
+
+- Renomear default para subcomando `waybar` explícito.
+- Deletar `action-right` ou unificar em `menu --provider` (ficaria opção B).
+- Mudar default de output para JSON.
+
+## §5 Erros (resumo operacional)
+
+| Situação | Comportamento |
+| --- | --- |
+| show falha | Status erro; sem filtro até haver dados bons |
+| apply falha | Status stderr; não grava interval |
+| Process busy | Ignora segundo Save/Show |
+| close durante Save | UI fecha; resultado do Process não reabre/não aplica draft fantasma |
+| quota JSON inválido | `stale` (inalterado) |
+
+## §6 Testes e verificação
+
+| Camada | Cobertura |
+| --- | --- |
+| Unit config_cmd | merge, schema, empty providers, unknown ids, displayMode, notify |
+| CLI parse | config show/apply; aliases remove/-t; help não lista internos |
+| omarchy / golden | manifest description; se houver golden QML, right-click ≠ menu |
+| Regressão | `cargo test cli`, `settings`, `omarchy_integration`; waybar_contract path modules |
+| Manual desktop | chips filtrados; settings save; interval; link TUI; largura; lado a lado model-usage |
+
+Hard rules: sem mutar desktop live nos testes; temp dirs + `--omarchy-plugins-dir` + `XDG_*`.
+
+## §7 Docs a atualizar na implementação
+
+- `docs/commands.md` — taxonomia nova; `config`; internos em seção própria.
+- `docs/omarchy-shell.md` — clicks, settingsMode, dual-write, filtro, trade-off Waybar.
+- `docs/architecture.md` — dispatch `config`; nota action-right ainda Waybar.
+- `README.md` — Omarchy: right = settings; menu = TUI.
+- `CHANGELOG.md` — só no corte de release.
+
+## §8 Ordem de implementação sugerida
+
+1. `config show` / `config apply` + testes Rust.
+2. Help + aliases + hide internals + testes help/parse.
+3. QML: largura, settingsMode, SettingsContent, filtro, Save, link TUI.
+4. Docs.
+5. Verificação manual Omarchy 4 (3 provas).
+
+## §9 Riscos
+
+| Risco | Mitigação |
+| --- | --- |
+| Widget.qml cresce muito | Components no mesmo arquivo; split se >~800 linhas de lógica nova |
+| Flash de chips | Sem filtro até primeiro show |
+| `remove` “sumiu” do help | Alias mantém o parse; help aponta `uninstall` |
+| displayMode sem efeito | Chip label (§3) |
+| User misto Waybar+Omarchy | apply não toca Waybar modules; documentado |
+
+## Referências
+
+- Plugin atual: `assets/omarchy/Widget.qml`, `docs/omarchy-shell.md`
+- Spec plugin v1: `docs/superpowers/specs/2026-07-21-omarchy-shell-plugin-design.md`
+- Settings: `src/settings.rs`; TUI Config: `src/tui/render/config.rs` (intocada)
+- model-usage: `/usr/share/omarchy/shell/plugins/model-usage/Widget.qml`
+- JSON quota: `docs/json-output.md` (inalterado)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -108,8 +108,6 @@ const KNOWN_COMMANDS: &[&str] = &[
     "menu",
     "status",
     "setup",
-    "assets",
-    "export",
     "update",
     "uninstall",
     "remove",
@@ -230,7 +228,11 @@ pub fn parse_args(args: &[String]) -> Result<CliOptions, CliError> {
 
             "update" => opts.command = Command::Update,
             "uninstall" => opts.command = Command::Uninstall,
-            "remove" => opts.command = Command::Remove,
+            // Alias: force uninstall (yes=true) sem vitrine no help.
+            "remove" => {
+                opts.command = Command::Uninstall;
+                opts.yes = true;
+            }
             "doctor" => opts.command = Command::Doctor,
 
             "config" => match args.get(i + 1).map(|s| s.as_str()) {
@@ -269,7 +271,8 @@ pub fn parse_args(args: &[String]) -> Result<CliOptions, CliError> {
 
             "--yes" | "-y" => opts.yes = true,
 
-            "--terminal" | "-t" => opts.command = Command::Terminal,
+            // Alias histórico de status (não Command::Terminal).
+            "--terminal" | "-t" => opts.command = Command::Status,
 
             "--refresh" | "-r" => opts.refresh = true,
 
@@ -601,7 +604,7 @@ pub fn build_help(no_color: bool) -> String {
 
     out.push_str(&format!("{}\n", v_line(no_color)));
 
-    // Seção Commands
+    // Seção Commands (vitrine pública — internos ficam parseáveis mas ocultos)
     out.push_str(&format!("{}\n", label_line("Commands", no_color)));
     out.push_str(&format!(
         "{}\n",
@@ -613,29 +616,17 @@ pub fn build_help(no_color: bool) -> String {
     ));
     out.push_str(&format!(
         "{}\n",
+        cmd_line("config show", "Print editable settings (JSON)", no_color)
+    ));
+    out.push_str(&format!(
+        "{}\n",
+        cmd_line("config apply", "Apply settings patch from JSON", no_color)
+    ));
+    out.push_str(&format!(
+        "{}\n",
         cmd_line(
             "setup",
             &format!("Install + wire {APP_NAME} in Waybar"),
-            no_color
-        )
-    ));
-    out.push_str(&format!(
-        "{}\n",
-        cmd_line("assets install", "Install icons/helper only", no_color)
-    ));
-    out.push_str(&format!(
-        "{}\n",
-        cmd_line(
-            "export waybar-modules",
-            "Print Waybar JSON module contract",
-            no_color
-        )
-    ));
-    out.push_str(&format!(
-        "{}\n",
-        cmd_line(
-            "export waybar-css",
-            "Print Waybar CSS JSON contract",
             no_color
         )
     ));
@@ -657,10 +648,6 @@ pub fn build_help(no_color: bool) -> String {
     ));
     out.push_str(&format!(
         "{}\n",
-        cmd_line("remove", "Force remove without prompt", no_color)
-    ));
-    out.push_str(&format!(
-        "{}\n",
         cmd_line(
             "doctor",
             &format!("Detect & clean {APP_NAME} leftovers in $HOME"),
@@ -669,19 +656,27 @@ pub fn build_help(no_color: bool) -> String {
     ));
     out.push_str(&format!("{}\n", v_line(no_color)));
 
-    // Seção Waybar
-    out.push_str(&format!("{}\n", label_line("Waybar", no_color)));
+    // Seção Omarchy / Waybar (resumo curto)
+    out.push_str(&format!("{}\n", label_line("Omarchy / Waybar", no_color)));
     out.push_str(&format!(
         "{}\n",
-        wb_line("Left click", "Interactive menu", no_color)
+        wb_line("Default poll", "Waybar JSON; --format json = shell", no_color)
     ));
     out.push_str(&format!(
         "{}\n",
-        wb_line("Right click", "Refresh / Login", no_color)
+        wb_line(
+            "Omarchy",
+            "Left usage · right settings · middle refresh",
+            no_color
+        )
     ));
     out.push_str(&format!(
         "{}\n",
-        wb_line("Hover", "Detailed tooltip", no_color)
+        wb_line(
+            "Waybar",
+            "Left menu · right action (internal) · hover tooltip",
+            no_color
+        )
     ));
     out.push_str(&format!("{}\n", v_line(no_color)));
 
@@ -893,10 +888,16 @@ mod tests {
 
     #[test]
     fn command_remove() {
-        assert_eq!(
-            parse_args(&args(&["remove"])).unwrap().command,
-            Command::Remove
-        );
+        let opts = parse_args(&args(&["remove"])).unwrap();
+        assert_eq!(opts.command, Command::Uninstall);
+        assert!(opts.yes);
+    }
+
+    #[test]
+    fn remove_aliases_uninstall_yes() {
+        let opts = parse_args(&args(&["remove"])).unwrap();
+        assert_eq!(opts.command, Command::Uninstall);
+        assert!(opts.yes);
     }
 
     #[test]
@@ -1021,6 +1022,12 @@ mod tests {
     }
 
     #[test]
+    fn action_right_still_parses() {
+        let opts = parse_args(&args(&["action-right", "claude"])).unwrap();
+        assert_eq!(opts.command, Command::ActionRight);
+    }
+
+    #[test]
     fn command_version_long() {
         assert_eq!(
             parse_args(&args(&["--version"])).unwrap().command,
@@ -1064,7 +1071,7 @@ mod tests {
     fn flag_terminal_long() {
         assert_eq!(
             parse_args(&args(&["--terminal"])).unwrap().command,
-            Command::Terminal
+            Command::Status
         );
     }
 
@@ -1072,8 +1079,16 @@ mod tests {
     fn flag_terminal_short() {
         assert_eq!(
             parse_args(&args(&["-t"])).unwrap().command,
-            Command::Terminal
+            Command::Status
         );
+    }
+
+    #[test]
+    fn terminal_flag_aliases_status() {
+        let opts = parse_args(&args(&["--terminal"])).unwrap();
+        assert_eq!(opts.command, Command::Status);
+        let opts = parse_args(&args(&["-t"])).unwrap();
+        assert_eq!(opts.command, Command::Status);
     }
 
     #[test]
@@ -1391,5 +1406,22 @@ mod tests {
     fn build_help_ends_with_newline() {
         let help = build_help(false);
         assert!(help.ends_with('\n'), "build_help deve terminar em '\\n'");
+    }
+
+    #[test]
+    fn build_help_hides_internals() {
+        let help = build_help(true);
+        assert!(help.contains("config"));
+        assert!(help.contains("menu"));
+        assert!(help.contains("status"));
+        assert!(!help.contains("action-right"));
+        assert!(!help.contains("assets install"));
+        assert!(!help.contains("export waybar-modules"));
+        assert!(!help.contains("menu-font"));
+        // remove não como comando de vitrine
+        assert!(
+            !help.lines().any(|l| l.contains("remove") && l.contains("Force")),
+            "remove não deve aparecer como comando primário"
+        );
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -30,6 +30,10 @@ pub enum Command {
     /// `settings.menu` p/ o helper `scripts/agent-bar-open-terminal`. Não
     /// aparece no help nem em `KNOWN_COMMANDS` (não é sugerido em typos).
     MenuFont,
+    /// `config show` — imprime subset editável do settings como JSON.
+    ConfigShow,
+    /// `config apply` — aplica patch JSON (--json / --file / stdin).
+    ConfigApply,
 }
 
 /// Formato de saída do módulo Waybar.
@@ -57,6 +61,12 @@ pub struct CliOptions {
     pub terminal_script: Option<String>,
     pub dry_run: bool,
     pub yes: bool,
+    /// Payload de `config apply --json` (None se `--json -` ou `--file`).
+    pub config_json: Option<String>,
+    /// `config apply --json -` — main deve ler o blob de stdin.
+    pub config_json_stdin: bool,
+    /// Path de `config apply --file <path>` — main lê o arquivo.
+    pub config_file: Option<String>,
     /// Avisos não-fatais coletados durante o parse — o caller imprime em stderr.
     pub warnings: Vec<String>,
 }
@@ -79,6 +89,9 @@ impl Default for CliOptions {
             terminal_script: None,
             dry_run: false,
             yes: false,
+            config_json: None,
+            config_json_stdin: false,
+            config_file: None,
             warnings: Vec::new(),
         }
     }
@@ -102,6 +115,7 @@ const KNOWN_COMMANDS: &[&str] = &[
     "remove",
     "action-right",
     "doctor",
+    "config",
     "help",
 ];
 
@@ -219,6 +233,31 @@ pub fn parse_args(args: &[String]) -> Result<CliOptions, CliError> {
             "remove" => opts.command = Command::Remove,
             "doctor" => opts.command = Command::Doctor,
 
+            "config" => match args.get(i + 1).map(|s| s.as_str()) {
+                Some("show") => {
+                    opts.command = Command::ConfigShow;
+                    i += 1;
+                }
+                Some("apply") => {
+                    opts.command = Command::ConfigApply;
+                    i += 1;
+                }
+                Some("--help" | "help" | "-h") => {
+                    opts.command = Command::Help;
+                    i += 1;
+                }
+                None => {
+                    opts.command = Command::Help;
+                }
+                Some(other) => {
+                    return Err(CliError {
+                        message: format!(
+                            "Unknown subcommand for 'config': {other}. Use 'show' or 'apply'."
+                        ),
+                    });
+                }
+            },
+
             "action-right" => {
                 let provider = require_next_arg(args, i, "action-right")?;
                 opts.provider = Some(provider.to_string());
@@ -315,6 +354,22 @@ pub fn parse_args(args: &[String]) -> Result<CliOptions, CliError> {
                 i += 1;
             }
 
+            "--json" => {
+                let val = require_next_arg(args, i, "--json")?;
+                if val == "-" {
+                    opts.config_json_stdin = true;
+                } else {
+                    opts.config_json = Some(val.to_string());
+                }
+                i += 1;
+            }
+
+            "--file" => {
+                let val = require_next_arg(args, i, "--file")?;
+                opts.config_file = Some(val.to_string());
+                i += 1;
+            }
+
             "--help" | "-h" | "help" => opts.command = Command::Help,
 
             "--version" | "-V" => opts.command = Command::Version,
@@ -358,6 +413,28 @@ pub fn parse_args(args: &[String]) -> Result<CliOptions, CliError> {
     if interval_given && !opts.watch {
         opts.warnings
             .push("[agent-bar] --interval has no effect without --watch".to_string());
+    }
+
+    if opts.command == Command::ConfigApply {
+        let sources = [
+            opts.config_json.is_some(),
+            opts.config_json_stdin,
+            opts.config_file.is_some(),
+        ]
+        .into_iter()
+        .filter(|b| *b)
+        .count();
+        if sources == 0 {
+            return Err(CliError {
+                message: "config apply requires --json <blob>, --json -, or --file <path>"
+                    .to_string(),
+            });
+        }
+        if sources > 1 {
+            return Err(CliError {
+                message: "config apply: use only one of --json or --file".to_string(),
+            });
+        }
     }
 
     Ok(opts)
@@ -827,6 +904,62 @@ mod tests {
         assert_eq!(
             parse_args(&args(&["doctor"])).unwrap().command,
             Command::Doctor
+        );
+    }
+
+    #[test]
+    fn command_config_show() {
+        let opts = parse_args(&args(&["config", "show"])).unwrap();
+        assert_eq!(opts.command, Command::ConfigShow);
+    }
+
+    #[test]
+    fn command_config_apply_json() {
+        let opts = parse_args(&args(&[
+            "config",
+            "apply",
+            "--json",
+            r#"{"schemaVersion":1}"#,
+        ]))
+        .unwrap();
+        assert_eq!(opts.command, Command::ConfigApply);
+        assert_eq!(
+            opts.config_json.as_deref(),
+            Some(r#"{"schemaVersion":1}"#)
+        );
+        assert!(!opts.config_json_stdin);
+        assert!(opts.config_file.is_none());
+    }
+
+    #[test]
+    fn command_config_apply_json_stdin() {
+        let opts = parse_args(&args(&["config", "apply", "--json", "-"])).unwrap();
+        assert_eq!(opts.command, Command::ConfigApply);
+        assert!(opts.config_json_stdin);
+        assert!(opts.config_json.is_none());
+        assert!(opts.config_file.is_none());
+    }
+
+    #[test]
+    fn command_config_apply_file() {
+        let opts = parse_args(&args(&["config", "apply", "--file", "/tmp/c.json"])).unwrap();
+        assert_eq!(opts.command, Command::ConfigApply);
+        assert_eq!(opts.config_file.as_deref(), Some("/tmp/c.json"));
+        assert!(opts.config_json.is_none());
+        assert!(!opts.config_json_stdin);
+    }
+
+    #[test]
+    fn command_config_apply_requires_payload() {
+        let err = parse_args(&args(&["config", "apply"])).unwrap_err();
+        assert!(err.message.contains("--json") || err.message.contains("--file"));
+    }
+
+    #[test]
+    fn command_config_bare_is_help() {
+        assert_eq!(
+            parse_args(&args(&["config"])).unwrap().command,
+            Command::Help
         );
     }
 

--- a/src/config_cmd.rs
+++ b/src/config_cmd.rs
@@ -1,0 +1,262 @@
+//! `agent-bar config show|apply` — subset editável do settings.json (spec
+//! 2026-07-21-omarchy-settings-and-cli-simplify).
+
+use serde::{Deserialize, Serialize};
+
+use crate::config::Paths;
+use crate::settings::{normalize_provider_selection, DisplayMode, Settings};
+
+pub const CONFIG_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConfigView {
+    pub schema_version: u32,
+    pub providers: Vec<String>,
+    pub provider_order: Vec<String>,
+    pub display_mode: DisplayMode,
+    pub notify: NotifyView,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct NotifyView {
+    pub enabled: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ApplyError {
+    Validation(String),
+    Io(String),
+}
+
+impl std::fmt::Display for ApplyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ApplyError::Validation(m) | ApplyError::Io(m) => write!(f, "{m}"),
+        }
+    }
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ConfigPatch {
+    schema_version: Option<u32>,
+    providers: Option<Vec<String>>,
+    provider_order: Option<Vec<String>>,
+    display_mode: Option<String>,
+    notify: Option<NotifyPatch>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct NotifyPatch {
+    enabled: Option<bool>,
+}
+
+pub fn view_from_settings(s: &Settings) -> ConfigView {
+    ConfigView {
+        schema_version: CONFIG_SCHEMA_VERSION,
+        providers: s.waybar.providers.clone(),
+        provider_order: s.waybar.provider_order.clone(),
+        display_mode: s.waybar.display_mode,
+        notify: NotifyView {
+            enabled: s.notify.enabled,
+        },
+    }
+}
+
+pub fn show(paths: &Paths) -> ConfigView {
+    view_from_settings(&crate::settings::load(paths))
+}
+
+pub fn apply_json(paths: &Paths, raw: &str) -> Result<ConfigView, ApplyError> {
+    let patch: ConfigPatch = serde_json::from_str(raw).map_err(|e| {
+        ApplyError::Validation(format!("invalid JSON: {e}"))
+    })?;
+
+    match patch.schema_version {
+        Some(CONFIG_SCHEMA_VERSION) => {}
+        Some(v) => {
+            return Err(ApplyError::Validation(format!(
+                "unsupported schemaVersion: {v} (expected {CONFIG_SCHEMA_VERSION})"
+            )));
+        }
+        None => {
+            return Err(ApplyError::Validation(
+                "schemaVersion is required".into(),
+            ));
+        }
+    }
+
+    let mut s = crate::settings::load(paths);
+
+    if let Some(providers) = patch.providers {
+        let order_src = patch
+            .provider_order
+            .clone()
+            .unwrap_or_else(|| s.waybar.provider_order.clone());
+        let (providers, order) = normalize_provider_selection(&providers, &order_src);
+        if providers.is_empty() {
+            return Err(ApplyError::Validation(
+                "providers must contain at least one known id".into(),
+            ));
+        }
+        s.waybar.providers = providers;
+        s.waybar.provider_order = order;
+    } else if let Some(order) = patch.provider_order {
+        let (providers, order) =
+            normalize_provider_selection(&s.waybar.providers, &order);
+        s.waybar.providers = providers;
+        s.waybar.provider_order = order;
+    }
+
+    if let Some(mode) = patch.display_mode {
+        s.waybar.display_mode = match mode.as_str() {
+            "remaining" => DisplayMode::Remaining,
+            "used" => DisplayMode::Used,
+            other => {
+                return Err(ApplyError::Validation(format!(
+                    "invalid displayMode: '{other}' (remaining|used)"
+                )));
+            }
+        };
+    }
+
+    if let Some(n) = patch.notify {
+        if let Some(en) = n.enabled {
+            s.notify.enabled = en;
+        }
+    }
+
+    crate::settings::save(paths, &s).map_err(|e| ApplyError::Io(e.to_string()))?;
+    Ok(view_from_settings(&s))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Paths;
+    use crate::settings::{self, DisplayMode};
+    use std::path::PathBuf;
+    use tempfile::tempdir;
+
+    fn paths_in(dir: &std::path::Path) -> Paths {
+        Paths {
+            cache_dir: dir.join("cache"),
+            config_dir: dir.join("config"),
+            claude_credentials: PathBuf::new(),
+            codex_auth: PathBuf::new(),
+            codex_sessions: PathBuf::new(),
+            amp_settings: PathBuf::new(),
+            amp_threads: PathBuf::new(),
+            grok_home: PathBuf::new(),
+            grok_auth: PathBuf::new(),
+        }
+    }
+
+    #[test]
+    fn show_defaults_when_no_file() {
+        let dir = tempdir().unwrap();
+        let v = show(&paths_in(dir.path()));
+        assert_eq!(v.schema_version, 1);
+        assert_eq!(v.providers, vec!["claude", "codex", "amp", "grok"]);
+        assert_eq!(v.provider_order, v.providers);
+        assert_eq!(v.display_mode, DisplayMode::Remaining);
+        assert!(v.notify.enabled);
+    }
+
+    #[test]
+    fn apply_rejects_wrong_schema() {
+        let dir = tempdir().unwrap();
+        let p = paths_in(dir.path());
+        let err = apply_json(&p, r#"{"schemaVersion":2,"providers":["claude"]}"#).unwrap_err();
+        assert!(matches!(err, ApplyError::Validation(_)));
+    }
+
+    #[test]
+    fn apply_rejects_empty_providers() {
+        let dir = tempdir().unwrap();
+        let p = paths_in(dir.path());
+        let err = apply_json(&p, r#"{"schemaVersion":1,"providers":[]}"#).unwrap_err();
+        assert!(matches!(err, ApplyError::Validation(_)));
+    }
+
+    #[test]
+    fn apply_partial_preserves_omitted_fields() {
+        let dir = tempdir().unwrap();
+        let p = paths_in(dir.path());
+        // seed
+        let mut s = settings::load(&p);
+        s.waybar.display_mode = DisplayMode::Used;
+        s.notify.enabled = false;
+        settings::save(&p, &s).unwrap();
+
+        let v = apply_json(
+            &p,
+            r#"{"schemaVersion":1,"providers":["claude","codex"]}"#,
+        )
+        .unwrap();
+        assert_eq!(v.providers, vec!["claude", "codex"]);
+        assert_eq!(v.display_mode, DisplayMode::Used);
+        assert!(!v.notify.enabled);
+
+        let loaded = settings::load(&p);
+        assert_eq!(loaded.waybar.providers, vec!["claude", "codex"]);
+        assert_eq!(loaded.waybar.display_mode, DisplayMode::Used);
+        assert!(!loaded.notify.enabled);
+        // separators etc. intact
+        assert_eq!(loaded.waybar.separators, s.waybar.separators);
+    }
+
+    #[test]
+    fn apply_display_mode_and_notify() {
+        let dir = tempdir().unwrap();
+        let p = paths_in(dir.path());
+        let v = apply_json(
+            &p,
+            r#"{"schemaVersion":1,"displayMode":"used","notify":{"enabled":false}}"#,
+        )
+        .unwrap();
+        assert_eq!(v.display_mode, DisplayMode::Used);
+        assert!(!v.notify.enabled);
+    }
+
+    #[test]
+    fn apply_rejects_invalid_display_mode() {
+        let dir = tempdir().unwrap();
+        let p = paths_in(dir.path());
+        let err = apply_json(&p, r#"{"schemaVersion":1,"displayMode":"nope"}"#).unwrap_err();
+        assert!(matches!(err, ApplyError::Validation(_)));
+    }
+
+    #[test]
+    fn apply_drops_unknown_provider_ids() {
+        let dir = tempdir().unwrap();
+        let p = paths_in(dir.path());
+        let v = apply_json(
+            &p,
+            r#"{"schemaVersion":1,"providers":["claude","nope","codex"]}"#,
+        )
+        .unwrap();
+        assert_eq!(v.providers, vec!["claude", "codex"]);
+    }
+
+    #[test]
+    fn apply_all_unknown_providers_is_error() {
+        let dir = tempdir().unwrap();
+        let p = paths_in(dir.path());
+        let err =
+            apply_json(&p, r#"{"schemaVersion":1,"providers":["nope"]}"#).unwrap_err();
+        assert!(matches!(err, ApplyError::Validation(_)));
+    }
+
+    #[test]
+    fn show_json_wire_format() {
+        let dir = tempdir().unwrap();
+        let v = show(&paths_in(dir.path()));
+        let j = serde_json::to_value(&v).unwrap();
+        assert_eq!(j["schemaVersion"], 1);
+        assert_eq!(j["displayMode"], "remaining");
+        assert_eq!(j["notify"]["enabled"], true);
+        assert!(j["providers"].is_array());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod app_identity;
 pub mod cache;
 pub mod cli;
 pub mod config;
+pub mod config_cmd;
 pub mod doctor;
 pub mod formatters;
 pub mod http;

--- a/src/main.rs
+++ b/src/main.rs
@@ -183,6 +183,81 @@ async fn main() {
             std::process::exit(0);
         }
 
+        Command::ConfigShow => {
+            let paths = match Paths::from_env() {
+                Ok(p) => p,
+                Err(e) => {
+                    log::error!("{e}");
+                    std::process::exit(1);
+                }
+            };
+            let view = agent_bar::config_cmd::show(&paths);
+            match serde_json::to_string_pretty(&view) {
+                Ok(j) => {
+                    println!("{j}");
+                    std::process::exit(0);
+                }
+                Err(e) => {
+                    log::error!("{e}");
+                    std::process::exit(1);
+                }
+            }
+        }
+
+        Command::ConfigApply => {
+            let paths = match Paths::from_env() {
+                Ok(p) => p,
+                Err(e) => {
+                    log::error!("{e}");
+                    std::process::exit(1);
+                }
+            };
+            let raw = if opts.config_json_stdin {
+                use std::io::Read;
+                let mut buf = String::new();
+                if let Err(e) = std::io::stdin().read_to_string(&mut buf) {
+                    log::error!("failed to read stdin: {e}");
+                    std::process::exit(2);
+                }
+                buf
+            } else if let Some(path) = &opts.config_file {
+                match std::fs::read_to_string(path) {
+                    Ok(s) => s,
+                    Err(e) => {
+                        log::error!("failed to read {path}: {e}");
+                        std::process::exit(1);
+                    }
+                }
+            } else if let Some(j) = &opts.config_json {
+                j.clone()
+            } else {
+                log::error!(
+                    "config apply requires --json <blob>, --json -, or --file <path>"
+                );
+                std::process::exit(2);
+            };
+            match agent_bar::config_cmd::apply_json(&paths, &raw) {
+                Ok(view) => match serde_json::to_string_pretty(&view) {
+                    Ok(j) => {
+                        println!("{j}");
+                        std::process::exit(0);
+                    }
+                    Err(e) => {
+                        log::error!("{e}");
+                        std::process::exit(1);
+                    }
+                },
+                Err(agent_bar::config_cmd::ApplyError::Validation(m)) => {
+                    eprintln!("{m}");
+                    std::process::exit(1);
+                }
+                Err(agent_bar::config_cmd::ApplyError::Io(m)) => {
+                    eprintln!("{m}");
+                    std::process::exit(1);
+                }
+            }
+        }
+
         Command::Setup => {
             let paths = match Paths::from_env() {
                 Ok(p) => p,

--- a/src/main.rs
+++ b/src/main.rs
@@ -601,6 +601,7 @@ async fn main() {
             }
         }
 
+        // `remove` parseia como Uninstall + yes=true; `--yes` no uninstall também força.
         Command::Uninstall => {
             let paths = match Paths::from_env() {
                 Ok(p) => p,
@@ -614,42 +615,13 @@ async fn main() {
                 .unwrap_or_default();
             let settings_dir = home.join(".config").join(APP_NAME);
             let ipaths = waybar_integration::get_default_waybar_integration_paths();
+            let force = opts.yes;
             match uninstall::run_uninstall(
                 &settings_dir,
                 &paths.cache_dir,
                 &home,
-                false,
+                force,
                 &format!("{APP_NAME} uninstall"),
-                &ipaths,
-                &omarchy_integration::default_omarchy_plugins_dir(&home),
-            ) {
-                Ok(()) => std::process::exit(0),
-                Err(e) => {
-                    log::error!("{e}");
-                    std::process::exit(1);
-                }
-            }
-        }
-
-        Command::Remove => {
-            let paths = match Paths::from_env() {
-                Ok(p) => p,
-                Err(e) => {
-                    log::error!("{e}");
-                    std::process::exit(1);
-                }
-            };
-            let home = std::env::var_os("HOME")
-                .map(PathBuf::from)
-                .unwrap_or_default();
-            let settings_dir = home.join(".config").join(APP_NAME);
-            let ipaths = waybar_integration::get_default_waybar_integration_paths();
-            match uninstall::run_uninstall(
-                &settings_dir,
-                &paths.cache_dir,
-                &home,
-                true,
-                &format!("{APP_NAME} remove"),
                 &ipaths,
                 &omarchy_integration::default_omarchy_plugins_dir(&home),
             ) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -217,7 +217,7 @@ async fn main() {
                 let mut buf = String::new();
                 if let Err(e) = std::io::stdin().read_to_string(&mut buf) {
                     log::error!("failed to read stdin: {e}");
-                    std::process::exit(2);
+                    std::process::exit(1);
                 }
                 buf
             } else if let Some(path) = &opts.config_file {
@@ -234,7 +234,7 @@ async fn main() {
                 log::error!(
                     "config apply requires --json <blob>, --json -, or --file <path>"
                 );
-                std::process::exit(2);
+                std::process::exit(1);
             };
             match agent_bar::config_cmd::apply_json(&paths, &raw) {
                 Ok(view) => match serde_json::to_string_pretty(&view) {

--- a/src/snapshots/agent_bar__omarchy_integration__tests__omarchy_manifest.snap
+++ b/src/snapshots/agent_bar__omarchy_integration__tests__omarchy_manifest.snap
@@ -1,5 +1,6 @@
 ---
 source: src/omarchy_integration.rs
+assertion_line: 237
 expression: rendered
 ---
 {
@@ -17,7 +18,7 @@ expression: rendered
   },
   "barWidget": {
     "displayName": "agent-bar",
-    "description": "Quota chips per provider; left = popup, right = TUI, middle = refresh.",
+    "description": "Quota chips per provider; left = usage, right = settings, middle = refresh.",
     "category": "AI",
     "aliases": ["agent-bar"],
     "allowMultiple": false,


### PR DESCRIPTION
## Summary

- Right-click no plugin Omarchy abre settings no mesmo popup (estilo `model-usage`): providers, ordem, display, notify, refresh interval
- `agent-bar config show` / `config apply` como bridge para `settings.json` (sem recarregar Waybar)
- Dual-write: apply primeiro, depois `updateEntryInline` só pro `refreshIntervalSec`
- Help limpo: internos escondidos; `remove` ≡ `uninstall -y`; `-t` ≡ `status`
- TUI continua via `agent-bar menu` ou link no popup; Waybar/`action-right` intactos

Spec: `docs/superpowers/specs/2026-07-21-omarchy-settings-and-cli-simplify-design.md`  
Plano: `docs/superpowers/plans/2026-07-21-omarchy-settings-and-cli-simplify.md`

## Test plan

- [x] `cargo test config_cmd` / `cli` / `settings` / `omarchy_integration`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] Smoke XDG: `config show` / `apply`; help sem `action-right`/`assets install`/`export`
- [ ] Manual Omarchy 4 (3 provas): right → settings; Save dual-write; filtro de chips; link TUI; largura vs model-usage
- [ ] Após build: `agent-bar setup` (ou copiar Widget) para refresh do drop-in

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an in-popup settings experience for Omarchy, including provider visibility and ordering, remaining/used display, notifications, and refresh interval controls.
  * Added `agent-bar config show` and `config apply` for viewing and updating settings via JSON, files, or standard input.
  * Updated click behavior: left opens usage, right opens settings, and middle refreshes.

* **Documentation**
  * Updated CLI, Omarchy, architecture, and usage documentation to reflect the new settings and command behavior.
  * Documented `remove` as an uninstall alias.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->