### PR TITLE
chore: limpeza de legado verificada (v9, PR 1/5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,6 @@ dependencies = [
  "throbber-widgets-tui",
  "time",
  "tokio",
- "tokio-util",
  "tui-input",
  "wiremock",
 ]
@@ -2714,7 +2713,6 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
- "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ ratatui = "0.30.2"
 crossterm = { version = "0.29", features = ["event-stream"] }
 tui-input = "0.15.3"
 throbber-widgets-tui = "0.11.1"
-tokio-util = { version = "0.7", features = ["rt"] }
 tachyonfx = "0.25"
 
 [dev-dependencies]

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -42,7 +42,7 @@ reads assets from `/usr/share/agent-bar/`.
 
 ## Settings
 
-Settings schema version: `2`.
+Settings schema version: `3`.
 
 Defaults:
 
@@ -50,7 +50,6 @@ Defaults:
 - provider order: `claude`, `codex`, `amp`, `grok`
 - separator style: `gap`
 - display mode: `remaining`
-- show percentage: `true`
 - Codex window policy: `both`
 - menu animations: `true`
 - menu font family: `IBM Plex Mono`

--- a/docs/superpowers/plans/2026-07-21-v9-01-limpeza-legado.md
+++ b/docs/superpowers/plans/2026-07-21-v9-01-limpeza-legado.md
@@ -1,0 +1,1092 @@
+# Limpeza de legado (v9 — PR 1/Seção G) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remover código morto verificado adversarialmente (Seção G do spec) antes do
+contrato `windowKind` (PR 2) pousar em cima — `Command::Terminal`,
+`get_all_provider_ids`, `install::ensure_amp_cli`, `AMP_INSTALL_COMMAND`
+duplicada, dep `tokio-util`, `ConfigField::settings_key`, 7 variantes órfãs de
+`Icon`, comentário morto em `render/shared.rs`, migração settings v2→v3
+dropando `waybar.show_percentage`, e housekeeping do worktree/branch mergeados
+de `feat/omarchy-settings-cli`.
+
+**Architecture:** Sequência de remoções cirúrgicas, cada uma com baseline
+verde → edit → verificação focada → commit. Zero mudança de comportamento
+observável (Waybar/TUI/CLI); só reduz superfície. Task 7 é a única com um
+teste genuinamente novo (TDD completo); as demais são remoção de código morto
+confirmada por grep prévio (zero outros callers).
+
+**Tech Stack:** Rust 2021 (`agent-bar` crate + bin `src/main.rs`), cargo
+test/clippy, `insta` (não tocado nesta PR), git worktree.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-21-omarchy-first-popup-redesign-design.md`
+  Seção G (fonte de verdade desta PR).
+- Rust/cargo only; `scripts/agent-bar-open-terminal` permanece Bash (CLAUDE.md §1).
+- **Nunca `unwrap()`/`expect()` em produção** — nenhuma task adiciona código
+  novo de produção, só remove; se alguma remoção deixar um `unwrap` órfão
+  exposto, propagar erro em vez de silenciar.
+- Provider error strings = contrato verbatim — **não alterar** (nenhuma task
+  toca strings de erro de provider).
+- Claude continua **fora** de `BaseProvider` (não tocado nesta PR).
+- XML-escape **só** em `render_pango.rs` (não tocado nesta PR).
+- Sem round-trip JSONC via serde em `waybar_integration` (não tocado nesta PR).
+- stdout limpo no path Waybar; logs em stderr (não tocado nesta PR).
+- Não mutar desktop ao vivo (`setup`/`update`/`uninstall` sem aprovação);
+  testes com temp dirs + `XDG_*`.
+- Conventional Commits em PT, subject ≤ 50 chars. **Zero atribuição de AI**
+  em commits/PRs.
+- Gotcha RTK: **um único filtro posicional** por invocação de `cargo test`.
+  `check-types` não existe; verificação = `cargo test <filtro>` +
+  `cargo clippy --all-targets -- -D warnings`.
+- Implementers: Read cada arquivo antes de Edit; se Edit falhar com
+  `string not found`, re-Read antes de re-tentar; após git pull/checkout/
+  retorno de outro agente, o Read anterior está morto — re-Read; rodar
+  `cargo test` com cache limpo antes de commit se algo parecer "PASS velho".
+- Esta é a **Task 1 de 5 PRs em sequência** (Entrega do spec). PRs 2-5
+  (contrato `windowKind`, Widget.qml, gates de plataforma, docs) assumem que
+  esta PR já landou em `master`.
+
+## Ordem e dependências
+
+```text
+T1 Command::Terminal ──┐
+T2 get_all_provider_ids ──┤
+T3 install::ensure_amp_cli ──┼──► (independentes entre si; série no mesmo branch)
+T4 AMP_INSTALL_COMMAND dup ──┤
+T5 dep tokio-util ──┘
+T6 higiene TUI (settings_key/Icon/comentário) ──► depende de T1-T5 landarem (mesmo arquivo main.rs/cli.rs intocado, mas evita conflito de diff)
+T7 settings v2→v3 (show_percentage) ──► após T6 (toca tui/render + tui/update, mesma área)
+T8 housekeeping worktree/branch ──► último (não toca código)
+```
+
+T1-T5 são mutuamente independentes (arquivos diferentes) mas rodam em série
+no mesmo branch para manter o histórico de commits limpo e evitar qualquer
+conflito incidental. T6 e T7 tocam árvores adjacentes (`tui/`) e rodam depois.
+T8 é puro housekeeping de git, sem tocar `src/`.
+
+## Produces (para as PRs 2-5 consumirem)
+
+- `Command` (src/cli.rs) sem a variante `Terminal` — PR 2/3 não referenciam
+  `Command::Terminal`.
+- `waybar_contract.rs` sem `get_all_provider_ids` — nenhuma PR seguinte
+  precisa dela (Seção A do spec não a menciona).
+- `install.rs` sem `ensure_amp_cli`; `providers::amp_cli` sem
+  `AMP_INSTALL_COMMAND` duplicada (única fonte: `app_identity::AMP_INSTALL_COMMAND`).
+- `Cargo.toml`/`Cargo.lock` sem `tokio-util`.
+- `settings::CURRENT_VERSION == 3`; `settings::Waybar` sem `show_percentage`
+  — PR 2/3 (contrato `windowKind`, `config show` com `menuAnimations`) partem
+  desta forma já enxuta do struct `Waybar`.
+- `tui::state::ConfigField` sem `settings_key()`; `tui::widgets::icons::Icon`
+  só com `{Ok, LoggedOut, Warn, NoToken}`.
+
+---
+
+### Task 1: Remover `Command::Terminal`
+
+**Files:**
+- Modify: `src/cli.rs:15` (variante do enum `Command`)
+- Modify: `src/main.rs:761` (match arm), `src/main.rs:894-904` (teste
+  `should_notify_false_when_command_is_terminal`)
+
+**Interfaces:**
+- Consumes: nenhum (variante sem nenhum caller de `parse_args` — só o alias
+  `--terminal`/`-t` mapeia para `Command::Status`, comentário em
+  `cli.rs:274` já documenta isso).
+- Produces: `Command` com 17 variantes em vez de 18 (Waybar, Menu, Status,
+  Help, Version, ActionRight, Setup, AssetsInstall, ExportWaybarModules,
+  ExportWaybarCss, Update, Uninstall, Remove→Uninstall+yes, Doctor,
+  MenuFont, ConfigShow, ConfigApply).
+
+- [ ] **Step 1: Baseline verde**
+
+```bash
+cargo test cli
+```
+
+Expected: `test result: ok` (todos os testes de `src/cli.rs::tests` passam,
+baseline limpa antes da remoção).
+
+- [ ] **Step 2: Ajustar o teste que usa `Command::Terminal` antes de remover a variante**
+
+Em `src/main.rs`, o teste atual (linhas 894-904):
+
+```rust
+    #[test]
+    fn should_notify_false_when_command_is_terminal() {
+        let s = settings_with_notify(true);
+        assert!(!should_notify(
+            &s,
+            Command::Terminal,
+            Format::Waybar,
+            false,
+            false
+        ));
+    }
+```
+
+`should_notify` só retorna `true` quando `command == Command::Waybar`
+(`src/main.rs:44`); qualquer outra variante cobre o mesmo caminho. Trocar
+para `Command::Menu` (variante já testada em outros pontos do arquivo, sem
+relação com Waybar) e renomear o teste:
+
+```rust
+    #[test]
+    fn should_notify_false_when_command_is_not_waybar() {
+        let s = settings_with_notify(true);
+        assert!(!should_notify(
+            &s,
+            Command::Menu,
+            Format::Waybar,
+            false,
+            false
+        ));
+    }
+```
+
+- [ ] **Step 3: Remover o match arm em `main.rs`**
+
+Em `src/main.rs:761`:
+
+```rust
+        Command::Terminal | Command::Status => {
+```
+
+vira:
+
+```rust
+        Command::Status => {
+```
+
+- [ ] **Step 4: Remover a variante do enum em `cli.rs`**
+
+Em `src/cli.rs`, o enum `Command` (linhas 12-37) tem `Terminal` na linha 15:
+
+```rust
+pub enum Command {
+    Waybar,
+    Terminal,
+    Menu,
+```
+
+Remove a linha `Terminal,`:
+
+```rust
+pub enum Command {
+    Waybar,
+    Menu,
+```
+
+- [ ] **Step 5: Verificar**
+
+```bash
+cargo test cli
+```
+
+Expected: `test result: ok`.
+
+```bash
+cargo test should_notify
+```
+
+Expected: `test result: ok` (inclui o teste renomeado no Step 2).
+
+```bash
+cargo clippy --all-targets -- -D warnings
+```
+
+Expected: zero warnings (nenhum match não-exaustivo quebra — ambos os
+matches de `Command` em `main.rs` têm `_ => {}`/wildcard).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/cli.rs src/main.rs
+git status  # confirmar só os 2 arquivos
+git commit -m "$(cat <<'EOF'
+refactor: remove Command::Terminal morto
+EOF
+)"
+```
+
+---
+
+### Task 2: Remover `waybar_contract::get_all_provider_ids`
+
+**Files:**
+- Modify: `src/waybar_contract.rs:102-117` (bloco de comentário de seção +
+  função `get_all_provider_ids`)
+
+**Interfaces:**
+- Consumes: nenhum caller em `src/` (confirmado por grep — só a própria
+  definição).
+- Produces: nada (função pública sem uso; remoção não afeta API consumida
+  por outras PRs — Seção A/E do spec não a referenciam).
+
+- [ ] **Step 1: Baseline verde**
+
+```bash
+cargo test waybar_contract
+```
+
+Expected: `test result: ok`.
+
+- [ ] **Step 2: Remover a função**
+
+Em `src/waybar_contract.rs`, remover o bloco (linhas 102-117):
+
+```rust
+// ---------------------------------------------------------------------------
+// getAllProviderIds
+// ---------------------------------------------------------------------------
+
+/// Todos os provider ids conhecidos — built-in + registrados sem duplicatas.
+/// Espelha `getAllProviderIds` do TS.
+pub fn get_all_provider_ids() -> Vec<String> {
+    let mut ids: Vec<String> = WAYBAR_PROVIDERS.iter().map(|s| s.to_string()).collect();
+    for id in crate::providers::registered_provider_ids() {
+        let id_str = id.to_string();
+        if !ids.contains(&id_str) {
+            ids.push(id_str);
+        }
+    }
+    ids
+}
+
+```
+
+(A seção `// CSS export` que vem logo depois permanece intacta.)
+
+- [ ] **Step 3: Verificar**
+
+```bash
+cargo test waybar_contract
+```
+
+Expected: `test result: ok` (nenhum teste exercitava `get_all_provider_ids`
+diretamente — grep prévio não encontrou `#[test]` referenciando-a).
+
+```bash
+cargo clippy --all-targets -- -D warnings
+```
+
+Expected: zero warnings.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/waybar_contract.rs
+git commit -m "$(cat <<'EOF'
+refactor: remove get_all_provider_ids sem uso
+EOF
+)"
+```
+
+---
+
+### Task 3: Remover `install::ensure_amp_cli` + atualizar comentário de módulo
+
+**Files:**
+- Modify: `src/install.rs:1-9` (doc comment do módulo + import),
+  `src/install.rs:28-42` (função `ensure_amp_cli`),
+  `src/install.rs:76-82` (teste `ensure_amp_cli_absent_returns_false`)
+
+**Interfaces:**
+- Consumes: nenhum caller de `ensure_amp_cli` em `src/` fora do próprio
+  módulo (confirmado por grep — o locator real e usado em produção é
+  `providers::amp_cli::find_amp_bin`, não `install::ensure_amp_cli`).
+- Produces: `install.rs` mantém `has_cmd`/`ensure_command` (usados e
+  testados) — só a função de guidance do Amp sai.
+
+- [ ] **Step 1: Baseline verde**
+
+```bash
+cargo test install
+```
+
+Expected: `test result: ok`.
+
+- [ ] **Step 2: Remover a função e seu teste**
+
+Em `src/install.rs`, remover a função (linhas 28-42):
+
+```rust
+/// Verifica se `amp` esta disponivel. Se ausente, loga o comando de instalacao
+/// oficial e retorna `false`. Nao executa o instalador automaticamente.
+///
+/// Para instalacao real, o usuario deve rodar manualmente:
+/// `curl -fsSL https://ampcode.com/install.sh | bash`
+pub fn ensure_amp_cli() -> bool {
+    if has_cmd("amp") {
+        return true;
+    }
+    log::warn!(
+        "Amp CLI não encontrado. Para instalar, rode: {}",
+        AMP_INSTALL_COMMAND
+    );
+    false
+}
+
+```
+
+E o teste correspondente (linhas 76-82, dentro de `mod tests`):
+
+```rust
+    #[test]
+    fn ensure_amp_cli_absent_returns_false() {
+        let _env = crate::test_support::env_guard();
+        // Em ambiente CI/test, amp provavelmente nao esta instalado.
+        // Se estiver, o test passa com true; se nao, com false. Ambos sao corretos.
+        let _ = ensure_amp_cli(); // apenas verifica que nao panica
+    }
+
+```
+
+- [ ] **Step 3: Remover o import agora não-usado**
+
+`AMP_INSTALL_COMMAND` só era usado dentro de `ensure_amp_cli`. Remover a
+linha 9:
+
+```rust
+use crate::app_identity::AMP_INSTALL_COMMAND;
+```
+
+- [ ] **Step 4: Atualizar o doc comment do módulo**
+
+O comentário atual (linhas 1-8):
+
+```rust
+//! Verificacao de presenca de comandos no PATH. Port de `src/install.ts` +
+//! a parte `ensure_amp_cli` de `src/amp-cli.ts`.
+//!
+//! NOTA: `ensure_amp_cli` aqui **orienta** o usuario (imprime o comando de
+//! instalacao) em vez de executar `curl | bash` automaticamente. O instalador
+//! interativo foi descartado por seguranca: a TUI nao deve pipe-executar codigo
+//! remoto sem confirmacao explicita do usuario.
+```
+
+vira (reflete que a função foi removida por não ter caller — o locator real
+é `providers::amp_cli::find_amp_bin`):
+
+```rust
+//! Verificacao de presenca de comandos no PATH. Port de `src/install.ts`.
+//!
+//! `ensure_amp_cli` (guidance de instalacao do Amp, port de `src/amp-cli.ts`)
+//! foi removida (v9, limpeza de legado) por nao ter caller: o locator real
+//! em producao e `providers::amp_cli::find_amp_bin`.
+```
+
+- [ ] **Step 5: Verificar**
+
+```bash
+cargo test install
+```
+
+Expected: `test result: ok` (`has_cmd_finds_sh`, `has_cmd_misses_nonexistent`,
+`ensure_command_true_when_present`, `ensure_command_false_when_absent`
+continuam passando).
+
+```bash
+cargo clippy --all-targets -- -D warnings
+```
+
+Expected: zero warnings (import não-usado removido no Step 3 evita erro de
+clippy).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/install.rs
+git commit -m "$(cat <<'EOF'
+refactor: remove install::ensure_amp_cli sem uso
+EOF
+)"
+```
+
+---
+
+### Task 4: Remover `amp_cli::AMP_INSTALL_COMMAND` duplicada
+
+**Files:**
+- Modify: `src/providers/amp_cli.rs:7-9` (comentário + const),
+  `src/providers/amp_cli.rs:106-112` (teste `install_command_is_official`)
+
+**Interfaces:**
+- Consumes: `app_identity::AMP_INSTALL_COMMAND` (já existe e já é a fonte
+  usada por `src/install.rs` e `src/tui/login_spawn.rs:109` — esta task só
+  faz `providers::amp_cli` parar de ter a sua própria cópia).
+- Produces: `providers::amp_cli` sem constante própria; único
+  `AMP_INSTALL_COMMAND` do crate vive em `app_identity.rs:15`.
+
+- [ ] **Step 1: Baseline verde**
+
+```bash
+cargo test providers::amp_cli
+```
+
+Expected: `test result: ok` (5 testes: `candidate_paths_under_home`,
+`empty_home_yields_no_candidates`, `prefers_path_when_available`,
+`falls_back_to_known_locations`, `none_when_unavailable`,
+`install_command_is_official`).
+
+- [ ] **Step 2: Apontar o teste para `app_identity` antes de remover a const local**
+
+Em `src/providers/amp_cli.rs`, o teste atual (linhas 106-112):
+
+```rust
+    #[test]
+    fn install_command_is_official() {
+        assert_eq!(
+            AMP_INSTALL_COMMAND,
+            "curl -fsSL https://ampcode.com/install.sh | bash"
+        );
+    }
+```
+
+vira (import explícito da constante canônica; `use super::*` não traz mais
+`AMP_INSTALL_COMMAND` depois do Step 3):
+
+```rust
+    #[test]
+    fn install_command_is_official() {
+        use crate::app_identity::AMP_INSTALL_COMMAND;
+        assert_eq!(
+            AMP_INSTALL_COMMAND,
+            "curl -fsSL https://ampcode.com/install.sh | bash"
+        );
+    }
+```
+
+- [ ] **Step 3: Remover a constante duplicada**
+
+Em `src/providers/amp_cli.rs`, remover (linhas 7-9):
+
+```rust
+/// Comando oficial de instalação (usado pelo Plano 6; contrato de display).
+pub const AMP_INSTALL_COMMAND: &str = "curl -fsSL https://ampcode.com/install.sh | bash";
+
+```
+
+- [ ] **Step 4: Verificar**
+
+```bash
+cargo test providers::amp_cli
+```
+
+Expected: `test result: ok`.
+
+```bash
+cargo clippy --all-targets -- -D warnings
+```
+
+Expected: zero warnings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/providers/amp_cli.rs
+git commit -m "$(cat <<'EOF'
+refactor: unifica AMP_INSTALL_COMMAND
+EOF
+)"
+```
+
+---
+
+### Task 5: Remover dep `tokio-util`
+
+**Files:**
+- Modify: `Cargo.toml:36` (linha da dependência)
+- Modify: `Cargo.lock` (regenerado por `cargo build`, não editado a mão)
+
+**Interfaces:**
+- Consumes: nada — grep prévio confirma zero `use tokio_util` em `src/`.
+- Produces: `Cargo.lock` sem a entrada `tokio-util` (e suas transitivas
+  exclusivas, se houver).
+
+- [ ] **Step 1: Baseline verde**
+
+```bash
+cargo build
+```
+
+Expected: build limpo (baseline antes de tocar `Cargo.toml`).
+
+- [ ] **Step 2: Remover a dependência**
+
+Em `Cargo.toml`, remover a linha 36:
+
+```toml
+tokio-util = { version = "0.7", features = ["rt"] }
+```
+
+- [ ] **Step 3: Regenerar o lockfile**
+
+```bash
+cargo build
+```
+
+Expected: build limpo; `git diff Cargo.lock` mostra a remoção do pacote
+`tokio-util` (e nada mais — se outras entradas mudarem de versão por
+resolução de deps, parar e investigar antes de prosseguir).
+
+- [ ] **Step 4: Verificar**
+
+```bash
+cargo test cli
+```
+
+Expected: `test result: ok` (smoke de que o crate ainda compila/roda testes
+após a mudança de dependências).
+
+```bash
+cargo clippy --all-targets -- -D warnings
+```
+
+Expected: zero warnings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Cargo.toml Cargo.lock
+git status  # confirmar só Cargo.toml + Cargo.lock
+git commit -m "$(cat <<'EOF'
+chore: remove dependência tokio-util sem uso
+EOF
+)"
+```
+
+---
+
+### Task 6: Higiene TUI — `settings_key`, ícones órfãos, comentário morto
+
+**Files:**
+- Modify: `src/tui/state.rs:119-130` (método `ConfigField::settings_key`)
+- Modify: `src/tui/widgets/icons.rs` (enum `Icon`, `match` em `glyph`, teste
+  `nerd_and_box_glyphs_differ_and_are_nonempty`)
+- Modify: `src/tui/render/shared.rs:1-11` (doc comment do módulo)
+
+**Interfaces:**
+- Consumes: nenhum — grep prévio confirma zero callers de
+  `ConfigField::settings_key()`; só 4 dos 11 variants de `Icon` têm caller
+  (`Ok`, `LoggedOut`, `Warn`, `NoToken`, todos em `src/tui/render/login.rs` e
+  `src/tui/render/detail/states.rs:49`).
+- Produces: `Icon` com 4 variantes; `ConfigField` sem `settings_key`;
+  `render/shared.rs` com doc comment que reflete o estado real (consumidor
+  de `series_now` é `history.rs`, não `detail.rs` — `dashboard.rs` já não
+  existe).
+
+- [ ] **Step 1: Baseline verde**
+
+```bash
+cargo test tui::
+```
+
+Expected: `test result: ok`.
+
+- [ ] **Step 2: Remover `ConfigField::settings_key`**
+
+Em `src/tui/state.rs`, remover o método (linhas 119-130):
+
+```rust
+    /// Chave técnica (settings / docs) — dica no painel de ajuda.
+    pub fn settings_key(self) -> &'static str {
+        match self {
+            ConfigField::Providers => "providers",
+            ConfigField::ProviderOrder => "providerOrder",
+            ConfigField::Separators => "separators",
+            ConfigField::DisplayMode => "displayMode",
+            ConfigField::Signal => "signal",
+            ConfigField::Interval => "interval",
+            ConfigField::FxRate => "fxRate",
+        }
+    }
+```
+
+(O método `label()` logo acima, usado pelo render, permanece intacto.)
+
+- [ ] **Step 3: Remover as 7 variantes órfãs de `Icon` e seus braços em `glyph`**
+
+Em `src/tui/widgets/icons.rs`, o enum atual:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Icon {
+    Ok,
+    LoggedOut,
+    Warn,
+    NoToken,
+    Reset,
+    Cost,
+    History,
+    Peak,
+    Refresh,
+    Login,
+    Waybar,
+}
+```
+
+vira (só as 4 variantes com caller real):
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Icon {
+    Ok,
+    LoggedOut,
+    Warn,
+    NoToken,
+}
+```
+
+E a função `glyph` atual:
+
+```rust
+pub fn glyph(icon: Icon, mode: GlyphMode) -> &'static str {
+    match (icon, mode) {
+        (Icon::Ok, GlyphMode::Nerd) => "\u{f00c}",
+        (Icon::Ok, GlyphMode::Box) => "✓",
+        (Icon::LoggedOut, GlyphMode::Nerd) => "\u{f00d}",
+        (Icon::LoggedOut, GlyphMode::Box) => "✗",
+        (Icon::Warn, GlyphMode::Nerd) => "\u{f071}",
+        (Icon::Warn, GlyphMode::Box) => "!",
+        (Icon::NoToken, GlyphMode::Nerd) => "\u{f023}",
+        (Icon::NoToken, GlyphMode::Box) => "×",
+        (Icon::Reset, GlyphMode::Nerd) => "\u{f017}",
+        (Icon::Reset, GlyphMode::Box) => "↻",
+        (Icon::Cost, GlyphMode::Nerd) => "\u{f155}",
+        (Icon::Cost, GlyphMode::Box) => "$",
+        (Icon::History, GlyphMode::Nerd) => "\u{f201}",
+        (Icon::History, GlyphMode::Box) => "≡",
+        (Icon::Peak, GlyphMode::Nerd) => "\u{f0e7}",
+        (Icon::Peak, GlyphMode::Box) => "▲",
+        (Icon::Refresh, GlyphMode::Nerd) => "\u{f021}",
+        (Icon::Refresh, GlyphMode::Box) => "↻",
+        (Icon::Login, GlyphMode::Nerd) => "\u{f090}",
+        (Icon::Login, GlyphMode::Box) => "→",
+        (Icon::Waybar, GlyphMode::Nerd) => "\u{f013}",
+        (Icon::Waybar, GlyphMode::Box) => "⚙",
+    }
+}
+```
+
+vira:
+
+```rust
+pub fn glyph(icon: Icon, mode: GlyphMode) -> &'static str {
+    match (icon, mode) {
+        (Icon::Ok, GlyphMode::Nerd) => "\u{f00c}",
+        (Icon::Ok, GlyphMode::Box) => "✓",
+        (Icon::LoggedOut, GlyphMode::Nerd) => "\u{f00d}",
+        (Icon::LoggedOut, GlyphMode::Box) => "✗",
+        (Icon::Warn, GlyphMode::Nerd) => "\u{f071}",
+        (Icon::Warn, GlyphMode::Box) => "!",
+        (Icon::NoToken, GlyphMode::Nerd) => "\u{f023}",
+        (Icon::NoToken, GlyphMode::Box) => "×",
+    }
+}
+```
+
+- [ ] **Step 4: Ajustar o teste de glyphs**
+
+Em `src/tui/widgets/icons.rs`, o teste atual itera as 11 variantes; ajustar
+para as 4 restantes:
+
+```rust
+    #[test]
+    fn nerd_and_box_glyphs_differ_and_are_nonempty() {
+        for icon in [
+            Icon::Ok,
+            Icon::LoggedOut,
+            Icon::Warn,
+            Icon::NoToken,
+        ] {
+            assert!(!glyph(icon, GlyphMode::Nerd).is_empty());
+            assert!(!glyph(icon, GlyphMode::Box).is_empty());
+        }
+        // Nerd usa PUA (>= U+E000); Box nunca:
+        assert!(glyph(Icon::Ok, GlyphMode::Nerd)
+            .chars()
+            .all(|c| c as u32 >= 0xE000));
+        assert!(glyph(Icon::Ok, GlyphMode::Box)
+            .chars()
+            .all(|c| (c as u32) < 0xE000));
+    }
+```
+
+- [ ] **Step 5: Atualizar o comentário morto em `render/shared.rs`**
+
+Em `src/tui/render/shared.rs`, o doc comment atual (linhas 1-11):
+
+```rust
+//! Helpers compartilhados entre telas de render. `series_now` era usada por
+//! `dashboard.rs` (apagado na Task 11 junto com o Overview) e por
+//! `detail.rs` (Task 12) — ambas as telas precisavam da MESMA âncora
+//! temporal pra série real de 24h, então a lógica mora aqui em vez de
+//! duplicada em cada módulo de tela; `detail.rs` continua consumindo.
+//!
+//! `abbrev_tokens` (formatador de tokens com ponto decimal) morou aqui até
+//! o fix gate de dados reais — removido: `detail.rs` unificou pra
+//! `column_chart::fmt_tokens_short` (vírgula decimal), a mesma usada pelas
+//! legendas do chart e por `history.rs`, pra não ter dois formatos de
+//! número na mesma tela (`719.6M` vs `719,6M`).
+```
+
+vira (o consumidor real hoje é `history.rs`, não `detail.rs`; `dashboard.rs`
+já não existe no repo):
+
+```rust
+//! Helpers compartilhados entre telas de render. `series_now` calcula a
+//! âncora temporal da série real de 24h; `history.rs` é quem consome hoje
+//! (`render_chart_section` do chart de History).
+//!
+//! `abbrev_tokens` (formatador de tokens com ponto decimal) morou aqui até
+//! o fix gate de dados reais — removido: `detail.rs` unificou pra
+//! `column_chart::fmt_tokens_short` (vírgula decimal), a mesma usada pelas
+//! legendas do chart e por `history.rs`, pra não ter dois formatos de
+//! número na mesma tela (`719.6M` vs `719,6M`).
+```
+
+- [ ] **Step 6: Verificar**
+
+```bash
+cargo test tui::widgets::icons
+```
+
+Expected: `test result: ok` (1 teste, `nerd_and_box_glyphs_differ_and_are_nonempty`).
+
+```bash
+cargo test tui::
+```
+
+Expected: `test result: ok` (nenhuma outra tela quebrou — `settings_key` e
+os 7 ícones removidos não tinham caller).
+
+```bash
+cargo clippy --all-targets -- -D warnings
+```
+
+Expected: zero warnings.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/tui/state.rs src/tui/widgets/icons.rs src/tui/render/shared.rs
+git commit -m "$(cat <<'EOF'
+refactor: remove settings_key e ícones órfãos
+EOF
+)"
+```
+
+---
+
+### Task 7: Settings v2→v3 — drop de `waybar.show_percentage`
+
+**Files:**
+- Modify: `src/settings.rs:9` (`CURRENT_VERSION`), `src/settings.rs:97`
+  (campo em `Waybar`), `src/settings.rs:168` (campo em `RawWaybar`),
+  `src/settings.rs:302` (uso em `normalize`), `src/settings.rs:391`
+  (teste `defaults_when_no_file`, assert de `version`)
+- Modify: `src/tui/render/config.rs:281`, `src/tui/render/mod.rs:296`,
+  `src/tui/update/mod.rs:701`, `src/tui/update/navigation.rs:172` (fixtures
+  `Waybar { .. }` com `show_percentage: true,`)
+
+**Interfaces:**
+- Consumes: nenhum — grep prévio confirma que `show_percentage` só é lido
+  em `settings.rs` (schema) e escrito nas 4 fixtures de teste acima; nenhum
+  formatter/render usa o valor para decidir exibição (o nome sobreviveu do
+  design pré-v8, nunca ligado a comportamento).
+- Produces: `Settings::version == 3` por padrão; `Waybar` (schema tipado e
+  JSON serializado por `config show`) sem `showPercentage`. Auto-repair
+  existente em `settings::load` (linhas 344-348, compara `norm_value` com
+  `raw_value` e resalva) já cobre a migração — nenhuma lógica condicional
+  por versão é necessária.
+
+- [ ] **Step 1: Baseline verde**
+
+```bash
+cargo test settings
+```
+
+Expected: `test result: ok`.
+
+- [ ] **Step 2: Escrever o teste que falha — migração dropa a chave**
+
+Em `src/settings.rs`, dentro de `mod tests`, adicionar (após
+`fn keeps_valid_signal_and_separator`, antes de
+`fn provider_selection_filters_dedups_and_orders`):
+
+```rust
+    #[test]
+    fn v2_settings_drops_show_percentage_on_load() {
+        let dir = tempdir().unwrap();
+        let p = paths_in(dir.path());
+        std::fs::create_dir_all(&p.config_dir).unwrap();
+        std::fs::write(
+            p.settings_file(),
+            r#"{"version":2,"waybar":{"providers":["claude"],"showPercentage":false,
+                "separators":"gap","providerOrder":["claude"],"displayMode":"remaining",
+                "interval":60}}"#,
+        )
+        .unwrap();
+
+        let s = load(&p);
+        assert_eq!(s.version, CURRENT_VERSION);
+
+        // Auto-repair já regravou o arquivo sem a chave legada.
+        let saved = std::fs::read_to_string(p.settings_file()).unwrap();
+        assert!(
+            !saved.contains("showPercentage"),
+            "showPercentage deveria ter sido dropada no re-save: {saved}"
+        );
+    }
+```
+
+- [ ] **Step 3: Rodar e ver falhar**
+
+```bash
+cargo test v2_settings_drops_show_percentage_on_load
+```
+
+Expected: FAIL — `showPercentage` ainda está no arquivo resalvo, porque
+hoje `Waybar`/`RawWaybar` ainda declaram o campo (o auto-repair preserva o
+valor em vez de dropá-lo).
+
+- [ ] **Step 4: Implementação mínima — remover o campo do schema**
+
+Em `src/settings.rs`, bump da versão (linha 9):
+
+```rust
+pub const CURRENT_VERSION: u32 = 2;
+```
+
+vira:
+
+```rust
+pub const CURRENT_VERSION: u32 = 3;
+```
+
+Remover o campo de `Waybar` (linha 97):
+
+```rust
+pub struct Waybar {
+    pub providers: Vec<String>,
+    pub show_percentage: bool,
+    pub separators: SeparatorStyle,
+```
+
+vira:
+
+```rust
+pub struct Waybar {
+    pub providers: Vec<String>,
+    pub separators: SeparatorStyle,
+```
+
+Remover o campo de `RawWaybar` (linha 168):
+
+```rust
+struct RawWaybar {
+    providers: Option<Vec<String>>,
+    show_percentage: Option<bool>,
+    separators: Option<String>,
+```
+
+vira:
+
+```rust
+struct RawWaybar {
+    providers: Option<Vec<String>>,
+    separators: Option<String>,
+```
+
+Remover o uso em `normalize()` (linha 302):
+
+```rust
+        waybar: Waybar {
+            providers,
+            show_percentage: rw.show_percentage.unwrap_or(true),
+            separators,
+```
+
+vira:
+
+```rust
+        waybar: Waybar {
+            providers,
+            separators,
+```
+
+Atualizar o assert de versão em `defaults_when_no_file` (linha 391):
+
+```rust
+        assert_eq!(s.version, 2);
+```
+
+vira:
+
+```rust
+        assert_eq!(s.version, 3);
+```
+
+- [ ] **Step 5: Corrigir as 4 fixtures que ainda setam o campo removido**
+
+Em `src/tui/render/config.rs:281`, `src/tui/render/mod.rs:296`,
+`src/tui/update/mod.rs:701` (todas com o mesmo formato — literal
+`Waybar { .. }` de teste) remover a linha:
+
+```rust
+                show_percentage: true,
+```
+
+E em `src/tui/update/navigation.rs:172` (indentação diferente, dentro do
+literal `crate::settings::Waybar { .. }`):
+
+```rust
+                        show_percentage: true,
+```
+
+remover também.
+
+- [ ] **Step 6: Rodar e ver passar**
+
+```bash
+cargo test v2_settings_drops_show_percentage_on_load
+```
+
+Expected: `test result: ok`.
+
+```bash
+cargo test settings
+```
+
+Expected: `test result: ok` (inclui `defaults_when_no_file` com
+`version == 3`).
+
+```bash
+cargo test tui::
+```
+
+Expected: `test result: ok` (as 4 fixtures compilam sem `show_percentage`).
+
+```bash
+cargo clippy --all-targets -- -D warnings
+```
+
+Expected: zero warnings.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/settings.rs src/tui/render/config.rs src/tui/render/mod.rs src/tui/update/mod.rs src/tui/update/navigation.rs
+git commit -m "$(cat <<'EOF'
+feat: settings v3 dropa waybar.show_percentage
+EOF
+)"
+```
+
+---
+
+### Task 8: Housekeeping — worktree e branch mergeados
+
+**Files:** nenhum em `src/` — só estado de git (worktree + branches local/remota).
+
+**Interfaces:** nenhuma (não toca código).
+
+Pré-condição já confirmada nesta investigação: `feat/omarchy-settings-cli`
+foi mergeada via PR #18 (`e616f59 Merge pull request #18 from
+othavi0/feat/omarchy-settings-cli`), o worktree
+`.worktrees/omarchy-settings-cli` está limpo (`git status --short` vazio) e
+`git branch --merged master` lista a branch. Seguro remover.
+
+- [ ] **Step 1: Confirmar pré-condição (idempotente, só leitura)**
+
+```bash
+git -C .worktrees/omarchy-settings-cli status --short
+git branch --merged master | grep omarchy-settings-cli
+```
+
+Expected: primeiro comando sem saída (working tree limpa); segundo comando
+lista `feat/omarchy-settings-cli`. Se qualquer um divergir (mudanças não
+commitadas, ou branch não mergeada), **parar e reportar BLOCKED** — não
+prosseguir com a remoção.
+
+- [ ] **Step 2: Remover o worktree**
+
+```bash
+git worktree remove .worktrees/omarchy-settings-cli
+```
+
+Expected: comando silencioso (sem erro); `git worktree list` não lista mais
+o path.
+
+- [ ] **Step 3: Remover a branch local**
+
+```bash
+git branch -d feat/omarchy-settings-cli
+```
+
+Expected: `Deleted branch feat/omarchy-settings-cli (was 163b1b4)`. `-d`
+(minúsculo, não `-D`) recusa se a branch não estiver mergeada — confirmação
+adicional de segurança.
+
+- [ ] **Step 4: Remover a branch remota**
+
+```bash
+git push origin --delete feat/omarchy-settings-cli
+```
+
+Expected: ` - [deleted]         feat/omarchy-settings-cli`.
+
+- [ ] **Step 5: Verificar**
+
+```bash
+git worktree list
+git branch -a --list "*omarchy-settings-cli*"
+```
+
+Expected: nenhuma linha menciona `omarchy-settings-cli` em nenhum dos dois
+comandos.
+
+- [ ] **Step 6: Sem commit de código** — esta task não gera diff em `src/`;
+  nada a commitar além do estado de git já refletido em `git worktree
+  list`/`git branch -a` (não há arquivo para `git add`).
+
+---
+
+## Gate final da PR 1
+
+- [ ] **Rodar a verificação ampla antes de abrir PR/mergear**
+
+```bash
+cargo test
+```
+
+Expected: `test result: ok` em todos os targets (lib + bin `agent-bar`).
+
+```bash
+cargo clippy --all-targets -- -D warnings
+```
+
+Expected: zero warnings.
+
+```bash
+git status --short
+```
+
+Expected: working tree limpa (todas as 7 tasks de código já commitadas
+individualmente; Task 8 não gera diff de arquivo).
+
+- [ ] **Confirmar zero regressão de contrato**
+
+```bash
+cargo test --test golden
+cargo test waybar_contract
+```
+
+Expected: `test result: ok` — nenhuma das remoções desta PR toca o payload
+Waybar/golden (só código morto saiu).
+
+Após o gate verde, invocar
+`superpowers:finishing-a-development-branch` para decidir merge/PR — não
+mergear/abrir PR sem esse checkpoint.

--- a/docs/superpowers/plans/2026-07-21-v9-02-contrato-windowkind.md
+++ b/docs/superpowers/plans/2026-07-21-v9-02-contrato-windowkind.md
@@ -1,0 +1,1818 @@
+# Contrato windowKind + fixes de dado (PR 2/5) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Introduzir `windowKind` (fiveHour/sevenDay/daily/context/other) como fonte
+única de verdade pro rótulo de janela, matar o fallback forçado do Codex que
+duplicava "Weekly", e dar TUI/Codex-builder paridade de fuso local + countdown
++ dedup — sem tocar QML nem tela alguma (isso é PR 3).
+
+**Fora deste plano:** a ocultação platform-aware dos campos
+Separators/Signal/Interval na TUI Config (Seção D do spec) fica no plano 04,
+pois depende de `platform::detect()`.
+
+**Architecture:** `WindowKind` nasce em `src/providers/types.rs` (mesmo enum
+que hoje vive, incompleto, em `formatters/shared.rs`); cada provider tag a
+janela na origem (`window_kind: Some(...)`); `classify_window` continua
+derivando fiveHour/sevenDay/other por tolerância de minutos, mas devolve o
+enum canônico; `is_duplicate_window` compara `(window_kind, resetsAt,
+remaining arredondado)` e é consumido pela TUI (Codex builder ganha rótulo de
+duração real pras janelas `other`; QML implementa o mesmo predicado em JS na
+PR 3). Mudança 100% aditiva em `QuotaWindow` — `schemaVersion` continua 1.
+
+**Tech Stack:** Rust/cargo, serde (camelCase), time (local-offset), insta
+(snapshots), ratatui (TUI).
+
+## Global Constraints
+
+- Rust/cargo only; nunca `unwrap()`/`expect()` em produção — propagar com `?`
+  ou `anyhow::bail!`.
+- Constantes de identidade vêm de `src/app_identity.rs`, nunca strings
+  hardcoded.
+- Provider error strings são contrato (testes assertam verbatim) — esta
+  mudança não altera nenhuma string de erro existente.
+- XML-escape só em `render_pango.rs`; builders nunca escapam.
+- Nunca round-trip de `config.jsonc` do Waybar via `serde_json`.
+- Testes: `#[tokio::test]` async / `#[test]` sync; sem rede/CLIs vivas/Waybar
+  real; `XDG_CONFIG_HOME`/`XDG_CACHE_HOME` setados ANTES de qualquer import
+  que leia `src/config.rs`.
+- Snapshots via `insta` (Waybar byte-for-byte, terminal sanitizado) —
+  atualizar só quando o contrato de display mudar de propósito, com
+  justificativa no commit.
+- Gotcha RTK: `cargo test` com APENAS UM filtro posicional por invocação.
+  Verificação = `cargo test <filtro>` + `cargo clippy --all-targets --
+  -D warnings`. `check-types` não existe.
+- Commits: Conventional Commits em PT, subject ≤50 chars. ZERO atribuição de
+  AI em qualquer texto (commit/PR/comentário).
+- Prosa em pt-BR; identificadores/código em inglês.
+
+## Pré-requisito de sequência
+
+Este plano assume que o **plano 01** (limpeza de legado, seção G do spec) já
+foi mergeado em `master` antes de começar — em particular a migração de
+settings v2→v3 que dropa `waybar.show_percentage`. Se `git log` não mostrar
+esse commit, pare e confirme com quem orquestra antes de prosseguir.
+
+---
+
+### Task 1: `WindowKind` + campo `window_kind` em `QuotaWindow`
+
+Maior raio de explosão do plano: `QuotaWindow` não deriva `Default`, então
+todo `QuotaWindow { .. }` literal do crate (produção E testes) precisa do
+campo novo pra compilar. Produção real (Claude/Codex/Amp/Grok) fica com
+`window_kind: None` nesta task — as Tasks 2-4 substituem por `Some(kind)`
+real. Todo o resto (fixtures de teste em `formatters/`, `tui/`, `notify.rs`,
+`tests/golden.rs`) recebe `window_kind: None,` mecânico, sem mudança de
+comportamento.
+
+**Files:**
+- Modify: `src/providers/types.rs` (struct `QuotaWindow` linhas 10-25; testes
+  do módulo linhas 138-146, 160-176)
+- Modify: `src/formatters/shared.rs` (remove enum local linhas 39-44; vira
+  re-export)
+- Modify (mecânico, só compile-fix — ver Step 5 pra lista completa e exata):
+  `src/formatters/builders/amp.rs`, `src/formatters/builders/claude.rs`,
+  `src/formatters/builders/codex.rs`, `src/formatters/builders/generic.rs`,
+  `src/formatters/builders/grok.rs`, `src/formatters/builders/shared.rs`,
+  `src/formatters/codex_helpers.rs`, `src/formatters/json.rs`,
+  `src/formatters/terminal.rs`, `src/formatters/view_model.rs`,
+  `src/formatters/waybar.rs`, `src/tui/render/detail/mod.rs`,
+  `src/tui/render/mod.rs`, `src/tui/render/sidebar.rs`,
+  `src/tui/update/mod.rs`, `src/notify.rs`, `tests/golden.rs`
+- Modify (produção, `window_kind: None` temporário — Tasks 2-4 substituem):
+  `src/providers/claude.rs` (linhas 120-127, 180-187),
+  `src/providers/codex/normalize.rs` (linhas 26-34),
+  `src/providers/amp.rs` (linhas 94-100, 140-146, 163-169),
+  `src/providers/grok.rs` (linhas 295-307)
+
+**Interfaces:**
+- Produces: `pub enum WindowKind { FiveHour, SevenDay, Daily, Context, Other }`
+  em `src/providers/types.rs` — `#[derive(Debug, Clone, Copy, PartialEq, Eq,
+  Serialize)]`, `#[serde(rename_all = "camelCase")]`. Campo `pub window_kind:
+  Option<WindowKind>` em `QuotaWindow`, `#[serde(rename = "windowKind",
+  skip_serializing_if = "Option::is_none")]`.
+- Consumes (Task 2-9): toda construção de `QuotaWindow` no crate.
+
+- [ ] Escrever teste que falha em `src/providers/types.rs` (dentro de `mod
+      tests`, dedica um bloco novo — cole logo antes do fechamento do
+      arquivo, depois de `stale_reason_omitted_when_none_present_when_some`):
+
+  ```rust
+  #[test]
+  fn window_kind_serializes_camelcase_variants() {
+      let cases = [
+          (WindowKind::FiveHour, "fiveHour"),
+          (WindowKind::SevenDay, "sevenDay"),
+          (WindowKind::Daily, "daily"),
+          (WindowKind::Context, "context"),
+          (WindowKind::Other, "other"),
+      ];
+      for (kind, expected) in cases {
+          let w = QuotaWindow {
+              remaining: 50.0,
+              resets_at: None,
+              window_minutes: None,
+              used: None,
+              severity: None,
+              window_kind: Some(kind),
+          };
+          let j = serde_json::to_value(&w).unwrap();
+          assert_eq!(j["windowKind"], expected, "kind={kind:?}");
+      }
+  }
+
+  #[test]
+  fn window_kind_omitted_when_none() {
+      let w = window(50.0); // helper já existente do módulo
+      let j = serde_json::to_value(&w).unwrap();
+      assert!(
+          j.get("windowKind").is_none(),
+          "windowKind deve ser omitido quando None"
+      );
+  }
+  ```
+
+  Ainda não compila: `WindowKind` não existe e o helper `window()` (linha
+  138-146) não tem o campo `window_kind`.
+
+- [ ] Rodar `cargo test types` e ver falhar (erro de compilação, não de
+      assert): `error[E0433]: failed to resolve: use of undeclared type
+      `WindowKind`` (ou similar, `no field `window_kind` on type
+      `QuotaWindow``).
+
+- [ ] Implementar o enum + campo em `src/providers/types.rs`. Substituir o
+      struct `QuotaWindow` (linhas 10-25):
+
+  ```rust
+  #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+  #[serde(rename_all = "camelCase")]
+  pub enum WindowKind {
+      FiveHour,
+      SevenDay,
+      Daily,
+      Context,
+      Other,
+  }
+
+  #[derive(Debug, Clone, PartialEq, Serialize)]
+  #[serde(rename_all = "camelCase")]
+  pub struct QuotaWindow {
+      pub remaining: f64,
+      /// Sempre presente no JSON (pode ser null).
+      pub resets_at: Option<String>,
+      #[serde(skip_serializing_if = "Option::is_none")]
+      pub window_minutes: Option<i64>,
+      #[serde(skip_serializing_if = "Option::is_none")]
+      pub used: Option<f64>,
+      /// Severidade vinda da API (`limits[].severity` do Claude). `None` =
+      /// calcular localmente por threshold. Omitida do JSON quando ausente
+      /// (mantém golden/waybar_contract intactos).
+      #[serde(skip_serializing_if = "Option::is_none")]
+      pub severity: Option<String>,
+      /// Classificação da janela decidida UMA VEZ na origem (provider).
+      /// `None` só em dado sintético de teste antigo; produção sempre seta.
+      /// Rótulos de UI (TUI/QML) derivam só disso, nunca de magic numbers.
+      #[serde(rename = "windowKind", skip_serializing_if = "Option::is_none")]
+      pub window_kind: Option<WindowKind>,
+  }
+  ```
+
+- [ ] Atualizar os 2 helpers de teste do próprio arquivo pra adicionar o
+      campo. `window()` (linhas 138-146):
+
+  ```rust
+  fn window(remaining: f64) -> QuotaWindow {
+      QuotaWindow {
+          remaining,
+          resets_at: Some("2026-06-19T14:00:00Z".into()),
+          window_minutes: None,
+          used: None,
+          severity: None,
+          window_kind: None,
+      }
+  }
+  ```
+
+  E o literal standalone em `quota_window_keeps_null_resets_at` (linhas
+  162-168):
+
+  ```rust
+  let w = QuotaWindow {
+      remaining: 100.0,
+      resets_at: None,
+      window_minutes: Some(300),
+      used: None,
+      severity: None,
+      window_kind: None,
+  };
+  ```
+
+- [ ] Rodar `cargo test types` — ainda falha (agora por erro de compilação
+      em OUTROS arquivos do crate: todo `QuotaWindow { .. }` sem o campo
+      novo). Confirmar que a lista de erros bate com os arquivos do Step 5.
+
+- [ ] **Fix mecânico** — adicionar `window_kind: None,` (mesma indentação da
+      linha `severity: None,` vizinha) em cada um dos sites abaixo. Nenhuma
+      lógica muda, só o campo novo pra satisfazer o compilador:
+
+  `src/notify.rs:262` (helper `win`) e `:403` (literal em
+  `honors_provider_used_over_100`):
+  ```rust
+  fn win(remaining: f64, resets: Option<&str>) -> QuotaWindow {
+      QuotaWindow {
+          remaining,
+          resets_at: resets.map(str::to_string),
+          window_minutes: None,
+          used: None,
+          severity: None,
+          window_kind: None,
+      }
+  }
+  ```
+  ```rust
+  c.primary = Some(QuotaWindow {
+      remaining: 0.0,
+      resets_at: None,
+      window_minutes: None,
+      used: Some(232.0),
+      severity: None,
+      window_kind: None,
+  });
+  ```
+
+  `src/formatters/shared.rs:315` (literal em
+  `to_window_display_honours_provider_used`):
+  ```rust
+  let w = QuotaWindow {
+      remaining: 30.0,
+      resets_at: None,
+      window_minutes: None,
+      used: Some(70.0),
+      severity: None,
+      window_kind: None,
+  };
+  ```
+
+  `src/formatters/builders/amp.rs:401` (helper `win`):
+  ```rust
+  fn win(r: f64) -> QuotaWindow {
+      QuotaWindow {
+          remaining: r,
+          resets_at: Some("2026-06-19T14:00:00Z".into()),
+          window_minutes: None,
+          used: None,
+          severity: None,
+          window_kind: None,
+      }
+  }
+  ```
+
+  `src/formatters/builders/claude.rs:195` (helper `win`):
+  ```rust
+  fn win(r: f64, m: Option<i64>) -> QuotaWindow {
+      QuotaWindow {
+          remaining: r,
+          resets_at: Some("2026-06-19T14:00:00Z".into()),
+          window_minutes: m,
+          used: None,
+          severity: None,
+          window_kind: None,
+      }
+  }
+  ```
+
+  `src/formatters/builders/codex.rs:219-225` (closure `w` dentro de
+  `entry`):
+  ```rust
+  fn entry(name: &str, five: f64, seven: f64) -> CodexModelEntry {
+      let w = |r: f64| QuotaWindow {
+          remaining: r,
+          resets_at: Some("2026-06-19T14:00:00Z".into()),
+          window_minutes: None,
+          used: None,
+          severity: None,
+          window_kind: None,
+      };
+      CodexModelEntry {
+          name: name.into(),
+          windows: ModelWindows {
+              five_hour: Some(w(five)),
+              seven_day: Some(w(seven)),
+              other: None,
+          },
+          severity: five.min(seven),
+      }
+  }
+  ```
+
+  `src/formatters/builders/generic.rs:99-105` (literal em `quota`):
+  ```rust
+  primary: Some(QuotaWindow {
+      remaining: 60.0,
+      resets_at: None,
+      window_minutes: None,
+      used: None,
+      severity: None,
+      window_kind: None,
+  }),
+  ```
+
+  `src/formatters/builders/grok.rs:173-179` (literal em
+  `quota_with_primary`):
+  ```rust
+  primary: Some(QuotaWindow {
+      remaining: 87.0,
+      resets_at: None,
+      window_minutes: None,
+      used: Some(13.0),
+      severity: None,
+      window_kind: None,
+  }),
+  ```
+
+  `src/formatters/builders/shared.rs:218-224` (literal em
+  `model_line_segment_shape`) e `:245-251` (literal em
+  `model_line_null_eta_override`):
+  ```rust
+  let w = QuotaWindow {
+      remaining: 75.0,
+      resets_at: Some("2026-06-19T14:00:00Z".into()),
+      window_minutes: None,
+      used: None,
+      severity: None,
+      window_kind: None,
+  };
+  ```
+  ```rust
+  let w = QuotaWindow {
+      remaining: 50.0,
+      resets_at: None,
+      window_minutes: None,
+      used: None,
+      severity: None,
+      window_kind: None,
+  };
+  ```
+
+  `src/formatters/codex_helpers.rs:112-118` (helper `win`):
+  ```rust
+  fn win(remaining: f64, minutes: Option<i64>) -> QuotaWindow {
+      QuotaWindow {
+          remaining,
+          resets_at: Some("2026-06-19T14:00:00Z".into()),
+          window_minutes: minutes,
+          used: None,
+          severity: None,
+          window_kind: None,
+      }
+  }
+  ```
+
+  `src/formatters/json.rs:44-50` (literal inline no vetor `providers`):
+  ```rust
+  primary: Some(QuotaWindow {
+      remaining: 60.0,
+      resets_at: None,
+      window_minutes: None,
+      used: None,
+      severity: None,
+      window_kind: None,
+  }),
+  ```
+
+  `src/formatters/terminal.rs:188-194` (literal em `claude`):
+  ```rust
+  primary: Some(QuotaWindow {
+      remaining: 75.0,
+      resets_at: Some("2026-03-28T14:00:00Z".into()),
+      window_minutes: Some(300),
+      used: None,
+      severity: None,
+      window_kind: None,
+  }),
+  ```
+
+  `src/formatters/view_model.rs:56-62` (literal em `codex_quota`):
+  ```rust
+  QuotaWindow {
+      remaining: 80.0,
+      resets_at: None,
+      window_minutes: Some(300),
+      used: None,
+      severity: None,
+      window_kind: None,
+  },
+  ```
+
+  `src/formatters/waybar.rs:331-337` (literal em `claude`):
+  ```rust
+  primary: Some(QuotaWindow {
+      remaining,
+      resets_at: Some("2026-03-28T14:00:00Z".into()),
+      window_minutes: Some(300),
+      used: None,
+      severity: None,
+      window_kind: None,
+  }),
+  ```
+
+  `src/tui/render/detail/mod.rs:298-304` (helper `window`):
+  ```rust
+  fn window(remaining: f64, resets_at: Option<&str>, severity: Option<&str>) -> QuotaWindow {
+      QuotaWindow {
+          remaining,
+          resets_at: resets_at.map(|s| s.to_string()),
+          window_minutes: Some(300),
+          used: Some(100.0 - remaining),
+          severity: severity.map(|s| s.to_string()),
+          window_kind: None,
+      }
+  }
+  ```
+
+  `src/tui/render/mod.rs:333-339` (literal inline):
+  ```rust
+  primary: Some(QuotaWindow {
+      remaining,
+      resets_at: resets_at.map(|s| s.to_string()),
+      window_minutes: Some(300),
+      used: Some(100.0 - remaining),
+      severity: None,
+      window_kind: None,
+  }),
+  ```
+
+  `src/tui/render/sidebar.rs:204-210` (literal em `make_provider`):
+  ```rust
+  primary: Some(QuotaWindow {
+      remaining,
+      resets_at: None,
+      window_minutes: Some(300),
+      used: Some(100.0 - remaining),
+      severity: None,
+      window_kind: None,
+  }),
+  ```
+
+  `src/tui/update/mod.rs:108-114` (literal em `test_quota`):
+  ```rust
+  q.primary = Some(QuotaWindow {
+      remaining,
+      resets_at: None,
+      window_minutes: None,
+      used: Some(100.0 - remaining),
+      severity: None,
+      window_kind: None,
+  });
+  ```
+
+  `tests/golden.rs:62-70` (helper `qw`, usado por todo o arquivo):
+  ```rust
+  fn qw(remaining: f64, resets_at: &str, window_minutes: Option<i64>) -> QuotaWindow {
+      QuotaWindow {
+          remaining,
+          resets_at: Some(resets_at.into()),
+          window_minutes,
+          used: None,
+          severity: None,
+          window_kind: None,
+      }
+  }
+  ```
+
+  Produção (`window_kind: None` temporário — Tasks 2-4 trocam por
+  `Some(kind)`):
+
+  `src/providers/claude.rs:118-127` (`window_from`) e `:178-187`
+  (`window_from_limit`):
+  ```rust
+  fn window_from(raw: &ClaudeWindowRaw) -> QuotaWindow {
+      let used = raw.utilization.round();
+      QuotaWindow {
+          remaining: 100.0 - used,
+          resets_at: raw.resets_at.clone().filter(|s| !s.is_empty()),
+          window_minutes: None,
+          used: None,
+          severity: None,
+          window_kind: None,
+      }
+  }
+  ```
+  ```rust
+  fn window_from_limit(l: &ClaudeLimitRaw) -> QuotaWindow {
+      let used = l.percent.unwrap_or(0.0).round();
+      QuotaWindow {
+          remaining: 100.0 - used,
+          resets_at: l.resets_at.clone().filter(|s| !s.is_empty()),
+          window_minutes: None,
+          used: Some(used),
+          severity: l.severity.clone(),
+          window_kind: None,
+      }
+  }
+  ```
+
+  `src/providers/codex/normalize.rs:26-34` (`to_quota_window`):
+  ```rust
+  fn to_quota_window(raw: &CodexWindowRaw) -> QuotaWindow {
+      QuotaWindow {
+          remaining: 100.0 - raw.used_percent.round(),
+          resets_at: unix_to_iso(raw.resets_at),
+          window_minutes: Some(raw.window_minutes),
+          used: None,
+          severity: None,
+          window_kind: None,
+      }
+  }
+  ```
+
+  `src/providers/amp.rs:94-100`, `:140-146`, `:163-169` (3 literais):
+  ```rust
+  let window = QuotaWindow {
+      remaining: pct,
+      resets_at,
+      window_minutes: None,
+      used: None,
+      severity: None,
+      window_kind: None,
+  };
+  ```
+  ```rust
+  let window = QuotaWindow {
+      remaining: pct,
+      resets_at: full_at.clone(),
+      window_minutes: None,
+      used: None,
+      severity: None,
+      window_kind: None,
+  };
+  ```
+  ```rust
+  QuotaWindow {
+      remaining: if balance > 0.0 { 100.0 } else { 0.0 },
+      resets_at: None,
+      window_minutes: None,
+      used: None,
+      severity: None,
+      window_kind: None,
+  },
+  ```
+
+  `src/providers/grok.rs:295-307` (`build_primary_window`):
+  ```rust
+  fn build_primary_window(session: &SessionSnap) -> Option<QuotaWindow> {
+      let used = session.context_tokens_used?;
+      let window = session.context_window_tokens.filter(|w| *w > 0)?;
+      let remaining = context_remaining_pct(used, window)?;
+      let used_pct = 100.0 * (used as f64) / (window as f64);
+      Some(QuotaWindow {
+          remaining: remaining.round(),
+          resets_at: None,
+          window_minutes: None,
+          used: Some(used_pct.round()),
+          severity: None,
+          window_kind: None,
+      })
+  }
+  ```
+
+- [ ] Fazer `formatters/shared.rs` reexportar o enum canônico em vez de
+      definir o seu próprio. Remover o bloco (linhas 39-44):
+      ```rust
+      #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+      pub enum WindowKind {
+          FiveHour,
+          SevenDay,
+          Other,
+      }
+      ```
+      e substituir a linha 3 (`use crate::providers::types::QuotaWindow;`)
+      por um `use` + um `pub use` — o `pub use` é o que faz
+      `crate::formatters::shared::WindowKind` continuar resolvendo pra quem
+      já importa de lá (`codex_helpers.rs`, `codex/normalize.rs`), sem
+      precisar tocar nesses 2 arquivos:
+      ```rust
+      use crate::providers::types::QuotaWindow;
+      pub use crate::providers::types::WindowKind;
+      ```
+      `classify_window` (linhas 47-60) não muda de corpo,
+      só o tipo de retorno passa a resolver pro enum de 5 variantes (mesma
+      API pública: assinatura `pub fn classify_window(minutes: Option<i64>)
+      -> WindowKind` idêntica).
+
+- [ ] Rodar `cargo test types` e ver passar (todo o crate compila; os 2
+      testes novos de serialização passam).
+
+- [ ] Rodar `cargo test formatters` (cobre `classify_window`,
+      `to_window_display`, os builders) e `cargo test providers::codex` e
+      `cargo test providers::claude` e `cargo test providers::amp` e
+      `cargo test providers::grok` — todos verdes (comportamento idêntico,
+      só o campo novo em `None`).
+
+- [ ] `cargo clippy --all-targets -- -D warnings` — zero warnings.
+
+- [ ] Commit:
+  ```
+  git add -A
+  git commit -m "feat: adiciona windowKind a QuotaWindow"
+  ```
+
+---
+
+### Task 2: Claude seta `window_kind` na origem (legacy + limits[])
+
+**Files:**
+- Modify: `src/providers/claude.rs` (import linha 14; `window_from` linhas
+  118-127; `window_from_limit` linhas 178-187; `quota_from_limits` linhas
+  205-221; `quota_from_usage` linhas 452-464; testes
+  `claude_limits_block_takes_precedence_over_legacy` linhas 893-932 e
+  `claude_falls_back_to_legacy_when_limits_absent` linhas 934-962)
+
+**Interfaces:**
+- Consumes: `WindowKind` de `super::types` (Task 1).
+- Produces: `primary`/`secondary`/`models["Opus"|"Sonnet"|"Cowork"|"Fable"]`
+  do Claude sempre com `window_kind` correto (nunca `None` em produção).
+
+- [ ] Estender os 2 testes end-to-end existentes com asserts de
+      `window_kind` (ainda vão falhar — `window_from`/`window_from_limit`
+      não recebem `kind` ainda). Em `claude_limits_block_takes_precedence_over_legacy`
+      (depois de `assert_eq!(p.used, Some(11.0));`, `assert_eq!(s.remaining,
+      97.0);` e `assert_eq!(models.get("Fable").unwrap().remaining,
+      97.0);` respectivamente):
+      ```rust
+      assert_eq!(p.window_kind, Some(crate::providers::types::WindowKind::FiveHour));
+      ```
+      ```rust
+      assert_eq!(s.window_kind, Some(crate::providers::types::WindowKind::SevenDay));
+      ```
+      ```rust
+      assert_eq!(
+          models.get("Fable").unwrap().window_kind,
+          Some(crate::providers::types::WindowKind::SevenDay)
+      );
+      ```
+      Em `claude_falls_back_to_legacy_when_limits_absent` (depois de
+      `assert_eq!(p.remaining, 75.0);` e `assert_eq!(q.secondary.as_ref().unwrap().remaining, 60.0);`):
+      ```rust
+      assert_eq!(p.window_kind, Some(crate::providers::types::WindowKind::FiveHour));
+      ```
+      ```rust
+      assert_eq!(
+          q.secondary.as_ref().unwrap().window_kind,
+          Some(crate::providers::types::WindowKind::SevenDay)
+      );
+      ```
+
+- [ ] Rodar `cargo test providers::claude` e ver falhar: `assertion failed:
+      \`(left == right)\`` — `left: None, right: Some(FiveHour)`.
+
+- [ ] Implementar: adicionar `WindowKind` ao import (linha 14):
+      ```rust
+      use super::types::{ClaudeQuotaExtra, ExtraUsage, ProviderExtra, ProviderQuota, QuotaWindow, WindowKind};
+      ```
+      Dar um parâmetro `kind: WindowKind` pras 2 funções construtoras:
+      ```rust
+      fn window_from(raw: &ClaudeWindowRaw, kind: WindowKind) -> QuotaWindow {
+          let used = raw.utilization.round();
+          QuotaWindow {
+              remaining: 100.0 - used,
+              resets_at: raw.resets_at.clone().filter(|s| !s.is_empty()),
+              window_minutes: None,
+              used: None,
+              severity: None,
+              window_kind: Some(kind),
+          }
+      }
+      ```
+      ```rust
+      fn window_from_limit(l: &ClaudeLimitRaw, kind: WindowKind) -> QuotaWindow {
+          let used = l.percent.unwrap_or(0.0).round();
+          QuotaWindow {
+              remaining: 100.0 - used,
+              resets_at: l.resets_at.clone().filter(|s| !s.is_empty()),
+              window_minutes: None,
+              used: Some(used),
+              severity: l.severity.clone(),
+              window_kind: Some(kind),
+          }
+      }
+      ```
+      Atualizar `quota_from_limits` (linhas 205-221) pra passar o kind certo
+      por `kind`:
+      ```rust
+      for l in &u.limits {
+          match l.kind.as_str() {
+              "session" => primary = Some(window_from_limit(l, WindowKind::FiveHour)),
+              "weekly_all" => secondary = Some(window_from_limit(l, WindowKind::SevenDay)),
+              "weekly_scoped" => {
+                  let name = l
+                      .scope
+                      .as_ref()
+                      .and_then(|s| s.model.as_ref())
+                      .and_then(|m| m.display_name.clone());
+                  if let Some(name) = name {
+                      weekly.insert(name, window_from_limit(l, WindowKind::SevenDay));
+                  }
+              }
+              other => log::debug!("Claude limits[]: kind desconhecido ignorado: {other}"),
+          }
+      }
+      ```
+      Atualizar o branch legado de `quota_from_usage` (linhas 452-464):
+      ```rust
+      let primary = usage.five_hour.as_ref().map(|w| window_from(w, WindowKind::FiveHour));
+      let secondary = usage.seven_day.as_ref().map(|w| window_from(w, WindowKind::SevenDay));
+      let mut weekly: IndexMap<String, QuotaWindow> = IndexMap::new();
+      if let Some(w) = usage.seven_day_opus.as_ref() {
+          weekly.insert("Opus".to_string(), window_from(w, WindowKind::SevenDay));
+      }
+      if let Some(w) = usage.seven_day_sonnet.as_ref() {
+          weekly.insert("Sonnet".to_string(), window_from(w, WindowKind::SevenDay));
+      }
+      if let Some(w) = usage.seven_day_cowork.as_ref() {
+          weekly.insert("Cowork".to_string(), window_from(w, WindowKind::SevenDay));
+      }
+      ```
+
+- [ ] Rodar `cargo test providers::claude` e ver passar.
+
+- [ ] `cargo clippy --all-targets -- -D warnings`.
+
+- [ ] Commit:
+  ```
+  git add -A
+  git commit -m "feat: claude seta windowKind na origem"
+  ```
+
+---
+
+### Task 3: Codex — `to_quota_window` seta kind + mata o fallback forçado
+
+Este é o fix do bug central da auditoria (Codex duplicado). O fallback
+incondicional forçava `primary→fiveHour`/`secondary→sevenDay` mesmo quando
+`classify_window` já tinha classificado como `other` — resultado: a mesma
+janela aparecia 2x (uma em `other`, outra forçada em `fiveHour`/`sevenDay`).
+
+**Files:**
+- Modify: `src/providers/codex/normalize.rs` (`to_quota_window` linhas
+  26-34; `place_window` linhas 66-73; `build_model_windows` — remove
+  fallback linhas 88-98 e linhas 125-134)
+- Modify: `src/providers/codex/mod.rs` (teste `unrecognized_window_uses_fallback_mapping`
+  linhas 520-547 — reescrito e renomeado)
+
+**Interfaces:**
+- Consumes: `classify_window`/`WindowKind` de `formatters::shared` (já
+  importados na linha 8 do arquivo).
+- Produces: toda `ModelWindows` do Codex (`five_hour`/`seven_day`/`other[]`)
+  com `window_kind` correto e SEM duplicação — janela fora de tolerância
+  fica só em `other`, nunca também forçada em `five_hour`/`seven_day`.
+
+- [ ] Reescrever o teste que documentava o bug (linhas 520-547) pro novo
+      comportamento — renomeado porque o fallback que ele documentava não
+      existe mais. Apagar o teste antigo POR NOME: localizar a linha
+      `#[test]` que precede `fn unrecognized_window_uses_fallback_mapping`
+      e apagar tudo até o `}` que fecha essa função, colando o teste novo
+      no lugar (não confiar só no range de linhas citado):
+      ```rust
+      #[test]
+      fn unrecognized_window_stays_other_no_fallback() {
+          // 60 min = "other" via classify_window; SEM fallback, fica só
+          // em `other` (nunca forçado em fiveHour/sevenDay) — é o fix do
+          // bug de duplicação do Codex (auditoria 2026-07-21).
+          let mut buckets = IndexMap::new();
+          buckets.insert(
+              "b1".to_string(),
+              CodexLimitBucket {
+                  limit_id: "b1".into(),
+                  limit_name: None,
+                  primary: Some(win(10.0, 60, future_unix())),
+                  secondary: Some(win(20.0, 60, future_unix())),
+              },
+          );
+          let limits = CodexRateLimits {
+              buckets: Some(buckets),
+              ..Default::default()
+          };
+          let q = build_codex_quota(&limits, base());
+          let md = codex_extra(&q).models_detailed.as_ref().unwrap();
+          let model = md.values().next().unwrap();
+          assert!(model.five_hour.is_none(), "60min não deve ir pra fiveHour");
+          assert!(model.seven_day.is_none(), "60min não deve ir pra sevenDay");
+          let other = model.other.as_ref().expect("other deve ter as 2 janelas");
+          assert_eq!(other.len(), 2, "primary+secondary de 60min, ambas em other");
+          for w in other {
+              assert_eq!(
+                  w.window_kind,
+                  Some(crate::formatters::shared::WindowKind::Other)
+              );
+          }
+      }
+      ```
+
+- [ ] Rodar `cargo test providers::codex` e ver falhar: o teste antigo
+      esperava `model.five_hour.is_some()` — com o nome novo, o compilador
+      vai reclamar de método/campo inexistente até o rename ser aplicado
+      (o teste antigo já não existe mais no arquivo após o Step acima), e
+      os asserts novos falham porque o fallback ainda está no código
+      (`model.five_hour.is_none()` falha, pois hoje é `Some`).
+
+- [ ] Implementar: `to_quota_window` passa a setar `window_kind` via
+      `classify_window` (linhas 26-34):
+      ```rust
+      fn to_quota_window(raw: &CodexWindowRaw) -> QuotaWindow {
+          QuotaWindow {
+              remaining: 100.0 - raw.used_percent.round(),
+              resets_at: unix_to_iso(raw.resets_at),
+              window_minutes: Some(raw.window_minutes),
+              used: None,
+              severity: None,
+              window_kind: Some(classify_window(Some(raw.window_minutes))),
+          }
+      }
+      ```
+      `place_window` deixa de chamar `classify_window` de novo — reusa o
+      `window_kind` que `to_quota_window` já calculou (kind decidido UMA
+      única vez, linhas 66-73):
+      ```rust
+      fn place_window(windows: &mut ModelWindows, raw: &CodexWindowRaw) {
+          let qw = to_quota_window(raw);
+          match qw.window_kind {
+              Some(WindowKind::FiveHour) if windows.five_hour.is_none() => {
+                  windows.five_hour = Some(qw)
+              }
+              Some(WindowKind::SevenDay) if windows.seven_day.is_none() => {
+                  windows.seven_day = Some(qw)
+              }
+              _ => windows.other.get_or_insert_with(Vec::new).push(qw),
+          }
+      }
+      ```
+      Remover o fallback forçado dentro do loop de buckets (linhas 88-98 —
+      o comentário `// Fallback de mapeamento quando as durações não
+      classificam limpo.` e os dois `if windows.five_hour.is_none() { .. }`
+      / `if windows.seven_day.is_none() { .. }` que seguem): antes de
+      apagar, reler o arquivo com Read e localizar o bloco pelo
+      comentário `// Fallback de mapeamento` (não confiar só no range de
+      linhas citado — pode ter deslocado). Apagar as linhas inteiras,
+      deixando o código ir direto de `place_window(&mut windows, raw);`
+      (fim do loop de `bucket.primary`/`bucket.secondary`) pro check `if
+      windows.five_hour.is_none() && windows.seven_day.is_none() && ...`
+      que decide o `continue`.
+      Remover o fallback equivalente no branch legado (linhas 125-134 — os
+      dois blocos `if windows.five_hour.is_none() { .. }` / `if
+      windows.seven_day.is_none() { .. }` logo antes de `models.insert("Codex".to_string(),
+      windows);`): apagar, deixando o `for raw in [...] { place_window(&mut
+      windows, raw); }` seguido direto por `models.insert(...)`.
+
+- [ ] Rodar `cargo test providers::codex` e ver passar (incluindo os outros
+      testes de tolerância — `tolerates_five_hour_within_90min`,
+      `tolerates_seven_day_within_1440min` — que continuam verdes porque
+      `place_window` já classificava certo pra esses casos independente do
+      fallback).
+
+- [ ] `cargo clippy --all-targets -- -D warnings`.
+
+- [ ] Commit:
+  ```
+  git add -A
+  git commit -m "fix: codex para de forcar fallback five/seven"
+  ```
+
+---
+
+### Task 4: Amp (`Daily`) e Grok (`Context`)
+
+**Files:**
+- Modify: `src/providers/amp.rs` (import linha 17; 3 literais linhas 94-100,
+  140-146, 163-169; testes `parses_full_output` linha 356 e
+  `fixture_free_pct_parses_primary` linha 407)
+- Modify: `src/providers/grok.rs` (import linha 17; `build_primary_window`
+  linhas 295-307; teste `happy_path_remaining_90` linha 648)
+
+**Interfaces:**
+- Consumes: `WindowKind` de `super::types` (Task 1).
+- Produces: toda janela do Amp (`primary`, `models["Free Tier"]`,
+  `models["Credits"]`) com `window_kind: Some(WindowKind::Daily)`; a janela
+  de contexto do Grok (`primary`) com `window_kind:
+  Some(WindowKind::Context)`.
+
+- [ ] Estender 2 testes existentes do Amp com o assert de `window_kind`
+      (ainda falha — campo é `None`). Em `parses_full_output` (depois de
+      `assert_eq!(models["Credits"].remaining, 100.0);`):
+      ```rust
+      assert_eq!(
+          q.primary.as_ref().unwrap().window_kind,
+          Some(crate::providers::types::WindowKind::Daily)
+      );
+      assert_eq!(
+          models["Credits"].window_kind,
+          Some(crate::providers::types::WindowKind::Daily)
+      );
+      ```
+      Em `fixture_free_pct_parses_primary` (depois de
+      `assert_eq!(models["Credits"].remaining, 100.0);`):
+      ```rust
+      assert_eq!(
+          models["Free Tier"].window_kind,
+          Some(crate::providers::types::WindowKind::Daily)
+      );
+      ```
+
+- [ ] Estender `happy_path_remaining_90` do Grok (depois de
+      `assert_eq!(primary.used, Some(10.0));`):
+      ```rust
+      assert_eq!(
+          primary.window_kind,
+          Some(crate::providers::types::WindowKind::Context)
+      );
+      ```
+
+- [ ] Rodar `cargo test providers::amp` e `cargo test providers::grok` e
+      ver falhar (`left: None, right: Some(Daily)` / `Some(Context)`).
+
+- [ ] Implementar Amp: adicionar `WindowKind` ao import (linha 17):
+      ```rust
+      use super::types::{AmpQuotaExtra, ProviderExtra, ProviderQuota, QuotaWindow, WindowKind};
+      ```
+      Setar `window_kind: Some(WindowKind::Daily)` nos 3 literais (linhas
+      94-100, 140-146, 163-169):
+      ```rust
+      let window = QuotaWindow {
+          remaining: pct,
+          resets_at,
+          window_minutes: None,
+          used: None,
+          severity: None,
+          window_kind: Some(WindowKind::Daily),
+      };
+      ```
+      ```rust
+      let window = QuotaWindow {
+          remaining: pct,
+          resets_at: full_at.clone(),
+          window_minutes: None,
+          used: None,
+          severity: None,
+          window_kind: Some(WindowKind::Daily),
+      };
+      ```
+      ```rust
+      QuotaWindow {
+          remaining: if balance > 0.0 { 100.0 } else { 0.0 },
+          resets_at: None,
+          window_minutes: None,
+          used: None,
+          severity: None,
+          window_kind: Some(WindowKind::Daily),
+      },
+      ```
+
+- [ ] Implementar Grok: adicionar `WindowKind` ao import (linha 17):
+      ```rust
+      use super::types::{GrokQuotaExtra, ProviderExtra, ProviderQuota, QuotaWindow, WindowKind};
+      ```
+      Setar `window_kind: Some(WindowKind::Context)` em
+      `build_primary_window` (linhas 295-307):
+      ```rust
+      fn build_primary_window(session: &SessionSnap) -> Option<QuotaWindow> {
+          let used = session.context_tokens_used?;
+          let window = session.context_window_tokens.filter(|w| *w > 0)?;
+          let remaining = context_remaining_pct(used, window)?;
+          let used_pct = 100.0 * (used as f64) / (window as f64);
+          Some(QuotaWindow {
+              remaining: remaining.round(),
+              resets_at: None,
+              window_minutes: None,
+              used: Some(used_pct.round()),
+              severity: None,
+              window_kind: Some(WindowKind::Context),
+          })
+      }
+      ```
+
+- [ ] Rodar `cargo test providers::amp` e `cargo test providers::grok` e
+      ver passar.
+
+- [ ] `cargo clippy --all-targets -- -D warnings`.
+
+- [ ] Commit:
+  ```
+  git add -A
+  git commit -m "feat: amp/grok setam windowKind (daily/context)"
+  ```
+
+---
+
+### Task 5: `classify_window` → `WindowKind` canônico + `is_duplicate_window`
+
+**Files:**
+- Modify: `src/formatters/shared.rs` (imports linha 3; enum local removido
+  na Task 1 — aqui só falta adicionar `is_duplicate_window`; novo bloco de
+  testes)
+
+**Interfaces:**
+- Produces: `pub fn is_duplicate_window(a: &QuotaWindow, b: &QuotaWindow) ->
+  bool` — true quando `(window_kind, resets_at, remaining.round())`
+  coincidem nas duas janelas; `window_kind` ausente (`None`) em qualquer
+  lado nunca é considerado duplicata (dado incompleto não deduplica).
+- Consumes (Task 7): TUI (`src/tui/render/detail/windows.rs`).
+
+- [ ] Escrever teste que falha, no bloco `mod tests` existente de
+      `formatters/shared.rs` (depois de `to_window_display_honours_provider_used`):
+      ```rust
+      #[test]
+      fn is_duplicate_window_same_kind_reset_and_rounded_remaining() {
+          let a = QuotaWindow {
+              remaining: 60.4,
+              resets_at: Some("2026-06-26T12:00:00Z".into()),
+              window_minutes: Some(10080),
+              used: None,
+              severity: None,
+              window_kind: Some(WindowKind::SevenDay),
+          };
+          let b = QuotaWindow {
+              remaining: 59.6,
+              resets_at: Some("2026-06-26T12:00:00Z".into()),
+              window_minutes: Some(300),
+              used: None,
+              severity: None,
+              window_kind: Some(WindowKind::SevenDay),
+          };
+          // 60.4.round() == 59.6.round() == 60 — remaining "igual" mesmo
+          // vindo de fontes com precisão diferente.
+          assert!(is_duplicate_window(&a, &b));
+      }
+
+      #[test]
+      fn is_duplicate_window_different_kind_is_not_duplicate() {
+          let mut a = QuotaWindow {
+              remaining: 60.0,
+              resets_at: Some("2026-06-26T12:00:00Z".into()),
+              window_minutes: Some(300),
+              used: None,
+              severity: None,
+              window_kind: Some(WindowKind::FiveHour),
+          };
+          let b = QuotaWindow {
+              window_kind: Some(WindowKind::SevenDay),
+              ..a.clone()
+          };
+          assert!(!is_duplicate_window(&a, &b));
+          a.window_kind = None;
+          let c = QuotaWindow {
+              window_kind: None,
+              ..b.clone()
+          };
+          assert!(!is_duplicate_window(&a, &c), "window_kind None nunca duplica");
+      }
+
+      #[test]
+      fn is_duplicate_window_different_reset_is_not_duplicate() {
+          let a = QuotaWindow {
+              remaining: 60.0,
+              resets_at: Some("2026-06-26T12:00:00Z".into()),
+              window_minutes: Some(10080),
+              used: None,
+              severity: None,
+              window_kind: Some(WindowKind::SevenDay),
+          };
+          let b = QuotaWindow {
+              resets_at: Some("2026-06-27T12:00:00Z".into()),
+              ..a.clone()
+          };
+          assert!(!is_duplicate_window(&a, &b));
+      }
+      ```
+
+- [ ] Rodar `cargo test formatters` e ver falhar: `error[E0425]: cannot
+      find function `is_duplicate_window` in this scope`.
+
+- [ ] Implementar em `src/formatters/shared.rs`, logo depois de
+      `classify_window` (linha 60):
+      ```rust
+      /// Dedup display-level (TUI/QML): duas janelas são a "mesma" quando
+      /// `windowKind`, `resetsAt` e `remaining` arredondado coincidem —
+      /// mata o Weekly triplicado do Codex sem tocar no JSON (que continua
+      /// emitindo primary/secondary/models cru, contrato intacto).
+      /// `window_kind` ausente em qualquer lado nunca deduplica (dado
+      /// incompleto não é assumido igual).
+      pub fn is_duplicate_window(a: &QuotaWindow, b: &QuotaWindow) -> bool {
+          match (a.window_kind, b.window_kind) {
+              (Some(ka), Some(kb)) if ka == kb => {
+                  a.resets_at == b.resets_at && a.remaining.round() == b.remaining.round()
+              }
+              _ => false,
+          }
+      }
+      ```
+
+- [ ] Rodar `cargo test formatters` e ver passar.
+
+- [ ] `cargo clippy --all-targets -- -D warnings`.
+
+- [ ] Commit:
+  ```
+  git add -A
+  git commit -m "feat: is_duplicate_window para dedup display-level"
+  ```
+
+---
+
+### Task 6: Builder do Codex renderiza janelas `other`
+
+Sem o fallback (Task 3), uma janela de duração não-padrão fica só em
+`ModelWindows.other` — hoje o builder terminal/waybar do Codex nunca lê
+esse campo, então ela vira invisível. Rótulo pela duração real (ex.: "1h
+window"), sempre visível independente da `WindowPolicy` (não é nem
+`FiveHour` nem `SevenDay`, então nenhuma das duas políticas deveria
+escondê-la).
+
+**Files:**
+- Modify: `src/formatters/builders/codex.rs` (novo helper + chamada dentro
+  de `build_codex`, inserido depois do bloco `if policy !=
+  WindowPolicy::FiveHour { .. }`, linha 117-118, antes do bloco `if let
+  Some(eu) = get_codex_extra(p)...` linha 120; novo teste no módulo)
+- tests/golden.rs — avaliado e mantido sem mudança (ver step: fixture não
+  muda neste commit; caso other coberto por teste unitário no builder)
+
+**Interfaces:**
+- Consumes: `ModelWindows.other: Option<Vec<QuotaWindow>>` (já existe desde
+  antes deste plano).
+- Produces: linha extra por janela `other`, rotulada por duração
+  (`"{h}h window"` / `"{m}m window"` / `"{h}h {m}m window"`).
+
+- [ ] Escrever teste que falha, dentro de `mod tests` de
+      `src/formatters/builders/codex.rs` (depois de
+      `empty_models_shows_placeholder`):
+      ```rust
+      fn entry_with_other(name: &str, other_minutes: i64, remaining: f64) -> CodexModelEntry {
+          CodexModelEntry {
+              name: name.into(),
+              windows: ModelWindows {
+                  five_hour: None,
+                  seven_day: None,
+                  other: Some(vec![QuotaWindow {
+                      remaining,
+                      resets_at: Some("2026-06-19T14:00:00Z".into()),
+                      window_minutes: Some(other_minutes),
+                      used: None,
+                      severity: None,
+                      window_kind: Some(crate::providers::types::WindowKind::Other),
+                  }]),
+              },
+              severity: remaining,
+          }
+      }
+
+      #[test]
+      fn other_window_renders_with_duration_label() {
+          let vm = CodexViewModel {
+              models: vec![entry_with_other("gpt-5", 60, 40.0)],
+              policy: WindowPolicy::Both,
+          };
+          let out = render_pango(&build_codex(&clk(), &quota(), &vm, &opts(None)));
+          assert!(out.contains("1h window"), "esperava rótulo de duração:\n{out}");
+          assert!(out.contains("40%"));
+      }
+
+      #[test]
+      fn other_window_label_formats_by_minutes() {
+          assert_eq!(other_window_label(Some(60)), "1h window");
+          assert_eq!(other_window_label(Some(90)), "1h 30m window");
+          assert_eq!(other_window_label(Some(45)), "45m window");
+          assert_eq!(other_window_label(None), "window");
+      }
+      ```
+
+- [ ] Rodar `cargo test formatters::builders::codex` e ver falhar:
+      `error[E0425]: cannot find function `other_window_label``.
+
+- [ ] Implementar. Helper de rótulo (colar antes de `pub fn build_codex`,
+      depois dos imports):
+      ```rust
+      /// Rótulo de janela `other` (nem 5h nem 7d) pela duração real — o
+      /// fallback forçado que escondia isso morreu na Task 3. "1h
+      /// window"/"45m window"/"1h 30m window"; sem `window_minutes` (não
+      /// deveria acontecer em dado real) → "window", nunca panic.
+      fn other_window_label(minutes: Option<i64>) -> String {
+          match minutes {
+              Some(m) if m > 0 => {
+                  let h = m / 60;
+                  let mm = m % 60;
+                  match (h, mm) {
+                      (0, _) => format!("{mm}m window"),
+                      (_, 0) => format!("{h}h window"),
+                      _ => format!("{h}h {mm}m window"),
+                  }
+              }
+              _ => "window".to_string(),
+          }
+      }
+      ```
+      Renderizar as janelas `other` de cada model, inserido logo depois do
+      bloco `if policy != WindowPolicy::FiveHour { .. }` (linha 117-118) e
+      antes de `if let Some(eu) = get_codex_extra(p)...` (linha 120):
+      ```rust
+      for model in models {
+          if let Some(others) = model.windows.other.as_ref() {
+              for w in others {
+                  lines.push(vline(ColorToken::Green));
+                  lines.push(label_line(
+                      &other_window_label(w.window_minutes),
+                      options.label_color,
+                      ColorToken::Green,
+                  ));
+                  lines.push(model_line(
+                      clock,
+                      &model.name,
+                      Some(w),
+                      model_len,
+                      mode,
+                      ColorToken::Green,
+                      Some("N/A"),
+                  ));
+              }
+          }
+      }
+      ```
+
+- [ ] Rodar `cargo test formatters::builders::codex` e ver passar.
+
+- [ ] Golden: estender `codex_healthy()` em `tests/golden.rs` (linhas
+      135-165) com uma janela `other` na entrada `"Codex"` de
+      `models_detailed`, pra provar que o golden (waybar/terminal) também
+      passa a mostrar essa janela:
+      ```rust
+      fn codex_healthy() -> ProviderQuota {
+          let mut models_detailed = BTreeMap::new();
+          models_detailed.insert(
+              "Codex".to_string(),
+              ModelWindows {
+                  five_hour: Some(qw(60.0, FIXED_RESET, Some(300))),
+                  seven_day: Some(qw(85.0, FIXED_RESET, Some(10080))),
+                  other: None,
+              },
+          );
+          let mut models = IndexMap::new();
+          models.insert("Codex".to_string(), qw(60.0, FIXED_RESET, Some(300)));
+
+          ProviderQuota {
+              provider: "codex".into(),
+              display_name: "Codex".into(),
+              available: true,
+              account: None,
+              plan: Some("Pro".into()),
+              plan_type: Some("pro".into()),
+              primary: Some(qw(60.0, FIXED_RESET, Some(300))),
+              secondary: Some(qw(85.0, FIXED_RESET, Some(10080))),
+              models: Some(models),
+              extra: Some(ProviderExtra::Codex(CodexQuotaExtra {
+                  models_detailed: Some(models_detailed),
+                  extra_usage: None,
+              })),
+              error: None,
+              stale_reason: None,
+          }
+      }
+      ```
+      Este fixture NÃO muda neste commit — ele já não tinha janela `other`
+      e continua sem. A cobertura de golden pra `other` fica coberta pelo
+      teste unitário `other_window_renders_with_duration_label` acima (o
+      golden runner `tests/golden.rs` roda por `insta` com snapshots
+      colados do TS e não é o lugar certo pra introduzir um caso NOVO sem
+      um `.snap` de referência do TS pra comparar — ver comentário de
+      topo do arquivo: "os goldens NUNCA são gravados via `cargo insta
+      accept`"). Não editar `tests/golden.rs` nesta task.
+
+- [ ] `cargo test --test golden` — continua verde (nada mudou de fato no
+      arquivo).
+
+- [ ] `cargo clippy --all-targets -- -D warnings`.
+
+- [ ] Commit:
+  ```
+  git add -A
+  git commit -m "feat: builder codex renderiza janelas other"
+  ```
+
+---
+
+### Task 7: TUI — fuso local, countdown e dedup no Detail
+
+**Files:**
+- Modify: `src/tui/render/detail/format.rs` (assinatura de `fmt_reset`
+  linhas 67-79; novo helper de weekday)
+- Modify: `src/tui/render/detail/windows.rs` (`window_line` linhas 21-39;
+  `model_window_line` linhas 47-69; `window_lines` linhas 80-105)
+- Modify: `src/tui/render/detail/mod.rs` (`render_full` linha 64; testes:
+  helper `window` já ajustado na Task 1, novos testes de `fmt_reset` e
+  dedup; snapshots existentes atualizados de propósito)
+- Modify: `src/formatters/shared.rs` (visibilidade de `parse_iso`, linha
+  183, de privada pra `pub(crate)`)
+
+**Interfaces:**
+- Consumes: `format_eta`/`parse_iso` de `formatters::shared` (Task 5 já
+  deixou `WindowKind` acessível); `is_duplicate_window` (Task 5);
+  `Clock` de `formatters::clock`; `state.last_update`/`state.local_offset`
+  (já existentes em `AppState`, mesmo padrão de
+  `chart::render_chart_section`).
+- Produces: `fmt_reset(clock: &Clock, resets_at: Option<&str>, remaining:
+  f64) -> String` — `"Xh Ym · HH:MM"` no mesmo dia local, `"{d}d {h}h · seg
+  HH:MM"` (abrev. PT do weekday) quando o reset cai em outro dia local;
+  `window_lines(clock: &Clock, q, provider_usage, content_width)` (novo 1º
+  parâmetro) já deduplica linhas de `q.models` que colidem com
+  `primary`/`secondary` via `is_duplicate_window`.
+
+Desvio documentado do contrato: `fmt_reset` reaproveita `parse_iso` +
+`format_eta` e converte fuso inline; NÃO chama `format_reset_time` porque o
+formato pedido (weekday PT, sem parênteses) difere do dele — aprovado pelo
+orquestrador.
+
+- [ ] Tornar `parse_iso` acessível fora de `formatters::shared` — mudar de
+      `fn parse_iso` pra `pub(crate) fn parse_iso` (linha 183 de
+      `src/formatters/shared.rs`):
+      ```rust
+      pub(crate) fn parse_iso(iso: &str) -> Option<OffsetDateTime> {
+          OffsetDateTime::parse(iso, &Rfc3339).ok()
+      }
+      ```
+
+- [ ] Escrever teste que falha em `src/tui/render/detail/mod.rs`, dentro de
+      `mod tests` (perto de `truncate_name_ellipsizes_long_names`, antes da
+      seção "Snapshots"):
+      ```rust
+      #[test]
+      fn fmt_reset_same_local_day_shows_countdown_and_time() {
+          let clock = crate::formatters::clock::Clock {
+              now: time::macros::datetime!(2026-06-19 12:00:00 UTC),
+              local_offset: time::UtcOffset::from_hms(3, 0, 0).unwrap(),
+          };
+          // 14:05 UTC + 03:00 = 17:05 local, mesmo dia local que "now" (+03:00 = 15:00)
+          let out = super::format::fmt_reset(&clock, Some("2026-06-19T14:05:00Z"), 50.0);
+          assert_eq!(out, "2h 05m \u{b7} 17:05");
+      }
+
+      #[test]
+      fn fmt_reset_different_local_day_shows_weekday_abbrev() {
+          let clock = crate::formatters::clock::Clock {
+              now: time::macros::datetime!(2026-06-19 23:30:00 UTC), // sex 23:30 UTC → sáb 02:30 local
+              local_offset: time::UtcOffset::from_hms(3, 0, 0).unwrap(),
+          };
+          // reset seg 2026-06-22T13:00:00Z + 03:00 = seg 16:00 local (dia diferente do "now" local)
+          let out = super::format::fmt_reset(&clock, Some("2026-06-22T13:00:00Z"), 30.0);
+          assert_eq!(out, "2d 13h \u{b7} seg 16:00");
+      }
+
+      #[test]
+      fn fmt_reset_full_and_unknown_passthrough() {
+          let clock = crate::formatters::clock::Clock {
+              now: time::macros::datetime!(2026-06-19 12:00:00 UTC),
+              local_offset: time::UtcOffset::UTC,
+          };
+          assert_eq!(
+              super::format::fmt_reset(&clock, Some("2026-06-19T14:00:00Z"), 100.0),
+              "Full"
+          );
+          assert_eq!(super::format::fmt_reset(&clock, None, 50.0), "?");
+      }
+
+      #[test]
+      fn window_lines_dedups_model_matching_secondary() {
+          use crate::providers::types::WindowKind;
+          let clock = crate::formatters::clock::Clock {
+              now: time::macros::datetime!(2026-06-19 12:00:00 UTC),
+              local_offset: time::UtcOffset::UTC,
+          };
+          let mut q = minimal_quota("codex");
+          q.secondary = Some(QuotaWindow {
+              remaining: 85.0,
+              resets_at: Some("2026-06-26T12:00:00Z".into()),
+              window_minutes: Some(10080),
+              used: None,
+              severity: None,
+              window_kind: Some(WindowKind::SevenDay),
+          });
+          let mut models = IndexMap::new();
+          models.insert(
+              "Codex".to_string(),
+              QuotaWindow {
+                  remaining: 85.0,
+                  resets_at: Some("2026-06-26T12:00:00Z".into()),
+                  window_minutes: Some(10080),
+                  used: None,
+                  severity: None,
+                  window_kind: Some(WindowKind::SevenDay),
+              },
+          );
+          q.models = Some(models);
+          let lines = super::windows::window_lines(&clock, &q, None, 100);
+          // só "semana" (secondary) — o model "Codex" duplica e some.
+          assert_eq!(lines.len(), 1, "model duplicado deveria sumir");
+      }
+      ```
+
+- [ ] Rodar `cargo test detail` e ver falhar: `error[E0425]: cannot find
+      function `fmt_reset` in module `super::format`` (assinatura ainda
+      antiga, 1 argumento) e `error[E0061]: this function takes 3
+      arguments but 4 were supplied` pra `window_lines`.
+
+- [ ] Implementar `fmt_reset` em `src/tui/render/detail/format.rs`. Primeiro
+      o import (linha 3, junto do `use` existente):
+      ```rust
+      use crate::formatters::clock::Clock;
+      use crate::formatters::shared::{format_eta, parse_iso};
+      use crate::usage::{ModelUsage, ProviderUsage};
+      ```
+      Depois substituir o bloco da função inteira (linhas 67-79):
+      ```rust
+      /// Abreviação PT (3 letras) do weekday — usada só quando o reset cai
+      /// em dia local diferente de "agora" (janela de 7 dias, tipicamente).
+      fn weekday_pt(w: time::Weekday) -> &'static str {
+          use time::Weekday::*;
+          match w {
+              Monday => "seg",
+              Tuesday => "ter",
+              Wednesday => "qua",
+              Thursday => "qui",
+              Friday => "sex",
+              Saturday => "s\u{e1}b",
+              Sunday => "dom",
+          }
+      }
+
+      /// Countdown + horário de reset em fuso LOCAL — substitui o slice cru
+      /// de UTC (bug da auditoria: TUI mostrava o reset em UTC). "Xh Ym ·
+      /// HH:MM" no mesmo dia local; "{d}d {h}h · seg HH:MM" (weekday
+      /// abreviado) quando o reset cai em outro dia local (janela de 7
+      /// dias). `Full`/`?` (via `format_eta`) passam direto — sem hora.
+      pub(super) fn fmt_reset(clock: &Clock, resets_at: Option<&str>, remaining: f64) -> String {
+          let eta = format_eta(clock, resets_at, remaining);
+          if eta == "Full" || eta == "?" {
+              return eta;
+          }
+          let Some(iso) = resets_at else { return eta };
+          let Some(dt) = parse_iso(iso) else { return eta };
+          let local = dt.to_offset(clock.local_offset);
+          let today_local = clock.now.to_offset(clock.local_offset).date();
+          if local.date() == today_local {
+              format!("{eta} \u{b7} {:02}:{:02}", local.hour(), local.minute())
+          } else {
+              format!(
+                  "{eta} \u{b7} {} {:02}:{:02}",
+                  weekday_pt(local.weekday()),
+                  local.hour(),
+                  local.minute()
+              )
+          }
+      }
+      ```
+      (remove a função antiga de mesmo nome, que fazia só o slice de
+      `resets_at.split('T').nth(1)...`.)
+
+- [ ] Implementar em `src/tui/render/detail/windows.rs`: threading do
+      `clock` e dedup. Import (linhas 1-15):
+      ```rust
+      use ratatui::style::Style;
+      use ratatui::text::{Line, Span};
+
+      use crate::formatters::clock::Clock;
+      use crate::formatters::shared::is_duplicate_window;
+      use crate::providers::types::{ProviderQuota, QuotaWindow};
+      use crate::theme::ColorToken;
+      use crate::tui::theme_bridge::to_ratatui;
+      use crate::tui::widgets::quota_gauge::gauge_spans;
+      use crate::tui::widgets::severity::severity_color_api;
+      use crate::usage::ProviderUsage;
+
+      use super::format::{
+          derive_bar_width, find_model_usage, fmt_reset, truncate_name, LABEL_W, WINDOW_SUFFIX_W,
+      };
+      ```
+      `window_line` (linhas 21-39) e `model_window_line` (linhas 47-69)
+      ganham `clock: &Clock` como 1º parâmetro:
+      ```rust
+      fn window_line(clock: &Clock, label: &str, w: &QuotaWindow, gauge_w: usize) -> Line<'static> {
+          let color = severity_color_api(w.severity.as_deref(), Some(w.remaining));
+          let reset_str = fmt_reset(clock, w.resets_at.as_deref(), w.remaining);
+          let name = truncate_name(label, LABEL_W);
+          let mut spans = vec![Span::styled(
+              format!(" {name:<LABEL_W$} "),
+              Style::default().fg(to_ratatui(ColorToken::Muted)),
+          )];
+          spans.extend(gauge_spans(w.remaining, gauge_w, color));
+          spans.push(Span::styled(
+              format!(" {:>4.0}%", w.remaining),
+              Style::default().fg(to_ratatui(ColorToken::TextBright)),
+          ));
+          spans.push(Span::styled(
+              format!("  \u{2192} {reset_str}"),
+              Style::default().fg(to_ratatui(ColorToken::Comment)),
+          ));
+          Line::from(spans)
+      }
+      ```
+      ```rust
+      fn model_window_line(
+          clock: &Clock,
+          name: &str,
+          w: &QuotaWindow,
+          gauge_w: usize,
+          content_width: u16,
+          provider_usage: Option<&ProviderUsage>,
+      ) -> Line<'static> {
+          let mut line = window_line(clock, name, w, gauge_w);
+          if let Some(cost) = provider_usage
+              .and_then(|pu| find_model_usage(&pu.by_model, name))
+              .and_then(|mu| mu.cost.as_ref())
+          {
+              let cost_span = format!("  ${:.2}", cost.usd);
+              let current_w: usize = line.spans.iter().map(|s| s.content.chars().count()).sum();
+              if current_w + cost_span.chars().count() <= content_width as usize {
+                  line.spans.push(Span::styled(
+                      cost_span,
+                      Style::default().fg(to_ratatui(ColorToken::Comment)),
+                  ));
+              }
+          }
+          line
+      }
+      ```
+      `window_lines` (linhas 80-105) ganha `clock` e passa a deduplicar
+      `q.models` contra `primary`/`secondary`:
+      ```rust
+      pub(super) fn window_lines(
+          clock: &Clock,
+          q: &ProviderQuota,
+          provider_usage: Option<&ProviderUsage>,
+          content_width: u16,
+      ) -> Vec<Line<'static>> {
+          let bar_width = derive_bar_width(content_width, WINDOW_SUFFIX_W);
+          let mut lines = Vec::new();
+          if let Some(primary) = &q.primary {
+              lines.push(window_line(clock, "sess\u{e3}o", primary, bar_width));
+          }
+          if let Some(secondary) = &q.secondary {
+              lines.push(window_line(clock, "semana", secondary, bar_width));
+          }
+          if let Some(models) = &q.models {
+              for (name, w) in models {
+                  let dup_primary = q.primary.as_ref().is_some_and(|p| is_duplicate_window(w, p));
+                  let dup_secondary =
+                      q.secondary.as_ref().is_some_and(|s| is_duplicate_window(w, s));
+                  if dup_primary || dup_secondary {
+                      continue;
+                  }
+                  lines.push(model_window_line(
+                      clock,
+                      name,
+                      w,
+                      bar_width,
+                      content_width,
+                      provider_usage,
+                  ));
+              }
+          }
+          lines
+      }
+      ```
+
+- [ ] Recalibrar `WINDOW_SUFFIX_W` em `src/tui/render/detail/format.rs`
+      (linha 16) — o suffix cresceu (countdown + hora, ou countdown +
+      weekday + hora); orçamento antigo (9 chars pro reset) estoura com o
+      texto novo. Substituir:
+      ```rust
+      pub(super) const WINDOW_SUFFIX_W: usize = 1 + 4 + 1 + 2 + 1 + 20; // pct(" NNN%"=6) + reset("  → "+countdown até "99d 23h · qua 23:59"=20)
+      ```
+
+- [ ] Atualizar o único call site de `window_lines`, em
+      `src/tui/render/detail/mod.rs` — `render_full` (linha 64). Substituir:
+      ```rust
+      let clock = crate::formatters::clock::Clock {
+          now: state
+              .last_update
+              .unwrap_or(time::OffsetDateTime::UNIX_EPOCH),
+          local_offset: state.local_offset,
+      };
+      let windows = window_lines(&clock, q, provider_usage, area.width);
+      ```
+      (mesmo padrão de `now` já usado por `render_chart_section` — nunca
+      `OffsetDateTime::now_utc()` dentro de render, pra manter snapshots
+      determinísticos.)
+
+- [ ] Rodar `cargo test detail` e ver passar os 4 testes novos. Os
+      snapshots existentes (`detail_claude_full`,
+      `detail_chart_absorbs_extra_height_no_blank_gap`,
+      `detail_collapse_short_terminal`, `detail_amp_credits`,
+      `detail_codex_logged_out`, `detail_narrow_80`,
+      `detail_extra_usage_disabled`, `detail_extra_usage_no_limit`,
+      `detail_provider_error_shows_icon_and_message`) vão FALHAR — o texto
+      do reset mudou de propósito (UTC cru → countdown + hora local).
+      Confirmar, pra cada snapshot que falhar, que o diff é exatamente essa
+      mudança (countdown/hora), nada mais:
+      ```
+      cargo insta test --review -- detail
+      ```
+      Revisar cada diff mostrado (aceitar só se o ÚNICO delta for o texto
+      do reset — countdown + `· HH:MM`/weekday no lugar do HH:MM cru).
+
+- [ ] `cargo test detail` de novo — todos verdes.
+
+- [ ] `cargo clippy --all-targets -- -D warnings`.
+
+- [ ] Commit (a mensagem documenta a mudança de propósito dos snapshots
+      pro histórico do repo):
+  ```
+  git add -A
+  git commit -m "feat: tui mostra reset em fuso local com countdown"
+  ```
+
+---
+
+### Task 8: `config show` ganha `menuAnimations` (read-only)
+
+**Files:**
+- Modify: `src/config_cmd.rs` (struct `ConfigView` linhas 13-19;
+  `view_from_settings` linhas 55-65; teste `show_json_wire_format` linhas
+  252-261)
+
+**Interfaces:**
+- Consumes: `Settings.menu.animations: bool` (já existe em
+  `src/settings.rs`, default `true`).
+- Produces: `ConfigView.menu_animations: bool` → JSON `menuAnimations`
+  (aditivo, `schemaVersion` continua 1). `config apply` não aceita esse
+  campo — `ConfigPatch` não ganha o campo, então `serde_json` ignora
+  silenciosamente qualquer `menuAnimations` recebido (sem
+  `deny_unknown_fields` no struct).
+
+- [ ] Escrever teste que falha, estendendo `show_json_wire_format` (linhas
+      252-261):
+      ```rust
+      #[test]
+      fn show_json_wire_format() {
+          let dir = tempdir().unwrap();
+          let v = show(&paths_in(dir.path()));
+          let j = serde_json::to_value(&v).unwrap();
+          assert_eq!(j["schemaVersion"], 1);
+          assert_eq!(j["displayMode"], "remaining");
+          assert_eq!(j["notify"]["enabled"], true);
+          assert!(j["providers"].is_array());
+          assert_eq!(j["menuAnimations"], true, "default do Settings.menu.animations");
+      }
+
+      #[test]
+      fn apply_ignores_menu_animations_field() {
+          let dir = tempdir().unwrap();
+          let p = paths_in(dir.path());
+          let v = apply_json(
+              &p,
+              r#"{"schemaVersion":1,"displayMode":"used","menuAnimations":false}"#,
+          )
+          .unwrap();
+          assert_eq!(v.display_mode, DisplayMode::Used);
+          // campo ignorado: não existe em ConfigPatch, apply não falha, e o
+          // valor real de menu.animations em settings.json não é tocado.
+          let loaded = crate::settings::load(&p);
+          assert!(loaded.menu.animations, "apply não deve mexer em menu.animations");
+      }
+      ```
+
+- [ ] Rodar `cargo test config_cmd` e ver falhar: `error[E0609]: no field
+      `menu_animations` on type `ConfigView``.
+
+- [ ] Implementar. `ConfigView` (linhas 13-19):
+      ```rust
+      #[derive(Debug, Clone, PartialEq, Serialize)]
+      #[serde(rename_all = "camelCase")]
+      pub struct ConfigView {
+          pub schema_version: u32,
+          pub providers: Vec<String>,
+          pub provider_order: Vec<String>,
+          pub display_mode: DisplayMode,
+          pub notify: NotifyView,
+          pub menu_animations: bool,
+      }
+      ```
+      `view_from_settings` (linhas 55-65):
+      ```rust
+      pub fn view_from_settings(s: &Settings) -> ConfigView {
+          ConfigView {
+              schema_version: CONFIG_SCHEMA_VERSION,
+              providers: s.waybar.providers.clone(),
+              provider_order: s.waybar.provider_order.clone(),
+              display_mode: s.waybar.display_mode,
+              notify: NotifyView {
+                  enabled: s.notify.enabled,
+              },
+              menu_animations: s.menu.animations,
+          }
+      }
+      ```
+      (`ConfigPatch`, linhas 40-48, não ganha campo nenhum — é assim que
+      `apply` "ignora" `menuAnimations".)
+
+- [ ] Rodar `cargo test config_cmd` e ver passar.
+
+- [ ] `cargo clippy --all-targets -- -D warnings`.
+
+- [ ] Commit:
+  ```
+  git add -A
+  git commit -m "feat: config show expoe menuAnimations read-only"
+  ```
+
+---
+
+### Task 9: `docs/json-output.md` — `windowKind` + shapes de `extra`
+
+**Files:**
+- Modify: `docs/json-output.md` (envelope de exemplo linhas 24-42; tabela
+  de campos linhas 46-59; definição de `Window` linhas 61-69; nova seção
+  depois de "Stability", antes de "Quickshell example")
+
+**Interfaces:**
+- Nenhuma (documentação pura — verificação é `git diff --check`).
+
+- [ ] Atualizar a definição de `Window` (linhas 61-69) pra incluir
+      `windowKind`:
+      ```markdown
+      `Window`: `{ remaining: number, used?: number|null, resetsAt: string|null, windowMinutes?: number|null, severity?: string, windowKind?: string }`.
+      `remaining`/`used` are percentages (0-100). `used` is only present when a provider
+      reports a distinct "used" metric that is not simply `100 - remaining` (it can exceed 100 with overage).
+      `severity` is optional (`Option<String>`, omitted when absent) and comes from the
+      provider's own API — today only Claude populates it, from `limits[].severity`.
+      Known values: `normal`/`ok`/`warning`/`elevated`/`high`/`critical`/`exceeded`/`blocked`.
+      Consumers should fall back to a local threshold on `remaining` (≥60/30/10) when
+      `severity` is absent or unrecognized — this mirrors `severity_color_api` in
+      `src/tui/widgets/severity.rs`.
+      `windowKind` is one of `fiveHour`/`sevenDay`/`daily`/`context`/`other`, decided once
+      by the provider at fetch time (never a client-side magic-number guess). It replaces
+      any window-duration heuristic a consumer might have written against `windowMinutes`
+      — `fiveHour`/`sevenDay` map to Claude's and Codex's own quota tiers, `daily` is Amp's
+      free-tier reset cadence, `context` is Grok's context-window usage (no reset — see
+      `contextTokensUsed`/`contextWindowTokens` in `extra` instead), `other` is any window
+      that doesn't fit those tiers (e.g. a Codex bucket with a non-standard duration).
+      Omitted when the provider hasn't classified the window (should not happen in
+      production; only seen in hand-built test fixtures).
+      ```
+
+- [ ] Adicionar `windowKind` ao exemplo do envelope (linha 34):
+      ```markdown
+      "primary":   { "remaining": 30, "used": 70, "resetsAt": "2026-06-17T20:09:59Z", "windowMinutes": 300, "windowKind": "fiveHour" },
+      ```
+
+- [ ] Adicionar uma nova seção depois de "## Stability" (antes de "##
+      Quickshell example"), documentando os shapes de `extra` por provider
+      (hoje só descritos implicitamente pelo `ProviderExtra` untagged em
+      Rust):
+      ```markdown
+      ## `extra` shapes by provider
+
+      `extra` is untagged (no variant key in the JSON — see Stability above:
+      unstable, no `schemaVersion` bump on change). Shape depends on `provider`:
+
+      - **`claude`** (`ClaudeQuotaExtra`): `{ weeklyModels?: Record<string, Window>,
+        extraUsage?: { enabled: boolean, remaining: number, limit: number, used: number } }`.
+        `weeklyModels` keys are model display names (e.g. `"Opus"`, `"Sonnet"`,
+        `"Cowork"`, or a `weekly_scoped` display name from `limits[]`). `extraUsage`
+        mirrors Claude's `spend`/legacy `extra_usage` block — `limit === -1` means
+        unlimited (Codex-style sentinel, see below); a real `$0` limit with `enabled:
+        true` is not expected from Claude today.
+      - **`codex`** (`CodexQuotaExtra`): `{ modelsDetailed?: Record<string, ModelWindows>,
+        extraUsage?: { enabled, remaining, limit, used } }`. `ModelWindows` is `{
+        fiveHour?: Window, sevenDay?: Window, other?: Window[] }` — `other` holds any
+        window that didn't classify as `fiveHour`/`sevenDay` (non-standard bucket
+        duration; see `windowKind: "other"` above). `extraUsage.limit === -1` means
+        unlimited credits; `0` means a real (informational) balance with no configured
+        cap.
+      - **`amp`** (`AmpQuotaExtra`): `{ meta?: Record<string, string> }` — free-form
+        key/value pairs scraped from `amp usage` output (e.g. `freeRemaining`,
+        `freeTotal`, `replenishRate`, `bonus`, `creditsBalance`, `creditsReplenish`, or
+        `raw0`..`raw3` when the CLI's text format wasn't recognized). No fixed key set —
+        treat as display-only strings, never parse them back into numbers.
+      - **`grok`** (`GrokQuotaExtra`): `{ sessionsToday?: number, turnsToday?: number,
+        contextTokensUsed?: number, contextWindowTokens?: number, recentModel?: string }`.
+        Grok's `primary` window (`windowKind: "context"`) has no `resetsAt` — context
+        usage doesn't reset on a timer, it resets when the session/thread does.
+      ```
+
+- [ ] Verificar: `git diff --check` (whitespace) na matriz de docs do
+      CLAUDE.md.
+
+- [ ] `git diff --stat docs/json-output.md` — conferir visualmente que só
+      as seções pretendidas mudaram.
+
+- [ ] Commit:
+  ```
+  git add -A
+  git commit -m "docs: windowKind e shapes de extra por provider"
+  ```
+
+---
+
+## Nota de fechamento (não é task)
+
+Ao final da Task 9, invocar `superpowers:finishing-a-development-branch`
+pra decidir merge/PR — não esperar pedido explícito (regra global do
+dono). Antes disso, rodar a verificação ampla da matriz (mudança tocou
+múltiplos contratos): `cargo test && cargo clippy --all-targets --
+-D warnings`.

--- a/docs/superpowers/plans/2026-07-21-v9-03-widget-qml.md
+++ b/docs/superpowers/plans/2026-07-21-v9-03-widget-qml.md
@@ -1,0 +1,1790 @@
+# Widget.qml v9 (usage + settings + motion) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reescrever `assets/omarchy/Widget.qml` para o popup "Painéis" aprovado (hero % por provider, grade de colunas fixas, countdown local, `extra` na tela, dedup de janelas) e o settings mode v2 (prévia da barra, sem rodapé de dicas, salvar só pelo botão), com motion M1/M2/M4 gated por `menuAnimations`.
+
+**Architecture:** Um único arquivo QML (`BarWidget` do omarchy-shell) consumindo `agent-bar --format json` (envelope `schemaVersion: 1`, agora com `windowKind` por janela — Plano 02) e `agent-bar config show --format json` (agora com `menuAnimations` — Plano 02). Toda heurística de rótulo/dedup que hoje vive espalhada em magic numbers QML morre; rótulo vem de `windowKind`, dedup é um predicado JS espelhando `is_duplicate_window` do Rust. Motion é só `Behavior`/`NumberAnimation`/`RotationAnimation` QML, sem lib externa, gated por uma property lida de `config show`.
+
+**Tech Stack:** QML (Quickshell, componentes `qs.Ui`/`qs.Commons` do omarchy-shell — não versionados neste repo, contrato inferido dos call-sites já em produção no arquivo atual). Sem Node/build step: o arquivo é copiado literalmente pelo `agent-bar setup`.
+
+**Pré-requisitos (Planos 01 e 02, já landados antes desta task):**
+- `QuotaWindow.windowKind: Option<WindowKind>` serializado como `"fiveHour"|"sevenDay"|"daily"|"context"|"other"` (camelCase, `skip_serializing_if` quando ausente).
+- `classify_window`/normalize do Codex sem o fallback incondicional primary→five_hour/secondary→seven_day — janela fora de tolerância vira `other`.
+- `config show --format json` expõe `menuAnimations: bool` (read-only; `config apply` ignora o campo se enviado).
+- `fn is_duplicate_window(a: &QuotaWindow, b: &QuotaWindow) -> bool` existe em `src/formatters/shared.rs` como referência de contrato — esta plan reimplementa o MESMO predicado em JS (QML não pode chamar Rust).
+
+## Global Constraints
+
+- **Rust/cargo only** para o resto do repo — mas este PR é 100% `.qml`; não criar nenhum arquivo Rust/Node novo.
+- **`scripts/agent-bar-open-terminal` permanece script Bash** — não tocado nesta plan.
+- **Nunca mutar desktop ao vivo como verificação intermediária** — `agent-bar setup`/`update`/`uninstall` sem `--omarchy-plugins-dir`/temp dir é proibido em qualquer task exceto a Task 6 (verificação final, explicitamente autorizada e isolada em dir temporário).
+- **QML não tem test harness neste repo.** Cada task substitui "red/green" por: (1) código completo, (2) `qmllint` (detecta erro de sintaxe real — confirmado localmente: aceita o arquivo atual com exit 0 e rejeita QML quebrado com exit 255, mesmo sem resolver os módulos `qs.*`/`Quickshell.*`), (3) checklist de leitura manual (assertions contra dado de exemplo, sem executar). A prova comportamental completa fica só na Task 6, no desktop real.
+- **Numeração de linha:** cada task cita a linha real conferida por `Read` no momento em que esta plan foi escrita. A Task 1 opera sobre o arquivo tal como está hoje (linhas exatas). Da Task 2 em diante, a Task anterior já alterou a contagem de linhas — a linha citada é uma ESTIMATIVA (marcada "aprox."); a âncora de verdade é o bloco de texto exato (`old_string`) mostrado no step. **Sempre rode `Read` no arquivo completo imediatamente antes de cada Edit desta task** — nunca edite às cegas por número de linha.
+- **Nenhuma remoção de contrato Rust** — este PR não toca `src/`. Strings de erro de provider (`p.error`) são exibidas verbatim, nunca traduzidas.
+- **Decisão de idioma da UI (registrar, não é óbvio):** os mockups aprovados (`popup-b1-styles.html` estilo 2, `settings-v2.html`) usam cópia estática em PT-BR ("Sessão 5h", "Semana", "Providers"→mantido, "Exibição", "Alertas & atualização", "← Uso", "Salvar"). Esta plan usa PT-BR em todo texto estático NOVO do QML (rótulos de janela, cabeçalhos de seção, botões, tooltips). Isso é específico deste widget — **não** contradiz o contrato de strings de erro do Rust (que continuam em inglês, verbatim, vindas de `p.error`) nem os textos de `cli.rs`/help (inglês, inalterados).
+- **Cores "reais vêm do tema do shell"** (spec, Estilo 2): o fundo do painel não usa os hex literais do mockup (`#1f2530` etc. são só do protótipo HTML) — é um tint semi-transparente de `root.fg` (`Qt.rgba(fg.r,fg.g,fg.b, alpha)`), do mesmo jeito que o track da barra e `severityColor` já fazem hoje. A calibração fina de opacidade é validada na Task 6 (prova perceptual).
+- Motion: **M1** (barras preenchem, 320ms `Easing.OutCubic`, stagger 60ms, só na abertura do popup) + **M2** (↻ gira durante fetch) + **M4** (hover 160ms em botões/iconbtns). **M3 (pulso no crítico) fica de fora** — decisão travada do spec, não reintroduzir.
+- Sem Conventional Commits em inglês; commits em PT, subject ≤ 50 chars, sem atribuição de IA.
+
+---
+
+### Task 1: Helpers JS puros + estado novo do root
+
+**Files:**
+- Modify: `assets/omarchy/Widget.qml` — bloco de properties (linhas 21-37), `refreshIntervalSec` (linha 42), bloco `chipLabel`/`windowLabel`/`fmtReset` (linhas 106-136), `applyConfigView` (linhas 163-169), `onConfigShowFinished` (linha 180), `onConfigApplyFinished` (linha 264), `setRefreshInterval` (linhas 318-321), Timer de refresh (linhas 402-408, só para inserir o novo Timer de clock ao lado).
+
+**Interfaces:**
+- Consumes: `provider.primary/secondary/models[*].windowKind` (string, um de `fiveHour|sevenDay|daily|context|other`, pode estar ausente em payload velho — tratar como `other`), `provider.primary.windowMinutes` (fallback de rótulo do `other`), `provider.extra.meta.{creditsBalance,creditsReplenish}` (Amp), `provider.extra.{sessionsToday,turnsToday,contextTokensUsed,contextWindowTokens,recentModel}` (Grok), `provider.extra.extraUsage.{enabled,used,limit}` (Claude), `config show` → `data.menuAnimations` (bool, ausente = tratar como `true`).
+- Produces (consumido pelas Tasks 2-4): `root.windowLabel(w)`, `root.otherWindowLabel(w)`, `root.windowKey(w)`, `root.isDuplicateWindow(a,b)`, `root.providerRows(p)` → `[{name,window,isSub}]`, `root.extraInfoRows(p)` → `[{label,info}]`, `root.windowDisplayValue(w,mode)`, `root.formatDisplayPct(v)`, `root.chipLabel(p)` (mesma assinatura de hoje, reimplementado por dentro), `root.previewChipLabel(p)`, `root.clampRefreshInterval(sec)`, `root.fmtAgo(iso, now)`, `root.fmtEta(w, extra, now)`, `root.fmtDuration(ms)`, `root.fmtLocalClock(d, now)`, `root.fmtTokCount(n)`, `root.contextRatioLabel(extra)`; properties `root.menuAnimationsEnabled`, `root.barsAnimating`, `root.clockTick`.
+
+- [ ] **Step 1: Ler o arquivo atual para confirmar as âncoras**
+
+```bash
+grep -n "property bool settingsBusy\|readonly property int refreshIntervalSec\|function chipLabel\|function windowLabel\|function fmtReset\|function applyConfigView\|refreshIntervalSec: Math.min\|function setRefreshInterval" assets/omarchy/Widget.qml
+```
+
+Expected: confirma que as linhas 33, 42, 106, 122, 131, 163, 180, 264, 318 (± poucas linhas, conferir com o número real impresso) ainda batem com o que este plano assume. Se divergir, use o texto abaixo como âncora (não o número).
+
+- [ ] **Step 2: Adicionar as 3 properties novas**
+
+Old string (linhas 33-34):
+```qml
+  property bool settingsBusy: false
+
+  readonly property color fg: bar ? bar.foreground : Color.foreground
+```
+
+New string:
+```qml
+  property bool settingsBusy: false
+  // Lido de `config show` (contrato do Plano 02) — gate único de motion
+  // (M1/M2/M4). Ausente no payload = true (nunca bloqueia motion à toa).
+  property bool menuAnimationsEnabled: true
+  // true só durante a janela de abertura do popup — M1 é "abertura", não
+  // "toda atualização"; sem isto as barras re-animariam a cada refresh de
+  // 60s enquanto o popup fica aberto, o que é ruído, não sinal.
+  property bool barsAnimating: false
+  // Incrementado a cada 30s só para forçar QML a reavaliar bindings de
+  // texto que dependem do relógio ("há Xm", countdown) — QML não reavalia
+  // sozinho por passagem de tempo, só por mudança de dependência. Uso:
+  // `text: (root.clockTick, root.fmtAgo(...))`.
+  property int clockTick: 0
+
+  readonly property color fg: bar ? bar.foreground : Color.foreground
+```
+
+- [ ] **Step 3: Centralizar o clamp do intervalo de refresh**
+
+Old string (linha 42):
+```qml
+  readonly property int refreshIntervalSec: Math.min(3600, Math.max(30, Number(setting("refreshIntervalSec", 60)) || 60))
+```
+
+New string:
+```qml
+  readonly property int refreshIntervalSec: root.clampRefreshInterval(Number(setting("refreshIntervalSec", 60)) || 60)
+```
+
+- [ ] **Step 4: Substituir `chipLabel`/`windowLabel`/`fmtReset` pelo bloco de helpers**
+
+Old string (linhas 106-136, bloco completo `chipLabel` até `fmtReset`):
+```qml
+  function chipLabel(p) {
+    if (!p.available) return "–"
+    var w = p.primary
+    if (!w) return ""
+    if (root.displayMode === "used") {
+      var used = Number(w.used)
+      if (isFinite(used)) return Math.round(used) + "%"
+      var rem = Number(w.remaining)
+      if (isFinite(rem)) return Math.round(100 - rem) + "%"
+      return ""
+    }
+    if (!isFinite(Number(w.remaining))) return ""
+    return Math.round(Number(w.remaining)) + "%"
+  }
+
+  // 300min ~ "5h", 10080min ~ "Weekly" (tolerâncias de classify_window).
+  function windowLabel(w, fallback) {
+    var m = Number(w && w.windowMinutes)
+    if (isFinite(m) && m > 0) {
+      if (Math.abs(m - 300) <= 90) return "5h"
+      if (Math.abs(m - 10080) <= 1440) return "Weekly"
+    }
+    return fallback
+  }
+
+  function fmtReset(iso) {
+    if (!iso) return ""
+    var d = new Date(iso)
+    if (isNaN(d.getTime())) return ""
+    return Qt.formatDateTime(d, "ddd HH:mm")
+  }
+```
+
+New string:
+```qml
+  // ── Display value (remaining vs used) ────────────────────────────────
+  // Espelha `to_window_display` (src/formatters/shared.rs): honra `used`
+  // do provider quando `mode === "used"` e o campo existe; senão deriva de
+  // `remaining`. Usado tanto pelo chip da barra quanto pelas linhas do popup
+  // (spec: "displayMode used passa a valer nas linhas, não só no chip").
+  function windowDisplayValue(w, mode) {
+    if (!w) return NaN
+    if (mode === "used") {
+      var used = Number(w.used)
+      if (isFinite(used)) return used
+      var rem = Number(w.remaining)
+      return isFinite(rem) ? 100 - rem : NaN
+    }
+    return Number(w.remaining)
+  }
+
+  function formatDisplayPct(v) {
+    return isFinite(v) ? Math.round(v) + "%" : ""
+  }
+
+  function chipLabel(p) {
+    if (!p.available) return "–"
+    return root.formatDisplayPct(root.windowDisplayValue(p.primary, root.displayMode))
+  }
+
+  // Mesmo cálculo de chipLabel, mas para a prévia ao vivo do Settings — usa
+  // o modo em RASCUNHO (draftSettings), não o modo salvo, para o usuário ver
+  // o efeito antes de clicar Salvar.
+  function previewChipLabel(p) {
+    if (!p.available) return "–"
+    var mode = root.draftSettings.displayMode === "used" ? "used" : "remaining"
+    return root.formatDisplayPct(root.windowDisplayValue(p.primary, mode))
+  }
+
+  // ── Rótulo de janela — só a partir de windowKind (Plano 02), zero magic
+  // number aqui (o antigo ±90/±1440 morreu junto com o backend). "other"
+  // ainda carrega windowMinutes cru; usamos só para um rótulo por duração
+  // real, nunca para reclassificar.
+  function windowLabel(w) {
+    var kind = w ? String(w.windowKind || "") : ""
+    if (kind === "fiveHour") return "Sessão 5h"
+    if (kind === "sevenDay") return "Semana"
+    if (kind === "daily") return "Diário"
+    if (kind === "context") return "Contexto"
+    return root.otherWindowLabel(w)
+  }
+
+  function otherWindowLabel(w) {
+    var m = Number(w && w.windowMinutes)
+    if (!isFinite(m) || m <= 0) return "Janela"
+    if (m % 1440 === 0) return "Janela de " + (m / 1440) + "d"
+    var h = Math.floor(m / 60)
+    var mm = m % 60
+    return mm === 0 ? ("Janela de " + h + "h") : ("Janela de " + h + "h" + mm + "m")
+  }
+
+  // ── Dedup display-level — espelha `is_duplicate_window`
+  // (src/formatters/shared.rs, Plano 02): mesma (windowKind, resetsAt,
+  // remaining arredondado) = mesma janela. O JSON continua emitindo
+  // primary/secondary/models sem cortes; o corte é só aqui, na tela.
+  function windowKey(w) {
+    if (!w) return null
+    var kind = String(w.windowKind || "other")
+    var resets = w.resetsAt || ""
+    var rem = isFinite(Number(w.remaining)) ? Math.round(Number(w.remaining)) : "?"
+    return kind + "|" + resets + "|" + rem
+  }
+
+  function isDuplicateWindow(a, b) {
+    if (!a || !b) return false
+    return root.windowKey(a) === root.windowKey(b)
+  }
+
+  // primary/secondary sempre entram (rotulados por windowKind); um model só
+  // entra quando NÃO duplica uma janela já incluída — mata o triplo "Weekly"
+  // do Codex (primary e secondary na mesma janela) sem esconder um model que
+  // genuinamente diverge (ex.: "Fable" com remaining diferente da agregada).
+  function providerRows(p) {
+    var rows = []
+    function addRow(name, w, isSub) {
+      if (!w) return
+      for (var i = 0; i < rows.length; i++) {
+        if (root.isDuplicateWindow(rows[i].window, w)) return
+      }
+      rows.push({ name: name, window: w, isSub: !!isSub })
+    }
+    addRow(root.windowLabel(p.primary), p.primary, false)
+    addRow(root.windowLabel(p.secondary), p.secondary, false)
+    var models = p.models || {}
+    var keys = Object.keys(models)
+    for (var j = 0; j < keys.length; j++) {
+      addRow(keys[j], models[keys[j]], true)
+    }
+    return rows
+  }
+
+  // ── `extra` na tela — shapes documentados em docs/json-output.md /
+  // src/providers/types.rs (AmpQuotaExtra.meta, GrokQuotaExtra,
+  // ClaudeQuotaExtra.extraUsage). `extra` é unstable por contrato: qualquer
+  // chave ausente vira linha omitida, nunca um valor inventado.
+  function extraInfoRows(p) {
+    var rows = []
+    var extra = p.extra
+    if (!extra) return rows
+    if (p.provider === "amp") {
+      var bal = extra.meta && extra.meta.creditsBalance
+      if (bal) {
+        var rep = (extra.meta.creditsReplenish === "auto") ? " · replenish automático" : ""
+        rows.push({ label: "Créditos", info: "<b>" + bal + "</b>" + rep })
+      }
+    } else if (p.provider === "grok") {
+      var sessions = Number(extra.sessionsToday)
+      var turns = Number(extra.turnsToday)
+      if (isFinite(sessions) || isFinite(turns)) {
+        var parts = []
+        if (isFinite(sessions)) parts.push("<b>" + sessions + " sessões</b>")
+        if (isFinite(turns)) parts.push("<b>" + turns + " turnos</b>")
+        if (extra.recentModel) parts.push(String(extra.recentModel))
+        rows.push({ label: "Hoje", info: parts.join(" · ") })
+      }
+    } else if (p.provider === "claude") {
+      var eu = extra.extraUsage
+      if (eu && eu.enabled) {
+        var used = Number(eu.used)
+        var limit = Number(eu.limit)
+        var info = (isFinite(limit) && limit > 0)
+          ? "<b>$" + used.toFixed(2) + "</b> de $" + limit.toFixed(2)
+          : "<b>$" + used.toFixed(2) + "</b> gasto"
+        rows.push({ label: "Extra usage", info: info })
+      }
+    }
+    return rows
+  }
+
+  // ── Relógio local (JS Date pega o fuso do SO automaticamente — sem
+  // equivalente a `Clock.local_offset` do Rust necessário aqui). ─────────
+  readonly property var ptWeekdays: ["dom", "seg", "ter", "qua", "qui", "sex", "sáb"]
+
+  function clampRefreshInterval(sec) {
+    var n = Math.round(Number(sec))
+    if (!isFinite(n)) n = 60
+    return Math.min(3600, Math.max(30, n))
+  }
+
+  function fmtAgo(iso, now) {
+    if (!iso) return ""
+    var d = new Date(iso)
+    if (isNaN(d.getTime())) return ""
+    var diffMs = now.getTime() - d.getTime()
+    if (diffMs < 60000) return "agora mesmo"
+    var mins = Math.floor(diffMs / 60000)
+    if (mins < 60) return "há " + mins + "m"
+    return "há " + Math.floor(mins / 60) + "h"
+  }
+
+  function fmtDuration(ms) {
+    var totalMin = Math.max(0, Math.floor(ms / 60000))
+    var days = Math.floor(totalMin / 1440)
+    var hours = Math.floor((totalMin % 1440) / 60)
+    var mins = totalMin % 60
+    if (days > 0) return days + "d " + hours + "h"
+    var mm = mins < 10 ? "0" + mins : String(mins)
+    return hours + "h " + mm + "m"
+  }
+
+  function fmtLocalClock(d, now) {
+    var hh = String(d.getHours()).padStart(2, "0")
+    var mm = String(d.getMinutes()).padStart(2, "0")
+    var sameDay = d.getFullYear() === now.getFullYear()
+      && d.getMonth() === now.getMonth()
+      && d.getDate() === now.getDate()
+    if (sameDay) return hh + ":" + mm
+    return root.ptWeekdays[d.getDay()] + " " + hh + ":" + mm
+  }
+
+  function fmtTokCount(n) {
+    var v = Number(n)
+    if (!isFinite(v)) return "?"
+    if (v >= 1000) return (v / 1000).toFixed(1) + "k"
+    return String(Math.round(v))
+  }
+
+  // Grok "context" não tem resetsAt (não é baseado em tempo) — a coluna de
+  // ETA vira a razão de tokens usados/janela (spec: "253.9k/500k tok").
+  function contextRatioLabel(extra) {
+    if (!extra) return ""
+    var used = Number(extra.contextTokensUsed)
+    var total = Number(extra.contextWindowTokens)
+    if (!isFinite(used) || !isFinite(total) || total <= 0) return ""
+    return root.fmtTokCount(used) + "/" + root.fmtTokCount(total) + " tok"
+  }
+
+  // Coluna de reset/countdown da grade. "Full" quando remaining==100 (só
+  // pra manter paridade com `format_eta` do Rust); "?" sem resetsAt; senão
+  // "{duração} · {HH:MM ou seg HH:MM}" — dia da semana só aparece quando o
+  // reset cai num dia diferente de `now` (local).
+  function fmtEta(w, extra, now) {
+    if (!w) return ""
+    var kind = String(w.windowKind || "")
+    if (kind === "context") return root.contextRatioLabel(extra)
+    var rem = Number(w.remaining)
+    if (isFinite(rem) && rem >= 100) return "Full"
+    var iso = w.resetsAt
+    if (!iso) return "?"
+    var d = new Date(iso)
+    if (isNaN(d.getTime())) return "?"
+    var diffMs = d.getTime() - now.getTime()
+    var dur = diffMs > 0 ? root.fmtDuration(diffMs) : "0h 00m"
+    return dur + " · " + root.fmtLocalClock(d, now)
+  }
+```
+
+- [ ] **Step 5: Propagar `menuAnimations` do `config show` para o root**
+
+Old string (dentro de `applyConfigView`, linhas 163-169):
+```qml
+  function applyConfigView(data) {
+    if (!data || data.schemaVersion !== 1) return false
+    enabledIds = Array.isArray(data.providerOrder) ? data.providerOrder.slice()
+              : (Array.isArray(data.providers) ? data.providers.slice() : [])
+    displayMode = data.displayMode === "used" ? "used" : "remaining"
+    return true
+  }
+```
+
+New string:
+```qml
+  function applyConfigView(data) {
+    if (!data || data.schemaVersion !== 1) return false
+    enabledIds = Array.isArray(data.providerOrder) ? data.providerOrder.slice()
+              : (Array.isArray(data.providers) ? data.providers.slice() : [])
+    displayMode = data.displayMode === "used" ? "used" : "remaining"
+    // Ausente/omitido no payload = true — nunca desliga motion à toa num
+    // payload de config show mais velho que o campo.
+    menuAnimationsEnabled = data.menuAnimations !== false
+    return true
+  }
+```
+
+- [ ] **Step 6: Trocar os 3 clamps duplicados restantes pelo helper central**
+
+Old string (dentro de `onConfigShowFinished`):
+```qml
+        refreshIntervalSec: Math.min(3600, Math.max(30, Number(setting("refreshIntervalSec", 60)) || 60))
+```
+New string:
+```qml
+        refreshIntervalSec: root.clampRefreshInterval(Number(setting("refreshIntervalSec", 60)) || 60)
+```
+
+Old string (dentro de `onConfigApplyFinished`):
+```qml
+    var interval = Math.min(3600, Math.max(30, Number(draftSettings.refreshIntervalSec) || 60))
+```
+New string:
+```qml
+    var interval = root.clampRefreshInterval(Number(draftSettings.refreshIntervalSec) || 60)
+```
+
+Old string (`setRefreshInterval` completo):
+```qml
+  function setRefreshInterval(sec) {
+    var n = Math.min(3600, Math.max(30, Number(sec) || 60))
+    draftSettings = Object.assign({}, draftSettings, { refreshIntervalSec: n })
+  }
+```
+New string:
+```qml
+  function setRefreshInterval(sec) {
+    draftSettings = Object.assign({}, draftSettings, { refreshIntervalSec: root.clampRefreshInterval(sec) })
+  }
+```
+
+- [ ] **Step 7: Timer do relógio (clockTick)**
+
+Old string (bloco do Timer de refresh existente):
+```qml
+  Timer {
+    interval: root.refreshIntervalSec * 1000
+    running: true
+    repeat: true
+    triggeredOnStart: true
+    onTriggered: root.refresh(false)
+  }
+```
+New string:
+```qml
+  Timer {
+    interval: root.refreshIntervalSec * 1000
+    running: true
+    repeat: true
+    triggeredOnStart: true
+    onTriggered: root.refresh(false)
+  }
+
+  // Só força reavaliação de texto ("há Xm", countdown) — nunca dispara
+  // fetch nem I/O.
+  Timer {
+    interval: 30000
+    running: true
+    repeat: true
+    onTriggered: root.clockTick++
+  }
+```
+
+- [ ] **Step 8: `qmllint`**
+
+Run: `qmllint assets/omarchy/Widget.qml`
+Expected: exit 0, sem output (o binário `qmllint` local não resolve `qs.*`/`Quickshell.*` mas pega erro de sintaxe real — confirmado antes de escrever este plano: injetar um `(` sobrando faz o mesmo comando sair com 255).
+
+- [ ] **Step 9: Checklist de leitura manual (sem executar)**
+
+Verifique lendo o arquivo, contra estes casos de exemplo:
+- `root.windowLabel({windowKind: "fiveHour"})` → `"Sessão 5h"`; `{windowKind: "sevenDay"}` → `"Semana"`; `{windowKind: "daily"}` → `"Diário"`; `{windowKind: "context"}` → `"Contexto"`; `{windowKind: "other", windowMinutes: 60}` → `"Janela de 1h"`; `{windowKind: "other", windowMinutes: 1440}` → `"Janela de 1d"`; `null` → `"Janela"`.
+- `root.isDuplicateWindow({windowKind:"sevenDay",resetsAt:"2026-07-27T00:00:00Z",remaining:100}, {windowKind:"sevenDay",resetsAt:"2026-07-27T00:00:00Z",remaining:100})` → `true` (o caso do Codex duplicado da spec). Com `remaining:41` no segundo → `false`.
+- `root.providerRows({primary:{windowKind:"sevenDay",resetsAt:"2026-07-27T00:00:00Z",remaining:100}, secondary:{windowKind:"sevenDay",resetsAt:"2026-07-27T00:00:00Z",remaining:100}, models:{}})` → 1 linha só (o duplo Weekly morreu).
+- `root.fmtEta({windowKind:"context"}, {contextTokensUsed:253900, contextWindowTokens:500000}, new Date())` → `"253.9k/500k tok"`.
+- `root.extraInfoRows({provider:"amp", extra:{meta:{creditsBalance:"$4.19", creditsReplenish:"auto"}}})` → `[{label:"Créditos", info:"<b>$4.19</b> · replenish automático"}]`.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add assets/omarchy/Widget.qml
+git commit -m "feat: helpers de windowKind/dedup/eta no widget"
+```
+
+---
+
+### Task 2: Titlebar (uso + settings) e componente `IconButton` (M2 + M4)
+
+**Files:**
+- Modify: `assets/omarchy/Widget.qml` — `onPopupOpenChanged` (linhas 57-61 originais), `PopupCard`/`contentWidth` (linha 496 original), bloco "Settings header" + `PanelSeparator` logo abaixo (linhas 522-567 originais, **aprox. +118 linhas após a Task 1** — reconfirme com `Read`), bloco "Usage footer" (linhas ~800-830 originais, mesmo aviso de deslocamento), fecho do `PopupCard` (linha 834 original, mesmo aviso de deslocamento), `PanelKeyCatcher`/`onTextKey` (linhas 507-510 originais).
+
+**Interfaces:**
+- Consumes: `root.menuAnimationsEnabled`, `root.clockTick`, `root.fmtAgo` (Task 1); `fetchProc.running` (existente) para o spin do ↻; `root.bar.showTooltip/hideTooltip` (existente, mesmo padrão dos chips).
+- Produces (consumido pelas Tasks 3-4): `component IconButton` reutilizável (glyph, tooltip, spinning, enabled) com hover/spin já gated por `menuAnimationsEnabled`.
+
+- [ ] **Step 1: Reconferir as âncoras após a Task 1**
+
+```bash
+grep -n "onPopupOpenChanged\|contentWidth: Style.space\|Settings header\|Usage footer\|PanelKeyCatcher\|onTextKey\|PanelSeparator\|component QuotaRow" assets/omarchy/Widget.qml
+```
+Expected: uma lista de linhas — anote os números reais antes de editar (vão estar deslocados da Task 1 em ~+118, mas o conteúdo textual abaixo é a âncora que importa).
+
+- [ ] **Step 2: Animar a abertura das barras só na transição de abrir**
+
+Old string (`onPopupOpenChanged`, conteúdo original inalterado pela Task 1):
+```qml
+  onPopupOpenChanged: {
+    if (popupOpen) Qt.callLater(function() {
+      if (root.popupOpen && keyCatcher) keyCatcher.forceActiveFocus()
+    })
+  }
+```
+New string:
+```qml
+  onPopupOpenChanged: {
+    if (popupOpen) {
+      // M1 é "abertura", não "toda atualização" — arma a janela de motion
+      // e desarma sozinho depois (Timer abaixo), pra refresh de fundo não
+      // re-disparar o preenchimento das barras.
+      root.barsAnimating = root.menuAnimationsEnabled
+      barsAnimationResetTimer.restart()
+      Qt.callLater(function() {
+        if (root.popupOpen && keyCatcher) keyCatcher.forceActiveFocus()
+      })
+    }
+  }
+
+  // 1500ms cobre o pior caso plausível (~4 providers x 3-4 linhas, stagger
+  // 60ms por linha dentro de cada painel + 320ms de duração) com folga.
+  Timer {
+    id: barsAnimationResetTimer
+    interval: 1500
+    running: false
+    repeat: false
+    onTriggered: root.barsAnimating = false
+  }
+```
+
+- [ ] **Step 3: Largura nova do popup**
+
+Old string:
+```qml
+    contentWidth: Style.space(370)
+```
+New string:
+```qml
+    contentWidth: Style.space(540)
+```
+
+- [ ] **Step 4: Remover o atalho de teclado `s`/`S` de salvar (decisão travada — salvar só pelo botão)**
+
+Old string:
+```qml
+      onCloseRequested: root.close()
+      onTextKey: function(t) {
+        if (t === "s" || t === "S")
+          root.settingsMode ? root.saveSettings() : root.openSettings()
+      }
+
+```
+New string:
+```qml
+      onCloseRequested: root.close()
+
+```
+
+- [ ] **Step 5: Titlebar de uso (nova) + titlebar de settings (restruturada) + remoção do separador que vinha logo abaixo**
+
+Old string (bloco "Settings header" completo, do comentário até o `PanelSeparator` que vem em seguida):
+```qml
+        // ── Settings header ──────────────────────────────────────────
+        RowLayout {
+          visible: root.settingsMode
+          Layout.fillWidth: true
+          spacing: 8
+
+          Button {
+            text: "← Usage"
+            foreground: root.fg
+            fontFamily: root.fontFamily
+            fontSize: 10
+            horizontalPadding: 8
+            verticalPadding: 4
+            onClicked: root.showUsage()
+          }
+
+          Text {
+            text: "Settings"
+            color: root.fg
+            font.family: root.fontFamily
+            font.pixelSize: 13
+            font.bold: true
+            Layout.fillWidth: true
+            Layout.alignment: Qt.AlignVCenter
+          }
+
+          Button {
+            text: root.settingsBusy ? "Saving…" : "Save"
+            foreground: root.fg
+            accent: Color.accent
+            fontFamily: root.fontFamily
+            fontSize: 10
+            horizontalPadding: 8
+            verticalPadding: 4
+            active: true
+            enabled: !root.settingsBusy
+            onClicked: root.saveSettings()
+          }
+        }
+
+        PanelSeparator {
+          visible: root.settingsMode
+          Layout.fillWidth: true
+          foreground: root.fg
+          strength: 0.18
+        }
+```
+New string:
+```qml
+        // ── Titlebar de uso (B1: título à esquerda, ações à direita) ───
+        RowLayout {
+          visible: !root.settingsMode
+          Layout.fillWidth: true
+          spacing: 6
+
+          Text {
+            text: "agent-bar"
+            color: root.fg
+            font.family: root.fontFamily
+            font.pixelSize: 12.5
+            font.bold: true
+          }
+          Text {
+            text: (root.clockTick, root.payload ? "· " + root.fmtAgo(root.payload.fetchedAt, new Date()) : "")
+            color: root.dim
+            font.family: root.fontFamily
+            font.pixelSize: 10.5
+          }
+
+          Item { Layout.fillWidth: true }
+
+          IconButton {
+            glyph: "↻"
+            tooltip: "Atualizar"
+            spinning: fetchProc.running
+            onClicked: root.refresh(true)
+          }
+          IconButton {
+            glyph: "⚙︎"
+            tooltip: "Settings"
+            onClicked: root.openSettings()
+          }
+          IconButton {
+            glyph: "❯"
+            tooltip: "Abrir TUI"
+            onClicked: root.openTui()
+          }
+        }
+
+        // ── Titlebar de settings ────────────────────────────────────────
+        RowLayout {
+          visible: root.settingsMode
+          Layout.fillWidth: true
+          spacing: 8
+
+          Text {
+            text: "agent-bar"
+            color: root.fg
+            font.family: root.fontFamily
+            font.pixelSize: 12.5
+            font.bold: true
+          }
+          Text {
+            text: "· Settings"
+            color: root.dim
+            font.family: root.fontFamily
+            font.pixelSize: 12.5
+          }
+
+          Item { Layout.fillWidth: true }
+
+          Button {
+            text: "← Uso"
+            foreground: root.fg
+            fontFamily: root.fontFamily
+            fontSize: 10
+            horizontalPadding: 8
+            verticalPadding: 4
+            onClicked: root.showUsage()
+          }
+          Button {
+            text: root.settingsBusy ? "Salvando…" : "Salvar"
+            foreground: root.fg
+            accent: Color.accent
+            fontFamily: root.fontFamily
+            fontSize: 10
+            horizontalPadding: 8
+            verticalPadding: 4
+            active: true
+            enabled: !root.settingsBusy
+            onClicked: root.saveSettings()
+          }
+        }
+```
+
+Nota: `"⚙︎"` é `⚙︎` (U+2699 GEAR + U+FE0E VARIATION SELECTOR-15, força apresentação text-style — igual ao mockup `&#9881;&#xFE0E;`). Digite o caractere literal `⚙︎` se o editor preservar UTF-8 corretamente; o escape `\u` é só a forma seguro-contra-mojibake caso não preserve.
+
+- [ ] **Step 6: Remover o bloco "Usage footer" original (fetched/hint/link TUI) — a titlebar do Step 5 já cobre isso**
+
+A nova titlebar de uso (Step 5) já mostra "fetched há Xm" via `root.fmtAgo` e dá acesso a refresh/settings/TUI pelos 3 `IconButton` (↻/⚙︎/❯) — o rodapé antigo (linha "fetched"/hint de clique/link "Abrir menu (TUI)") fica redundante e morto. **Reconfirme via `grep -n "Usage footer" assets/omarchy/Widget.qml` antes de editar** — as linhas deslocaram com os steps anteriores desta task.
+
+Old string (bloco completo, do comentário `// ── Usage footer` até o fecho da última `Text`/`MouseArea` — "Abrir menu (TUI)"):
+```qml
+        // ── Usage footer ─────────────────────────────────────────────
+        Text {
+          visible: !root.settingsMode
+          text: root.stale ? "stale — last fetch failed" : (root.payload ? "fetched " + root.fmtReset(root.payload.fetchedAt) : "loading…")
+          color: root.dim
+          font.family: root.fontFamily
+          font.pixelSize: 10
+        }
+
+        Text {
+          visible: !root.settingsMode
+          text: "right-click: settings · middle: refresh"
+          color: Qt.darker(root.fg, 1.6)
+          font.family: root.fontFamily
+          font.pixelSize: 10
+        }
+
+        Text {
+          visible: !root.settingsMode
+          text: "Abrir menu (TUI)"
+          color: Color.accent
+          font.family: root.fontFamily
+          font.pixelSize: 11
+          font.underline: true
+
+          MouseArea {
+            anchors.fill: parent
+            cursorShape: Qt.PointingHandCursor
+            onClicked: root.openTui()
+          }
+        }
+```
+New string: (bloco inteiro removido — nada substitui, o item anterior do `ColumnLayout` passa a encostar direto no fecho seguinte)
+
+Nota sobre `fmtReset`: a função já foi removida na Task 1 (Step 4 — o bloco de helpers novo não a redeclara). Este step remove a penúltima chamada solta a ela (a do "fetched"). Depois de aplicar este step, rode `grep -n "fmtReset" assets/omarchy/Widget.qml`: o único match esperado agora é dentro do `component QuotaRow` original, ainda intocado no fim do arquivo — ele será reescrito por completo na Task 3 (Step 3), cujo novo `QuotaRow` não chama `fmtReset`. Não há ação adicional a fazer aqui; é o gap intencional já registrado no checklist da Task 3 (Step 5), que existe porque `qmllint` não resolve símbolo em runtime.
+
+- [ ] **Step 7: Componente `IconButton` (M2 spin + M4 hover, ambos gated por `menuAnimationsEnabled`)**
+
+Old string (linha imediatamente antes do `component QuotaRow` existente — o fecho do `PopupCard`):
+```qml
+  }
+
+  component QuotaRow: RowLayout {
+```
+New string:
+```qml
+  }
+
+  // Botão quadrado só-ícone (↻ ⚙︎ ❯, e reusado nas Tasks 3-4 para ↑/↓/−/+).
+  // Unicode puro — sem dependência de Nerd Font (spec).
+  component IconButton: Item {
+    id: btn
+    property string glyph: ""
+    property string tooltip: ""
+    property bool spinning: false
+    signal clicked()
+
+    implicitWidth: 28
+    implicitHeight: 25
+    opacity: btn.enabled ? 1.0 : 0.4
+
+    Rectangle {
+      anchors.fill: parent
+      radius: 6
+      color: mouse.containsMouse && btn.enabled
+        ? Qt.rgba(root.fg.r, root.fg.g, root.fg.b, 0.14)
+        : Qt.rgba(root.fg.r, root.fg.g, root.fg.b, 0.08)
+      border.width: 1
+      border.color: mouse.containsMouse && btn.enabled
+        ? Color.accent
+        : Qt.rgba(root.fg.r, root.fg.g, root.fg.b, 0.20)
+
+      Behavior on color { enabled: root.menuAnimationsEnabled; ColorAnimation { duration: 160 } }
+      Behavior on border.color { enabled: root.menuAnimationsEnabled; ColorAnimation { duration: 160 } }
+    }
+
+    Text {
+      id: glyphText
+      anchors.centerIn: parent
+      text: btn.glyph
+      color: mouse.containsMouse && btn.enabled ? Color.accent : root.fg
+      font.family: root.fontFamily
+      font.pixelSize: 13
+
+      RotationAnimation {
+        target: glyphText
+        property: "rotation"
+        running: btn.spinning && root.menuAnimationsEnabled
+        from: 0; to: 360
+        duration: 900
+        loops: Animation.Infinite
+        onRunningChanged: if (!running) glyphText.rotation = 0
+      }
+    }
+
+    MouseArea {
+      id: mouse
+      anchors.fill: parent
+      enabled: btn.enabled
+      hoverEnabled: true
+      cursorShape: btn.enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
+      onEntered: if (root.bar && btn.tooltip) root.bar.showTooltip(btn, btn.tooltip)
+      onExited: if (root.bar) root.bar.hideTooltip(btn)
+      onClicked: btn.clicked()
+    }
+  }
+
+  component QuotaRow: RowLayout {
+```
+
+- [ ] **Step 8: `qmllint`**
+
+Run: `qmllint assets/omarchy/Widget.qml`
+Expected: exit 0.
+
+- [ ] **Step 9: Checklist de leitura manual**
+
+- Confirme que `IconButton` está declarado UMA vez só e usado 3x na titlebar de uso.
+- Confirme que a titlebar de settings tem exatamente 2 botões (`← Uso`, `Salvar`) à direita e o título à esquerda — sem duplicar o padrão antigo (botão-texto-botão espalhado).
+- Confirme que não sobrou nenhum `onTextKey` no arquivo: `grep -n "onTextKey" assets/omarchy/Widget.qml` → sem match.
+- Confirme que `contentWidth: Style.space(540)` é a única ocorrência de `contentWidth` no arquivo.
+- Confirme que não sobrou nenhum resquício do "Usage footer": `grep -n "Usage footer\|right-click: settings\|Abrir menu (TUI)" assets/omarchy/Widget.qml` → sem match.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add assets/omarchy/Widget.qml
+git commit -m "feat: titlebar com iconbtns e motion M2/M4"
+```
+
+---
+
+### Task 3: Usage view — painel por provider, grade de colunas fixas, dedup, `extra`, M1
+
+**Files:**
+- Modify: `assets/omarchy/Widget.qml` — bloco "Usage sections" `Repeater` (linhas 570-632 originais, deslocado pelas Tasks 1-2 — reconfirme com `Read`/`grep`), componente `QuotaRow` (linhas 836-878 originais, mesmo aviso).
+
+**Interfaces:**
+- Consumes: `root.providerRows`, `root.extraInfoRows`, `root.fmtEta`, `root.windowDisplayValue`, `root.formatDisplayPct`, `root.chipLabel`, `root.barsAnimating`, `root.menuAnimationsEnabled`, `root.clockTick` (Task 1); `root.severityBucket`/`root.severityColor`/`root.iconFile` (existentes, inalterados).
+- Produces: componente `InfoRow` novo (linhas de `extra`), `QuotaRow` com colunas fixas (`rótulo 82 · barra flex · % 44 · reset/eta 132`, conforme a grade do mockup `popup-b1-styles.html`).
+
+- [ ] **Step 1: Reconferir a âncora**
+
+```bash
+grep -n "Usage sections\|component QuotaRow" assets/omarchy/Widget.qml
+```
+
+- [ ] **Step 2: Substituir o Repeater de seções por Painéis**
+
+Old string (bloco "Usage sections" completo, do comentário até o fecho do `Repeater`):
+```qml
+        // ── Usage sections ───────────────────────────────────────────
+        Repeater {
+          model: root.settingsMode ? [] : root.visibleProviders()
+
+          ColumnLayout {
+            id: section
+            required property var modelData
+            Layout.fillWidth: true
+            spacing: 4
+
+            RowLayout {
+              Layout.fillWidth: true
+              spacing: 6
+
+              Image {
+                source: root.iconFile(section.modelData.provider) ? Qt.resolvedUrl(root.iconFile(section.modelData.provider)) : ""
+                visible: source !== ""
+                width: 14; height: 14
+                sourceSize.width: 14; sourceSize.height: 14
+                fillMode: Image.PreserveAspectFit
+              }
+              Text {
+                text: section.modelData.displayName
+                color: root.fg
+                font.family: root.fontFamily
+                font.pixelSize: 13
+                font.bold: true
+              }
+              Text {
+                Layout.fillWidth: true
+                text: String(section.modelData.plan || section.modelData.account || "")
+                color: root.dim
+                font.family: root.fontFamily
+                font.pixelSize: 11
+                elide: Text.ElideRight
+              }
+            }
+
+            Text {
+              visible: !section.modelData.available
+              text: String(section.modelData.error || "Unavailable")
+              color: Qt.darker(root.fg, 1.3)
+              font.family: root.fontFamily
+              font.pixelSize: 11
+              wrapMode: Text.WordWrap
+              Layout.fillWidth: true
+            }
+
+            QuotaRow { window: section.modelData.primary; name: root.windowLabel(section.modelData.primary, "Session") }
+            QuotaRow { window: section.modelData.secondary; name: root.windowLabel(section.modelData.secondary, "Weekly") }
+
+            Repeater {
+              // delegate sem required properties → `modelData` implícito do
+              // contexto é a chave (nome do modelo)
+              model: section.modelData.models ? Object.keys(section.modelData.models) : []
+              QuotaRow {
+                window: section.modelData.models[modelData]
+                name: modelData
+              }
+            }
+
+            PanelSeparator { Layout.fillWidth: true; foreground: root.fg; strength: 0.18 }
+          }
+        }
+```
+New string:
+```qml
+        // ── Usage: um painel elevado por provider (Estilo 2 — Painéis) ──
+        Repeater {
+          model: root.settingsMode ? [] : root.visibleProviders()
+
+          ColumnLayout {
+            id: panelWrap
+            required property var modelData
+            Layout.fillWidth: true
+            spacing: 0
+
+            Rectangle {
+              Layout.fillWidth: true
+              implicitHeight: panelContent.implicitHeight + 20
+              radius: 9
+              // Tint semi-transparente de root.fg — os hex do mockup são só
+              // do protótipo HTML; a cor real do tema do shell entra via fg.
+              color: Qt.rgba(root.fg.r, root.fg.g, root.fg.b, 0.05)
+              border.width: 1
+              border.color: Qt.rgba(root.fg.r, root.fg.g, root.fg.b, 0.14)
+              opacity: panelWrap.modelData.staleReason ? 0.55 : 1.0
+
+              ColumnLayout {
+                id: panelContent
+                anchors.fill: parent
+                anchors.margins: 10
+                spacing: 4
+
+                RowLayout {
+                  Layout.fillWidth: true
+                  spacing: 6
+
+                  Image {
+                    source: root.iconFile(panelWrap.modelData.provider) ? Qt.resolvedUrl(root.iconFile(panelWrap.modelData.provider)) : ""
+                    visible: source !== ""
+                    width: 15; height: 15
+                    sourceSize.width: 15; sourceSize.height: 15
+                    fillMode: Image.PreserveAspectFit
+                  }
+                  Text {
+                    text: panelWrap.modelData.displayName
+                    color: root.fg
+                    font.family: root.fontFamily
+                    font.pixelSize: 13
+                    font.bold: true
+                  }
+                  Text {
+                    Layout.fillWidth: true
+                    text: String(panelWrap.modelData.plan || panelWrap.modelData.account || "")
+                    color: root.dim
+                    font.family: root.fontFamily
+                    font.pixelSize: 11
+                    elide: Text.ElideRight
+                  }
+                  // Hero % — mesmo valor e severidade do chip da barra.
+                  Text {
+                    visible: panelWrap.modelData.available
+                    text: root.chipLabel(panelWrap.modelData)
+                    color: root.severityColor(root.severityBucket(panelWrap.modelData.primary))
+                    font.family: root.fontFamily
+                    font.pixelSize: 15
+                    font.bold: true
+                  }
+                }
+
+                Text {
+                  visible: !panelWrap.modelData.available
+                  text: String(panelWrap.modelData.error || "Unavailable")
+                  color: Qt.darker(root.fg, 1.3)
+                  font.family: root.fontFamily
+                  font.pixelSize: 11
+                  wrapMode: Text.WordWrap
+                  Layout.fillWidth: true
+                }
+
+                Text {
+                  visible: !!panelWrap.modelData.staleReason
+                  text: "stale — " + String(panelWrap.modelData.staleReason || "")
+                  color: root.dim
+                  font.family: root.fontFamily
+                  font.pixelSize: 10
+                  wrapMode: Text.WordWrap
+                  Layout.fillWidth: true
+                }
+
+                Repeater {
+                  model: panelWrap.modelData.available ? root.providerRows(panelWrap.modelData) : []
+
+                  QuotaRow {
+                    window: modelData.window
+                    extra: panelWrap.modelData.extra
+                    name: modelData.name
+                    isSub: modelData.isSub
+                    rowIndex: index
+                  }
+                }
+
+                Repeater {
+                  model: panelWrap.modelData.available ? root.extraInfoRows(panelWrap.modelData) : []
+
+                  InfoRow {
+                    label: modelData.label
+                    info: modelData.info
+                  }
+                }
+              }
+            }
+          }
+        }
+```
+
+- [ ] **Step 3: Reescrever `QuotaRow` com colunas fixas + M1, e adicionar `InfoRow`**
+
+Old string (componente `QuotaRow` completo, até o fecho do arquivo):
+```qml
+  component QuotaRow: RowLayout {
+    id: row
+    property var window: null
+    property string name: ""
+    visible: !!window
+    Layout.fillWidth: true
+    spacing: 6
+
+    Text {
+      text: row.name
+      color: Qt.darker(root.fg, 1.3)
+      font.family: root.fontFamily
+      font.pixelSize: 11
+      Layout.preferredWidth: 64
+      elide: Text.ElideRight
+    }
+
+    Item {
+      Layout.fillWidth: true
+      height: 6
+
+      Rectangle {
+        anchors.fill: parent
+        radius: 3
+        color: Qt.rgba(root.fg.r, root.fg.g, root.fg.b, 0.18)
+      }
+      Rectangle {
+        readonly property real used: row.window && isFinite(Number(row.window.remaining)) ? (100 - Math.max(0, Math.min(100, Number(row.window.remaining)))) / 100 : 0
+        width: parent.width * used
+        height: parent.height
+        radius: 3
+        color: root.severityColor(root.severityBucket(row.window))
+      }
+    }
+
+    Text {
+      readonly property string resetText: root.fmtReset(row.window ? row.window.resetsAt : "")
+      text: (row.window && isFinite(Number(row.window.remaining)) ? Math.round(Number(row.window.remaining)) + "% left" : "") + (resetText ? " · " + resetText : "")
+      color: Qt.darker(root.fg, 1.3)
+      font.family: root.fontFamily
+      font.pixelSize: 10
+    }
+  }
+}
+```
+New string:
+```qml
+  // Colunas fixas (spec): rótulo 82 · barra flex · % 44 · reset/eta 132.
+  // Toda barra idêntica, % e reset sempre na mesma coluna independente do
+  // provider — é o que mata a assimetria da versão antiga.
+  component QuotaRow: RowLayout {
+    id: row
+    property var window: null
+    property var extra: null
+    property string name: ""
+    property bool isSub: false
+    property int rowIndex: 0
+    visible: !!window
+    Layout.fillWidth: true
+    spacing: 6
+
+    Text {
+      text: row.name
+      color: row.isSub ? Qt.darker(root.fg, 1.6) : Qt.darker(root.fg, 1.3)
+      font.family: root.fontFamily
+      font.pixelSize: 11
+      leftPadding: row.isSub ? 12 : 0
+      Layout.preferredWidth: 82
+      elide: Text.ElideRight
+    }
+
+    Item {
+      Layout.fillWidth: true
+      height: 6
+
+      Rectangle {
+        anchors.fill: parent
+        radius: 3
+        color: Qt.rgba(root.fg.r, root.fg.g, root.fg.b, 0.18)
+      }
+      Rectangle {
+        readonly property real used: row.window && isFinite(Number(row.window.remaining)) ? (100 - Math.max(0, Math.min(100, Number(row.window.remaining)))) / 100 : 0
+        width: parent.width * used
+        height: parent.height
+        radius: 3
+        color: root.severityColor(root.severityBucket(row.window))
+
+        // M1: só anima durante a janela de abertura do popup (barsAnimating);
+        // fora dela o valor só salta, sem transição — refresh de fundo não
+        // deve re-disparar o preenchimento.
+        Behavior on width {
+          enabled: root.barsAnimating && root.menuAnimationsEnabled
+          SequentialAnimation {
+            PauseAnimation { duration: Math.min(row.rowIndex, 8) * 60 }
+            NumberAnimation { duration: 320; easing.type: Easing.OutCubic }
+          }
+        }
+      }
+    }
+
+    Text {
+      text: root.formatDisplayPct(root.windowDisplayValue(row.window, root.displayMode))
+      color: Qt.darker(root.fg, 1.3)
+      font.family: root.fontFamily
+      font.pixelSize: 11
+      Layout.preferredWidth: 44
+      horizontalAlignment: Text.AlignRight
+    }
+
+    Text {
+      text: (root.clockTick, root.fmtEta(row.window, row.extra, new Date()))
+      color: root.dim
+      font.family: root.fontFamily
+      font.pixelSize: 10.5
+      Layout.preferredWidth: 132
+      horizontalAlignment: Text.AlignRight
+      elide: Text.ElideRight
+    }
+  }
+
+  // Linha de `extra` (Créditos/Hoje/Extra usage) — mesma coluna de rótulo
+  // (82) do QuotaRow; o valor ocupa o resto da largura (aproxima o
+  // `grid-column: 2/5` do mockup sem depender da grade CSS que QML não tem).
+  component InfoRow: RowLayout {
+    id: infoRow
+    property string label: ""
+    property string info: ""
+    visible: info !== ""
+    Layout.fillWidth: true
+    spacing: 6
+
+    Text {
+      text: infoRow.label
+      color: Qt.darker(root.fg, 1.3)
+      font.family: root.fontFamily
+      font.pixelSize: 11
+      Layout.preferredWidth: 82
+      elide: Text.ElideRight
+    }
+    Text {
+      text: infoRow.info
+      textFormat: Text.RichText
+      color: root.dim
+      font.family: root.fontFamily
+      font.pixelSize: 11
+      Layout.fillWidth: true
+      wrapMode: Text.WordWrap
+    }
+  }
+}
+```
+
+- [ ] **Step 4: `qmllint`**
+
+Run: `qmllint assets/omarchy/Widget.qml`
+Expected: exit 0.
+
+- [ ] **Step 5: Checklist de leitura manual**
+
+- Confirme que `QuotaRow` não referencia mais `fmtReset` em lugar nenhum: `grep -n "fmtReset" assets/omarchy/Widget.qml` → sem match (a função foi removida na Task 1; se algo ainda a chamar, o `qmllint` acusaria símbolo indefinido só em runtime, não em lint — por isso o grep é necessário aqui).
+- Confirme visualmente as 4 larguras (`82`, `Layout.fillWidth`, `44`, `132`) presentes nesta ordem dentro do `QuotaRow`.
+- Para um payload sintético Codex com `primary` e `secondary` ambos `{windowKind:"sevenDay", resetsAt:"2026-07-27T00:00:00Z", remaining:100}`: confirme que `providerRows` (Task 1) produz 1 linha só, e portanto o painel Codex mostra 1 `QuotaRow`, não 2.
+
+- [ ] **Step 6: Validação manual em desktop temporário (não é a prova final — só sintaxe/visual isolado)**
+
+```bash
+mktemp -d
+agent-bar setup --omarchy-plugins-dir /tmp/agent-bar-widget-check --waybar-dir /tmp/agent-bar-waybar-check
+cat /tmp/agent-bar-widget-check/agent-bar.usage/Widget.qml | tail -40
+rm -rf /tmp/agent-bar-widget-check /tmp/agent-bar-waybar-check
+```
+Expected: o arquivo copiado termina no fecho do `InfoRow`/`}` final, sem erro do `setup` no stdout.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add assets/omarchy/Widget.qml
+git commit -m "feat: painel por provider com grade e dedup"
+```
+
+---
+
+### Task 4: Settings view v2 — Providers/Exibição+prévia/Alertas, sem rodapé
+
+**Files:**
+- Modify: `assets/omarchy/Widget.qml` — bloco "Settings body" completo (linhas 635-798 originais, deslocado pelas Tasks 1-3 — reconfirme com `Read`/`grep`).
+
+**Interfaces:**
+- Consumes: `root.settingsProviderRows()`, `root.setProviderEnabled`, `root.moveProvider`, `root.setDisplayMode`, `root.setRefreshInterval`, `root.setNotifyEnabled`, `root.draftSettings`, `root.previewChipLabel`, `root.visibleProviders()` (existentes/Task 1); `component IconButton` (Task 2).
+- Produces: nenhuma interface nova exposta a outras tasks — é a folha do settings mode.
+
+- [ ] **Step 1: Reconferir a âncora**
+
+```bash
+grep -n "Settings body\|Providers\"\|Display\"\|Alerts\"\|Refresh (seconds)\|s saves" assets/omarchy/Widget.qml
+```
+
+- [ ] **Step 2: Substituir o bloco "Settings body" inteiro**
+
+Old string (bloco completo, do comentário `// ── Settings body` até o fecho do último `Text` "s saves · esc closes"):
+```qml
+        // ── Settings body ────────────────────────────────────────────
+        ColumnLayout {
+          visible: root.settingsMode
+          Layout.fillWidth: true
+          spacing: 12
+
+          PanelSectionHeader {
+            Layout.fillWidth: true
+            text: "Providers"
+            foreground: root.fg
+            fontFamily: root.fontFamily
+            fontSize: 11
+          }
+
+          Repeater {
+            model: root.settingsMode ? root.settingsProviderRows() : []
+
+            ColumnLayout {
+              id: provRow
+              required property var modelData
+              Layout.fillWidth: true
+              spacing: 4
+
+              Toggle {
+                Layout.fillWidth: true
+                label: root.providerLabel(provRow.modelData.id)
+                description: checked ? "Shown in bar chips" : "Hidden from the bar"
+                checked: provRow.modelData.on
+                foreground: root.fg
+                accent: Color.accent
+                fontFamily: root.fontFamily
+                onClicked: root.setProviderEnabled(provRow.modelData.id, !checked)
+              }
+
+              RowLayout {
+                visible: provRow.modelData.on
+                Layout.fillWidth: true
+                spacing: 6
+
+                Item { Layout.fillWidth: true }
+
+                Button {
+                  text: "↑"
+                  enabled: provRow.modelData.index > 0
+                  foreground: root.fg
+                  fontFamily: root.fontFamily
+                  fontSize: 11
+                  horizontalPadding: 8
+                  verticalPadding: 3
+                  onClicked: root.moveProvider(provRow.modelData.id, -1)
+                }
+                Button {
+                  text: "↓"
+                  enabled: provRow.modelData.index >= 0 && provRow.modelData.index < provRow.modelData.count - 1
+                  foreground: root.fg
+                  fontFamily: root.fontFamily
+                  fontSize: 11
+                  horizontalPadding: 8
+                  verticalPadding: 3
+                  onClicked: root.moveProvider(provRow.modelData.id, 1)
+                }
+              }
+            }
+          }
+
+          PanelSectionHeader {
+            Layout.fillWidth: true
+            text: "Display"
+            foreground: root.fg
+            fontFamily: root.fontFamily
+            fontSize: 11
+          }
+
+          RowLayout {
+            Layout.fillWidth: true
+            spacing: 6
+
+            Button {
+              text: "Remaining"
+              Layout.fillWidth: true
+              foreground: root.fg
+              accent: Color.accent
+              fontFamily: root.fontFamily
+              fontSize: 11
+              horizontalPadding: 8
+              verticalPadding: 5
+              active: (root.draftSettings.displayMode || "remaining") !== "used"
+              onClicked: root.setDisplayMode("remaining")
+            }
+            Button {
+              text: "Used"
+              Layout.fillWidth: true
+              foreground: root.fg
+              accent: Color.accent
+              fontFamily: root.fontFamily
+              fontSize: 11
+              horizontalPadding: 8
+              verticalPadding: 5
+              active: root.draftSettings.displayMode === "used"
+              onClicked: root.setDisplayMode("used")
+            }
+          }
+
+          PanelSectionHeader {
+            Layout.fillWidth: true
+            text: "Alerts"
+            foreground: root.fg
+            fontFamily: root.fontFamily
+            fontSize: 11
+          }
+
+          Toggle {
+            Layout.fillWidth: true
+            label: "Desktop notifications"
+            description: checked ? "notify-send on quota thresholds" : "Notifications off"
+            checked: !!root.draftSettings.notifyEnabled
+            foreground: root.fg
+            accent: Color.accent
+            fontFamily: root.fontFamily
+            onClicked: root.setNotifyEnabled(!checked)
+          }
+
+          PanelSectionHeader {
+            Layout.fillWidth: true
+            text: "Refresh"
+            foreground: root.fg
+            fontFamily: root.fontFamily
+            fontSize: 11
+          }
+
+          NumberField {
+            id: refreshIntervalField
+            Layout.fillWidth: true
+            label: "Interval (seconds)"
+            value: Number(root.draftSettings.refreshIntervalSec || 60)
+            from: 30
+            to: 3600
+            stepSize: 30
+            fieldWidth: parent.width
+            foreground: root.fg
+            accent: Color.accent
+            fontFamily: root.fontFamily
+            onModified: function(value) { root.setRefreshInterval(value) }
+          }
+
+          Text {
+            visible: root.settingsStatusText !== ""
+            Layout.fillWidth: true
+            text: root.settingsStatusText
+            color: root.dim
+            font.family: root.fontFamily
+            font.pixelSize: 10
+            horizontalAlignment: Text.AlignHCenter
+            wrapMode: Text.WordWrap
+          }
+
+          Text {
+            Layout.fillWidth: true
+            text: "s saves · esc closes"
+            color: root.dim
+            font.family: root.fontFamily
+            font.pixelSize: 10
+            horizontalAlignment: Text.AlignHCenter
+          }
+        }
+```
+New string:
+```qml
+        // ── Settings body v2: 3 painéis (Providers / Exibição / Alertas &
+        // atualização), prévia ao vivo da barra, sem rodapé de dicas ──────
+        Rectangle {
+          visible: root.settingsMode
+          Layout.fillWidth: true
+          implicitHeight: providersCol.implicitHeight + 20
+          radius: 9
+          color: Qt.rgba(root.fg.r, root.fg.g, root.fg.b, 0.05)
+          border.width: 1
+          border.color: Qt.rgba(root.fg.r, root.fg.g, root.fg.b, 0.14)
+
+          ColumnLayout {
+            id: providersCol
+            anchors.fill: parent
+            anchors.margins: 10
+            spacing: 8
+
+            PanelSectionHeader {
+              Layout.fillWidth: true
+              text: "Providers"
+              foreground: root.fg
+              fontFamily: root.fontFamily
+              fontSize: 11
+            }
+
+            Repeater {
+              model: root.settingsMode ? root.settingsProviderRows() : []
+
+              ColumnLayout {
+                id: provRow
+                required property var modelData
+                Layout.fillWidth: true
+                spacing: 4
+
+                RowLayout {
+                  Layout.fillWidth: true
+                  spacing: 8
+
+                  Image {
+                    source: root.iconFile(provRow.modelData.id) ? Qt.resolvedUrl(root.iconFile(provRow.modelData.id)) : ""
+                    visible: source !== ""
+                    width: 15; height: 15
+                    sourceSize.width: 15; sourceSize.height: 15
+                    fillMode: Image.PreserveAspectFit
+                  }
+                  Toggle {
+                    Layout.fillWidth: true
+                    label: root.providerLabel(provRow.modelData.id)
+                    description: checked ? "Visível na barra" : "Oculto da barra"
+                    checked: provRow.modelData.on
+                    foreground: root.fg
+                    accent: Color.accent
+                    fontFamily: root.fontFamily
+                    onClicked: root.setProviderEnabled(provRow.modelData.id, !checked)
+                  }
+                }
+
+                RowLayout {
+                  visible: provRow.modelData.on
+                  Layout.fillWidth: true
+                  spacing: 6
+
+                  Item { Layout.fillWidth: true }
+
+                  IconButton {
+                    glyph: "↑"
+                    tooltip: "Mover para cima"
+                    enabled: provRow.modelData.index > 0
+                    onClicked: root.moveProvider(provRow.modelData.id, -1)
+                  }
+                  IconButton {
+                    glyph: "↓"
+                    tooltip: "Mover para baixo"
+                    enabled: provRow.modelData.index >= 0 && provRow.modelData.index < provRow.modelData.count - 1
+                    onClicked: root.moveProvider(provRow.modelData.id, 1)
+                  }
+                }
+              }
+            }
+          }
+        }
+
+        Rectangle {
+          visible: root.settingsMode
+          Layout.fillWidth: true
+          implicitHeight: exibicaoCol.implicitHeight + 20
+          radius: 9
+          color: Qt.rgba(root.fg.r, root.fg.g, root.fg.b, 0.05)
+          border.width: 1
+          border.color: Qt.rgba(root.fg.r, root.fg.g, root.fg.b, 0.14)
+
+          ColumnLayout {
+            id: exibicaoCol
+            anchors.fill: parent
+            anchors.margins: 10
+            spacing: 8
+
+            PanelSectionHeader {
+              Layout.fillWidth: true
+              text: "Exibição"
+              foreground: root.fg
+              fontFamily: root.fontFamily
+              fontSize: 11
+            }
+
+            RowLayout {
+              Layout.fillWidth: true
+              spacing: 6
+
+              Text {
+                text: "Número do chip"
+                color: root.fg
+                font.family: root.fontFamily
+                font.pixelSize: 12
+                Layout.fillWidth: true
+              }
+              Button {
+                text: "Restante"
+                foreground: root.fg
+                accent: Color.accent
+                fontFamily: root.fontFamily
+                fontSize: 11
+                horizontalPadding: 10
+                verticalPadding: 5
+                active: (root.draftSettings.displayMode || "remaining") !== "used"
+                onClicked: root.setDisplayMode("remaining")
+              }
+              Button {
+                text: "Usado"
+                foreground: root.fg
+                accent: Color.accent
+                fontFamily: root.fontFamily
+                fontSize: 11
+                horizontalPadding: 10
+                verticalPadding: 5
+                active: root.draftSettings.displayMode === "used"
+                onClicked: root.setDisplayMode("used")
+              }
+            }
+
+            // Prévia ao vivo: usa o modo em RASCUNHO contra os dados reais
+            // já carregados — o usuário vê o efeito antes de clicar Salvar.
+            RowLayout {
+              Layout.fillWidth: true
+              spacing: 14
+
+              Text {
+                text: "Prévia"
+                color: Qt.darker(root.fg, 1.6)
+                font.family: root.fontFamily
+                font.pixelSize: 10
+              }
+
+              Repeater {
+                model: root.settingsMode ? root.visibleProviders() : []
+
+                RowLayout {
+                  required property var modelData
+                  spacing: 5
+
+                  Image {
+                    source: root.iconFile(modelData.provider) ? Qt.resolvedUrl(root.iconFile(modelData.provider)) : ""
+                    visible: source !== ""
+                    width: 13; height: 13
+                    sourceSize.width: 13; sourceSize.height: 13
+                    fillMode: Image.PreserveAspectFit
+                  }
+                  Text {
+                    text: root.previewChipLabel(modelData)
+                    color: root.severityColor(root.severityBucket(modelData.primary))
+                    font.family: root.fontFamily
+                    font.pixelSize: 11.5
+                  }
+                }
+              }
+            }
+          }
+        }
+
+        Rectangle {
+          visible: root.settingsMode
+          Layout.fillWidth: true
+          implicitHeight: alertasCol.implicitHeight + 20
+          radius: 9
+          color: Qt.rgba(root.fg.r, root.fg.g, root.fg.b, 0.05)
+          border.width: 1
+          border.color: Qt.rgba(root.fg.r, root.fg.g, root.fg.b, 0.14)
+
+          ColumnLayout {
+            id: alertasCol
+            anchors.fill: parent
+            anchors.margins: 10
+            spacing: 8
+
+            PanelSectionHeader {
+              Layout.fillWidth: true
+              text: "Alertas & atualização"
+              foreground: root.fg
+              fontFamily: root.fontFamily
+              fontSize: 11
+            }
+
+            Toggle {
+              Layout.fillWidth: true
+              label: "Notificações desktop"
+              description: checked ? "notify-send nos limites de quota" : "Notificações desligadas"
+              checked: !!root.draftSettings.notifyEnabled
+              foreground: root.fg
+              accent: Color.accent
+              fontFamily: root.fontFamily
+              onClicked: root.setNotifyEnabled(!checked)
+            }
+
+            RowLayout {
+              Layout.fillWidth: true
+              spacing: 8
+
+              ColumnLayout {
+                Layout.fillWidth: true
+                spacing: 0
+                Text {
+                  text: "Intervalo"
+                  color: root.fg
+                  font.family: root.fontFamily
+                  font.pixelSize: 12
+                }
+                Text {
+                  text: "segundos entre atualizações"
+                  color: Qt.darker(root.fg, 1.6)
+                  font.family: root.fontFamily
+                  font.pixelSize: 10.5
+                }
+              }
+
+              IconButton {
+                glyph: "−"
+                tooltip: "Diminuir 30s"
+                enabled: root.draftSettings.refreshIntervalSec > 30
+                onClicked: root.setRefreshInterval(root.draftSettings.refreshIntervalSec - 30)
+              }
+              Text {
+                text: root.draftSettings.refreshIntervalSec + "s"
+                color: root.fg
+                font.family: root.fontFamily
+                font.pixelSize: 11.5
+                horizontalAlignment: Text.AlignHCenter
+                Layout.preferredWidth: 46
+              }
+              IconButton {
+                glyph: "+"
+                tooltip: "Aumentar 30s"
+                enabled: root.draftSettings.refreshIntervalSec < 3600
+                onClicked: root.setRefreshInterval(root.draftSettings.refreshIntervalSec + 30)
+              }
+            }
+          }
+        }
+
+        Text {
+          visible: root.settingsMode && root.settingsStatusText !== ""
+          Layout.fillWidth: true
+          text: root.settingsStatusText
+          color: root.dim
+          font.family: root.fontFamily
+          font.pixelSize: 10
+          horizontalAlignment: Text.AlignHCenter
+          wrapMode: Text.WordWrap
+        }
+```
+
+Nota: o rodapé "s saves · esc closes" foi removido de propósito (decisão travada: sem rodapé de dicas — esc/clique-fora continuam fechando, é comportamento padrão de popup, não precisa de aviso).
+
+- [ ] **Step 3: Traduzir a string de guarda de `setProviderEnabled`**
+
+É string de UI em QML, não contrato Rust (o contrato de string verbatim é só de `p.error`, vindo do provider) — traduzir é seguro.
+
+Old string (dentro de `setProviderEnabled`, ~linhas 281-295 do Widget.qml atual — reconfirme com `grep -n "Keep at least one provider"` antes de editar, pois há uma segunda ocorrência idêntica dentro de `saveSettings`, fora do escopo deste step):
+```qml
+    if (!on) {
+      if (p.length <= 1 && idx >= 0) {
+        settingsStatusText = "Keep at least one provider"
+        return
+      }
+      if (idx >= 0) p.splice(idx, 1)
+    }
+```
+New string:
+```qml
+    if (!on) {
+      if (p.length <= 1 && idx >= 0) {
+        settingsStatusText = "Mantenha ao menos 1 provider ativo"
+        return
+      }
+      if (idx >= 0) p.splice(idx, 1)
+    }
+```
+
+- [ ] **Step 4: `qmllint`**
+
+Run: `qmllint assets/omarchy/Widget.qml`
+Expected: exit 0.
+
+- [ ] **Step 5: Checklist de leitura manual**
+
+- `grep -n "NumberField\|s saves" assets/omarchy/Widget.qml` → sem match (o `NumberField` foi trocado pelo controle `−`/valor/`+`; o rodapé de dicas sumiu).
+- Confirme que `IconButton` do `−`/`+` chama `root.setRefreshInterval` (que já clampa via `clampRefreshInterval`, Task 1) — nenhum clamp duplicado aqui — e que `enabled` desabilita nos limites (30/3600), mesmo padrão dos botões ↑/↓ do reorder.
+- Confirme visualmente 3 `Rectangle` (painéis) dentro do bloco settings: Providers, Exibição, Alertas & atualização — nesta ordem, igual ao mockup `settings-v2.html`.
+- Confirme que a prévia (`previewChipLabel`) alterna de "72%"→"28%" (Claude, exemplo) ao clicar Usado/Restante SEM precisar salvar (é `draftSettings`, não `root.displayMode`).
+- Confirme que `settingsStatusText = "Mantenha ao menos 1 provider ativo"` aparece só na ocorrência de `setProviderEnabled` (a de `saveSettings` permanece em inglês, fora do escopo desta correção).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add assets/omarchy/Widget.qml
+git commit -m "feat: settings v2 com previa e sem rodape"
+```
+
+---
+
+### Task 5: Integração final — consistência do arquivo inteiro
+
+**Files:**
+- Modify: `assets/omarchy/Widget.qml` — arquivo inteiro (revisão final, sem bloco específico previsto — a Task 5 é uma passada de consistência, não uma feature nova).
+
+**Interfaces:**
+- Consumes: nada novo — só verifica que as Tasks 1-4 se encaixam.
+- Produces: `assets/omarchy/Widget.qml` pronto para a Task 6 (verificação ao vivo).
+
+- [ ] **Step 1: Ler o arquivo inteiro de uma vez**
+
+```bash
+wc -l assets/omarchy/Widget.qml
+```
+Expected: o arquivo cresceu em relação aos 879 originais (helpers da Task 1 + painéis/settings maiores) — número exato não importa, é só um sinal de que nada foi truncado.
+
+Leia o arquivo com a ferramenta `Read` (sem `head`/`tail`/`sed` — RTK não conta essas como leitura real) e confirme, em ordem:
+1. Properties (`menuAnimationsEnabled`, `barsAnimating`, `clockTick`) declaradas uma vez, antes de qualquer uso.
+2. Helpers da Task 1 todos presentes e sem duplicata (`grep -c "function chipLabel" assets/omarchy/Widget.qml` → `1`).
+3. `component IconButton` declarado uma vez, antes do fecho do `BarWidget`.
+4. `component QuotaRow` e `component InfoRow` declarados uma vez cada, no fim do arquivo.
+5. Nenhuma referência solta a identificadores removidos: `grep -n "fmtReset\|NumberField\|onTextKey\|Style.space(370)" assets/omarchy/Widget.qml` → sem match algum.
+
+- [ ] **Step 2: `qmllint` final**
+
+Run: `qmllint assets/omarchy/Widget.qml`
+Expected: exit 0, sem output.
+
+- [ ] **Step 3: Setup em diretório temporário (não é o desktop real do usuário)**
+
+```bash
+tmpplugins=$(mktemp -d)
+tmpwaybar=$(mktemp -d)
+agent-bar setup --omarchy-plugins-dir "$tmpplugins" --waybar-dir "$tmpwaybar"
+diff assets/omarchy/Widget.qml "$tmpplugins/agent-bar.usage/Widget.qml"
+echo "exit=$?"
+rm -rf "$tmpplugins" "$tmpwaybar"
+```
+Expected: `diff` sem output e `exit=0` — o `setup` copia o arquivo byte a byte (confirma que não há passo de build/transformação escondido).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add assets/omarchy/Widget.qml
+git commit -m "chore: passada final de consistencia do widget"
+```
+
+(Se o Step 1 não achar nada para corrigir, este commit fica vazio de propósito — pode ser pulado; registre no report da task qual foi o caso.)
+
+---
+
+### Task 6: Verificação final ao vivo no desktop (as 3 provas)
+
+Esta task não produz código novo — é a prova que as Tasks 1-5 realmente funcionam num Quickshell real, coisa que `qmllint` e os checklists de leitura não conseguem garantir (não resolvem `qs.Commons`/`qs.Ui`/`Quickshell.Io`). **Requer aprovação explícita do usuário antes de tocar o desktop real** (`CLAUDE.md` §1: não mutar desktop ao vivo sem aprovação) — se não houver, pare aqui e reporte o que falta para essa aprovação, em vez de prosseguir.
+
+- [ ] **Step 1: Instalar o plugin no diretório real do Omarchy (só com aprovação)**
+
+```bash
+agent-bar setup
+```
+Expected: hint de sucesso no stdout, sem erro. Isto SUBSTITUI o `Widget.qml` real do usuário — é o único ponto desta plan onde isso é esperado e autorizado.
+
+- [ ] **Step 2: Prova funcional**
+
+No shell real (reload do Quickshell ou `omarchy-shell reload`, conforme o ambiente do usuário):
+- Clique esquerdo no chip → popup de uso abre; ↻ gira durante o fetch e para ao terminar; hover nos 3 iconbtns muda cor/borda.
+- Clique em ⚙︎ (ou botão direito no chip, ADR-0001 mantido) → vai para settings; `← Uso` volta; `Salvar` desabilita e mostra "Salvando…" durante o apply, depois volta.
+- Em Providers: desligar todos menos 1 bloqueia o último (mensagem "Keep at least one provider" ou equivalente); ↑/↓ reordenam e ficam desabilitados nas pontas.
+- Em Exibição: alternar Restante/Usado muda a prévia na hora, sem salvar.
+- `esc` fecha o popup; clique fora fecha o popup; **nenhuma tecla salva** (confirmar que `s`/`S` não fazem nada).
+- ❯ abre o terminal com `agent-bar menu`.
+- Reiniciar o Quickshell/omarchy-shell por completo (não só fechar/reabrir o popup) e confirmar que as barras animam no primeiro open — gotcha: `Behavior on width` não anima a atribuição inicial durante a construção do item; se não animar, inicializar a `Rectangle` de fill com `width: 0` e reatribuir o `width` real via `Component.onCompleted`/`Qt.callLater`.
+
+- [ ] **Step 3: Prova perceptual (screenshot vs mockup aprovado)**
+
+Capture um screenshot do popup real e compare lado a lado com `.superpowers/brainstorm/157316-1784664831/content/popup-b1-styles.html` (Estilo 2) e `settings-v2.html`. Documente no report: largura bate (~540px), painéis por provider visíveis, grade de colunas alinhada entre providers diferentes, cores dos painéis (tint aproximado, não os hex exatos do protótipo HTML — ajuste a opacidade em `Qt.rgba(fg..., X)` nesta task se ficar ilegível ou contrastante demais contra o tema real).
+
+- [ ] **Step 4: Prova de dados (payload real, não mockado)**
+
+```bash
+agent-bar --format json --refresh > /tmp/agent-bar-live.json
+python3 -m json.tool /tmp/agent-bar-live.json | head -80
+```
+Confira contra o que a tela mostra: nenhuma janela duplicada (o caso Codex primary==secondary vira 1 linha só, se reproduzível na conta real), `windowKind` presente em pelo menos uma janela, `staleReason` (se algum provider estiver stale) aparece como linha de texto no painel, `extra` (Amp/Grok/Claude, o que a conta do usuário tiver) aparece como linha "Créditos"/"Hoje"/"Extra usage".
+
+- [ ] **Step 5: Reportar**
+
+No report desta task, seguir a regra de "Pronto" do `CLAUDE.md`: as 3 provas (funcional + perceptual + dados) juntas = "concluído"; qualquer uma faltando = "implementado, não verificado", nunca "concluído".

--- a/docs/superpowers/plans/2026-07-21-v9-04-plataforma-waybar-isolado.md
+++ b/docs/superpowers/plans/2026-07-21-v9-04-plataforma-waybar-isolado.md
@@ -1,0 +1,1882 @@
+# Plataforma Waybar Isolado Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Isolar o Waybar como tier legado gated por plataforma — `src/platform.rs::detect()` único, zero escrita em `~/.config/waybar/` sem Waybar no PATH, `update` reinstala o plugin omarchy quando detectado, e `doctor`/`uninstall` ficam Omarchy-aware.
+
+**Architecture:** Um módulo novo (`src/platform.rs`) expõe `Platform { omarchy, waybar }` via `detect()`; três pontos de escrita (`update` ManagedGit, `update` Standalone, Save da TUI) passam a consultar essa função em vez de hardcodar. `waybar_contract.rs`/`waybar_integration.rs` mudam de diretório (não de identidade de módulo) para `src/waybar/`, preservando os filtros de teste do CLAUDE.md via `#[path]`. `doctor`/`uninstall` ganham checagens/gates Omarchy que só avisam, nunca falham o comando.
+
+**Tech Stack:** Rust/cargo, tokio (`#[tokio::test]`), serde_json, insta (snapshots ratatui), tempfile, serial_test (mocks de env global).
+
+## Global Constraints
+
+- Rust/cargo only; nunca `unwrap()`/`expect()` em produção — propagar com `?`/`anyhow::bail!`.
+- Constantes de identidade de `src/app_identity.rs`, nunca strings hardcoded.
+- Provider error strings são contrato — este plano não as toca.
+- XML-escape só em `render_pango.rs`; nunca round-trip de `config.jsonc` do Waybar via `serde_json`.
+- `#[tokio::test]` async / `#[test]` sync; sem rede/CLIs vivas/Waybar real; `XDG_CONFIG_HOME`/`HOME` setados ANTES de qualquer chamada que os leia; restaurar env em todo teste que o mute (padrão save/restore já usado em `setup.rs`/`omarchy_integration.rs`).
+- Gotcha RTK: `cargo test` com APENAS UM filtro posicional por invocação.
+- Nunca mutar `~/.config/waybar`/`~/.config/agent-bar` reais em teste — sempre temp dirs; funções que leem `$HOME`/`XDG_CONFIG_HOME` direto exigem `#[serial_test::serial]` + save/restore do env.
+- Commits: Conventional Commits em PT, subject ≤50 chars. Zero atribuição de AI em qualquer texto.
+- Prosa em pt-BR; identificadores/código em inglês.
+
+## Nota sobre o contrato de interfaces (desvio deliberado)
+
+O contrato fixado pelo orquestrador descreve o passo de módulo (Task 6) como
+`pub use waybar::contract as waybar_contract;`. Isso quebraria
+`cargo test waybar_contract`: o filtro de `cargo test` casa **substring** na
+string totalmente qualificada do teste (`waybar::contract::tests::foo`), e
+`"waybar_contract"` (com `_`) não é substring de `"waybar::contract"` (com
+`::`). A Task 6 abaixo implementa o mesmo objetivo (arquivos físicos em
+`src/waybar/{contract,integration}.rs`, `crate::waybar_contract`/
+`crate::waybar_integration` continuam resolvendo) só que via `#[path]` +
+`pub use waybar::waybar_contract;` (nome do módulo preservado), que é a única
+forma de manter os dois filtros do CLAUDE.md passando sem editar os testes.
+Ver `openQuestions` do resumo desta tarefa. Desvio APROVADO pelo
+orquestrador: a alternativa literal quebraria os filtros
+`cargo test waybar_contract`/`cargo test waybar_integration` do CLAUDE.md.
+
+### Task 1: `src/platform.rs` — detecção única de plataforma
+
+**Files:**
+- Create: `src/platform.rs`
+- Modify: `src/lib.rs:14-16` (insere `pub mod platform;` entre `omarchy_integration` e `providers`)
+
+**Interfaces:**
+- Produces: `pub struct Platform { pub omarchy: bool, pub waybar: bool }`, `pub fn detect() -> Platform`, `pub fn detect_with(shell_dir: &Path, path_var: Option<&OsStr>) -> Platform` (núcleo testável de `detect()`).
+- Consumes: `omarchy_integration::omarchy_shell_present` (pub, `src/omarchy_integration.rs:37-39`), `setup::waybar_present` (pub, `src/setup.rs:31-36`).
+
+- [ ] Escrever o teste que falha — criar `src/platform.rs` só com o esqueleto de teste:
+  ```rust
+  //! Detecção única de plataforma (Omarchy-shell / Waybar) usada por todos os
+  //! gates de escrita em `~/.config/waybar/` (spec 2026-07-21, seção E): setup,
+  //! `update` (ManagedGit + Standalone) e o Save da TUI Config leem `detect()`
+  //! em vez de reimplementar a checagem cada um a seu jeito.
+
+  #[cfg(test)]
+  mod tests {
+      #[test]
+      fn detect_with_omarchy_only() {
+          panic!("not implemented");
+      }
+  }
+  ```
+- [ ] Rodar `cargo test platform` e ver falhar: `panicked at 'not implemented'`.
+- [ ] Implementação mínima — substituir o conteúdo inteiro de `src/platform.rs` por:
+  ```rust
+  //! Detecção única de plataforma (Omarchy-shell / Waybar) usada por todos os
+  //! gates de escrita em `~/.config/waybar/` (spec 2026-07-21, seção E): setup,
+  //! `update` (ManagedGit + Standalone) e o Save da TUI Config leem `detect()`
+  //! em vez de reimplementar a checagem cada um a seu jeito.
+
+  use std::ffi::OsStr;
+  use std::path::Path;
+
+  use crate::app_identity::OMARCHY_SHELL_DIR;
+
+  #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+  pub struct Platform {
+      /// omarchy-shell presente (`OMARCHY_SHELL_DIR` existe + CLI `omarchy` no PATH).
+      pub omarchy: bool,
+      /// Binário `waybar` no PATH.
+      pub waybar: bool,
+  }
+
+  /// Núcleo testável: mesma composição de `detect()`, com `shell_dir`/`path_var`
+  /// injetáveis — mesmo padrão de mock de
+  /// `omarchy_integration::omarchy_shell_present`/`setup::waybar_present`.
+  pub fn detect_with(shell_dir: &Path, path_var: Option<&OsStr>) -> Platform {
+      Platform {
+          omarchy: crate::omarchy_integration::omarchy_shell_present(shell_dir, path_var),
+          waybar: crate::setup::waybar_present(path_var),
+      }
+  }
+
+  /// Detecção real do processo — único ponto de decisão consumido pelos gates
+  /// de plataforma (setup, update, TUI Save).
+  pub fn detect() -> Platform {
+      detect_with(Path::new(OMARCHY_SHELL_DIR), std::env::var_os("PATH").as_deref())
+  }
+
+  #[cfg(test)]
+  mod tests {
+      use super::*;
+      use tempfile::tempdir;
+
+      #[test]
+      fn detect_with_omarchy_only() {
+          let shell = tempdir().unwrap();
+          let bin = tempdir().unwrap();
+          std::fs::write(bin.path().join("omarchy"), "#!/bin/sh\n").unwrap();
+          let path_var = std::ffi::OsString::from(bin.path());
+
+          let platform = detect_with(shell.path(), Some(&path_var));
+          assert!(platform.omarchy);
+          assert!(!platform.waybar);
+      }
+
+      #[test]
+      fn detect_with_waybar_only() {
+          let shell = tempdir().unwrap(); // dir existe, mas sem CLI `omarchy` no PATH
+          let bin = tempdir().unwrap();
+          std::fs::write(bin.path().join("waybar"), "#!/bin/sh\n").unwrap();
+          let path_var = std::ffi::OsString::from(bin.path());
+
+          let platform = detect_with(shell.path(), Some(&path_var));
+          assert!(!platform.omarchy);
+          assert!(platform.waybar);
+      }
+
+      #[test]
+      fn detect_with_neither_present() {
+          let shell = tempdir().unwrap();
+          let bin = tempdir().unwrap();
+          let path_var = std::ffi::OsString::from(bin.path());
+
+          let platform = detect_with(&shell.path().join("nope"), Some(&path_var));
+          assert!(!platform.omarchy);
+          assert!(!platform.waybar);
+      }
+
+      #[test]
+      fn detect_with_both_present() {
+          let shell = tempdir().unwrap();
+          let bin = tempdir().unwrap();
+          std::fs::write(bin.path().join("omarchy"), "#!/bin/sh\n").unwrap();
+          std::fs::write(bin.path().join("waybar"), "#!/bin/sh\n").unwrap();
+          let path_var = std::ffi::OsString::from(bin.path());
+
+          let platform = detect_with(shell.path(), Some(&path_var));
+          assert!(platform.omarchy);
+          assert!(platform.waybar);
+      }
+  }
+  ```
+- [ ] Registrar o módulo — em `src/lib.rs`, linhas 14-16 hoje são:
+  ```rust
+  pub mod notify;
+  pub mod omarchy_integration;
+  pub mod providers;
+  ```
+  Substituir por:
+  ```rust
+  pub mod notify;
+  pub mod omarchy_integration;
+  pub mod platform;
+  pub mod providers;
+  ```
+- [ ] Rodar `cargo test platform` e ver passar: 4 testes `ok`.
+- [ ] Commit: `git add src/platform.rs src/lib.rs && git commit -m "feat: platform::detect() unico p/ gates Waybar/Omarchy"`
+
+### Task 2: gate no `update` ManagedGit (main.rs)
+
+**Files:**
+- Modify: `src/main.rs:25-28` (import), `src/main.rs:50-60` (helper puros, insere função nova), `src/main.rs:396` (declara `let platform = platform::detect();`), `src/main.rs:479-498` (closure `run_setup` do braço `ManagedGit`), `src/main.rs:800-823` (test helpers, sem mudança de conteúdo — só referência), `src/main.rs` test module (novo teste)
+
+**Interfaces:**
+- Consumes: `platform::Platform`/`platform::detect()` (Task 1), `setup::SetupConfig`/`setup::OmarchySetupOptions` (`src/setup.rs:67-96`), `omarchy_integration::default_omarchy_plugins_dir` (`src/omarchy_integration.rs:26-32`).
+- Produces: `fn managed_update_setup_config(platform, repo_root, home) -> setup::SetupConfig` (testável, usada só por `Command::Update`).
+
+- [ ] Escrever o teste que falha — no `mod tests` de `src/main.rs` (após `settings_without_provider`, linha 840), adicionar:
+  ```rust
+  #[test]
+  fn managed_update_setup_config_gates_on_platform() {
+      let home = PathBuf::from("/tmp/agent-bar-test-managed-update-home");
+      let repo = PathBuf::from("/tmp/agent-bar-test-managed-update-repo");
+
+      let omarchy_only = managed_update_setup_config(
+          platform::Platform {
+              omarchy: true,
+              waybar: false,
+          },
+          repo.clone(),
+          home.clone(),
+      );
+      assert!(omarchy_only.omarchy.is_some());
+      assert!(omarchy_only.skip_waybar);
+
+      let waybar_only = managed_update_setup_config(
+          platform::Platform {
+              omarchy: false,
+              waybar: true,
+          },
+          repo,
+          home,
+      );
+      assert!(waybar_only.omarchy.is_none());
+      assert!(!waybar_only.skip_waybar);
+  }
+  ```
+- [ ] Rodar `cargo test update` e ver falhar: `error[E0425]: cannot find function 'managed_update_setup_config'`.
+- [ ] Implementação mínima — em `src/main.rs:25-28`, hoje:
+  ```rust
+  use agent_bar::{
+      doctor, install, omarchy_integration, runtime, setup, term_prompt, uninstall, update,
+      waybar_contract, waybar_integration,
+  };
+  ```
+  Substituir por:
+  ```rust
+  use agent_bar::{
+      doctor, install, omarchy_integration, platform, runtime, setup, term_prompt, uninstall,
+      update, waybar_contract, waybar_integration,
+  };
+  ```
+- [ ] Adicionar a função pura logo após `is_hidden_module` (linha 54, antes de `print_waybar`):
+  ```rust
+  /// `SetupConfig` do update ManagedGit (spec E/F): reinstala o plugin omarchy
+  /// quando `platform.omarchy` e só toca `~/.config/waybar/` quando
+  /// `platform.waybar` — mesma composição de `platform::detect()` usada pelo
+  /// Standalone e pelo Save da TUI.
+  fn managed_update_setup_config(
+      platform: platform::Platform,
+      repo_root: PathBuf,
+      home: PathBuf,
+  ) -> setup::SetupConfig {
+      setup::SetupConfig {
+          asset_paths: Some(waybar_contract::get_default_waybar_asset_paths()),
+          integration_paths: Some(waybar_integration::get_default_waybar_integration_paths()),
+          repo_root: Some(repo_root),
+          home: home.clone(),
+          skip_reload: false,
+          system_install: runtime::is_system_install(),
+          omarchy: platform.omarchy.then(|| setup::OmarchySetupOptions {
+              plugins_dir: omarchy_integration::default_omarchy_plugins_dir(&home),
+              run_cli: true,
+          }),
+          skip_waybar: !platform.waybar,
+      }
+  }
+  ```
+- [ ] Declarar `platform` no topo do braço `Command::Update` — em `src/main.rs:396`, hoje:
+  ```rust
+              let install_root = home.join(format!(".{APP_NAME}"));
+  ```
+  Substituir por:
+  ```rust
+              let install_root = home.join(format!(".{APP_NAME}"));
+              let platform = platform::detect();
+  ```
+  (declarada aqui para que a Task 2 compile sozinha; a Task 3 reusa esta
+  mesma variável — já declarada — no closure `omarchy_setup_hint`.)
+- [ ] Trocar o corpo do braço `ManagedGit`. Hoje (`src/main.rs:479-498`):
+  ```rust
+                      let settings_for_setup = settings.clone();
+                      let repo_root_for_setup = root.clone();
+                      let home_for_setup = home.clone();
+                      let run_setup = || {
+                          let asset_paths = waybar_contract::get_default_waybar_asset_paths();
+                          let ipaths = waybar_integration::get_default_waybar_integration_paths();
+                          let cfg = setup::SetupConfig {
+                              asset_paths: Some(asset_paths),
+                              integration_paths: Some(ipaths),
+                              repo_root: Some(repo_root_for_setup.clone()),
+                              home: home_for_setup.clone(),
+                              skip_reload: false,
+                              system_install: runtime::is_system_install(),
+                              omarchy: None,
+                              skip_waybar: false,
+                          };
+                          if let Err(e) = setup::run_setup(&settings_for_setup, cfg, false, false) {
+                              log::error!("Setup falhou após update: {e}");
+                          }
+                      };
+  ```
+  Substituir por:
+  ```rust
+                      let settings_for_setup = settings.clone();
+                      let repo_root_for_setup = root.clone();
+                      let home_for_setup = home.clone();
+                      let run_setup = || {
+                          let cfg = managed_update_setup_config(
+                              platform,
+                              repo_root_for_setup.clone(),
+                              home_for_setup.clone(),
+                          );
+                          if let Err(e) = setup::run_setup(&settings_for_setup, cfg, false, false) {
+                              log::error!("Setup falhou após update: {e}");
+                          }
+                      };
+  ```
+  (a variável `platform` já foi declarada acima, nesta mesma task — a Task 3 reusa-a sem redeclarar.)
+- [ ] Rodar `cargo test update` e ver passar: novo teste + suíte de `update.rs` `ok`.
+- [ ] Commit: `git add -A && git commit -m "feat: update ManagedGit usa platform::detect()"`
+
+### Task 3: gate no `update` Standalone (update.rs + main.rs)
+
+**Files:**
+- Modify: `src/update.rs:597-614` (`StandaloneUpdateOptions`), `src/update.rs:684-704` (`run_standalone_update` + `refresh_waybar_assets_from_extract`), `src/update.rs:1338-1350` e `:1374-1386` (2 testes existentes), `src/update.rs` (novos testes ao fim do módulo)
+- Modify: `src/main.rs:400-409` (`omarchy_setup_hint` passa a receber `platform`, já declarada na Task 2), `src/main.rs:517-519` (hint pós-ManagedGit), `src/main.rs:553-599` (opts + mensagem do Standalone)
+
+**Interfaces:**
+- Consumes: `platform::Platform` (Task 1), `omarchy_integration::install_omarchy_plugin` (`src/omarchy_integration.rs:70-90`).
+- Produces: `StandaloneUpdateOptions.skip_waybar: bool`, `StandaloneUpdateOptions.omarchy_plugins_dir: Option<&Path>`, `fn apply_standalone_platform_gates(...)` (testável sem download/checksum reais).
+
+- [ ] Escrever o teste que falha — ao fim do `mod tests` de `src/update.rs` (após `refresh_waybar_assets_from_extract_copies_icons_and_helper`, linha 1318), adicionar:
+  ```rust
+  #[test]
+  fn apply_standalone_platform_gates_skips_waybar_when_absent() {
+      let tmp = tempdir().unwrap();
+      let extracted = tmp.path().join("extracted");
+      fs::create_dir_all(extracted.join("icons")).unwrap();
+      fs::write(extracted.join("icons").join("grok-icon.svg"), b"<svg/>").unwrap();
+
+      let waybar_dir = tmp.path().join("waybar-agent-bar");
+      let scripts_dir = tmp.path().join("waybar-scripts");
+
+      apply_standalone_platform_gates(&extracted, &waybar_dir, &scripts_dir, true, None).unwrap();
+
+      assert!(
+          !waybar_dir.exists(),
+          "waybar_dir não deve ser tocado quando skip_waybar=true"
+      );
+  }
+
+  #[test]
+  fn apply_standalone_platform_gates_reinstalls_omarchy_plugin_when_detected() {
+      let tmp = tempdir().unwrap();
+      let extracted = tmp.path().join("extracted-empty");
+      fs::create_dir_all(&extracted).unwrap();
+      let waybar_dir = tmp.path().join("waybar-agent-bar");
+      let scripts_dir = tmp.path().join("waybar-scripts");
+      let plugins_dir = tmp.path().join("omarchy-plugins");
+
+      apply_standalone_platform_gates(
+          &extracted,
+          &waybar_dir,
+          &scripts_dir,
+          true,
+          Some(plugins_dir.as_path()),
+      )
+      .unwrap();
+
+      let plugin_dir = plugins_dir.join(crate::app_identity::OMARCHY_PLUGIN_ID);
+      assert!(plugin_dir.join("manifest.json").exists());
+      assert!(plugin_dir.join("Widget.qml").exists());
+  }
+  ```
+- [ ] Rodar `cargo test update` e ver falhar: `error[E0425]: cannot find function 'apply_standalone_platform_gates'`.
+- [ ] Implementação mínima — em `src/update.rs:597-614`, hoje:
+  ```rust
+  pub struct StandaloneUpdateOptions<'a> {
+      pub current_version: &'a str,
+      pub exe_path: &'a Path,
+      pub data_dir: &'a Path,
+      /// Destino dos icons Waybar (`~/.config/waybar/agent-bar` em produção).
+      /// Só re-copia icons/helper — **não** patcha config nem dá reload.
+      pub waybar_dir: &'a Path,
+      /// Destino do terminal helper (`~/.config/waybar/scripts` em produção).
+      pub scripts_dir: &'a Path,
+      pub run_command: &'a dyn Fn(&str, &[String], &Path) -> CommandResult,
+      pub http: &'a reqwest::Client,
+      pub releases_api_url: String,
+      pub download_base_url: String,
+      /// Seams de teste: substituem os checks reais de `sha256sum`/`tar` no PATH
+      /// (produção usa `crate::install::has_cmd`).
+      pub has_sha256sum: &'a dyn Fn() -> bool,
+      pub has_tar: &'a dyn Fn() -> bool,
+  }
+  ```
+  Substituir por:
+  ```rust
+  pub struct StandaloneUpdateOptions<'a> {
+      pub current_version: &'a str,
+      pub exe_path: &'a Path,
+      pub data_dir: &'a Path,
+      /// Destino dos icons Waybar (`~/.config/waybar/agent-bar` em produção).
+      /// Só re-copia icons/helper — **não** patcha config nem dá reload.
+      pub waybar_dir: &'a Path,
+      /// Destino do terminal helper (`~/.config/waybar/scripts` em produção).
+      pub scripts_dir: &'a Path,
+      /// `true` quando Waybar está ausente do PATH — pula
+      /// `refresh_waybar_assets_from_extract` (spec E: zero escrita em
+      /// `~/.config/waybar/` sem Waybar).
+      pub skip_waybar: bool,
+      /// `Some(dir)` quando omarchy-shell foi detectado — reinstala o plugin
+      /// com o binário novo, matando o drift binário↔QML (spec F).
+      pub omarchy_plugins_dir: Option<&'a Path>,
+      pub run_command: &'a dyn Fn(&str, &[String], &Path) -> CommandResult,
+      pub http: &'a reqwest::Client,
+      pub releases_api_url: String,
+      pub download_base_url: String,
+      /// Seams de teste: substituem os checks reais de `sha256sum`/`tar` no PATH
+      /// (produção usa `crate::install::has_cmd`).
+      pub has_sha256sum: &'a dyn Fn() -> bool,
+      pub has_tar: &'a dyn Fn() -> bool,
+  }
+  ```
+- [ ] Em `src/update.rs:684-704`, hoje:
+  ```rust
+      replace_binary_atomic(&new_binary, opts.exe_path)?;
+      install_standalone_assets(tmp_path, opts.data_dir)?;
+      // Icons/helper que a Waybar lê em ~/.config — sem re-patchar modules/CSS.
+      refresh_waybar_assets_from_extract(tmp_path, opts.waybar_dir, opts.scripts_dir)?;
+
+      Ok(StandaloneUpdateStatus::Updated {
+          old_version: opts.current_version.to_string(),
+          new_version: ver_bare,
+      })
+  }
+
+  /// Re-copia `icons/` e o terminal helper do tarball extraído para os paths da
+  /// Waybar. Não mexe em `config.jsonc` / `style.css` / reload — isso é `setup`.
+  fn refresh_waybar_assets_from_extract(
+      extracted_dir: &Path,
+      waybar_dir: &Path,
+      scripts_dir: &Path,
+  ) -> anyhow::Result<()> {
+      crate::waybar_contract::install_waybar_assets(waybar_dir, scripts_dir, Some(extracted_dir))
+          .map(|_| ())
+  }
+  ```
+  Substituir por:
+  ```rust
+      replace_binary_atomic(&new_binary, opts.exe_path)?;
+      install_standalone_assets(tmp_path, opts.data_dir)?;
+      apply_standalone_platform_gates(
+          tmp_path,
+          opts.waybar_dir,
+          opts.scripts_dir,
+          opts.skip_waybar,
+          opts.omarchy_plugins_dir,
+      )?;
+
+      Ok(StandaloneUpdateStatus::Updated {
+          old_version: opts.current_version.to_string(),
+          new_version: ver_bare,
+      })
+  }
+
+  /// Re-copia `icons/` e o terminal helper do tarball extraído para os paths da
+  /// Waybar. Não mexe em `config.jsonc` / `style.css` / reload — isso é `setup`.
+  fn refresh_waybar_assets_from_extract(
+      extracted_dir: &Path,
+      waybar_dir: &Path,
+      scripts_dir: &Path,
+  ) -> anyhow::Result<()> {
+      crate::waybar_contract::install_waybar_assets(waybar_dir, scripts_dir, Some(extracted_dir))
+          .map(|_| ())
+  }
+
+  /// Pós-extração, gated por plataforma (spec E/F): icons/helper da Waybar só
+  /// são re-copiados com Waybar no PATH; o plugin omarchy só é reinstalado
+  /// quando detectado. Extraída p/ ser testável sem rodar download/checksum
+  /// reais (mesmo motivo de `refresh_waybar_assets_from_extract` já ser uma
+  /// função à parte).
+  fn apply_standalone_platform_gates(
+      extracted_dir: &Path,
+      waybar_dir: &Path,
+      scripts_dir: &Path,
+      skip_waybar: bool,
+      omarchy_plugins_dir: Option<&Path>,
+  ) -> anyhow::Result<()> {
+      if !skip_waybar {
+          refresh_waybar_assets_from_extract(extracted_dir, waybar_dir, scripts_dir)?;
+      }
+      if let Some(plugins_dir) = omarchy_plugins_dir {
+          crate::omarchy_integration::install_omarchy_plugin(plugins_dir)?;
+      }
+      Ok(())
+  }
+  ```
+- [ ] Atualizar os 2 testes existentes que constroem `StandaloneUpdateOptions` para compilar. Em `run_standalone_update_reports_up_to_date` (linha ~1338) e `run_standalone_update_fails_clearly_without_sha256sum` (linha ~1374), em ambos, logo após a linha `scripts_dir: &tmp.path().join("scripts"),`, adicionar:
+  ```rust
+              skip_waybar: false,
+              omarchy_plugins_dir: None,
+  ```
+- [ ] Rodar `cargo test update` e ver passar: suíte inteira de `update.rs` `ok` (incl. os 2 testes novos).
+- [ ] Implementação em `main.rs` — nota: `let platform = platform::detect();` já foi
+  declarada na Task 2 (logo após `let install_root = ...`, `src/main.rs:396`);
+  esta task só troca o uso, no closure `omarchy_setup_hint`. Em
+  `src/main.rs:400-409`, hoje:
+  ```rust
+              // O binário novo traz QML novo — o drop-in do omarchy-shell só
+              // atualiza via setup (o update não toca nele; ver setup::SetupConfig.omarchy).
+              let omarchy_setup_hint = |home: &Path| {
+                  let plugin_dir = omarchy_integration::default_omarchy_plugins_dir(home)
+                      .join(app_identity::OMARCHY_PLUGIN_ID);
+                  if plugin_dir.exists() {
+                      term_prompt::note(&format!(
+                          "Plugin omarchy-shell detectado. Rode `{} setup` para atualizá-lo.",
+                          app_identity::APP_NAME
+                      ));
+                  }
+              };
+  ```
+  Substituir por:
+  ```rust
+              // O binário novo traz QML novo — update (T2/T3) já reinstala o
+              // drop-in quando `platform.omarchy`. O hint vira fallback só
+              // para quando a detecção falhar nesta rodada mas o diretório
+              // ainda existir (spec F).
+              let omarchy_setup_hint = |home: &Path, platform: platform::Platform| {
+                  if platform.omarchy {
+                      return;
+                  }
+                  let plugin_dir = omarchy_integration::default_omarchy_plugins_dir(home)
+                      .join(app_identity::OMARCHY_PLUGIN_ID);
+                  if plugin_dir.exists() {
+                      term_prompt::note(&format!(
+                          "Plugin omarchy-shell detectado mas fora de sync (detecção falhou nesta rodada). Rode `{} setup` para atualizá-lo.",
+                          app_identity::APP_NAME
+                      ));
+                  }
+              };
+  ```
+- [ ] Em `src/main.rs:517-519` (dentro de `ManagedUpdateStatus::Updated`), hoje:
+  ```rust
+                                  update::ManagedUpdateStatus::Updated => {
+                                      term_prompt::status("OK", "Update aplicado");
+                                      omarchy_setup_hint(&home);
+                                  }
+  ```
+  Substituir por:
+  ```rust
+                                  update::ManagedUpdateStatus::Updated => {
+                                      term_prompt::status("OK", "Update aplicado");
+                                      omarchy_setup_hint(&home, platform);
+                                  }
+  ```
+- [ ] Em `src/main.rs:553-573` (montagem de `opts` do Standalone), hoje:
+  ```rust
+                      let data_dir = update::default_data_dir(&home);
+                      let waybar_paths = waybar_contract::get_default_waybar_asset_paths();
+                      let opts = update::StandaloneUpdateOptions {
+                          current_version: app_identity::VERSION,
+                          exe_path: &current_exe,
+                          data_dir: &data_dir,
+                          waybar_dir: &waybar_paths.waybar_dir,
+                          scripts_dir: &waybar_paths.scripts_dir,
+                          run_command: &run_real_command,
+                          http: &http,
+                          releases_api_url: format!(
+                              "https://api.github.com/repos/{}/releases/latest",
+                              update::GITHUB_REPO
+                          ),
+                          download_base_url: format!(
+                              "https://github.com/{}/releases/download",
+                              update::GITHUB_REPO
+                          ),
+                          has_sha256sum: &|| install::has_cmd("sha256sum"),
+                          has_tar: &|| install::has_cmd("tar"),
+                      };
+  ```
+  Substituir por:
+  ```rust
+                      let data_dir = update::default_data_dir(&home);
+                      let waybar_paths = waybar_contract::get_default_waybar_asset_paths();
+                      let omarchy_plugin_dir_for_update = platform
+                          .omarchy
+                          .then(|| omarchy_integration::default_omarchy_plugins_dir(&home));
+                      let opts = update::StandaloneUpdateOptions {
+                          current_version: app_identity::VERSION,
+                          exe_path: &current_exe,
+                          data_dir: &data_dir,
+                          waybar_dir: &waybar_paths.waybar_dir,
+                          scripts_dir: &waybar_paths.scripts_dir,
+                          skip_waybar: !platform.waybar,
+                          omarchy_plugins_dir: omarchy_plugin_dir_for_update.as_deref(),
+                          run_command: &run_real_command,
+                          http: &http,
+                          releases_api_url: format!(
+                              "https://api.github.com/repos/{}/releases/latest",
+                              update::GITHUB_REPO
+                          ),
+                          download_base_url: format!(
+                              "https://github.com/{}/releases/download",
+                              update::GITHUB_REPO
+                          ),
+                          has_sha256sum: &|| install::has_cmd("sha256sum"),
+                          has_tar: &|| install::has_cmd("tar"),
+                      };
+  ```
+- [ ] Em `src/main.rs` (arm `Ok(update::StandaloneUpdateStatus::Updated { ... })`, logo abaixo do bloco anterior), hoje:
+  ```rust
+                          Ok(update::StandaloneUpdateStatus::Updated {
+                              old_version,
+                              new_version,
+                          }) => {
+                              term_prompt::status(
+                                  "OK",
+                                  &format!(
+                                      "agent-bar atualizado: v{old_version} -> v{new_version}. Icons e helper da Waybar atualizados."
+                                  ),
+                              );
+                              omarchy_setup_hint(&home);
+                              std::process::exit(0);
+                          }
+  ```
+  Substituir por:
+  ```rust
+                          Ok(update::StandaloneUpdateStatus::Updated {
+                              old_version,
+                              new_version,
+                          }) => {
+                              let mut msg = format!(
+                                  "agent-bar atualizado: v{old_version} -> v{new_version}."
+                              );
+                              if platform.waybar {
+                                  msg.push_str(" Icons e helper da Waybar atualizados.");
+                              }
+                              if platform.omarchy {
+                                  msg.push_str(" Plugin omarchy-shell reinstalado.");
+                              }
+                              term_prompt::status("OK", &msg);
+                              omarchy_setup_hint(&home, platform);
+                              std::process::exit(0);
+                          }
+  ```
+- [ ] Rodar `cargo test update` e ver passar (recompila `main.rs` + `update.rs`).
+- [ ] Rodar `cargo clippy --all-targets -- -D warnings` e ver passar (variável `platform` movida pro closure `run_setup` da Task 2 é `Copy`, sem warning de captura).
+- [ ] Commit: `git add -A && git commit -m "feat: update Standalone reinstala plugin omarchy"`
+
+### Task 4: `AppState.platform` + gate no Save da TUI
+
+**Files:**
+- Modify: `src/tui/state.rs:274-275` (campo novo em `AppState`), `src/tui/state.rs:308-309` (default em `AppState::new()`)
+- Modify: `src/tui/event_loop.rs:88-114` (`handle_save_config`), `src/tui/event_loop.rs:227` (boot override)
+- Create (dentro do arquivo existente): `#[cfg(test)] mod tests` ao fim de `src/tui/event_loop.rs`
+
+**Interfaces:**
+- Consumes: `platform::Platform`/`platform::detect()` (Task 1).
+- Produces: `AppState.platform: Platform` (consumido pela Task 5).
+
+- [ ] Escrever o teste que falha — criar `#[cfg(test)] mod tests` ao final de `src/tui/event_loop.rs` (arquivo tem 363 linhas hoje; adicionar depois da última `}`):
+  ```rust
+  #[cfg(test)]
+  mod tests {
+      use super::*;
+      use crate::config::Paths;
+      use crate::providers::OwnedCtx;
+      use crate::settings::load as load_settings;
+      use crate::tui::state::ConfigState;
+      use std::path::PathBuf;
+      use tempfile::tempdir;
+
+      fn make_octx(cfg_dir: &std::path::Path) -> OwnedCtx {
+          let paths = Paths {
+              cache_dir: cfg_dir.join("cache"),
+              config_dir: cfg_dir.join("config"),
+              claude_credentials: PathBuf::new(),
+              codex_auth: PathBuf::new(),
+              codex_sessions: PathBuf::new(),
+              amp_settings: PathBuf::new(),
+              amp_threads: PathBuf::new(),
+              grok_home: PathBuf::new(),
+              grok_auth: PathBuf::new(),
+          };
+          let settings = load_settings(&paths);
+          OwnedCtx {
+              client: reqwest::Client::new(),
+              paths,
+              settings,
+              local_offset: time::UtcOffset::UTC,
+              claude_usage_url: String::new(),
+              version: "0.0.0-test",
+              home: cfg_dir.to_path_buf(),
+          }
+      }
+
+      #[test]
+      #[serial_test::serial]
+      fn handle_save_config_skips_waybar_write_when_omarchy_only() {
+          let fake_home = tempdir().unwrap();
+          let prev_home = std::env::var_os("HOME");
+          std::env::set_var("HOME", fake_home.path());
+
+          let octx = make_octx(fake_home.path());
+          let mut state = AppState::new();
+          state.platform = crate::platform::Platform {
+              omarchy: true,
+              waybar: false,
+          };
+          state.config_state = Some(ConfigState::new(&octx.settings));
+
+          handle_save_config(&mut state, &octx);
+
+          assert!(
+              octx.paths.config_dir.join("settings.json").exists(),
+              "settings.json deveria ter sido salvo mesmo com waybar ausente"
+          );
+          assert!(
+              !fake_home.path().join(".config").join("waybar").exists(),
+              "zero escrita em ~/.config/waybar quando Omarchy-only"
+          );
+
+          match prev_home {
+              Some(v) => std::env::set_var("HOME", v),
+              None => std::env::remove_var("HOME"),
+          }
+      }
+  }
+  ```
+- [ ] Rodar `cargo test tui::event_loop` e ver falhar: `error[E0609]: no field 'platform' on type 'AppState'`.
+- [ ] Implementação mínima — em `src/tui/state.rs:266-267`, hoje:
+  ```rust
+      pub animations: bool,
+  }
+  ```
+  Substituir por:
+  ```rust
+      pub animations: bool,
+      /// Plataforma detectada (Omarchy-shell / Waybar) — gate de campos
+      /// só-Waybar na aba Config (`ConfigField::visible`) e do Save
+      /// (`handle_save_config`). Default `{omarchy:false, waybar:true}`
+      /// (mantém testes/snapshots determinísticos com o comportamento
+      /// legado); `event_loop::run` sobrescreve com `platform::detect()`
+      /// no boot real — mesmo padrão de `local_offset`/`glyph_mode`.
+      pub platform: crate::platform::Platform,
+  }
+  ```
+- [ ] Em `src/tui/state.rs:308-309` (dentro de `AppState::new()`), hoje:
+  ```rust
+              animations: true,
+          }
+      }
+  }
+  ```
+  Substituir por:
+  ```rust
+              animations: true,
+              platform: crate::platform::Platform {
+                  omarchy: false,
+                  waybar: true,
+              },
+          }
+      }
+  }
+  ```
+- [ ] Rodar `cargo test tui::event_loop` e ver falhar de novo (agora por comportamento): o teste espera que `~/.config/waybar` não seja criado, mas `handle_save_config` ainda chama `apply_waybar_integration` incondicional.
+- [ ] Gatear o Save — em `src/tui/event_loop.rs:88-114`, hoje:
+  ```rust
+  fn handle_save_config(state: &mut AppState, octx: &OwnedCtx) {
+      let edited = match state.config_state.as_ref() {
+          Some(cs) => cs.edit_settings.clone(),
+          None => return,
+      };
+
+      let result: Result<(), String> = (|| {
+          settings::save(&octx.paths, &edited).map_err(|e| format!("save falhou: {e}"))?;
+
+          let paths = get_default_waybar_integration_paths();
+          let opts = ApplyOptions {
+              paths,
+              icons_dir: None,
+              app_bin: None,
+              terminal_script: None,
+          };
+          waybar_integration::apply_waybar_integration(&edited, opts)
+              .map_err(|e| format!("apply falhou: {e}"))?;
+
+          setup::reload_waybar();
+          Ok(())
+      })();
+
+      for a in update(state, Action::ConfigSaveResult(result)) {
+          update(state, a);
+      }
+  }
+  ```
+  Substituir por:
+  ```rust
+  fn handle_save_config(state: &mut AppState, octx: &OwnedCtx) {
+      let edited = match state.config_state.as_ref() {
+          Some(cs) => cs.edit_settings.clone(),
+          None => return,
+      };
+      let platform = state.platform;
+
+      let result: Result<(), String> = (|| {
+          settings::save(&octx.paths, &edited).map_err(|e| format!("save falhou: {e}"))?;
+
+          if platform.waybar {
+              let paths = get_default_waybar_integration_paths();
+              let opts = ApplyOptions {
+                  paths,
+                  icons_dir: None,
+                  app_bin: None,
+                  terminal_script: None,
+              };
+              waybar_integration::apply_waybar_integration(&edited, opts)
+                  .map_err(|e| format!("apply falhou: {e}"))?;
+
+              setup::reload_waybar();
+          }
+          Ok(())
+      })();
+
+      for a in update(state, Action::ConfigSaveResult(result)) {
+          update(state, a);
+      }
+  }
+  ```
+- [ ] Boot real — em `src/tui/event_loop.rs:227` (logo após `state.animations = octx.settings.menu.animations;`), hoje a linha seguinte é:
+  ```rust
+      // Zonas clicaveis do frame atual (Task 9): populado por `render`, limpo
+  ```
+  Inserir ANTES dela:
+  ```rust
+      // Plataforma real (spec E): sem isto, `state.platform` fica no default
+      // {omarchy:false, waybar:true} do AppState::new() mesmo em Omarchy-only —
+      // o Save recriaria ~/.config/waybar do zero e a aba Config mostraria
+      // campos só-Waybar que não fazem sentido ali.
+      state.platform = crate::platform::detect();
+      // Zonas clicaveis do frame atual (Task 9): populado por `render`, limpo
+  ```
+- [ ] Rodar `cargo test tui::event_loop` e ver passar.
+- [ ] Rodar `cargo test tui::state` (garante que os fixtures `AppState::new()` de `render/config.rs`, `render/detail/mod.rs`, `render/history.rs`, `update/mod.rs` continuam OK com o campo novo) e ver passar sem snapshots quebrados.
+- [ ] Commit: `git add -A && git commit -m "feat: Save da TUI so escreve waybar com platform.waybar"`
+
+### Task 5: Config platform-aware (esconder campos só-Waybar)
+
+**Files:**
+- Modify: `src/tui/state.rs:94-103` (adiciona `ConfigField::visible` no `impl ConfigField`)
+- Modify: `src/tui/render/config.rs:16-46,49-50,67,109,119,161,186,193` (assinaturas + chamadas)
+- Modify: `src/tui/update/config.rs:150-158,160-171,181-201` (`config_down`, `config_enter_edit`, `config_confirm_edit`)
+- Modify: `src/tui/update/mod.rs` (novo teste após `config_navigate_clamps_at_bounds`, linha 781)
+
+**Interfaces:**
+- Consumes: `AppState.platform` (Task 4).
+- Produces: `ConfigField::visible(platform: Platform) -> Vec<ConfigField>`.
+
+- [ ] Escrever o teste que falha — em `src/tui/render/config.rs`, no `mod tests` (após `config_renders_waybar_and_tui_sections`, antes do `}` final de linha 419), adicionar:
+  ```rust
+  #[test]
+  fn config_hides_waybar_only_fields_when_omarchy_only() {
+      let backend = ratatui::backend::TestBackend::new(64, 24);
+      let mut terminal = ratatui::Terminal::new(backend).unwrap();
+      let mut state = state_on_waybar();
+      state.platform = crate::platform::Platform {
+          omarchy: true,
+          waybar: false,
+      };
+      terminal
+          .draw(|f| render_config(&state, f, f.area(), &mut HitMap::default()))
+          .unwrap();
+      let text = buffer_to_string(terminal.backend().buffer());
+
+      assert!(
+          !text.contains("Separadores"),
+          "Separadores deveria estar oculto:\n{text}"
+      );
+      assert!(!text.contains("Sinal"), "Sinal deveria estar oculto:\n{text}");
+      assert!(
+          !text.contains("Intervalo"),
+          "Intervalo deveria estar oculto:\n{text}"
+      );
+      assert!(
+          text.contains("Provedores"),
+          "Provedores deveria continuar visível:\n{text}"
+      );
+      assert!(
+          text.contains("Câmbio"),
+          "Câmbio (FxRate) deveria continuar visível:\n{text}"
+      );
+  }
+  ```
+- [ ] Rodar `cargo test config` e ver falhar: os campos só-Waybar aparecem mesmo com `platform.omarchy=true, waybar=false` (o teste falha nas 3 primeiras assertivas).
+- [ ] Implementação mínima — em `src/tui/state.rs`, dentro de `impl ConfigField` (logo após o array `pub const ALL`, linha 103, antes de `pub fn label`), adicionar:
+  ```rust
+      /// Campos exibidos p/ a plataforma dada: esconde Separators/Signal/
+      /// Interval (só afetam o Waybar) quando `platform` é exatamente
+      /// Omarchy-only (`omarchy: true, waybar: false`) — spec 2026-07-21 §E.
+      /// Providers/ProviderOrder/DisplayMode continuam (o Widget.qml também
+      /// os lê) e FxRate continua (só afeta esta TUI).
+      pub fn visible(platform: crate::platform::Platform) -> Vec<ConfigField> {
+          let hide_waybar_only = platform.omarchy && !platform.waybar;
+          ConfigField::ALL
+              .into_iter()
+              .filter(|f| {
+                  !hide_waybar_only
+                      || !matches!(
+                          f,
+                          ConfigField::Separators | ConfigField::Signal | ConfigField::Interval
+                      )
+              })
+              .collect()
+      }
+  ```
+- [ ] Em `src/tui/render/config.rs:27-45` (dispatch de `render_config`), hoje:
+  ```rust
+      match &state.config_state {
+          None => {
+              // Ainda nao inicializado (primeira entrada na aba)
+              let block = Block::default()
+                  .borders(Borders::ALL)
+                  .border_type(BorderType::Rounded)
+                  .border_style(Style::default().fg(to_ratatui(ColorToken::Comment)));
+              let p = Paragraph::new(Span::styled(
+                  " Carregando config...",
+                  Style::default().fg(to_ratatui(ColorToken::Muted)),
+              ))
+              .block(block);
+              frame.render_widget(p, area);
+          }
+          Some(cs) => {
+              render_field_list(cs, frame, list_area);
+              render_field_detail(cs, frame, detail_area, hits);
+          }
+      }
+  ```
+  Substituir o braço `Some(cs)` por:
+  ```rust
+          Some(cs) => {
+              let visible = ConfigField::visible(state.platform);
+              render_field_list(cs, &visible, frame, list_area);
+              render_field_detail(cs, &visible, frame, detail_area, hits);
+          }
+      }
+  ```
+- [ ] Em `src/tui/render/config.rs:49-91` (`render_field_list`), trocar a assinatura de:
+  ```rust
+  fn render_field_list(cs: &ConfigState, frame: &mut Frame, area: Rect) {
+  ```
+  por:
+  ```rust
+  fn render_field_list(cs: &ConfigState, visible: &[ConfigField], frame: &mut Frame, area: Rect) {
+  ```
+  e a linha 67 de:
+  ```rust
+      for (i, field) in ConfigField::ALL.iter().enumerate() {
+  ```
+  para:
+  ```rust
+      for (i, field) in visible.iter().enumerate() {
+  ```
+- [ ] Em `src/tui/render/config.rs:109-162` (`render_field_detail`), trocar a assinatura de:
+  ```rust
+  fn render_field_detail(cs: &ConfigState, frame: &mut Frame, area: Rect, hits: &mut HitMap) {
+  ```
+  por:
+  ```rust
+  fn render_field_detail(cs: &ConfigState, visible: &[ConfigField], frame: &mut Frame, area: Rect, hits: &mut HitMap) {
+  ```
+  a linha 119 de `let field = ConfigField::ALL[cs.selected_field];` para `let field = visible[cs.selected_field];`, e a chamada da linha 161 de:
+  ```rust
+      render_help_and_status(cs, frame, help_area, hits);
+  ```
+  para:
+  ```rust
+      render_help_and_status(cs, visible, frame, help_area, hits);
+  ```
+- [ ] Em `src/tui/render/config.rs:186-239` (`render_help_and_status`), trocar a assinatura de:
+  ```rust
+  fn render_help_and_status(cs: &ConfigState, frame: &mut Frame, area: Rect, hits: &mut HitMap) {
+  ```
+  por:
+  ```rust
+  fn render_help_and_status(cs: &ConfigState, visible: &[ConfigField], frame: &mut Frame, area: Rect, hits: &mut HitMap) {
+  ```
+  e a linha 193 de `let field = ConfigField::ALL[cs.selected_field];` para `let field = visible[cs.selected_field];`.
+- [ ] Rodar `cargo test tui::render::config` e ver passar (o teste novo `config_hides_waybar_only_fields_when_omarchy_only`; os snapshots existentes usam `state_on_waybar()` com `platform` default `{waybar:true}` → `visible == ALL`, então continuam byte-a-byte iguais).
+- [ ] Escrever o teste de navegação que falha — em `src/tui/update/mod.rs`, logo após `config_navigate_clamps_at_bounds` (linha 781), adicionar:
+  ```rust
+  #[test]
+  fn config_navigate_clamps_at_reduced_max_when_omarchy_only() {
+      let mut state = AppState::new();
+      state.platform = crate::platform::Platform {
+          omarchy: true,
+          waybar: false,
+      };
+      update(&mut state, Action::InitConfig(fake_settings()));
+
+      // Só Providers/ProviderOrder/DisplayMode/FxRate ficam visíveis (4
+      // campos, índices 0..=3) — Separators/Signal/Interval somem.
+      for _ in 0..10 {
+          update(&mut state, Action::ConfigDown);
+      }
+      assert_eq!(state.config_state.as_ref().unwrap().selected_field, 3);
+  }
+  ```
+- [ ] Rodar `cargo test tui::update` e ver falhar: `selected_field` chega em 6 (usa `ConfigField::ALL.len()` cheio), não 3.
+- [ ] Gatear a navegação — em `src/tui/update/config.rs:150-158`, hoje:
+  ```rust
+  pub(super) fn config_down(state: &mut AppState) -> Vec<Action> {
+      if let Some(cs) = state.config_state.as_mut() {
+          let max = ConfigField::ALL.len().saturating_sub(1);
+          if !cs.editing && cs.selected_field < max {
+              cs.selected_field += 1;
+          }
+      }
+      vec![]
+  }
+  ```
+  Substituir por:
+  ```rust
+  pub(super) fn config_down(state: &mut AppState) -> Vec<Action> {
+      let max = ConfigField::visible(state.platform).len().saturating_sub(1);
+      if let Some(cs) = state.config_state.as_mut() {
+          if !cs.editing && cs.selected_field < max {
+              cs.selected_field += 1;
+          }
+      }
+      vec![]
+  }
+  ```
+- [ ] Em `src/tui/update/config.rs:160-171`, hoje:
+  ```rust
+  pub(super) fn config_enter_edit(state: &mut AppState) -> Vec<Action> {
+      if let Some(cs) = state.config_state.as_mut() {
+          if !cs.editing {
+              let field = ConfigField::ALL[cs.selected_field];
+              let current = field_value_string(field, cs);
+              cs.input = tui_input::Input::new(current);
+              cs.editing = true;
+              cs.status_msg = None;
+          }
+      }
+      vec![]
+  }
+  ```
+  Substituir por:
+  ```rust
+  pub(super) fn config_enter_edit(state: &mut AppState) -> Vec<Action> {
+      let visible = ConfigField::visible(state.platform);
+      if let Some(cs) = state.config_state.as_mut() {
+          if !cs.editing {
+              let field = visible[cs.selected_field];
+              let current = field_value_string(field, cs);
+              cs.input = tui_input::Input::new(current);
+              cs.editing = true;
+              cs.status_msg = None;
+          }
+      }
+      vec![]
+  }
+  ```
+- [ ] Em `src/tui/update/config.rs:181-201`, hoje:
+  ```rust
+  pub(super) fn config_confirm_edit(state: &mut AppState) -> Vec<Action> {
+      if let Some(cs) = state.config_state.as_mut() {
+          if cs.editing {
+              let field = ConfigField::ALL[cs.selected_field];
+              let value = cs.input.value().to_string();
+              match apply_field_edit(field, &value, cs) {
+                  Ok(()) => {
+                      cs.editing = false;
+                      cs.input = tui_input::Input::default();
+                      cs.status_msg =
+                          Some("Campo atualizado. Pressione [s] para salvar.".to_string());
+                  }
+                  Err(e) => {
+                      cs.status_msg = Some(format!("Erro: {e}"));
+                      // Mantem edicao aberta para correcao.
+                  }
+              }
+          }
+      }
+      vec![]
+  }
+  ```
+  Substituir por:
+  ```rust
+  pub(super) fn config_confirm_edit(state: &mut AppState) -> Vec<Action> {
+      let visible = ConfigField::visible(state.platform);
+      if let Some(cs) = state.config_state.as_mut() {
+          if cs.editing {
+              let field = visible[cs.selected_field];
+              let value = cs.input.value().to_string();
+              match apply_field_edit(field, &value, cs) {
+                  Ok(()) => {
+                      cs.editing = false;
+                      cs.input = tui_input::Input::default();
+                      cs.status_msg =
+                          Some("Campo atualizado. Pressione [s] para salvar.".to_string());
+                  }
+                  Err(e) => {
+                      cs.status_msg = Some(format!("Erro: {e}"));
+                      // Mantem edicao aberta para correcao.
+                  }
+              }
+          }
+      }
+      vec![]
+  }
+  ```
+- [ ] Rodar `cargo test tui::update` e ver passar (os testes existentes `config_navigate_clamps_at_bounds`/`fx_rate_index`/`config_enter_edit_sets_input_to_current_value` continuam OK: `AppState::new()` tem `platform.waybar=true` por default → `visible() == ALL`).
+- [ ] Commit: `git add -A && git commit -m "feat: aba Config esconde campos so-Waybar em Omarchy-only"`
+
+### Task 6: mover `waybar_contract.rs`/`waybar_integration.rs` para `src/waybar/`
+
+**Files:**
+- Create: `src/waybar/mod.rs`
+- Modify (rename via `git mv`, sem edição de conteúdo): `src/waybar_contract.rs` → `src/waybar/contract.rs`, `src/waybar_integration.rs` → `src/waybar/integration.rs`
+- Modify: `src/lib.rs:29-30`
+
+**Interfaces:**
+- Produces: `crate::waybar_contract::*` e `crate::waybar_integration::*` continuam resolvendo (usados por `setup.rs`, `update.rs`, `main.rs`, `event_loop.rs`, `formatters/waybar.rs` sem qualquer edição neles).
+- Consumes: nenhuma interface nova de tasks anteriores — mecânico.
+
+- [ ] Rodar `cargo test waybar_contract` e `cargo test waybar_integration` ANTES da mudança — confirmar baseline verde (evita atribuir uma falha pré-existente à mudança).
+- [ ] Mover os arquivos preservando histórico:
+  ```bash
+  mkdir -p src/waybar
+  git mv src/waybar_contract.rs src/waybar/contract.rs
+  git mv src/waybar_integration.rs src/waybar/integration.rs
+  ```
+- [ ] Rodar `cargo test waybar_contract` e ver falhar: `error[E0433]: failed to resolve: could not find 'waybar_contract' in the crate root` (o `mod` antigo em `lib.rs` ainda aponta pro arquivo que não existe mais).
+- [ ] Implementação mínima — criar `src/waybar/mod.rs`:
+  ```rust
+  //! Agrupa o tier legado Waybar (spec 2026-07-21 §E): `contract.rs`
+  //! (formatos exportados: `modules.jsonc`/`style.css`) e `integration.rs`
+  //! (patch in-place do `config.jsonc`/`style.css` do usuário).
+  //!
+  //! Os módulos mantêm o IDENTIFICADOR original (`waybar_contract`,
+  //! `waybar_integration`) via `#[path]` — só o arquivo físico mudou de
+  //! lugar. Isso preserva `crate::waybar_contract::*`/`crate::waybar_integration::*`
+  //! em todo o resto do crate SEM editar nenhum callsite, e mantém
+  //! `cargo test waybar_contract`/`cargo test waybar_integration` (CLAUDE.md)
+  //! passando: o filtro de `cargo test` casa substring na string totalmente
+  //! qualificada do teste, e um `pub use ... as waybar_contract` (renomear
+  //! só no re-export) NÃO teria o mesmo efeito — o teste ficaria em
+  //! `waybar::contract::tests::…`, que não contém a substring
+  //! `"waybar_contract"` (o separador é `::`, não `_`).
+  #[path = "contract.rs"]
+  pub mod waybar_contract;
+  #[path = "integration.rs"]
+  pub mod waybar_integration;
+  ```
+- [ ] Em `src/lib.rs:29-30`, hoje:
+  ```rust
+  pub mod waybar_contract;
+  pub mod waybar_integration;
+  ```
+  Substituir por:
+  ```rust
+  pub mod waybar;
+  pub use waybar::waybar_contract;
+  pub use waybar::waybar_integration;
+  ```
+- [ ] Rodar `cargo test waybar_contract` e ver passar (mesma suíte de antes, agora em `crate::waybar::waybar_contract::tests::*`, mas o filtro substring continua casando).
+- [ ] Rodar `cargo test waybar_integration` e ver passar.
+- [ ] Rodar `cargo test setup` (consome `waybar_contract::install_waybar_assets`/`waybar_integration::apply_waybar_integration` via re-export) e ver passar sem edição.
+- [ ] Rodar `cargo clippy --all-targets -- -D warnings` e ver passar.
+- [ ] Commit: `git add -A && git commit -m "refactor: agrupa waybar_contract/integration em src/waybar/"`
+
+### Task 7: `doctor` ganha checagens Omarchy
+
+**Files:**
+- Modify: `src/omarchy_integration.rs:26-32` (adiciona `default_omarchy_shell_json_path` logo após `default_omarchy_plugins_dir`), `src/omarchy_integration.rs` (adiciona `shell_json_has_plugin_entry` + `json_contains_string` antes do `#[cfg(test)] mod tests`, linha 144), `src/omarchy_integration.rs` (novos testes)
+- Modify: `src/doctor.rs:1-3` (imports), `src/doctor.rs:25-30` (`DoctorResult` ganha campo), `src/doctor.rs:111-144` (adiciona `OmarchyFindings`/`scan_omarchy` após `scan`), `src/doctor.rs:162-210` (`run_doctor` popula o campo novo), `src/doctor.rs` (novos testes)
+- Modify: `src/main.rs:358-381` (`Command::Doctor`, imprime avisos)
+
+**Interfaces:**
+- Consumes: `app_identity::{APP_NAME, OMARCHY_PLUGIN_ID, VERSION}`, `omarchy_integration::default_omarchy_plugins_dir`.
+- Produces: `pub struct OmarchyFindings { .. }`, `pub fn scan_omarchy(home: &Path) -> OmarchyFindings`, `impl OmarchyFindings { pub fn warnings(&self) -> Vec<String> }`, `omarchy_integration::default_omarchy_shell_json_path`, `omarchy_integration::shell_json_has_plugin_entry`.
+
+- [ ] Escrever o teste que falha — em `src/omarchy_integration.rs`, no `mod tests` (após `default_plugins_dir_respects_xdg_config_home`, linha 170), adicionar:
+  ```rust
+  #[test]
+  fn shell_json_has_plugin_entry_finds_nested_id() {
+      let dir = tempdir().unwrap();
+      let path = dir.path().join("shell.json");
+      std::fs::write(&path, r#"{"bar":{"plugins":[{"id":"agent-bar.usage"}]}}"#).unwrap();
+      assert!(shell_json_has_plugin_entry(&path));
+  }
+
+  #[test]
+  fn shell_json_has_plugin_entry_false_when_absent_or_missing() {
+      let dir = tempdir().unwrap();
+      let path = dir.path().join("shell.json");
+      assert!(!shell_json_has_plugin_entry(&path)); // arquivo nao existe
+
+      std::fs::write(&path, r#"{"bar":{"plugins":[]}}"#).unwrap();
+      assert!(!shell_json_has_plugin_entry(&path));
+  }
+
+  #[test]
+  #[serial_test::serial]
+  fn default_shell_json_path_respects_xdg_config_home() {
+      let prev = std::env::var_os("XDG_CONFIG_HOME");
+      std::env::set_var("XDG_CONFIG_HOME", "/tmp/xdg-test-shell-json");
+      let path = default_omarchy_shell_json_path(std::path::Path::new("/home/u"));
+      assert_eq!(
+          path,
+          std::path::PathBuf::from("/tmp/xdg-test-shell-json/omarchy/shell.json")
+      );
+      std::env::remove_var("XDG_CONFIG_HOME");
+      let path = default_omarchy_shell_json_path(std::path::Path::new("/home/u"));
+      assert_eq!(
+          path,
+          std::path::PathBuf::from("/home/u/.config/omarchy/shell.json")
+      );
+      match prev {
+          Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
+          None => std::env::remove_var("XDG_CONFIG_HOME"),
+      }
+  }
+  ```
+- [ ] Rodar `cargo test omarchy_integration` e ver falhar: `error[E0425]: cannot find function 'shell_json_has_plugin_entry'`.
+- [ ] Implementação mínima — em `src/omarchy_integration.rs`, logo após `default_omarchy_plugins_dir` (linha 32, antes de `pub fn omarchy_shell_present`), adicionar:
+  ```rust
+  /// `${XDG_CONFIG_HOME:-<home>/.config}/omarchy/shell.json` — arquivo do
+  /// omarchy-shell (schema não é nosso; usado só como leitura pelo `doctor`).
+  /// NUNCA escrito por este binário (ADR-0002).
+  pub fn default_omarchy_shell_json_path(home: &Path) -> PathBuf {
+      let config_root = std::env::var_os("XDG_CONFIG_HOME")
+          .filter(|v| !v.is_empty())
+          .map(PathBuf::from)
+          .unwrap_or_else(|| home.join(".config"));
+      config_root.join("omarchy").join("shell.json")
+  }
+  ```
+  E, no fim do arquivo, logo antes de `#[cfg(test)]` (linha 144), adicionar:
+  ```rust
+  /// `true` se `OMARCHY_PLUGIN_ID` aparecer como valor de string em qualquer
+  /// lugar da árvore JSON de `shell_json_path` — tolerante ao shape exato do
+  /// `shell.json` (schema do omarchy-shell, não nosso). `false` se o arquivo
+  /// não existir ou não parsear (silencioso — é só um sinal pro `doctor`).
+  pub fn shell_json_has_plugin_entry(shell_json_path: &Path) -> bool {
+      let Ok(content) = std::fs::read_to_string(shell_json_path) else {
+          return false;
+      };
+      let Ok(value) = serde_json::from_str::<serde_json::Value>(&content) else {
+          return false;
+      };
+      json_contains_string(&value, OMARCHY_PLUGIN_ID)
+  }
+
+  fn json_contains_string(value: &serde_json::Value, needle: &str) -> bool {
+      match value {
+          serde_json::Value::String(s) => s == needle,
+          serde_json::Value::Array(items) => items.iter().any(|v| json_contains_string(v, needle)),
+          serde_json::Value::Object(map) => map.values().any(|v| json_contains_string(v, needle)),
+          _ => false,
+      }
+  }
+  ```
+- [ ] Rodar `cargo test omarchy_integration` e ver passar (3 testes novos).
+- [ ] Escrever o teste que falha para o `doctor` — em `src/doctor.rs`, no `mod tests` (após `scan_considers_dev_dependencies`, linha 316), adicionar:
+  ```rust
+  fn with_clean_xdg_config_home<T>(f: impl FnOnce() -> T) -> T {
+      let prev = std::env::var_os("XDG_CONFIG_HOME");
+      std::env::remove_var("XDG_CONFIG_HOME");
+      let result = f();
+      match prev {
+          Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
+          None => std::env::remove_var("XDG_CONFIG_HOME"),
+      }
+      result
+  }
+
+  #[test]
+  #[serial_test::serial]
+  fn scan_omarchy_clean_when_nothing_installed() {
+      with_clean_xdg_config_home(|| {
+          let h = tempdir().unwrap();
+          let f = scan_omarchy(h.path());
+          assert!(f.manifest_version_mismatch.is_none());
+          assert!(f.plugin_dir_without_shell_entry.is_none());
+          assert!(f.shell_entry_without_plugin_dir.is_none());
+          assert!(f.warnings().is_empty());
+      });
+  }
+
+  #[test]
+  #[serial_test::serial]
+  fn scan_omarchy_flags_manifest_version_mismatch() {
+      with_clean_xdg_config_home(|| {
+          let h = tempdir().unwrap();
+          let plugin_dir = h
+              .path()
+              .join(".config")
+              .join("omarchy")
+              .join("plugins")
+              .join(crate::app_identity::OMARCHY_PLUGIN_ID);
+          std::fs::create_dir_all(&plugin_dir).unwrap();
+          std::fs::write(
+              plugin_dir.join("manifest.json"),
+              r#"{"id":"agent-bar.usage","version":"0.0.1-old"}"#,
+          )
+          .unwrap();
+
+          let f = scan_omarchy(h.path());
+          assert!(f.manifest_version_mismatch.is_some());
+          assert!(f
+              .manifest_version_mismatch
+              .as_ref()
+              .unwrap()
+              .contains("0.0.1-old"));
+      });
+  }
+
+  #[test]
+  #[serial_test::serial]
+  fn scan_omarchy_flags_plugin_dir_without_shell_entry() {
+      with_clean_xdg_config_home(|| {
+          let h = tempdir().unwrap();
+          let plugin_dir = h
+              .path()
+              .join(".config")
+              .join("omarchy")
+              .join("plugins")
+              .join(crate::app_identity::OMARCHY_PLUGIN_ID);
+          std::fs::create_dir_all(&plugin_dir).unwrap();
+          std::fs::write(
+              plugin_dir.join("manifest.json"),
+              format!(
+                  r#"{{"id":"agent-bar.usage","version":"{}"}}"#,
+                  crate::app_identity::VERSION
+              ),
+          )
+          .unwrap();
+          let shell_json = h.path().join(".config").join("omarchy").join("shell.json");
+          std::fs::create_dir_all(shell_json.parent().unwrap()).unwrap();
+          std::fs::write(&shell_json, r#"{"bar":{"plugins":[]}}"#).unwrap();
+
+          let f = scan_omarchy(h.path());
+          assert!(f.manifest_version_mismatch.is_none());
+          assert!(f.plugin_dir_without_shell_entry.is_some());
+          assert!(f.shell_entry_without_plugin_dir.is_none());
+      });
+  }
+
+  #[test]
+  #[serial_test::serial]
+  fn scan_omarchy_flags_shell_entry_without_plugin_dir() {
+      with_clean_xdg_config_home(|| {
+          let h = tempdir().unwrap();
+          let shell_json = h.path().join(".config").join("omarchy").join("shell.json");
+          std::fs::create_dir_all(shell_json.parent().unwrap()).unwrap();
+          std::fs::write(
+              &shell_json,
+              r#"{"bar":{"plugins":[{"id":"agent-bar.usage"}]}}"#,
+          )
+          .unwrap();
+
+          let f = scan_omarchy(h.path());
+          assert!(f.shell_entry_without_plugin_dir.is_some());
+          assert!(f.plugin_dir_without_shell_entry.is_none());
+      });
+  }
+  ```
+- [ ] Rodar `cargo test doctor` e ver falhar: `error[E0425]: cannot find function 'scan_omarchy'`.
+- [ ] Implementação mínima — em `src/doctor.rs:1-3`, hoje:
+  ```rust
+  use serde_json::Value;
+  use std::fs;
+  use std::path::{Path, PathBuf};
+  ```
+  Substituir por:
+  ```rust
+  use serde_json::Value;
+  use std::fs;
+  use std::path::{Path, PathBuf};
+
+  use crate::app_identity::{APP_NAME, OMARCHY_PLUGIN_ID, VERSION};
+  use crate::omarchy_integration::{default_omarchy_plugins_dir, default_omarchy_shell_json_path, shell_json_has_plugin_entry};
+  ```
+  Em `src/doctor.rs:25-30`, hoje:
+  ```rust
+  #[derive(Debug, Clone)]
+  pub struct DoctorResult {
+      pub status: DoctorStatus,
+      pub removed: Vec<PathBuf>,
+      pub findings: DoctorFindings,
+  }
+  ```
+  Substituir por:
+  ```rust
+  #[derive(Debug, Clone)]
+  pub struct DoctorResult {
+      pub status: DoctorStatus,
+      pub removed: Vec<PathBuf>,
+      pub findings: DoctorFindings,
+      pub omarchy: OmarchyFindings,
+  }
+  ```
+  Logo após a função `scan` (linha 144, antes de `fn planned_removals`), adicionar:
+  ```rust
+  /// Achados Omarchy do `doctor`: drift binário↔plugin e referências
+  /// penduradas em `shell.json`. Leitura pura — NUNCA escreve nada, NUNCA
+  /// falha o comando (viram avisos, spec 2026-07-21 §F).
+  #[derive(Debug, Clone, Default)]
+  pub struct OmarchyFindings {
+      /// `Some` quando o manifest instalado tem `version` diferente do binário.
+      pub manifest_version_mismatch: Option<String>,
+      /// `Some` quando o diretório do plugin existe mas `shell.json` não
+      /// referencia `agent-bar.usage`.
+      pub plugin_dir_without_shell_entry: Option<String>,
+      /// `Some` quando `shell.json` referencia `agent-bar.usage` mas o
+      /// diretório do plugin não existe.
+      pub shell_entry_without_plugin_dir: Option<String>,
+  }
+
+  impl OmarchyFindings {
+      /// Achados como mensagens prontas p/ `term_prompt::status("Aviso", ...)`.
+      pub fn warnings(&self) -> Vec<String> {
+          [
+              &self.manifest_version_mismatch,
+              &self.plugin_dir_without_shell_entry,
+              &self.shell_entry_without_plugin_dir,
+          ]
+          .into_iter()
+          .filter_map(|w| w.clone())
+          .collect()
+      }
+  }
+
+  pub fn scan_omarchy(home: &Path) -> OmarchyFindings {
+      let plugin_dir = default_omarchy_plugins_dir(home).join(OMARCHY_PLUGIN_ID);
+      let dir_exists = plugin_dir.is_dir();
+
+      let manifest_version_mismatch = if dir_exists {
+          read_json(&plugin_dir.join("manifest.json"))
+              .and_then(|v| v.get("version").and_then(|v| v.as_str()).map(str::to_string))
+              .filter(|installed| installed != VERSION)
+              .map(|installed| {
+                  format!(
+                      "Plugin omarchy instalado (v{installed}) diverge do binário (v{VERSION}). Rode `{APP_NAME} setup` para atualizá-lo."
+                  )
+              })
+      } else {
+          None
+      };
+
+      let shell_json_path = default_omarchy_shell_json_path(home);
+      let shell_has_entry = shell_json_has_plugin_entry(&shell_json_path);
+
+      let plugin_dir_without_shell_entry = (dir_exists && !shell_has_entry).then(|| {
+          format!(
+              "Diretório do plugin existe ({}) mas {} não referencia `{OMARCHY_PLUGIN_ID}`. Rode `omarchy bar plugin add {OMARCHY_PLUGIN_ID}`.",
+              plugin_dir.display(),
+              shell_json_path.display()
+          )
+      });
+
+      let shell_entry_without_plugin_dir = (!dir_exists && shell_has_entry).then(|| {
+          format!(
+              "{} referencia `{OMARCHY_PLUGIN_ID}` mas o diretório do plugin não existe ({}). Rode `{APP_NAME} setup`.",
+              shell_json_path.display(),
+              plugin_dir.display()
+          )
+      });
+
+      OmarchyFindings {
+          manifest_version_mismatch,
+          plugin_dir_without_shell_entry,
+          shell_entry_without_plugin_dir,
+      }
+  }
+  ```
+  Em `src/doctor.rs:162-210` (`run_doctor`), hoje:
+  ```rust
+  pub fn run_doctor(opts: DoctorOptions<'_>) -> DoctorResult {
+      let findings = scan(opts.home);
+
+      let nothing_to_do = !findings.package_json_orphan
+          && !findings.package_json_mixed
+          && findings.node_modules_dir.is_none()
+          && findings.lockfiles.is_empty();
+
+      if nothing_to_do {
+          return DoctorResult {
+              status: DoctorStatus::Clean,
+              removed: vec![],
+              findings,
+          };
+      }
+
+      let approved = opts.yes || (opts.confirm)(&findings);
+      if !approved {
+          return DoctorResult {
+              status: DoctorStatus::Cancelled,
+              removed: vec![],
+              findings,
+          };
+      }
+
+      let removals = planned_removals(&findings);
+
+      if !opts.dry_run {
+          for path in &removals {
+              if path.is_dir() {
+                  let _ = fs::remove_dir_all(path);
+              } else {
+                  let _ = fs::remove_file(path);
+              }
+          }
+      }
+
+      let status = if findings.package_json_mixed && !findings.package_json_orphan {
+          DoctorStatus::MixedOnly
+      } else {
+          DoctorStatus::Cleaned
+      };
+
+      DoctorResult {
+          status,
+          removed: removals,
+          findings,
+      }
+  }
+  ```
+  Substituir por:
+  ```rust
+  pub fn run_doctor(opts: DoctorOptions<'_>) -> DoctorResult {
+      let findings = scan(opts.home);
+      let omarchy = scan_omarchy(opts.home);
+
+      let nothing_to_do = !findings.package_json_orphan
+          && !findings.package_json_mixed
+          && findings.node_modules_dir.is_none()
+          && findings.lockfiles.is_empty();
+
+      if nothing_to_do {
+          return DoctorResult {
+              status: DoctorStatus::Clean,
+              removed: vec![],
+              findings,
+              omarchy,
+          };
+      }
+
+      let approved = opts.yes || (opts.confirm)(&findings);
+      if !approved {
+          return DoctorResult {
+              status: DoctorStatus::Cancelled,
+              removed: vec![],
+              findings,
+              omarchy,
+          };
+      }
+
+      let removals = planned_removals(&findings);
+
+      if !opts.dry_run {
+          for path in &removals {
+              if path.is_dir() {
+                  let _ = fs::remove_dir_all(path);
+              } else {
+                  let _ = fs::remove_file(path);
+              }
+          }
+      }
+
+      let status = if findings.package_json_mixed && !findings.package_json_orphan {
+          DoctorStatus::MixedOnly
+      } else {
+          DoctorStatus::Cleaned
+      };
+
+      DoctorResult {
+          status,
+          removed: removals,
+          findings,
+          omarchy,
+      }
+  }
+  ```
+  Isso também exige atualizar os testes existentes de `run_doctor` (`run_doctor_clean`, `run_doctor_removes_orphan_set_when_confirmed`, `run_doctor_mixed_keeps_package_json`, `run_doctor_cancelled`, `run_doctor_dry_run_reports_without_removing`, `run_doctor_yes_skips_confirm`, linhas 318-465) — nenhum deles constrói `DoctorResult` diretamente (só chamam `run_doctor(...)` e leem `r.status`/`r.removed`), então continuam compilando sem alteração.
+- [ ] Rodar `cargo test doctor` e ver passar (4 testes novos + suíte existente intacta).
+- [ ] Imprimir os avisos no CLI — em `src/main.rs:358-381` (`Command::Doctor`), hoje o bloco termina em:
+  ```rust
+                  doctor::DoctorStatus::Cancelled => {
+                      term_prompt::status("Cancelado", "Doctor não aplicou mudanças");
+                  }
+              }
+              std::process::exit(0);
+          }
+  ```
+  Substituir por:
+  ```rust
+                  doctor::DoctorStatus::Cancelled => {
+                      term_prompt::status("Cancelado", "Doctor não aplicou mudanças");
+                  }
+              }
+              for warning in result.omarchy.warnings() {
+                  term_prompt::status("Aviso", &warning);
+              }
+              std::process::exit(0);
+          }
+  ```
+- [ ] Rodar `cargo test doctor` e ver passar novamente (recompilação de `main.rs`).
+- [ ] Rodar `cargo clippy --all-targets -- -D warnings` e ver passar.
+- [ ] Commit: `git add -A && git commit -m "feat: doctor detecta drift do plugin omarchy"`
+
+### Task 8: `uninstall` só remove o plugin se `omarchy ... remove` confirmar
+
+**Files:**
+- Modify: `src/uninstall.rs:36-44` (assinatura de `run_uninstall`), `src/uninstall.rs:85-98` (lógica de remoção), `src/uninstall.rs` (novo `#[cfg(test)] mod tests` — arquivo não tem testes hoje)
+- Modify: `src/main.rs:619-627` (call site)
+
+**Interfaces:**
+- Consumes: `omarchy_integration::{omarchy_cli_available, run_omarchy_remove_commands, remove_omarchy_plugin}` (agora injetadas via parâmetro, não chamadas direto).
+- Produces: `run_uninstall(..., cli_available_fn: &dyn Fn() -> bool, remove_commands_fn: &dyn Fn() -> Vec<String>)`.
+
+- [ ] Escrever o teste que falha — criar `#[cfg(test)] mod tests` ao final de `src/uninstall.rs` (arquivo tem 115 linhas hoje):
+  ```rust
+  #[cfg(test)]
+  mod tests {
+      use super::*;
+      use tempfile::tempdir;
+
+      fn integration_paths(dir: &Path) -> WaybarIntegrationPaths {
+          WaybarIntegrationPaths {
+              waybar_config_path: dir.join("config.jsonc"),
+              waybar_style_path: dir.join("style.css"),
+              modules_include_path: dir.join("agent-bar").join("modules.jsonc"),
+              style_include_path: dir.join("agent-bar").join("style.css"),
+          }
+      }
+
+      #[test]
+      #[serial_test::serial]
+      fn uninstall_removes_omarchy_plugin_when_cli_confirms() {
+          let home = tempdir().unwrap();
+          let prev_home = std::env::var_os("HOME");
+          std::env::set_var("HOME", home.path());
+
+          let plugins = tempdir().unwrap();
+          crate::omarchy_integration::install_omarchy_plugin(plugins.path()).unwrap();
+          let plugin_dir = plugins
+              .path()
+              .join(crate::app_identity::OMARCHY_PLUGIN_ID);
+          assert!(plugin_dir.exists());
+
+          run_uninstall(
+              &home.path().join("cfg"),
+              &home.path().join("cache"),
+              home.path(),
+              true, // force: pula confirmação interativa
+              "agent-bar uninstall",
+              &integration_paths(&home.path().join("waybar-unused")),
+              plugins.path(),
+              &|| true,
+              &Vec::new,
+          )
+          .unwrap();
+
+          assert!(!plugin_dir.exists());
+
+          match prev_home {
+              Some(v) => std::env::set_var("HOME", v),
+              None => std::env::remove_var("HOME"),
+          }
+      }
+  }
+  ```
+- [ ] Rodar `cargo test uninstall` e ver falhar: `error[E0061]: this function takes 7 arguments but 9 were supplied`.
+- [ ] Implementação mínima — em `src/uninstall.rs:36-44`, hoje:
+  ```rust
+  pub fn run_uninstall(
+      settings_dir: &Path,
+      cache_dir: &Path,
+      home: &Path,
+      force: bool,
+      title: &str,
+      integration_paths: &WaybarIntegrationPaths,
+      omarchy_plugins_dir: &Path,
+  ) -> anyhow::Result<()> {
+  ```
+  Substituir por (o `#[allow]` é necessário porque a assinatura vai a 9
+  parâmetros e `clippy::too_many_arguments` dispara com `-D warnings` —
+  mesma convenção já usada em `src/formatters/builders/shared.rs`):
+  ```rust
+  #[allow(clippy::too_many_arguments)]
+  pub fn run_uninstall(
+      settings_dir: &Path,
+      cache_dir: &Path,
+      home: &Path,
+      force: bool,
+      title: &str,
+      integration_paths: &WaybarIntegrationPaths,
+      omarchy_plugins_dir: &Path,
+      cli_available_fn: &dyn Fn() -> bool,
+      remove_commands_fn: &dyn Fn() -> Vec<String>,
+  ) -> anyhow::Result<()> {
+  ```
+  Em `src/uninstall.rs:3-11` (imports), hoje:
+  ```rust
+  use std::path::Path;
+
+  use crate::app_identity::{APP_NAME, OMARCHY_PLUGIN_ID};
+  use crate::omarchy_integration::{
+      omarchy_cli_available, remove_omarchy_plugin, run_omarchy_remove_commands,
+  };
+  use crate::waybar_contract::get_default_waybar_asset_paths;
+  use crate::waybar_integration::{remove_waybar_integration, WaybarIntegrationPaths};
+  use crate::{setup, term_prompt};
+  ```
+  Substituir por:
+  ```rust
+  use std::path::Path;
+
+  use crate::app_identity::{APP_NAME, OMARCHY_PLUGIN_ID};
+  use crate::omarchy_integration::remove_omarchy_plugin;
+  use crate::waybar_contract::get_default_waybar_asset_paths;
+  use crate::waybar_integration::{remove_waybar_integration, WaybarIntegrationPaths};
+  use crate::{setup, term_prompt};
+  ```
+  (`omarchy_cli_available`/`run_omarchy_remove_commands` deixam de ser chamadas direto — agora vêm por parâmetro, como seams de teste.)
+  Em `src/uninstall.rs:85-98`, hoje:
+  ```rust
+      // Omarchy-shell: desregistra no shell (best-effort) e remove o drop-in.
+      let plugin_dir = omarchy_plugins_dir.join(OMARCHY_PLUGIN_ID);
+      if plugin_dir.exists() {
+          if omarchy_cli_available() {
+              for warning in run_omarchy_remove_commands() {
+                  term_prompt::status("Aviso", &warning);
+              }
+          }
+          match remove_omarchy_plugin(omarchy_plugins_dir) {
+              Ok(true) => removed.push(plugin_dir.to_string_lossy().into_owned()),
+              Ok(false) => {}
+              Err(_) => failed.push(plugin_dir.to_string_lossy().into_owned()),
+          }
+      }
+  ```
+  Substituir por:
+  ```rust
+      // Omarchy-shell: só apaga o diretório do drop-in se os comandos
+      // `omarchy ... remove` confirmarem (CLI disponível E sem warnings) —
+      // senão fica referência pendurada em `shell.json` apontando pra um
+      // dir inexistente, pior do que manter o dir órfão (spec F).
+      let plugin_dir = omarchy_plugins_dir.join(OMARCHY_PLUGIN_ID);
+      if plugin_dir.exists() {
+          let mut remove_ok = cli_available_fn();
+          if remove_ok {
+              for warning in remove_commands_fn() {
+                  term_prompt::status("Aviso", &warning);
+                  remove_ok = false;
+              }
+          }
+          if remove_ok {
+              match remove_omarchy_plugin(omarchy_plugins_dir) {
+                  Ok(true) => removed.push(plugin_dir.to_string_lossy().into_owned()),
+                  Ok(false) => {}
+                  Err(_) => failed.push(plugin_dir.to_string_lossy().into_owned()),
+              }
+          } else {
+              term_prompt::status(
+                  "Aviso",
+                  &format!(
+                      "omarchy remove não confirmado — diretório do plugin mantido em {} (pode restar referência em shell.json)",
+                      plugin_dir.display()
+                  ),
+              );
+          }
+      }
+  ```
+- [ ] Rodar `cargo test uninstall` e ver falhar de novo: agora falha no call site de `main.rs` (`error[E0061]: this function takes 9 arguments but 7 were supplied`).
+- [ ] Atualizar o call site — em `src/main.rs:619-627`, hoje:
+  ```rust
+              match uninstall::run_uninstall(
+                  &settings_dir,
+                  &paths.cache_dir,
+                  &home,
+                  force,
+                  &format!("{APP_NAME} uninstall"),
+                  &ipaths,
+                  &omarchy_integration::default_omarchy_plugins_dir(&home),
+              ) {
+  ```
+  Substituir por:
+  ```rust
+              match uninstall::run_uninstall(
+                  &settings_dir,
+                  &paths.cache_dir,
+                  &home,
+                  force,
+                  &format!("{APP_NAME} uninstall"),
+                  &ipaths,
+                  &omarchy_integration::default_omarchy_plugins_dir(&home),
+                  &omarchy_integration::omarchy_cli_available,
+                  &omarchy_integration::run_omarchy_remove_commands,
+              ) {
+  ```
+- [ ] Rodar `cargo test uninstall` e ver passar.
+- [ ] Escrever + rodar os 2 testes de "não confirmado" (adicionar ao mesmo `mod tests` de `src/uninstall.rs`, seguindo o mesmo padrão de save/restore de `HOME`):
+  ```rust
+      #[test]
+      #[serial_test::serial]
+      fn uninstall_keeps_omarchy_plugin_when_cli_unavailable() {
+          let home = tempdir().unwrap();
+          let prev_home = std::env::var_os("HOME");
+          std::env::set_var("HOME", home.path());
+
+          let plugins = tempdir().unwrap();
+          crate::omarchy_integration::install_omarchy_plugin(plugins.path()).unwrap();
+          let plugin_dir = plugins
+              .path()
+              .join(crate::app_identity::OMARCHY_PLUGIN_ID);
+
+          run_uninstall(
+              &home.path().join("cfg"),
+              &home.path().join("cache"),
+              home.path(),
+              true,
+              "agent-bar uninstall",
+              &integration_paths(&home.path().join("waybar-unused")),
+              plugins.path(),
+              &|| false, // CLI omarchy indisponível
+              &Vec::new,
+          )
+          .unwrap();
+
+          assert!(plugin_dir.exists(), "diretório do plugin deveria ser mantido");
+
+          match prev_home {
+              Some(v) => std::env::set_var("HOME", v),
+              None => std::env::remove_var("HOME"),
+          }
+      }
+
+      #[test]
+      #[serial_test::serial]
+      fn uninstall_keeps_omarchy_plugin_when_remove_commands_warn() {
+          let home = tempdir().unwrap();
+          let prev_home = std::env::var_os("HOME");
+          std::env::set_var("HOME", home.path());
+
+          let plugins = tempdir().unwrap();
+          crate::omarchy_integration::install_omarchy_plugin(plugins.path()).unwrap();
+          let plugin_dir = plugins
+              .path()
+              .join(crate::app_identity::OMARCHY_PLUGIN_ID);
+
+          run_uninstall(
+              &home.path().join("cfg"),
+              &home.path().join("cache"),
+              home.path(),
+              true,
+              "agent-bar uninstall",
+              &integration_paths(&home.path().join("waybar-unused")),
+              plugins.path(),
+              &|| true,
+              &|| vec!["`omarchy bar plugin remove` falhou: boom".to_string()],
+          )
+          .unwrap();
+
+          assert!(
+              plugin_dir.exists(),
+              "diretório do plugin deveria ser mantido após falha"
+          );
+
+          match prev_home {
+              Some(v) => std::env::set_var("HOME", v),
+              None => std::env::remove_var("HOME"),
+          }
+      }
+  ```
+- [ ] Rodar `cargo test uninstall` e ver passar: 3 testes `ok`.
+- [ ] Rodar `cargo clippy --all-targets -- -D warnings` e ver passar.
+- [ ] Commit: `git add -A && git commit -m "feat: uninstall so apaga plugin omarchy se remove confirmar"`
+
+## Verificação final do PR
+
+Depois das 8 tasks, antes de abrir o PR:
+
+```bash
+cargo test
+cargo clippy --all-targets -- -D warnings
+```
+
+Ambos precisam terminar limpos (gotcha RTK: se `cargo test` completo não mostrar
+`test result:` claramente por causa da reformatação do hook, rodar os filtros
+por área — `cargo test platform`, `cargo test update`, `cargo test tui`,
+`cargo test waybar_contract`, `cargo test waybar_integration`, `cargo test doctor`,
+`cargo test uninstall`, `cargo test omarchy_integration`, `cargo test setup` —
+um de cada vez). Em seguida, `superpowers:finishing-a-development-branch` para
+decidir merge/PR (a spec prevê PR4 de uma sequência de 5 sobre `master`, então
+o destino natural é PR, não merge direto).

--- a/docs/superpowers/plans/2026-07-21-v9-05-docs-release.md
+++ b/docs/superpowers/plans/2026-07-21-v9-05-docs-release.md
@@ -1,0 +1,1178 @@
+# v9 Docs + Preparação de Release Implementation Plan
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Atualizar toda a documentação pública (README, CONTRIBUTING, docs/*,
+CLAUDE.md, CHANGELOG) para refletir o agent-bar 9.0.0 Omarchy-first, sem
+cortar o release.
+
+**Architecture:** Esta é a PR 5 (última) da sequência do spec
+`docs/superpowers/specs/2026-07-21-omarchy-first-popup-redesign-design.md`.
+Assume que as PRs 1-4 (limpeza de legado, contrato `windowKind`, Widget.qml
+novo, gates de plataforma + `src/waybar/`) já landaram em `master` — os
+símbolos que este plano cita como existentes (`platform::detect()`,
+`QuotaWindow.window_kind`, `src/waybar/contract.rs`, `menuAnimations` em
+`config show`, settings v3) são produto delas, não deste plano. Este plano
+só edita Markdown; nenhum arquivo `.rs` muda.
+
+**Tech Stack:** Markdown puro. Verificação via `git diff --check` (erros de
+whitespace) e `grep -n`/`grep -c` (consistência de conteúdo) — não há
+`cargo test` aplicável a texto.
+
+## Global Constraints
+- Prosa dos docs e commits em português; identificadores citados no texto em inglês.
+- Commits: Conventional Commits em PT, subject ≤ 50 chars.
+- ZERO atribuição de AI em qualquer texto (commit, PR, comentário).
+- `CHANGELOG.md` só é editado ao preparar/cortar release (é exatamente o que a Task 9 faz).
+- Error strings de provider são contrato — nenhuma task deste plano toca `src/`, então isso não se aplica, mas nenhum doc pode reescrever uma string de erro citada como se fosse diferente da real.
+- Não cortar release (sem bump de `Cargo.toml`, sem tag, sem GitHub Release) — isso é runbook manual do dono (`docs/releasing.md`).
+- Cada task só mexe no(s) arquivo(s) listado(s) em **Files** — não tocar em mudanças não relacionadas (`git status` limpo antes de cada task).
+
+---
+
+### Task 1: README.md — tagline e requisitos Omarchy-first
+
+**Files:**
+- Modify: `README.md:7` (tagline) e `README.md:25-32` (bloco `## Requisitos`)
+
+**Interfaces:**
+- Consumes: fatos já existentes no arquivo — instalador `install.sh`, AUR
+  `agent-bar-bin` (comentado como "sai em breve"), `cargo binstall --git`,
+  `agent-bar setup` (linhas 34-70, **não tocadas** por esta task).
+- Produces: primeira impressão do repo alinhada a "Omarchy-first, Waybar
+  tier legado" — nenhuma task futura depende do texto exato, mas a Task 9
+  (CHANGELOG) referencia esta mudança na entrada 9.0.0.
+
+**Steps:**
+
+- [ ] **Step 1: Confirmar que o texto antigo ainda está lá (checagem que falha depois do fix)**
+
+  Rodar:
+  ```bash
+  grep -n "Monitor de quota de Claude Code, OpenAI Codex, Amp e Grok Build na Waybar" README.md
+  grep -n "Linux x86_64 com Waybar. Uso no Hyprland" README.md
+  ```
+  Esperado: as duas linhas aparecem (7 e 27) — confirma o baseline antes do
+  edit.
+
+- [ ] **Step 2: Editar a tagline (linha 7)**
+
+  Trocar:
+  ```
+  Monitor de quota de Claude Code, OpenAI Codex, Amp e Grok Build na Waybar. Quota de agente é aquele recurso que você só descobre que acabou quando acabou; aqui ela fica visível na barra o tempo todo. Um binário em Rust, sem daemon: a Waybar chama, ele imprime JSON e vai embora.
+  ```
+  Por:
+  ```
+  Monitor de quota de Claude Code, OpenAI Codex, Amp e Grok Build — nativo no Omarchy 4 (omarchy-shell), com Waybar suportada como tier legado. Quota de agente é aquele recurso que você só descobre que acabou quando acabou; aqui ela fica visível na barra o tempo todo. Um binário em Rust, sem daemon: o shell chama, ele imprime JSON e vai embora.
+  ```
+
+- [ ] **Step 3: Editar o bloco `## Requisitos` (linhas 25-32)**
+
+  Trocar:
+  ```
+  ## Requisitos
+
+  - Linux x86_64 com Waybar. Uso no Hyprland, mas não tem nada específico dele aqui.
+  - **Omarchy 4 (omarchy-shell)**: bar-widget plugin nativo com chips + popup — `agent-bar setup` detecta e instala. Waybar segue suportada.
+  - `curl`, `tar` e `sha256sum` pro instalador.
+  - Um terminal que o helper reconheça: alacritty, kitty, foot, ghostty, wezterm, ou `xdg-terminal-exec`.
+  - As CLIs que você quer monitorar, instaladas. O login dá pra fazer pela própria TUI.
+  - `libnotify`, se quiser notificação de quota baixa. Opcional.
+  ```
+  Por:
+  ```
+  ## Requisitos
+
+  - Linux x86_64. **Omarchy 4 (omarchy-shell)** é o alvo principal: `agent-bar setup` detecta o omarchy-shell e instala o bar-widget plugin nativo (chips + popup) automaticamente.
+  - **Waybar** — suportada como **tier legado**: funciona, recebe fix, não recebe feature nova. `agent-bar setup` integra com ela também, quando presente.
+  - `curl`, `tar` e `sha256sum` pro instalador.
+  - Um terminal que o helper reconheça: alacritty, kitty, foot, ghostty, wezterm, ou `xdg-terminal-exec`.
+  - As CLIs que você quer monitorar, instaladas. O login dá pra fazer pela própria TUI.
+  - `libnotify`, se quiser notificação de quota baixa. Opcional.
+  ```
+
+- [ ] **Step 4: Rodar e ver passar**
+
+  ```bash
+  grep -c "Omarchy 4 (omarchy-shell)" README.md
+  grep -n "tier legado" README.md
+  grep -n "Monitor de quota de Claude Code, OpenAI Codex, Amp e Grok Build na Waybar" README.md
+  git diff --check
+  ```
+  Esperado: a primeira conta ≥2 (tagline + requisitos), a segunda encontra a
+  linha nova do bloco Requisitos, a terceira **não retorna nada** (tagline
+  antiga sumiu), `git diff --check` sem saída (sem erro de whitespace).
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add README.md
+  git commit -m "docs: tagline e requisitos Omarchy-first no README"
+  ```
+
+---
+
+### Task 2: CONTRIBUTING.md — MSRV 1.88
+
+**Files:**
+- Modify: `CONTRIBUTING.md:6-12` (tabela de Prerequisites)
+
+**Interfaces:**
+- Consumes: `Cargo.toml` `rust-version = "1.88"` (já correto no manifest;
+  este doc está desatualizado em relação a ele) e o comentário do próprio
+  `Cargo.toml` — `# 1.88: piso real, não 1.80 — tachyonfx (via anpa) exige 1.82.`
+- Produces: nenhuma task posterior depende disso; é uma correção de fato solta.
+
+**Steps:**
+
+- [ ] **Step 1: Confirmar o texto desatualizado**
+
+  ```bash
+  grep -n "stable (1.75+)" CONTRIBUTING.md
+  ```
+  Esperado: 1 ocorrência (linha 9) — confirma o baseline errado.
+
+- [ ] **Step 2: Editar a tabela de Prerequisites**
+
+  Trocar:
+  ```
+  | Tool | Minimum |
+  |------|---------|
+  | [Rust](https://rustup.rs) | stable (1.75+) |
+  | Git | recent |
+
+  Rust + Cargo is the only supported toolchain.
+  ```
+  Por:
+  ```
+  | Tool | Minimum |
+  |------|---------|
+  | [Rust](https://rustup.rs) | 1.88 (MSRV — `tachyonfx` via `anpa` requires it) |
+  | Git | recent |
+
+  Rust + Cargo is the only supported toolchain.
+  ```
+
+- [ ] **Step 3: Rodar e ver passar**
+
+  ```bash
+  grep -n "stable (1.75+)" CONTRIBUTING.md; echo "exit=$?"
+  grep -n "1.88 (MSRV" CONTRIBUTING.md
+  git diff --check
+  ```
+  Esperado: o primeiro grep não acha nada (`exit=1`), o segundo acha a linha
+  nova, `git diff --check` sem saída.
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add CONTRIBUTING.md
+  git commit -m "docs: corrige MSRV pra 1.88 no CONTRIBUTING"
+  ```
+
+---
+
+### Task 3: docs/waybar-contract.md — Grok + banner de tier legado
+
+**Files:**
+- Modify: `docs/waybar-contract.md:1-17` (título + seção `## Providers`)
+
+**Interfaces:**
+- Consumes: registro real de providers Waybar — `docs/waybar-contract.md`
+  hoje lista só `claude`/`codex`/`amp`; `grok` já é provider registrado
+  (`src/providers/grok.rs`, cache key `grok-usage`) e já aparece no módulo
+  Waybar (ícone shipado desde 8.2.1), só faltava no contrato documentado.
+- Produces: nenhuma task futura depende do texto exato; é a correção de um
+  gap de documentação pré-existente + o banner de tier legado que a Task 9
+  (CHANGELOG) e o README (Task 1) já anunciam.
+
+**Steps:**
+
+- [ ] **Step 1: Confirmar que `grok` está ausente do contrato documentado**
+
+  ```bash
+  grep -n '`grok`' docs/waybar-contract.md; echo "exit=$?"
+  ```
+  Esperado: nenhuma ocorrência (`exit=1`) — confirma o gap antes do fix.
+
+- [ ] **Step 2: Inserir o banner de tier legado logo após o título**
+
+  Trocar:
+  ```
+  # Waybar Contract
+
+  This is the generated contract used by setup and by the export commands.
+
+  ## Providers
+
+  Built-in Waybar providers:
+
+  - `claude`
+  - `codex`
+  - `amp`
+
+  Generated module IDs:
+
+  - `custom/agent-bar-claude`
+  - `custom/agent-bar-codex`
+  - `custom/agent-bar-amp`
+  ```
+  Por:
+  ```
+  # Waybar Contract
+
+  > **Waybar é tier legado** a partir da 9.0.0: funciona, recebe fix, não
+  > recebe feature nova. O alvo atual é o Omarchy 4 (omarchy-shell) — ver
+  > [`omarchy-shell.md`](omarchy-shell.md). Este documento descreve o
+  > contrato Waybar como está, para quem ainda depende dele.
+
+  This is the generated contract used by setup and by the export commands.
+
+  ## Providers
+
+  Built-in Waybar providers:
+
+  - `claude`
+  - `codex`
+  - `amp`
+  - `grok`
+
+  Generated module IDs:
+
+  - `custom/agent-bar-claude`
+  - `custom/agent-bar-codex`
+  - `custom/agent-bar-amp`
+  - `custom/agent-bar-grok`
+  ```
+
+- [ ] **Step 3: Rodar e ver passar**
+
+  ```bash
+  grep -n '`grok`' docs/waybar-contract.md
+  grep -n "custom/agent-bar-grok" docs/waybar-contract.md
+  grep -n "tier legado" docs/waybar-contract.md
+  git diff --check
+  ```
+  Esperado: as três buscas encontram a linha nova cada uma; `git diff
+  --check` sem saída.
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add docs/waybar-contract.md
+  git commit -m "docs: Grok no contrato Waybar + banner de tier legado"
+  ```
+
+---
+
+### Task 4: docs/json-output.md — remover seção Future
+
+**Files:**
+- Modify: `docs/json-output.md:123-129` (fim do arquivo, seção `## Future`)
+
+**Interfaces:**
+- Consumes: **produto da PR 2** (`windowKind` em `QuotaWindow` +
+  `docs/json-output.md` já documentando `extra` por provider —
+  `AmpQuotaExtra.meta`, `GrokQuotaExtra`, `ClaudeQuotaExtra.extraUsage`,
+  `CodexQuotaExtra.modelsDetailed` — conforme a Seção A do spec). Esta task
+  **não escreve** esse conteúdo — só confere que já está lá e remove a
+  seção `## Future` que ficou obsoleta (o "plugin Quickshell nativo" que ela
+  anunciava como futuro já existe desde a 8.4.0).
+- Produces: nada consome a ausência da seção; é limpeza terminal do arquivo.
+
+**Steps:**
+
+- [ ] **Step 1: Confirmar a pré-condição da PR 2 (bloqueante se falhar)**
+
+  ```bash
+  grep -c "windowKind" docs/json-output.md
+  grep -c "AmpQuotaExtra\|GrokQuotaExtra\|ClaudeQuotaExtra\|CodexQuotaExtra" docs/json-output.md
+  ```
+  Esperado: ambas as contagens ≥1. **Se qualquer uma vier 0, a PR 2 ainda
+  não landou o conteúdo que esta task assume — pare e reporte ao invés de
+  prosseguir** (não escrever esse conteúdo aqui; é escopo da PR 2, não
+  desta).
+
+- [ ] **Step 2: Confirmar que a seção Future ainda existe**
+
+  ```bash
+  grep -n "^## Future" docs/json-output.md
+  ```
+  Esperado: 1 ocorrência (linha 125) — confirma o baseline antes do fix.
+
+- [ ] **Step 3: Remover a seção Future**
+
+  Trocar (linhas 123-129, fim do arquivo):
+  ```
+  `Process.command` is an argv array (no shell) — keep each argument separate.
+
+  ## Future
+
+  A native Omarchy Quickshell bar-widget plugin
+  (`~/.config/omarchy/plugins/agent-bar/`) is a future step once Omarchy ships its
+  Quickshell release (v4).
+  ```
+  Por:
+  ```
+  `Process.command` is an argv array (no shell) — keep each argument separate.
+  ```
+
+- [ ] **Step 4: Rodar e ver passar**
+
+  ```bash
+  grep -n "^## Future" docs/json-output.md; echo "exit=$?"
+  tail -3 docs/json-output.md
+  git diff --check
+  ```
+  Esperado: o grep não acha nada (`exit=1`); `tail` mostra a linha do
+  `Process.command` como última linha não-vazia do arquivo; `git diff
+  --check` sem saída.
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add docs/json-output.md
+  git commit -m "docs: remove seção Future obsoleta do json-output"
+  ```
+
+---
+
+### Task 5: docs/troubleshooting.md — seção Grok
+
+**Files:**
+- Modify: `docs/troubleshooting.md:74-87` (bloco `### Amp`, entre ela e `##
+  Reset Managed Waybar Entries`)
+
+**Interfaces:**
+- Consumes: `src/providers/grok.rs` — `ctx.paths.grok_auth` (
+  `~/.grok/auth.json`), sessões em `{grok_home}/sessions/**/signals.json`
+  (função `collect_signals`), CHANGELOG 8.2.0 ("Login via `grok login` na
+  TUI"), e a nota de `parse_auth_entries`: token expirado não desloga
+  (renovado pelo Grok CLI via refresh token; o provider é zero-rede).
+- Produces: nada consome; é gap de documentação pré-existente (a seção
+  "Provider Auth" cobre Claude/Codex/Amp mas nunca teve Grok, apesar do
+  provider existir desde a 8.2.0).
+
+**Steps:**
+
+- [ ] **Step 1: Confirmar o gap**
+
+  ```bash
+  grep -n "### Grok" docs/troubleshooting.md; echo "exit=$?"
+  ```
+  Esperado: nenhuma ocorrência (`exit=1`).
+
+- [ ] **Step 2: Inserir a seção Grok após `### Amp`**
+
+  Trocar:
+  ````
+  ### Amp
+
+  Install Amp with the official installer:
+
+  ```bash
+  curl -fsSL https://ampcode.com/install.sh | bash
+  ```
+
+  Then run:
+
+  ```bash
+  amp login
+  ```
+
+  ## Reset Managed Waybar Entries
+  ````
+  Por:
+  ````
+  ### Amp
+
+  Install Amp with the official installer:
+
+  ```bash
+  curl -fsSL https://ampcode.com/install.sh | bash
+  ```
+
+  Then run:
+
+  ```bash
+  amp login
+  ```
+
+  ### Grok
+
+  Grok Build CLI uses OAuth in `~/.grok/auth.json`; the provider itself
+  makes zero network calls — it reads session `signals.json` files under
+  `~/.grok/sessions/**` for context-window data. Log in with:
+
+  ```bash
+  grok login
+  ```
+
+  An access token past its `expires_at` does **not** log you out: the Grok
+  CLI renews it via refresh token, and agent-bar only checks for a
+  non-empty `key` in `auth.json`.
+
+  ## Reset Managed Waybar Entries
+  ````
+
+- [ ] **Step 3: Rodar e ver passar**
+
+  ```bash
+  grep -n "### Grok" docs/troubleshooting.md
+  grep -n "grok login" docs/troubleshooting.md
+  grep -n "~/.grok/auth.json" docs/troubleshooting.md
+  git diff --check
+  ```
+  Esperado: as três buscas encontram as linhas novas; `git diff --check`
+  sem saída.
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add docs/troubleshooting.md
+  git commit -m "docs: seção Grok no troubleshooting"
+  ```
+
+---
+
+### Task 6: docs/runtime.md — seção Grok (tabela de credenciais)
+
+**Files:**
+- Modify: `docs/runtime.md:91-100` (bloco `## Provider Credentials`)
+
+**Interfaces:**
+- Consumes: mesma fonte da Task 5 (`src/providers/grok.rs`:
+  `ctx.paths.grok_auth`, `sessions/**/signals.json`).
+- Produces: nada consome; a tabela hoje lista Claude/Codex/Amp mas omite
+  Grok apesar dos defaults (linhas 49-50 do mesmo arquivo) já incluírem
+  `grok`.
+
+**Steps:**
+
+- [ ] **Step 1: Confirmar o gap**
+
+  ```bash
+  grep -n "| Grok |" docs/runtime.md; echo "exit=$?"
+  ```
+  Esperado: nenhuma ocorrência (`exit=1`).
+
+- [ ] **Step 2: Adicionar a linha Grok à tabela**
+
+  Trocar:
+  ```
+  | Provider | Source |
+  | --- | --- |
+  | Claude | `~/.claude/.credentials.json` |
+  | Codex | `~/.codex/auth.json`, recent `~/.codex/sessions/**` rate-limit events, or `codex app-server` |
+  | Amp | official `amp` CLI |
+  ```
+  Por:
+  ```
+  | Provider | Source |
+  | --- | --- |
+  | Claude | `~/.claude/.credentials.json` |
+  | Codex | `~/.codex/auth.json`, recent `~/.codex/sessions/**` rate-limit events, or `codex app-server` |
+  | Amp | official `amp` CLI |
+  | Grok | `~/.grok/auth.json`; session `signals.json` under `~/.grok/sessions/**` (read-only, no network) |
+  ```
+
+- [ ] **Step 3: Confirmar o baseline da versão do schema**
+
+  ```bash
+  grep -n "Settings schema version" docs/runtime.md
+  ```
+  Esperado: 1 ocorrência (linha 45) — `Settings schema version: \`2\`.` —
+  confirma o baseline antes do fix.
+
+- [ ] **Step 4: Atualizar a versão do settings schema (migração v2 → v3 do plano 01)**
+
+  Trocar:
+  ```
+  Settings schema version: `2`.
+  ```
+  Por:
+  ```
+  Settings schema version: `3`.
+  ```
+
+- [ ] **Step 5: Rodar e ver passar**
+
+  ```bash
+  grep -n "| Grok |" docs/runtime.md
+  grep -n "Settings schema version" docs/runtime.md
+  git diff --check
+  ```
+  Esperado: a primeira encontra a linha Grok nova; a segunda mostra
+  `Settings schema version: \`3\`.`; `git diff --check` sem saída.
+
+- [ ] **Step 6: Commit**
+
+  ```bash
+  git add docs/runtime.md
+  git commit -m "docs: linha Grok e schema v3 na tabela do runtime"
+  ```
+
+---
+
+### Task 7: docs/architecture.md — reescrito Omarchy-first
+
+**Files:**
+- Modify: `docs/architecture.md` (arquivo inteiro, 197 linhas hoje —
+  substituição completa do corpo, mantendo o mesmo título e a maioria dos
+  fatos técnicos, reordenados e ampliados)
+
+**Interfaces:**
+- Consumes (produto das PRs 1-4, conforme o CONTRATO DE INTERFACES
+  GLOBAIS): `src/platform.rs::{Platform, detect}`; `QuotaWindow.window_kind`
+  em `src/providers/types.rs`; `classify_window`/`is_duplicate_window` em
+  `src/formatters/shared.rs` (o `classify_window` interno já existe hoje —
+  ver `src/formatters/shared.rs:47`; `is_duplicate_window` é novo, produto
+  da PR 2); `menuAnimations` em `config show` (`src/config_cmd.rs`);
+  `src/waybar/contract.rs` / `src/waybar/integration.rs` com re-exports
+  (produto da PR 4). Fatos já reais hoje e preservados da versão atual:
+  fluxo `main.rs` → `cli.rs` → `providers/` → `cache.rs` →
+  `formatters/` → stdout; `BaseProvider` vs `ClaudeProvider` direto;
+  boundary de escape só em `render_pango.rs`.
+- Produces: mapa de módulos que `docs/new-provider.md` e onboarding humano
+  usam como referência; nenhuma outra task deste plano depende do texto
+  exato.
+
+**Steps:**
+
+- [ ] **Step 1: Confirmar o baseline pré-Omarchy-first**
+
+  ```bash
+  grep -n "^## Data Flow" docs/architecture.md
+  grep -c "src/waybar/" docs/architecture.md; echo "exit acima deve ser 0"
+  grep -c "windowKind\|window_kind" docs/architecture.md; echo "exit acima deve ser 0"
+  ```
+  Esperado: a primeira acha a seção atual (linha 6); as duas contagens são
+  `0` — confirma que o arquivo ainda não reflete `src/waybar/` nem
+  `windowKind` (produto das PRs 2/4 que este doc só passa a citar agora).
+
+- [ ] **Step 2: Substituir o arquivo inteiro**
+
+  Conteúdo completo novo de `docs/architecture.md`:
+  ````markdown
+  # Architecture
+
+  How agent-bar turns a fetch into something on screen. Omarchy 4
+  (omarchy-shell) is the primary target — `Widget.qml` renders the popup
+  straight from `--format json`. Waybar remains supported as a **legacy
+  tier** (works, gets fixes, no new features) via the classic Pango module
+  contract. `src/` is the source of truth and wins on any disagreement.
+
+  ## Data Flow
+
+  Two consumers read the same provider/formatter pipeline; they diverge
+  only at the very end.
+
+  ```text
+  Omarchy Widget.qml (native plugin, primary)      Waybar module (legacy tier)
+     │  polls                                          │  polls (interval from settings, default 60s)
+     ▼                                                  ▼
+  agent-bar --format json                       agent-bar --provider <id>
+     │                                                  │
+     └──────────────────┬───────────────────────────────┘
+                         ▼
+          parse_args → CliOptions                  src/cli.rs
+                         ▼
+          get_quota_for(id) / get_all_quotas()      src/providers/   fan-out + timeout/retry
+                         │  parallel · 10s timeout · 1 retry on timeout
+                         ▼
+          Provider::get_quota()
+             ├─ ClaudeProvider    (implements Provider direct) src/providers/claude.rs
+             └─ Codex/Amp/Grok   (extend BaseProvider)        src/providers/base.rs
+                         │  is_available() gate → credentials check
+                         ▼
+          Quota cache  (file · 5 min TTL · cross-process)    src/cache.rs
+                         │  hit → cached raw   miss → fetch_raw() → provider API/CLI → cache.set()
+                         ▼
+          ProviderQuota  (normalized, windowKind classified) src/providers/types.rs
+                         │
+             ┌───────────┴────────────┐
+             ▼                        ▼
+      to_json_output            formatters::waybar
+      (schemaVersion, no Pango)  format_for_waybar / format_provider_for_waybar
+      src/formatters/json.rs     builders → segments → render_pango() (XML escape)
+             │                        │
+             ▼                        ▼
+      stdout NDJSON/JSON envelope    stdout Waybar JSON {text,tooltip,class}
+             │
+             ▼
+      Widget.qml applyPayload() — collapses duplicate windows
+      (same windowKind/resetsAt/remaining), renders countdown from
+      resetsAt/fetchedAt, hero %, per-provider panel, extra line.
+  ```
+
+  `stdout` is reserved for the machine-readable payload the shell/Waybar
+  parses; all logging goes to `stderr` via `logger`. Breaking that contract
+  breaks both consumers.
+
+  `agent-bar menu` (the TUI) and `agent-bar status` read the exact same
+  `ProviderQuota` through their own formatter (`terminal.rs`) — a third,
+  interactive consumer of the same pipeline, not shown above for brevity.
+
+  ## Entry And Dispatch — `src/main.rs`
+
+  `parse_args` (`src/cli.rs`) turns argv into `CliOptions`. `main()`
+  dispatches:
+
+  - **Subcommands** (`menu`, `setup`, `doctor`, `update`, `config
+    show|apply`, `action-right`, …) are dispatched by pattern match and
+    handled, then the process exits. `config show|apply` is implemented in
+    `src/config_cmd.rs` (editable settings subset only, plus the read-only
+    `menuAnimations` flag on `show`; no Waybar reload). `action-right`
+    remains the Waybar right-click path; Omarchy uses the native popup
+    settings mode instead (see [omarchy-shell.md](omarchy-shell.md)).
+  - **`--watch`** hands off to `start_watch` (`src/watch.rs`) and streams
+    NDJSON.
+  - Otherwise it resolves quotas and prints a single payload. The default
+    command is `waybar`; `status` (`-t`/`--terminal` alias) prints the ANSI
+    view; `--format json` prints the versioned envelope Widget.qml
+    consumes.
+
+  `setup`, `update`, and TUI Config Save all gate their Waybar-directory
+  writes behind `platform::detect()` (`src/platform.rs`) — a single
+  `Platform { omarchy: bool, waybar: bool }` that composes
+  `omarchy_integration::detect_omarchy_shell()` and `setup::waybar_present()`.
+  On an Omarchy-only desktop, none of the three paths create
+  `~/.config/waybar/` from scratch.
+
+  Two Waybar render shapes share the formatter (legacy tier only):
+
+  - **Single-provider module** — `agent-bar --provider <id>` →
+    `formatProviderForWaybar`. This is what generated Waybar modules call
+    (one module per provider). A provider disabled in settings never
+    reaches the formatter — `main.rs` / gate `is_hidden_module`
+    short-circuits first and prints the hidden-module payload (`class:
+    agent-bar-hidden`) so Waybar collapses it.
+  - **Aggregate** — `agent-bar` with no provider → `outputWaybar` /
+    `formatForWaybar`, joining every enabled provider into one module.
+
+  After Waybar output, low/critical desktop notifications fire best-effort
+  (`src/notify.rs`) — only when `notify.enabled` is set (default on) and
+  stdout is piped (i.e. real Waybar polling), never on an interactive
+  terminal run, and never in json/terminal/watch modes.
+
+  ## Provider Layer — `src/providers/`
+
+  Providers are registered in `src/providers/mod.rs`. `get_all_quotas` runs
+  every registered provider in parallel behind `fetch_with_retry` (10s
+  timeout, one retry on timeout); a failing provider degrades to an
+  `available: false` quota with an error string instead of taking down the
+  bar. `get_quota_for` is the single-provider variant.
+
+  Every provider returns a normalized **`ProviderQuota`**
+  (`src/providers/types.rs`): `primary`/`secondary` quota windows (each
+  `{ remaining, resetsAt, windowKind, … }`), optional `extra` (per-provider,
+  pre-render data like Claude `weeklyModels`, Codex `modelsDetailed`, Amp
+  credits, or Grok session/turn counts), `plan`/`account`, or an `error`.
+  Everything downstream speaks this shape — formatters never see
+  provider-specific API responses.
+
+  Each provider sets `windowKind` at the source instead of downstream code
+  guessing from the number: Claude sets `fiveHour`/`sevenDay` directly; Amp
+  sets `daily`; Grok sets `context`; Codex classifies via
+  `classify_window` (below) with no fallback — a window outside tolerance
+  is `other`, not force-mapped onto `fiveHour`/`sevenDay`.
+
+  ### `BaseProvider` vs `ClaudeProvider`
+
+  `BaseProvider` (`src/providers/base.rs`) owns the `get_quota()`
+  orchestration so concrete providers implement only what differs:
+
+  ```text
+  get_quota():
+    base = build_base()
+    if !is_available()       → return ProviderQuota { error: unavailable_error(), .. }
+    raw = cache.get_or_fetch(cache_key, fetch_raw, 5min)  // cached
+    return build_quota(raw, base)                          // pure transform
+    (any error)              → return ProviderQuota { error: to_user_facing_error(e), .. }
+  ```
+
+  `CodexProvider`, `AmpProvider`, and `GrokProvider` extend it — they
+  supply `is_available`, `fetch_raw`, `build_quota`, and
+  `unavailable_error`, and inherit the availability gate, cache wrapper,
+  and error handling.
+
+  `ClaudeProvider` **implements `Provider` directly** and does not extend
+  `BaseProvider`. Its flow doesn't fit the template: it reads
+  `~/.claude/.credentials.json` for the OAuth token, distinguishes "no
+  file" / "invalid file" / "no token" / "token expired" as separate
+  user-facing errors, calls `cache.get_or_fetch` inline, and parses several
+  quota windows (`five_hour`, `seven_day`, per-model weeklies, extra
+  usage). Forcing it into `BaseProvider` would mean fighting the
+  abstraction, so it manages its own cache call. Do not "normalize" it back
+  into the template (see repo `CLAUDE.md`).
+
+  From the same credentials it also reads `expiresAt` — to short-circuit a
+  locally-expired access token (the API would reject it anyway, and
+  agent-bar must never refresh it: the single-use refresh token races
+  Claude Code) — and `rateLimitTier`, to surface the Max multiplier in the
+  plan label (e.g. `Max 5x`).
+
+  ## Window Classification & Display Dedup — `src/formatters/shared.rs`
+
+  `classify_window(window_minutes) -> WindowKind` is the single place
+  tolerance math lives (`fiveHour` = 300±90min, `sevenDay` = 10080±1440min,
+  else `other`) — providers call it once at the source; QML and the TUI
+  never re-derive a label from magic numbers. `format_eta`/
+  `format_reset_time` render the countdown (`Xh Ym`/`Nd Nh`) and the
+  localized reset clock (`Clock.local_offset`) from the same `resetsAt`
+  string — the TUI's `fmt_reset` (`src/tui/render/detail/format.rs`) calls
+  these instead of slicing the raw ISO string.
+
+  `is_duplicate_window(a, b) -> bool` collapses two windows that share
+  `(windowKind, resetsAt, remaining-rounded)` — the display-level fix for
+  the Codex Plus duplicate-Weekly bug (the JSON envelope still emits
+  `primary`/`secondary`/`models` untouched; only consumers that render
+  multiple windows side by side dedup). The TUI consumes it directly; QML
+  ports the same predicate in JS since it has no Rust runtime.
+
+  ## The Quota Cache
+
+  `src/cache.rs` is a file-based cache (`$XDG_CACHE_HOME/agent-bar/<key>.json`,
+  default `~/.cache`) with a **5-minute TTL** (`CONFIG.cache.ttl_ms`) and
+  **cross-process** lifetime — it survives between polls, which is what
+  matters here: both Widget.qml and Waybar poll at their own configured
+  interval but each poll is a *separate process*, so an in-memory cache
+  would never hit. The file-based cache means most polls within a
+  5-minute window read the cached response from disk and one triggers a
+  fresh fetch — the provider API is hit at most once per 5-minute window
+  regardless of the configured poll interval. `get_or_fetch` reads the
+  cache, and on a miss runs the fetcher once, writing atomically (temp
+  file + `rename`) because concurrent provider processes can write the
+  same key. An in-flight dedup map deduplicates concurrent fetches
+  *within* one process; failed fetches are never cached (a non-200 errors
+  before `set`); cache keys are validated against path traversal.
+
+  There is no separate settings cache — `settings::load` reads
+  `settings.json` directly on every call; no in-process memoization layer
+  exists.
+
+  ## Formatter Layer — `src/formatters/`
+
+  Quotas are rendered three ways from the same `ProviderQuota`:
+
+  - **JSON** (`json.rs`) → versioned, Pango-free envelope
+    (`{ schemaVersion, fetchedAt, providers[] }`), the contract Widget.qml
+    and any other native bar consumes. See [`json-output.md`](json-output.md).
+  - **Waybar** (`waybar.rs`) → `{ text, tooltip, class }` JSON, legacy
+    tier. `text` is the bar percentage; `tooltip` is multi-line Pango
+    built per provider; `class` is a provider-scoped compound carrying a
+    health state for CSS — `agent-bar-<provider> <status>` for a single
+    module, or `agent-bar` plus `<provider>-<status>` tokens in aggregate
+    (see [Waybar contract](waybar-contract.md)). States:
+    `ok`/`low`/`warn`/`critical`/`disconnected`.
+  - **Terminal** (`terminal.rs`) → ANSI view for `status`. `action-right`
+    no longer uses this path — it resolves focus and opens the TUI instead
+    (see `src/action_right.rs` below).
+
+  Builders (`formatters/builders/`) describe output as `Vec<Line>` of
+  typed `Segment`s (text + color token). **`render_pango.rs` is the single
+  XML-escape boundary** — `span()` / `render_pango()` are the only places
+  provider data gets Pango markup, and they escape every non-`raw`
+  segment. Builders never escape; a `raw` segment opts out of both
+  color-wrap *and* escape and must already be safe. Routing untrusted
+  provider strings around this boundary is a tooltip injection bug, so all
+  Pango output goes through it. Since the Codex fallback mapping is gone,
+  `formatters/builders/codex.rs` renders an `other`-kind window with a
+  label built from its real duration (e.g. `"1h window"`) instead of
+  assuming it must be the 5h or 7d bucket.
+
+  ## TUI — `src/tui/`
+
+  `agent-bar menu` shares the provider/cache/formatter layers above; its
+  own render tree (`src/tui/render/`) is a fourth consumer of
+  `ProviderQuota`, independent of Waybar/Omarchy. Detail's window rows use
+  the same `classify_window`/`is_duplicate_window`/`format_eta`/
+  `format_reset_time` helpers as Widget.qml, so the two surfaces never
+  drift on labels, dedup, or timezone. Config screens hide Waybar-only
+  fields (separators, signal, interval) when `platform::detect()` reports
+  Omarchy-only — the same gate `setup`/`update` use.
+
+  ## Omarchy Shell — `Widget.qml` (primary integration)
+
+  The Omarchy 4 (omarchy-shell/Quickshell) plugin is agent-bar's
+  first-class target: a native bar-widget with per-provider chips and a
+  popup, driven entirely by `agent-bar --format json` and `agent-bar
+  config show`/`config apply`. Titlebar actions (refresh, settings mode,
+  open TUI) are real Unicode icon buttons, not text hints. Settings mode
+  dual-writes: `config apply` owns `providers`/`providerOrder`/
+  `displayMode`/`notify.enabled` in `settings.json`; the plugin's own
+  `refreshIntervalSec` is written inline into Omarchy's `shell.json` via
+  `bar.shell.updateEntryInline`. Motion (bar fill on open, refresh spin,
+  hover) is gated by the read-only `menuAnimations` field `config show`
+  exposes — editing it stays a `settings.json` concern. `agent-bar update`
+  reinstalls the plugin whenever `detect_omarchy_shell()` is true, so the
+  binary and the embedded QML never drift apart; `doctor` additionally
+  checks the installed manifest version against the running binary. Full
+  plugin contract, click routing, and the dual-write table:
+  [omarchy-shell.md](omarchy-shell.md).
+
+  ## Waybar — legacy tier
+
+  Waybar keeps working — it gets fixes, not new features. Its contract
+  (module IDs, CSS classes, click actions, `signal`-based refresh) lives
+  in [waybar-contract.md](waybar-contract.md) and is implemented by
+  `src/waybar/contract.rs` and `src/waybar/integration.rs` (grouped under
+  `src/waybar/`, re-exported at the crate root as `waybar_contract` /
+  `waybar_integration` so the existing `cargo test waybar_contract` /
+  `cargo test waybar_integration` filters in `CLAUDE.md` keep working).
+  `platform::detect()` is what lets every write path (`setup`, `update`,
+  TUI Config Save) skip touching `~/.config/waybar/` entirely on an
+  Omarchy-only machine.
+
+  ## Module Map
+
+  | File | Role |
+  | --- | --- |
+  | `src/main.rs` | Entry point; dispatch by command/flags. |
+  | `src/cli.rs` | argv → `CliOptions`; `--help` rendering; command suggestions. |
+  | `src/platform.rs` | `Platform { omarchy, waybar }` + `detect()` — the single gate `setup`/`update`/TUI-save use before touching Waybar paths. |
+  | `src/config.rs` | Paths (XDG), cache TTL, API endpoints, color thresholds. |
+  | `src/config_cmd.rs` | `config show` / `config apply` — editable settings subset (JSON) + read-only `menuAnimations` on `show`. |
+  | `src/cache.rs` | File-based quota cache (5 min, cross-process, atomic writes). |
+  | `src/providers/mod.rs` | Registration, parallel fan-out, timeout/retry. |
+  | `src/providers/base.rs` | `BaseProvider` `get_quota()` orchestration. |
+  | `src/providers/{claude,codex,amp,grok}.rs` | Concrete providers. Claude is direct; others extend `BaseProvider`. Each sets `windowKind` at the source. |
+  | `src/providers/types.rs` | `ProviderQuota`, `QuotaWindow` (incl. `windowKind`), `Provider`, `AllQuotas`. |
+  | `src/formatters/shared.rs` | `classify_window`/`WindowKind`, `is_duplicate_window`, `format_eta`/`format_reset_time`. |
+  | `src/formatters/json.rs` | Versioned JSON envelope (`schemaVersion`) — the contract Widget.qml consumes. |
+  | `src/formatters/waybar.rs` | Waybar JSON assembly ({text,tooltip,class}) — legacy tier. |
+  | `src/formatters/render_pango.rs` | Single XML-escape boundary for Pango. |
+  | `src/formatters/terminal.rs` | ANSI terminal view. |
+  | `src/waybar/contract.rs` | Generated Waybar modules/CSS/asset install (re-exported as `crate::waybar_contract`). |
+  | `src/waybar/integration.rs` | In-place `config.jsonc`/`style.css` patcher (re-exported as `crate::waybar_integration`). |
+  | `src/notify.rs` | Best-effort low/critical desktop notifications. |
+  | `src/action_right.rs` | Waybar right-click handler — resolves TUI focus (provider detail or Login) from connection state. |
+  | `src/omarchy_integration.rs` | Omarchy drop-in install/remove; embeds `Widget.qml` / manifest; `detect_omarchy_shell()`. |
+
+  ## See Also
+
+  - [Commands](commands.md) — public CLI surface, `config`, flags, and internals.
+  - [Runtime](runtime.md) — owned paths, settings, cache, credentials.
+  - [Waybar contract](waybar-contract.md) — generated modules, classes, click actions (legacy tier).
+  - [Omarchy shell](omarchy-shell.md) — plugin drop-in, settings popup, dual-write.
+  - [JSON output](json-output.md) — `--format json` / `--watch` schema, incl. `windowKind` and `extra` shapes.
+  - [New provider guide](new-provider.md) — implementing a provider on `BaseProvider`.
+  ````
+
+- [ ] **Step 3: Rodar e ver passar**
+
+  ```bash
+  grep -c "src/waybar/" docs/architecture.md
+  grep -c "windowKind" docs/architecture.md
+  grep -n "^## Waybar — legacy tier" docs/architecture.md
+  grep -n "^## Omarchy Shell" docs/architecture.md
+  git diff --check
+  ```
+  Esperado: as duas primeiras contagens ≥1; as duas buscas de título
+  encontram a seção nova; `git diff --check` sem saída.
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add docs/architecture.md
+  git commit -m "docs: arquitetura reescrita Omarchy-first"
+  ```
+
+---
+
+### Task 8: CLAUDE.md — linha `providers::grok_cli` + nota do módulo `src/waybar/`
+
+**Files:**
+- Modify: `CLAUDE.md:49` (tabela da Seção 2, logo após a linha de CLI
+  locators do Amp) e `CLAUDE.md:69-71` (Seção 3, bullet sobre
+  `waybar_integration.rs`)
+
+**Interfaces:**
+- Consumes: `src/providers/grok_cli.rs` (locator do binário `grok`, mesmo
+  papel de `amp_cli.rs`); produto da PR 4 (`src/waybar/contract.rs` +
+  `src/waybar/integration.rs` com re-exports, já citado no CONTRATO DE
+  INTERFACES GLOBAIS deste plano).
+- Produces: a matriz de verificação (§2) e as regras de módulo (§3) que
+  todo agente futuro no repo lê antes de editar `src/waybar/` ou
+  `src/providers/grok_cli.rs`.
+
+**Steps:**
+
+- [ ] **Step 1: Confirmar a ausência das duas linhas**
+
+  ```bash
+  grep -n "providers::grok_cli" CLAUDE.md; echo "exit=$?"
+  grep -n "src/waybar/" CLAUDE.md; echo "exit=$?"
+  ```
+  Esperado: nenhuma das duas buscas acha nada (`exit=1` nas duas).
+
+- [ ] **Step 2: Adicionar a linha na matriz (Seção 2)**
+
+  Trocar:
+  ```
+  | CLI locators (Amp CLI) | `cargo test providers::amp_cli` |
+  | Contratos Rust | `cargo clippy --all-targets -- -D warnings` |
+  ```
+  Por:
+  ```
+  | CLI locators (Amp CLI) | `cargo test providers::amp_cli` |
+  | CLI locators (Grok CLI) | `cargo test providers::grok_cli` |
+  | Contratos Rust | `cargo clippy --all-targets -- -D warnings` |
+  ```
+
+- [ ] **Step 3: Adicionar o bullet sobre `src/waybar/` na Seção 3**
+
+  Trocar:
+  ```
+  - **Nunca round-trip live Waybar config via `serde_json`.**
+    Os `.jsonc` têm comentários e ordem que precisam sobreviver.
+    `waybar_integration.rs` patcha in-place.
+  ```
+  Por:
+  ```
+  - **Nunca round-trip live Waybar config via `serde_json`.**
+    Os `.jsonc` têm comentários e ordem que precisam sobreviver.
+    `waybar_integration.rs` patcha in-place.
+  - **Módulo `src/waybar/` agrupa o tier legado** (`src/waybar/contract.rs`,
+    `src/waybar/integration.rs`), com re-exports em `lib.rs` para
+    `crate::waybar_contract`/`crate::waybar_integration`. Os filtros
+    `cargo test waybar_contract`/`cargo test waybar_integration` da matriz
+    (§2) seguem em vigor — se um teste for movido pro módulo interno,
+    confira que o filtro ainda casa antes de commitar.
+  ```
+
+- [ ] **Step 4: Rodar e ver passar**
+
+  ```bash
+  grep -n "providers::grok_cli" CLAUDE.md
+  grep -n "src/waybar/" CLAUDE.md
+  git diff --check
+  ```
+  Esperado: as duas buscas encontram as linhas novas; `git diff --check`
+  sem saída.
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add CLAUDE.md
+  git commit -m "docs: matriz grok_cli e nota do módulo waybar no CLAUDE.md"
+  ```
+
+---
+
+### Task 9: CHANGELOG.md — entrada 9.0.0 + verificação final de consistência
+
+**Files:**
+- Modify: `CHANGELOG.md:8-10` (insere `## [9.0.0]` entre `## [Unreleased]`
+  e `## [8.5.0]`)
+
+**Interfaces:**
+- Consumes: todas as decisões do spec (Seções A-G + tabela "Decisões
+  travadas") e o resultado das Tasks 1-8 deste plano.
+- Produces: texto que o dono usa **verbatim** no `docs/releasing.md`
+  runbook quando decidir cortar o release (fora do escopo deste plano).
+
+**Steps:**
+
+- [ ] **Step 1: Confirmar o baseline**
+
+  ```bash
+  grep -n "^## \[9.0.0\]" CHANGELOG.md; echo "exit=$?"
+  sed -n '8,10p' CHANGELOG.md
+  ```
+  Esperado: o grep não acha nada (`exit=1`); o `sed` mostra:
+  ```
+  ## [Unreleased]
+
+  ## [8.5.0] - 2026-07-21
+  ```
+
+- [ ] **Step 2: Inserir a entrada 9.0.0**
+
+  Trocar:
+  ```
+  ## [Unreleased]
+
+  ## [8.5.0] - 2026-07-21
+  ```
+  Por:
+  ```
+  ## [Unreleased]
+
+  ## [9.0.0] - 2026-07-21
+
+  Redesign completo do popup (Omarchy-shell) + Waybar rebaixada a tier
+  legado. Marco de produto — sem mudança de contrato JSON.
+
+  ### Added
+  - **Widget.qml redesenhado**: hero % por provider igual ao chip, título
+    `agent-bar` + "há Xm" relativo, ações de topo viram botões Unicode
+    reais (↻ refresh, ⚙︎ settings, ❯ abrir TUI) em vez de texto/link. Um
+    cartão por provider, grade de colunas fixas (rótulo · barra · % ·
+    reset), countdown (`1h 46m · 18:30` / `7d 0h · seg 16:43`) em toda
+    janela. Largura `540` (antes `370`), igual nos dois modos.
+  - **`extra` visível no popup**: créditos do Amp (`$X · replenish`),
+    sessões/turnos/modelo do Grok, extra usage do Claude quando existir —
+    antes só existiam no `--format json`, nunca chegavam à tela.
+  - **Motion no popup**: barras preenchem na abertura (M1, stagger),
+    `↻` gira durante o fetch (M2), hover nos botões (M4) — gated por
+    `menu.animations` (exposto read-only em `config show` como
+    `menuAnimations`).
+  - **`windowKind`** (`"fiveHour" | "sevenDay" | "daily" | "context" |
+    "other"`) em `QuotaWindow`, decidido uma vez no Rust por cada
+    provider; dedup display-level (`(windowKind, resetsAt, remaining)`)
+    consumido pela TUI e por Widget.qml — some o "Weekly" triplicado do
+    Codex no plano Plus.
+  - **Countdown e fuso local na TUI**: `fmt_reset` do Detail passa a usar
+    `format_reset_time`/`format_eta` (antes fatiava o ISO em UTC cru, sem
+    contagem regressiva).
+  - Settings do popup ganham Providers (toggle + reordenar), Exibição
+    (segmentado remaining/used + prévia ao vivo da barra) e Alertas &
+    atualização (notify + intervalo) como painéis próprios.
+  - **`platform::detect()`** (`src/platform.rs`) único ponto de decisão
+    Omarchy/Waybar, usado por `setup`, `update` (os dois ramos) e pelo Save
+    da TUI Config — nenhum dos três cria mais `~/.config/waybar/` do zero
+    numa máquina Omarchy-only.
+  - **`agent-bar update` reinstala o plugin Omarchy** quando o shell é
+    detectado, eliminando o drift binário↔QML que antes exigia rodar
+    `setup` manualmente. `doctor` ganhou checagem de versão do manifest
+    instalado vs binário.
+  - Módulo `src/waybar/` agrupando o contrato Waybar (antigo
+    `waybar_contract.rs`/`waybar_integration.rs`) como tier legado isolado.
+
+  ### Changed
+  - **Fix do mislabeling do Codex**: `build_model_windows` não força mais
+    `primary→fiveHour`/`secondary→sevenDay` quando a classificação diverge
+    — uma janela fora de tolerância vira `other` com rótulo pela duração
+    real (ex.: "1h window").
+  - **Settings mode do popup**: salvar passa a ser **só pelo botão** — o
+    atalho de teclado `s` para salvar foi removido; o rodapé de dicas em
+    texto vira botões clicáveis de verdade.
+  - Migração de settings **v2 → v3**: `waybar.show_percentage` é dropada
+    silenciosamente e o arquivo é regravado na versão nova.
+  - TUI Config esconde os campos exclusivos de Waybar (separadores,
+    signal, intervalo do Waybar) quando `platform::detect()` reporta
+    Omarchy-only.
+  - `docs/waybar-contract.md` e `README.md` marcam Waybar como **tier
+    legado**: funciona, recebe fix, não recebe feature nova.
+
+  ### Removed
+  - Legado morto: variante `Command::Terminal`,
+    `waybar_contract::get_all_provider_ids`, `install::ensure_amp_cli`,
+    `amp_cli::AMP_INSTALL_COMMAND` duplicada, dependência `tokio-util`,
+    `ConfigField::settings_key()`, 7 variantes órfãs de `Icon`.
+
+  ### Breaking
+  - Nenhuma no contrato `--format json` — `windowKind` é aditivo,
+    `schemaVersion` continua `1`.
+
+  ## [8.5.0] - 2026-07-21
+  ```
+
+- [ ] **Step 3: Rodar e ver passar (entrada nova)**
+
+  ```bash
+  grep -n "^## \[9.0.0\]" CHANGELOG.md
+  grep -c "windowKind" CHANGELOG.md
+  git diff --check
+  ```
+  Esperado: o grep acha a linha nova; a contagem ≥1; `git diff --check`
+  sem saída.
+
+- [ ] **Step 4: Verificação final de consistência (todo o diff da PR 5)**
+
+  ```bash
+  git diff --check master
+  grep -rn "show_percentage" README.md CONTRIBUTING.md docs/*.md CLAUDE.md; echo "exit acima deve ser 1 (nada encontrado)"
+  grep -rn "get_all_provider_ids" README.md CONTRIBUTING.md docs/*.md CLAUDE.md; echo "exit acima deve ser 1"
+  grep -rn "^## Future" README.md CONTRIBUTING.md docs/*.md; echo "exit acima deve ser 1"
+  grep -c "grok" docs/waybar-contract.md docs/runtime.md docs/troubleshooting.md
+  ```
+  Esperado: `git diff --check master` sem saída (nenhum erro de
+  whitespace em toda a PR); os três `grep -rn` de proibição não encontram
+  nada (`exit=1` cada); a última linha mostra contagem ≥1 para os três
+  arquivos — confirma que nenhum doc "vivo" ainda cita
+  `show_percentage`/`get_all_provider_ids`/uma seção `## Future`, e que
+  `grok` está presente nos três docs tocados pelas Tasks 3/5/6.
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add CHANGELOG.md
+  git commit -m "docs: entrada 9.0.0 no CHANGELOG"
+  ```
+
+---
+
+### Task 10: docs/commands.md — `menuAnimations` no exemplo e na tabela de campos
+
+**Files:**
+- Modify: `docs/commands.md:33-42` (exemplo de envelope do `config show`) e
+  `docs/commands.md:47-52` (tabela de campos)
+
+**Interfaces:**
+- Consumes: `menuAnimations` em `config show` (`src/config_cmd.rs`), produto
+  da PR 4 conforme o CONTRATO DE INTERFACES GLOBAIS deste plano —
+  read-only, reflete `Settings.menu.animations`, ignorado em `apply`.
+- Produces: nada consome; é a documentação faltante de um campo já real do
+  envelope.
+
+**Steps:**
+
+- [ ] **Step 1: Confirmar o gap**
+
+  ```bash
+  grep -n "menuAnimations" docs/commands.md; echo "exit=$?"
+  ```
+  Esperado: nenhuma ocorrência (`exit=1`).
+
+- [ ] **Step 2: Adicionar `menuAnimations` ao exemplo de envelope**
+
+  Trocar:
+  ```
+  {
+    "schemaVersion": 1,
+    "providers": ["claude", "codex", "amp", "grok"],
+    "providerOrder": ["claude", "codex", "amp", "grok"],
+    "displayMode": "remaining",
+    "notify": { "enabled": true }
+  }
+  ```
+  Por:
+  ```
+  {
+    "schemaVersion": 1,
+    "providers": ["claude", "codex", "amp", "grok"],
+    "providerOrder": ["claude", "codex", "amp", "grok"],
+    "displayMode": "remaining",
+    "notify": { "enabled": true },
+    "menuAnimations": true
+  }
+  ```
+
+- [ ] **Step 3: Adicionar a linha na tabela de campos**
+
+  Trocar:
+  ```
+  | `notify.enabled` | Desktop low/critical notifications. |
+  ```
+  Por:
+  ```
+  | `notify.enabled` | Desktop low/critical notifications. |
+  | `menuAnimations` | Read-only; reflete `Settings.menu.animations`. Ignorado em `apply`. |
+  ```
+
+- [ ] **Step 4: Rodar e ver passar**
+
+  ```bash
+  grep -n "menuAnimations" docs/commands.md
+  git diff --check
+  ```
+  Esperado: encontra as duas linhas novas (exemplo + tabela); `git diff
+  --check` sem saída.
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add docs/commands.md
+  git commit -m "docs: menuAnimations no exemplo e tabela do commands"
+  ```

--- a/docs/superpowers/specs/2026-07-21-omarchy-first-popup-redesign-design.md
+++ b/docs/superpowers/specs/2026-07-21-omarchy-first-popup-redesign-design.md
@@ -1,0 +1,201 @@
+# Design: Omarchy-first — redesign do popup, contrato windowKind e Waybar como legado (v9.0.0)
+
+Data: 2026-07-21 · Status: aprovado pelo dono (brainstorming com mockups no visual companion)
+
+## Contexto
+
+Auditoria profunda de 2026-07-21 (21 agentes, read-only) confirmou contra o payload
+real da máquina do dono:
+
+1. **Codex duplicado**: no plano Plus, `primary` e `secondary` chegam ambos com
+   `windowMinutes: 10080` e mesmo `resetsAt` → o popup mostra 2 linhas "Weekly"
+   idênticas + uma 3ª igual em models. Agravante: `normalize.rs:88-98` força a
+   janela primária no slot `five_hour` mesmo quando `classify_window` a rejeitou
+   (teste `unrecognized_window_uses_fallback_mapping` documenta).
+2. **Sem countdown**: `format_eta` existe (`formatters/shared.rs:188`) e é usado
+   no tooltip Waybar, mas popup QML e TUI nunca o chamam. A TUI ainda mostra o
+   reset em **UTC cru** (`tui/render/detail/format.rs:69` fatia o ISO sem
+   `to_offset`).
+3. **`extra` invisível**: o Widget.qml nunca lê o campo `extra` — créditos do
+   Amp ($), sessões/turnos/contexto do Grok, extra usage do Claude morrem antes
+   da tela.
+4. **Ações como texto**: "right-click: settings · middle: refresh" é `Text` sem
+   clique; "Abrir menu (TUI)" é link sublinhado. Largura fixa `Style.space(370)`.
+5. **Heurísticas triplicadas**: severidade e rótulo de janela reimplementados em
+   Rust, QML (`windowLabel` com magic numbers ±90/±1440) e TUI; clamp do refresh
+   em 5 lugares.
+6. **3 caminhos escrevem `~/.config/waybar/` sem gate** (Save da TUI Config,
+   `update` ManagedGit, `update` Standalone) num desktop 100% Omarchy.
+7. **`update` não atualiza o plugin QML** — binário novo + widget velho até um
+   `setup` manual (só um hint impresso).
+
+## Relação com decisões anteriores (transparência)
+
+- **ADR-0001 (right-click = settings) é MANTIDO** — o redesign muda conteúdo e
+  forma do popup, não o roteamento dos cliques.
+- **Reverte conscientemente** duas decisões da spec 8.5.0 (mesmo dia): o rodapé
+  de dicas em texto vira botões reais, e o atalho `s` de salvar morre (salvar só
+  pelo botão). Pedido explícito do dono em 2026-07-21.
+- **Expande o escopo v1 do plugin** (que excluía "settings UI própria além do
+  manifest" e dados ricos no popup) — expansão consciente, não bug-fix.
+
+## Decisões travadas (aprovadas via mockups, 2026-07-21)
+
+| Tema | Decisão |
+| --- | --- |
+| Estrutura do popup | B1: hero % por provider (mesmo número do chip), ações no topo à direita |
+| Pele | Painéis: um cartão por provider (`#1f2530`-like sobre fundo mais escuro, radius 9) — cores reais vêm do tema do shell |
+| Título | `agent-bar` à esquerda + "há Xm" relativo; botões ↻ ⚙︎ ❯ à direita |
+| Ícones de ação | Unicode puro (↻ U+21BB, ⚙︎ U+2699+VS15, ❯ U+276F) — sem dependência de Nerd Font |
+| Largura | `Style.space(540)` (antes 370), igual nos dois modos |
+| Simetria | Grade de colunas fixas `rótulo 82 · barra flex · % 44 · reset 132` (proporções; valores exatos calibrados no shell) — toda barra idêntica, % em coluna tabular |
+| Countdown | `1h 46m · 18:30` / `7d 0h · seg 16:43`, sempre na mesma coluna; Grok (sem reset) usa a coluna para contexto `253.9k/500k tok` |
+| Linha por modelo | Só quando divergir da janela compartilhada (mata o triplo Weekly do Codex); mesma barra, rótulo indentado |
+| `extra` na tela | Amp: `Créditos $X · replenish`; Grok: `Hoje: N sessões · N turnos · modelo`; Claude: extra usage quando houver |
+| staleReason | Linha de texto discreta + opacity (hoje é só opacity) |
+| displayMode used | Passa a valer nas linhas do popup, não só no chip |
+| Settings | Painéis Providers (toggle + ↑↓) / Exibição (segmentado + **prévia ao vivo da barra**) / Alertas & atualização; `← Uso` e `Salvar` no topo à direita |
+| Salvar | **Só pelo botão**. Sem atalho `s` (remove o path de save do PanelKeyCatcher); esc/clique-fora só fecham, sem dica no rodapé |
+| Motion | M1 barras preenchem na abertura (≈320ms ease-out, stagger 60ms) + M2 ↻ gira durante fetch + M4 hover 160ms. **Sem pulso** (coerente com decisão do TUI v8). Gate por `menu.animations` |
+| Versão | **9.0.0** — marco de produto (Omarchy-first, Waybar vira tier legado) |
+
+## A. Contrato de dados (backend primeiro — destrava tudo)
+
+- **`windowKind`** novo em `QuotaWindow`: `"fiveHour" | "sevenDay" | "daily" |
+  "context" | "other"`, decidido uma única vez no Rust. Cada provider seta na
+  origem (Claude 5h/7d; Codex via `classify_window` SEM o fallback forçado;
+  Amp `daily`; Grok `context`). Rótulos de UI derivam só disso.
+- **Fix do mislabeling Codex**: `build_model_windows` deixa de forçar
+  `primary→five_hour`/`secondary→seven_day` quando a classificação diverge —
+  janela fora de tolerância vira `other` com `windowKind: "other"` e rótulo pela
+  duração real (ex.: "1h window").
+- **Dedup é display-level**: o JSON continua emitindo primary/secondary/models
+  (contrato intacto, mudança 100% aditiva, `schemaVersion` permanece 1);
+  QML e TUI colapsam janelas com mesmo `(windowKind, resetsAt, remaining)`.
+- **QML deixa de ter heurísticas**: `windowLabel` (magic numbers) morre;
+  severidade continua espelhada (severity da API + threshold), mas rótulo vem
+  pronto. Countdown e "há Xm" calculados no QML a partir de `resetsAt`/
+  `fetchedAt` (JS `Date`, fuso local automático).
+- **`extra` documentado por provider** em `docs/json-output.md` (shapes de
+  `AmpQuotaExtra.meta`, `GrokQuotaExtra`, `ClaudeQuotaExtra.extraUsage`,
+  `CodexQuotaExtra.modelsDetailed`) — continua `unstable`, mas com shape
+  descrito para o widget first-party consumir.
+
+## B. Widget.qml — Usage popup
+
+- Titlebar: `agent-bar` + fetched-ago relativo + iconbtns ↻ ⚙︎ ❯ (Refresh /
+  Settings mode / `openTui()` via terminal helper). Tooltips no hover
+  (`bar.showTooltip`, como os chips já fazem).
+- Um `Panel` por provider: header (ícone real, nome, plan/account elidido,
+  hero % à direita = mesmo valor e severidade do chip) + grade de janelas
+  (colunas fixas) + linha(s) de info do `extra`.
+- Estados: unavailable → mensagem de erro no cartão (comportamento atual);
+  stale → linha de motivo + opacity; parse falho → mantém último payload bom
+  (contrato atual do `applyPayload`).
+- Motion: M1/M2/M4 com `Behavior`/`NumberAnimation` QML; desliga quando
+  `menu.animations = false`. Requisito de contrato: `config show` passa a expor
+  `menu.animations` (read-only para o widget; edição continua via settings.json).
+
+## C. Widget.qml — Settings mode
+
+- Mantém dual-write do ADR-0002 (`config apply` → `updateEntryInline`).
+- Painéis: Providers (Toggle + ↑↓ por linha, mín. 1 ativo), Exibição
+  (segmentado Restante/Usado + prévia da barra com chips e valores reais
+  trocando ao vivo), Alertas & atualização (notify toggle, interval −/+ com
+  clamp 30–3600 — clamp centralizado numa função única no QML).
+- Header: `agent-bar · Settings`, botões `← Uso` e `Salvar` (busy → "Salvando…").
+- Remoções: rodapé de dicas; save via tecla `s` (o `PanelKeyCatcher` fica só
+  para esc-fecha, se necessário).
+
+## D. TUI — paridade de dados (este spec) + redesign visual (sub-projeto)
+
+Neste spec (independem de visual):
+- `fmt_reset` passa a converter para fuso local (usar `format_reset_time`
+  existente com `Clock.local_offset`).
+- Countdown `→ 1h 46m` nas janelas do Detail (via `format_eta` existente).
+- Rótulos de janela via `windowKind` + dedup display-level (some o duplo Weekly
+  também na TUI).
+- Config platform-aware: Separators/Signal/Interval-waybar ocultos quando
+  Omarchy-only (mesma detecção da seção E).
+
+**Sub-projeto seguinte (fora deste spec):** redesign visual da TUI — decisão do
+dono em 2026-07-21. Terá rodada própria de mockups e spec próprio; nada aqui
+pressupõe o resultado dele.
+
+## E. Waybar → tier legado isolado
+
+- Módulo `src/waybar/` agrupando `waybar_contract.rs`, `waybar_integration.rs`,
+  `formatters/waybar.rs` e `render_pango.rs` (re-exports para não quebrar a
+  matriz de testes do CLAUDE.md; filtros `cargo test waybar_contract` etc.
+  continuam funcionando).
+- **`platform::detect()` único** (Omarchy presente? Waybar presente?) usado por:
+  `setup` (já faz), `update` ManagedGit (hoje hardcoda `omarchy: None,
+  skip_waybar: false`), `update` Standalone (hoje sempre recopia assets) e
+  **Save da TUI Config** (hoje incondicional — pode criar `~/.config/waybar/`
+  do zero). Zero escrita em `~/.config/waybar/` sem Waybar no PATH.
+- Docs declaram Waybar em manutenção (tier legado): funciona, recebe fix, não
+  recebe feature nova. Remoção futura = deletar `src/waybar/` + gates + docs.
+
+## F. Omarchy first-class
+
+- `agent-bar update` (ambos os ramos) **reinstala o plugin** quando
+  `detect_omarchy_shell()` — mata o drift binário↔QML (risco nº 1 da auditoria).
+  O hint pós-update vira fallback para quando a detecção falhar.
+- `doctor` ganha checagens Omarchy: versão do manifest instalado vs binário;
+  entrada `agent-bar.usage` no shell.json sem diretório (ou vice-versa).
+- `uninstall`: só remove o diretório do plugin se os comandos `omarchy ...
+  remove` tiverem funcionado (ou avisar que ficou referência no shell.json).
+
+## G. Limpeza de legado (verificada adversarialmente, aprovada)
+
+Remover: variante `Command::Terminal` (+ ajuste do teste sintético e do match
+em main.rs), `waybar_contract::get_all_provider_ids`, `install::ensure_amp_cli`
+(+ comentário de módulo), `amp_cli::AMP_INSTALL_COMMAND` duplicada (+ teste
+aponta pra `app_identity`), dep `tokio-util`. Higiene: `waybar.show_percentage`
+(migração settings v2→v3 que dropa a chave), `ConfigField::settings_key()`,
+7 variantes órfãs de `Icon` (+ teste), comentário morto em `render/shared.rs`.
+Housekeeping: `git worktree remove .worktrees/omarchy-settings-cli` + branch
+local/remota (mergeada). NÃO remover (refutados): `watch.rs`, `doctor.rs`,
+`notify.rs`, `pricing.rs`, `extras.rs`, `install.rs`, subcomandos CLI, specs
+de 2026-07-17.
+
+## H. Docs
+
+- `README.md`: tagline e requisitos Omarchy-first ("Waybar suportada, tier
+  legado"); `CONTRIBUTING.md`: MSRV 1.88; `docs/waybar-contract.md`: +grok e
+  banner de tier legado; `docs/json-output.md`: seção Future removida, `extra`
+  shapes e `windowKind` documentados; `docs/troubleshooting.md` +
+  `docs/runtime.md`: seções Grok; `docs/architecture.md`: reescrito com
+  omarchy-shell no centro (Widget.qml, `--format json`, `config show/apply`
+  no diagrama); CLAUDE.md: linha `providers::grok_cli` na matriz.
+
+## Testes e verificação
+
+- Rust: unit para `windowKind` por provider (incl. regressão do fallback Codex
+  com janela de 60min → `other`), golden para formatos `Xh Ym · HH:MM`, dedup,
+  fuso local na TUI (Clock mockado), snapshots insta atualizados de propósito.
+- Gates de plataforma: testes de `update`/`setup`/TUI-save com dirs temporários
+  provando zero escrita em waybar-dir quando Omarchy-only.
+- QML (sem harness): validação ao vivo no desktop do dono com as 3 provas —
+  funcional (fluxos clique/refresh/settings), perceptual (screenshot vs mockup
+  aprovado), dados (payload real conferido contra o renderizado).
+
+## Entrega
+
+PRs em sequência sobre `master`:
+1. `chore`: limpeza de legado (G) + worktree.
+2. `feat`: contrato de dados `windowKind` + fixes normalize/fuso/eta (A + D-dados).
+3. `feat`: Widget.qml novo — usage + settings + motion (B + C).
+4. `feat`: gates de plataforma + módulo `src/waybar/` + update-reinstala-plugin +
+   doctor (E + F).
+5. `docs`: H + CHANGELOG.
+Release **9.0.0** ao final (runbook `docs/releasing.md`; AUR automatizado no CI).
+
+## Não-objetivos
+
+- Custo $/tokens/histórico no popup (exige expor `src/usage/*` no envelope —
+  candidato a fase 2, decisão adiada de propósito).
+- Mudar roteamento de cliques (ADR-0001 mantido) ou bump de `schemaVersion`.
+- Drag-and-drop na ordenação de providers.
+- Remover Waybar (só isolar; remoção é decisão futura).
+- Redesign visual da TUI (sub-projeto próprio com mockups, na sequência).

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -270,7 +270,7 @@ pub fn parse_args(args: &[String]) -> Result<CliOptions, CliError> {
 
             "--yes" | "-y" => opts.yes = true,
 
-            // Alias histórico de status (não Command::Terminal).
+            // Alias histórico de status.
             "--terminal" | "-t" => opts.command = Command::Status,
 
             "--refresh" | "-r" => opts.refresh = true,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -12,7 +12,6 @@ use crate::config::DEFAULT_INTERVAL_SECS;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Command {
     Waybar,
-    Terminal,
     Menu,
     Status,
     Help,

--- a/src/install.rs
+++ b/src/install.rs
@@ -1,12 +1,9 @@
-//! Verificacao de presenca de comandos no PATH. Port de `src/install.ts` +
-//! a parte `ensure_amp_cli` de `src/amp-cli.ts`.
+//! Verificacao de presenca de comandos no PATH. Port de `src/install.ts`.
 //!
-//! NOTA: `ensure_amp_cli` aqui **orienta** o usuario (imprime o comando de
-//! instalacao) em vez de executar `curl | bash` automaticamente. O instalador
-//! interativo foi descartado por seguranca: a TUI nao deve pipe-executar codigo
-//! remoto sem confirmacao explicita do usuario.
+//! `ensure_amp_cli` (guidance de instalacao do Amp, port de `src/amp-cli.ts`)
+//! foi removida (v9, limpeza de legado) por nao ter caller: o locator real
+//! em producao e `providers::amp_cli::find_amp_bin`.
 
-use crate::app_identity::AMP_INSTALL_COMMAND;
 use crate::providers::amp_cli::which_in_path;
 
 /// Verifica se `cmd` existe no `$PATH`. Usa `which_in_path` do providers/amp_cli.rs
@@ -22,22 +19,6 @@ pub fn ensure_command(cmd: &str, install_hint: &str) -> bool {
         return true;
     }
     log::warn!("{cmd} não encontrado. {install_hint}");
-    false
-}
-
-/// Verifica se `amp` esta disponivel. Se ausente, loga o comando de instalacao
-/// oficial e retorna `false`. Nao executa o instalador automaticamente.
-///
-/// Para instalacao real, o usuario deve rodar manualmente:
-/// `curl -fsSL https://ampcode.com/install.sh | bash`
-pub fn ensure_amp_cli() -> bool {
-    if has_cmd("amp") {
-        return true;
-    }
-    log::warn!(
-        "Amp CLI não encontrado. Para instalar, rode: {}",
-        AMP_INSTALL_COMMAND
-    );
     false
 }
 
@@ -71,13 +52,5 @@ mod tests {
             "__agent_bar_nonexistent_cmd_xyz__",
             "instale-o"
         ));
-    }
-
-    #[test]
-    fn ensure_amp_cli_absent_returns_false() {
-        let _env = crate::test_support::env_guard();
-        // Em ambiente CI/test, amp provavelmente nao esta instalado.
-        // Se estiver, o test passa com true; se nao, com false. Ambos sao corretos.
-        let _ = ensure_amp_cli(); // apenas verifica que nao panica
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -758,7 +758,7 @@ async fn main() {
     let mode = settings.waybar.display_mode;
 
     match opts.command {
-        Command::Terminal | Command::Status => {
+        Command::Status => {
             println!(
                 "{}",
                 format_for_terminal(&clock, &quotas, &settings, mode, no_color)
@@ -892,11 +892,11 @@ mod tests {
     }
 
     #[test]
-    fn should_notify_false_when_command_is_terminal() {
+    fn should_notify_false_when_command_is_not_waybar() {
         let s = settings_with_notify(true);
         assert!(!should_notify(
             &s,
-            Command::Terminal,
+            Command::Menu,
             Format::Waybar,
             false,
             false

--- a/src/providers/amp_cli.rs
+++ b/src/providers/amp_cli.rs
@@ -1,6 +1,6 @@
 //! Descoberta do binário `amp` (locator). Port de `src/amp-cli.ts` (só a metade
-//! locator; o `ensure_amp_cli` interativo é Plano 6). Ordem: PATH (`which`),
-//! depois caminhos conhecidos sob `$HOME`.
+//! locator; a metade `ensure_amp_cli` foi removida na limpeza v9 por não ter
+//! caller). Ordem: PATH (`which`), depois caminhos conhecidos sob `$HOME`.
 
 use std::path::{Path, PathBuf};
 

--- a/src/providers/amp_cli.rs
+++ b/src/providers/amp_cli.rs
@@ -4,9 +4,6 @@
 
 use std::path::{Path, PathBuf};
 
-/// Comando oficial de instalação (usado pelo Plano 6; contrato de display).
-pub const AMP_INSTALL_COMMAND: &str = "curl -fsSL https://ampcode.com/install.sh | bash";
-
 /// Caminhos candidatos sob `$HOME`, na ordem de preferência. Vazio se `home` vazio.
 pub fn amp_candidate_paths(home: &str) -> Vec<PathBuf> {
     if home.is_empty() {
@@ -105,6 +102,7 @@ mod tests {
 
     #[test]
     fn install_command_is_official() {
+        use crate::app_identity::AMP_INSTALL_COMMAND;
         assert_eq!(
             AMP_INSTALL_COMMAND,
             "curl -fsSL https://ampcode.com/install.sh | bash"

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::config::Paths;
 
-pub const CURRENT_VERSION: u32 = 2;
+pub const CURRENT_VERSION: u32 = 3;
 
 /// Modo de glyph para a TUI.
 ///
@@ -94,7 +94,6 @@ pub struct Tooltip {}
 #[serde(rename_all = "camelCase")]
 pub struct Waybar {
     pub providers: Vec<String>,
-    pub show_percentage: bool,
     pub separators: SeparatorStyle,
     pub provider_order: Vec<String>,
     pub display_mode: DisplayMode,
@@ -165,7 +164,6 @@ struct RawSettings {
 #[serde(rename_all = "camelCase")]
 struct RawWaybar {
     providers: Option<Vec<String>>,
-    show_percentage: Option<bool>,
     separators: Option<String>,
     provider_order: Option<Vec<String>>,
     display_mode: Option<String>,
@@ -299,7 +297,6 @@ fn normalize(raw: RawSettings) -> Settings {
         version: CURRENT_VERSION,
         waybar: Waybar {
             providers,
-            show_percentage: rw.show_percentage.unwrap_or(true),
             separators,
             provider_order,
             display_mode,
@@ -388,7 +385,7 @@ mod tests {
     fn defaults_when_no_file() {
         let dir = tempdir().unwrap();
         let s = load(&paths_in(dir.path()));
-        assert_eq!(s.version, 2);
+        assert_eq!(s.version, 3);
         assert_eq!(s.waybar.providers, vec!["claude", "codex", "amp", "grok"]);
         assert_eq!(s.waybar.separators, SeparatorStyle::Gap);
         assert_eq!(s.waybar.display_mode, DisplayMode::Remaining);
@@ -432,6 +429,30 @@ mod tests {
         let s = load(&p);
         assert_eq!(s.waybar.separators, SeparatorStyle::Glass);
         assert_eq!(s.waybar.signal, Some(8));
+    }
+
+    #[test]
+    fn v2_settings_drops_show_percentage_on_load() {
+        let dir = tempdir().unwrap();
+        let p = paths_in(dir.path());
+        std::fs::create_dir_all(&p.config_dir).unwrap();
+        std::fs::write(
+            p.settings_file(),
+            r#"{"version":2,"waybar":{"providers":["claude"],"showPercentage":false,
+                "separators":"gap","providerOrder":["claude"],"displayMode":"remaining",
+                "interval":60}}"#,
+        )
+        .unwrap();
+
+        let s = load(&p);
+        assert_eq!(s.version, CURRENT_VERSION);
+
+        // Auto-repair já regravou o arquivo sem a chave legada.
+        let saved = std::fs::read_to_string(p.settings_file()).unwrap();
+        assert!(
+            !saved.contains("showPercentage"),
+            "showPercentage deveria ter sido dropada no re-save: {saved}"
+        );
     }
 
     #[test]

--- a/src/tui/render/config.rs
+++ b/src/tui/render/config.rs
@@ -278,7 +278,6 @@ mod tests {
             version: 2,
             waybar: Waybar {
                 providers: vec!["claude".to_string(), "codex".to_string()],
-                show_percentage: true,
                 separators: SeparatorStyle::Gap,
                 provider_order: vec!["claude".to_string(), "codex".to_string()],
                 display_mode: DisplayMode::Remaining,

--- a/src/tui/render/config.rs
+++ b/src/tui/render/config.rs
@@ -275,7 +275,7 @@ mod tests {
 
     fn fake_settings() -> Settings {
         Settings {
-            version: 2,
+            version: crate::settings::CURRENT_VERSION,
             waybar: Waybar {
                 providers: vec!["claude".to_string(), "codex".to_string()],
                 separators: SeparatorStyle::Gap,

--- a/src/tui/render/mod.rs
+++ b/src/tui/render/mod.rs
@@ -290,7 +290,7 @@ mod tests {
         use crate::settings::*;
         use std::collections::BTreeMap;
         Settings {
-            version: 2,
+            version: CURRENT_VERSION,
             waybar: Waybar {
                 providers: vec!["claude".to_string(), "codex".to_string()],
                 separators: SeparatorStyle::Gap,

--- a/src/tui/render/mod.rs
+++ b/src/tui/render/mod.rs
@@ -293,7 +293,6 @@ mod tests {
             version: 2,
             waybar: Waybar {
                 providers: vec!["claude".to_string(), "codex".to_string()],
-                show_percentage: true,
                 separators: SeparatorStyle::Gap,
                 provider_order: vec!["claude".to_string(), "codex".to_string()],
                 display_mode: DisplayMode::Remaining,

--- a/src/tui/render/shared.rs
+++ b/src/tui/render/shared.rs
@@ -1,8 +1,6 @@
-//! Helpers compartilhados entre telas de render. `series_now` era usada por
-//! `dashboard.rs` (apagado na Task 11 junto com o Overview) e por
-//! `detail.rs` (Task 12) — ambas as telas precisavam da MESMA âncora
-//! temporal pra série real de 24h, então a lógica mora aqui em vez de
-//! duplicada em cada módulo de tela; `detail.rs` continua consumindo.
+//! Helpers compartilhados entre telas de render. `series_now` calcula a
+//! âncora temporal da série real de 24h; `history.rs` é quem consome hoje
+//! (`render_chart_section` do chart de History).
 //!
 //! `abbrev_tokens` (formatador de tokens com ponto decimal) morou aqui até
 //! o fix gate de dados reais — removido: `detail.rs` unificou pra

--- a/src/tui/render/shared.rs
+++ b/src/tui/render/shared.rs
@@ -1,6 +1,7 @@
 //! Helpers compartilhados entre telas de render. `series_now` calcula a
 //! âncora temporal da série real de 24h; `history.rs` é quem consome hoje
-//! (`render_chart_section` do chart de History).
+//! (`render_history`, que alimenta o `render_top_chart` do chart de
+//! History).
 //!
 //! `abbrev_tokens` (formatador de tokens com ponto decimal) morou aqui até
 //! o fix gate de dados reais — removido: `detail.rs` unificou pra

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -115,19 +115,6 @@ impl ConfigField {
             ConfigField::FxRate => "Câmbio R$",
         }
     }
-
-    /// Chave técnica (settings / docs) — dica no painel de ajuda.
-    pub fn settings_key(self) -> &'static str {
-        match self {
-            ConfigField::Providers => "providers",
-            ConfigField::ProviderOrder => "providerOrder",
-            ConfigField::Separators => "separators",
-            ConfigField::DisplayMode => "displayMode",
-            ConfigField::Signal => "signal",
-            ConfigField::Interval => "interval",
-            ConfigField::FxRate => "fxRate",
-        }
-    }
 }
 
 /// Estado da aba Waybar config.

--- a/src/tui/update/mod.rs
+++ b/src/tui/update/mod.rs
@@ -695,7 +695,7 @@ mod tests {
         use crate::settings::*;
         use std::collections::BTreeMap;
         Settings {
-            version: 2,
+            version: CURRENT_VERSION,
             waybar: Waybar {
                 providers: vec!["claude".to_string(), "codex".to_string()],
                 separators: SeparatorStyle::Gap,

--- a/src/tui/update/mod.rs
+++ b/src/tui/update/mod.rs
@@ -698,7 +698,6 @@ mod tests {
             version: 2,
             waybar: Waybar {
                 providers: vec!["claude".to_string(), "codex".to_string()],
-                show_percentage: true,
                 separators: SeparatorStyle::Gap,
                 provider_order: vec!["claude".to_string(), "codex".to_string()],
                 display_mode: DisplayMode::Remaining,

--- a/src/tui/update/navigation.rs
+++ b/src/tui/update/navigation.rs
@@ -169,7 +169,6 @@ pub(super) fn activate(state: &mut AppState, item: SidebarItem) -> Vec<Action> {
                     version: 0, // sentinela; event_loop sobrescreve com real
                     waybar: crate::settings::Waybar {
                         providers: vec![],
-                        show_percentage: true,
                         separators: crate::settings::SeparatorStyle::Gap,
                         provider_order: vec![],
                         display_mode: crate::settings::DisplayMode::Remaining,

--- a/src/tui/widgets/icons.rs
+++ b/src/tui/widgets/icons.rs
@@ -9,13 +9,6 @@ pub enum Icon {
     LoggedOut,
     Warn,
     NoToken,
-    Reset,
-    Cost,
-    History,
-    Peak,
-    Refresh,
-    Login,
-    Waybar,
 }
 
 pub fn glyph(icon: Icon, mode: GlyphMode) -> &'static str {
@@ -28,20 +21,6 @@ pub fn glyph(icon: Icon, mode: GlyphMode) -> &'static str {
         (Icon::Warn, GlyphMode::Box) => "!",
         (Icon::NoToken, GlyphMode::Nerd) => "\u{f023}",
         (Icon::NoToken, GlyphMode::Box) => "×",
-        (Icon::Reset, GlyphMode::Nerd) => "\u{f017}",
-        (Icon::Reset, GlyphMode::Box) => "↻",
-        (Icon::Cost, GlyphMode::Nerd) => "\u{f155}",
-        (Icon::Cost, GlyphMode::Box) => "$",
-        (Icon::History, GlyphMode::Nerd) => "\u{f201}",
-        (Icon::History, GlyphMode::Box) => "≡",
-        (Icon::Peak, GlyphMode::Nerd) => "\u{f0e7}",
-        (Icon::Peak, GlyphMode::Box) => "▲",
-        (Icon::Refresh, GlyphMode::Nerd) => "\u{f021}",
-        (Icon::Refresh, GlyphMode::Box) => "↻",
-        (Icon::Login, GlyphMode::Nerd) => "\u{f090}",
-        (Icon::Login, GlyphMode::Box) => "→",
-        (Icon::Waybar, GlyphMode::Nerd) => "\u{f013}",
-        (Icon::Waybar, GlyphMode::Box) => "⚙",
     }
 }
 
@@ -55,13 +34,6 @@ mod tests {
             Icon::Ok,
             Icon::LoggedOut,
             Icon::Warn,
-            Icon::Reset,
-            Icon::Cost,
-            Icon::History,
-            Icon::Peak,
-            Icon::Refresh,
-            Icon::Login,
-            Icon::Waybar,
             Icon::NoToken,
         ] {
             assert!(!glyph(icon, GlyphMode::Nerd).is_empty());

--- a/src/waybar_contract.rs
+++ b/src/waybar_contract.rs
@@ -100,23 +100,6 @@ pub fn export_waybar_modules(
 }
 
 // ---------------------------------------------------------------------------
-// getAllProviderIds
-// ---------------------------------------------------------------------------
-
-/// Todos os provider ids conhecidos — built-in + registrados sem duplicatas.
-/// Espelha `getAllProviderIds` do TS.
-pub fn get_all_provider_ids() -> Vec<String> {
-    let mut ids: Vec<String> = WAYBAR_PROVIDERS.iter().map(|s| s.to_string()).collect();
-    for id in crate::providers::registered_provider_ids() {
-        let id_str = id.to_string();
-        if !ids.contains(&id_str) {
-            ids.push(id_str);
-        }
-    }
-    ids
-}
-
-// ---------------------------------------------------------------------------
 // CSS export
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Contexto

Primeira PR da sequência v9 (spec: `docs/superpowers/specs/2026-07-21-omarchy-first-popup-redesign-design.md`, Seção G). Remove código morto verificado adversarialmente na auditoria de 2026-07-21 — cada item teve refutação tentada (call sites, testes, docs, contratos) antes de entrar no escopo. Zero mudança de comportamento observável; as PRs 2-5 (contrato windowKind, Widget.qml, gates de plataforma, docs) assumem esta forma do código.

## Mudanças

- **`Command::Terminal`** removido (20a7be4) — variante inalcançável; `--terminal`/`-t` já mapeava pra `Status`. Teste renomeado pra `should_notify_false_when_command_is_not_waybar`.
- **`waybar_contract::get_all_provider_ids`** removida (2aafce0) — zero call sites.
- **`install::ensure_amp_cli`** removida (7ed20de) — órfã; o locator real é `providers::amp_cli::find_amp_bin`.
- **`AMP_INSTALL_COMMAND` duplicada** removida de `amp_cli` (a3c5417) — fonte única em `app_identity` (regra do CLAUDE.md §3).
- **dep `tokio-util`** removida (0415e4c) — zero uso direto. Permanece no lock como transitiva de h2/hyper (documentado no body do commit).
- **Higiene TUI** (dde9583 + 6c15e44): `ConfigField::settings_key` (zero callers), `Icon` reduzido de 11 pra 4 variantes com caller real, doc comment de `series_now` corrigido pro consumidor verdadeiro (`render_history`/`render_top_chart`).
- **Settings v2→v3** (8c0f731, TDD): dropa `waybar.show_percentage` (nunca afetou render). Migração cai do auto-repair existente do `load` — sem lógica condicional. Downgrade seguro: binário 8.x lendo settings v3 ignora o campo `version` e trata `show_percentage` ausente com default.
- **Fix-wave do review final** (1b9b6d7): dois comentários que citavam código já removido.
- **Housekeeping git** (fora do diff): worktree e branch local/remota de `feat/omarchy-settings-cli` (mergeada no PR #18) removidas.

## Verificação

- `cargo test`: 795 passed (suite completa)
- `cargo clippy --all-targets -- -D warnings`: limpo
- `cargo test --test golden` (78) e `cargo test waybar_contract` (19): verdes — contrato Waybar intacto
- Review de branch inteira: zero Critical/Important; flake pré-existente do filtro `cargo test install` (corrida de PATH entre `grok::not_installed` e `test_support::ENV_LOCK`) ficou deferido — fora do blast radius desta PR, candidato a issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed the legacy `terminal` command path and unused terminal-only options.
  * Removed the obsolete `showPercentage` setting; existing version 2 configurations are automatically migrated to settings version 3.
  * Simplified available TUI icons and configuration options.

* **Documentation**
  * Added implementation plans covering upcoming window classification, popup redesign, platform-aware Waybar support, legacy cleanup, and release documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->