### PR TITLE
feat: redesenha Widget.qml (popup + settings v2)

### DIFF
--- a/assets/omarchy/Widget.qml
+++ b/assets/omarchy/Widget.qml
@@ -31,6 +31,18 @@ BarWidget {
   property string displayMode: "remaining"
   property string settingsStatusText: ""
   property bool settingsBusy: false
+  // Lido de `config show` (contrato do Plano 02) — gate único de motion
+  // (M1/M2/M4). Ausente no payload = true (nunca bloqueia motion à toa).
+  property bool menuAnimationsEnabled: true
+  // true só durante a janela de abertura do popup — M1 é "abertura", não
+  // "toda atualização"; sem isto as barras re-animariam a cada refresh de
+  // 60s enquanto o popup fica aberto, o que é ruído, não sinal.
+  property bool barsAnimating: false
+  // Incrementado a cada 30s só para forçar QML a reavaliar bindings de
+  // texto que dependem do relógio ("há Xm", countdown) — QML não reavalia
+  // sozinho por passagem de tempo, só por mudança de dependência. Uso:
+  // `text: (root.clockTick, root.fmtAgo(...))`.
+  property int clockTick: 0
 
   readonly property color fg: bar ? bar.foreground : Color.foreground
   readonly property color urgent: bar ? bar.urgent : Color.urgent
@@ -39,7 +51,7 @@ BarWidget {
   readonly property var providers: payload && Array.isArray(payload.providers) ? payload.providers : []
   // Clamp aos limites do schema do manifest (min 30 / max 3600) — o editor
   // do shell respeita o schema, mas shell.json editado à mão não.
-  readonly property int refreshIntervalSec: Math.min(3600, Math.max(30, Number(setting("refreshIntervalSec", 60)) || 60))
+  readonly property int refreshIntervalSec: root.clampRefreshInterval(Number(setting("refreshIntervalSec", 60)) || 60)
   readonly property var knownProviderIds: ["claude", "codex", "amp", "grok"]
 
   // Chamado pelo PopupCard no clique-fora (owner.close()). Sem isto o card
@@ -55,9 +67,26 @@ BarWidget {
   // o catcher quando o popup abre. Sem click no card o compositor pode ainda
   // não entregar teclas — mesmo padrão do shell quando o surface não é Exclusive.
   onPopupOpenChanged: {
-    if (popupOpen) Qt.callLater(function() {
-      if (root.popupOpen && keyCatcher) keyCatcher.forceActiveFocus()
-    })
+    if (popupOpen) {
+      // M1 é "abertura", não "toda atualização" — arma a janela de motion
+      // e desarma sozinho depois (Timer abaixo), pra refresh de fundo não
+      // re-disparar o preenchimento das barras.
+      root.barsAnimating = root.menuAnimationsEnabled
+      barsAnimationResetTimer.restart()
+      Qt.callLater(function() {
+        if (root.popupOpen && keyCatcher) keyCatcher.forceActiveFocus()
+      })
+    }
+  }
+
+  // 1500ms cobre o pior caso plausível (~4 providers x 3-4 linhas, stagger
+  // 60ms por linha dentro de cada painel + 320ms de duração) com folga.
+  Timer {
+    id: barsAnimationResetTimer
+    interval: 1500
+    running: false
+    repeat: false
+    onTriggered: root.barsAnimating = false
   }
 
   function pathFromUrl(url) { return String(url).replace(/^file:\/\//, "") }
@@ -103,36 +132,215 @@ BarWidget {
     return String(id || "")
   }
 
+  // ── Display value (remaining vs used) ────────────────────────────────
+  // Espelha `to_window_display` (src/formatters/shared.rs): honra `used`
+  // do provider quando `mode === "used"` e o campo existe; senão deriva de
+  // `remaining`. Usado tanto pelo chip da barra quanto pelas linhas do popup
+  // (spec: "displayMode used passa a valer nas linhas, não só no chip").
+  function windowDisplayValue(w, mode) {
+    if (!w) return NaN
+    if (mode === "used") {
+      var used = Number(w.used)
+      if (isFinite(used)) return used
+      var rem = Number(w.remaining)
+      return isFinite(rem) ? 100 - rem : NaN
+    }
+    return Number(w.remaining)
+  }
+
+  function formatDisplayPct(v) {
+    return isFinite(v) ? Math.round(v) + "%" : ""
+  }
+
   function chipLabel(p) {
     if (!p.available) return "–"
-    var w = p.primary
-    if (!w) return ""
-    if (root.displayMode === "used") {
-      var used = Number(w.used)
-      if (isFinite(used)) return Math.round(used) + "%"
-      var rem = Number(w.remaining)
-      if (isFinite(rem)) return Math.round(100 - rem) + "%"
-      return ""
-    }
-    if (!isFinite(Number(w.remaining))) return ""
-    return Math.round(Number(w.remaining)) + "%"
+    return root.formatDisplayPct(root.windowDisplayValue(p.primary, root.displayMode))
   }
 
-  // 300min ~ "5h", 10080min ~ "Weekly" (tolerâncias de classify_window).
-  function windowLabel(w, fallback) {
+  // Mesmo cálculo de chipLabel, mas para a prévia ao vivo do Settings — usa
+  // o modo em RASCUNHO (draftSettings), não o modo salvo, para o usuário ver
+  // o efeito antes de clicar Salvar.
+  function previewChipLabel(p) {
+    if (!p.available) return "–"
+    var mode = root.draftSettings.displayMode === "used" ? "used" : "remaining"
+    return root.formatDisplayPct(root.windowDisplayValue(p.primary, mode))
+  }
+
+  // ── Rótulo de janela — só a partir de windowKind (Plano 02), zero magic
+  // number aqui (o antigo ±90/±1440 morreu junto com o backend). "other"
+  // ainda carrega windowMinutes cru; usamos só para um rótulo por duração
+  // real, nunca para reclassificar.
+  function windowLabel(w) {
+    var kind = w ? String(w.windowKind || "") : ""
+    if (kind === "fiveHour") return "Sessão 5h"
+    if (kind === "sevenDay") return "Semana"
+    if (kind === "daily") return "Diário"
+    if (kind === "context") return "Contexto"
+    return root.otherWindowLabel(w)
+  }
+
+  function otherWindowLabel(w) {
     var m = Number(w && w.windowMinutes)
-    if (isFinite(m) && m > 0) {
-      if (Math.abs(m - 300) <= 90) return "5h"
-      if (Math.abs(m - 10080) <= 1440) return "Weekly"
-    }
-    return fallback
+    if (!isFinite(m) || m <= 0) return "Janela"
+    if (m % 1440 === 0) return "Janela de " + (m / 1440) + "d"
+    var h = Math.floor(m / 60)
+    var mm = m % 60
+    return mm === 0 ? ("Janela de " + h + "h") : ("Janela de " + h + "h" + mm + "m")
   }
 
-  function fmtReset(iso) {
+  // ── Dedup display-level — espelha `is_duplicate_window`
+  // (src/formatters/shared.rs, Plano 02): mesma (windowKind, resetsAt,
+  // remaining arredondado) = mesma janela. O JSON continua emitindo
+  // primary/secondary/models sem cortes; o corte é só aqui, na tela.
+  function windowKey(w) {
+    if (!w) return null
+    var kind = String(w.windowKind || "other")
+    var resets = w.resetsAt || ""
+    var rem = isFinite(Number(w.remaining)) ? Math.round(Number(w.remaining)) : "?"
+    return kind + "|" + resets + "|" + rem
+  }
+
+  function isDuplicateWindow(a, b) {
+    if (!a || !b) return false
+    return root.windowKey(a) === root.windowKey(b)
+  }
+
+  // primary/secondary sempre entram (rotulados por windowKind); um model só
+  // entra quando NÃO duplica uma janela já incluída — mata o triplo "Weekly"
+  // do Codex (primary e secondary na mesma janela) sem esconder um model que
+  // genuinamente diverge (ex.: "Fable" com remaining diferente da agregada).
+  function providerRows(p) {
+    var rows = []
+    function addRow(name, w, isSub) {
+      if (!w) return
+      for (var i = 0; i < rows.length; i++) {
+        if (root.isDuplicateWindow(rows[i].window, w)) return
+      }
+      rows.push({ name: name, window: w, isSub: !!isSub })
+    }
+    addRow(root.windowLabel(p.primary), p.primary, false)
+    addRow(root.windowLabel(p.secondary), p.secondary, false)
+    var models = p.models || {}
+    var keys = Object.keys(models)
+    for (var j = 0; j < keys.length; j++) {
+      addRow(keys[j], models[keys[j]], true)
+    }
+    return rows
+  }
+
+  // ── `extra` na tela — shapes documentados em docs/json-output.md /
+  // src/providers/types.rs (AmpQuotaExtra.meta, GrokQuotaExtra,
+  // ClaudeQuotaExtra.extraUsage). `extra` é unstable por contrato: qualquer
+  // chave ausente vira linha omitida, nunca um valor inventado.
+  function extraInfoRows(p) {
+    var rows = []
+    var extra = p.extra
+    if (!extra) return rows
+    if (p.provider === "amp") {
+      var bal = extra.meta && extra.meta.creditsBalance
+      if (bal) {
+        var rep = (extra.meta.creditsReplenish === "auto") ? " · replenish automático" : ""
+        rows.push({ label: "Créditos", info: "<b>" + bal + "</b>" + rep })
+      }
+    } else if (p.provider === "grok") {
+      var sessions = Number(extra.sessionsToday)
+      var turns = Number(extra.turnsToday)
+      if (isFinite(sessions) || isFinite(turns)) {
+        var parts = []
+        if (isFinite(sessions)) parts.push("<b>" + sessions + " sessões</b>")
+        if (isFinite(turns)) parts.push("<b>" + turns + " turnos</b>")
+        if (extra.recentModel) parts.push(String(extra.recentModel))
+        rows.push({ label: "Hoje", info: parts.join(" · ") })
+      }
+    } else if (p.provider === "claude") {
+      var eu = extra.extraUsage
+      if (eu && eu.enabled) {
+        var used = Number(eu.used)
+        var limit = Number(eu.limit)
+        var info = (isFinite(limit) && limit > 0)
+          ? "<b>$" + used.toFixed(2) + "</b> de $" + limit.toFixed(2)
+          : "<b>$" + used.toFixed(2) + "</b> gasto"
+        rows.push({ label: "Extra usage", info: info })
+      }
+    }
+    return rows
+  }
+
+  // ── Relógio local (JS Date pega o fuso do SO automaticamente — sem
+  // equivalente a `Clock.local_offset` do Rust necessário aqui). ─────────
+  readonly property var ptWeekdays: ["dom", "seg", "ter", "qua", "qui", "sex", "sáb"]
+
+  function clampRefreshInterval(sec) {
+    var n = Math.round(Number(sec))
+    if (!isFinite(n)) n = 60
+    return Math.min(3600, Math.max(30, n))
+  }
+
+  function fmtAgo(iso, now) {
     if (!iso) return ""
     var d = new Date(iso)
     if (isNaN(d.getTime())) return ""
-    return Qt.formatDateTime(d, "ddd HH:mm")
+    var diffMs = now.getTime() - d.getTime()
+    if (diffMs < 60000) return "agora mesmo"
+    var mins = Math.floor(diffMs / 60000)
+    if (mins < 60) return "há " + mins + "m"
+    return "há " + Math.floor(mins / 60) + "h"
+  }
+
+  function fmtDuration(ms) {
+    var totalMin = Math.max(0, Math.floor(ms / 60000))
+    var days = Math.floor(totalMin / 1440)
+    var hours = Math.floor((totalMin % 1440) / 60)
+    var mins = totalMin % 60
+    if (days > 0) return days + "d " + hours + "h"
+    var mm = mins < 10 ? "0" + mins : String(mins)
+    return hours + "h " + mm + "m"
+  }
+
+  function fmtLocalClock(d, now) {
+    var hh = String(d.getHours()).padStart(2, "0")
+    var mm = String(d.getMinutes()).padStart(2, "0")
+    var sameDay = d.getFullYear() === now.getFullYear()
+      && d.getMonth() === now.getMonth()
+      && d.getDate() === now.getDate()
+    if (sameDay) return hh + ":" + mm
+    return root.ptWeekdays[d.getDay()] + " " + hh + ":" + mm
+  }
+
+  function fmtTokCount(n) {
+    var v = Number(n)
+    if (!isFinite(v)) return "?"
+    if (v >= 1000) return (v / 1000).toFixed(1) + "k"
+    return String(Math.round(v))
+  }
+
+  // Grok "context" não tem resetsAt (não é baseado em tempo) — a coluna de
+  // ETA vira a razão de tokens usados/janela (spec: "253.9k/500k tok").
+  function contextRatioLabel(extra) {
+    if (!extra) return ""
+    var used = Number(extra.contextTokensUsed)
+    var total = Number(extra.contextWindowTokens)
+    if (!isFinite(used) || !isFinite(total) || total <= 0) return ""
+    return root.fmtTokCount(used) + "/" + root.fmtTokCount(total) + " tok"
+  }
+
+  // Coluna de reset/countdown da grade. "Full" quando remaining==100 (só
+  // pra manter paridade com `format_eta` do Rust); "?" sem resetsAt; senão
+  // "{duração} · {HH:MM ou seg HH:MM}" — dia da semana só aparece quando o
+  // reset cai num dia diferente de `now` (local).
+  function fmtEta(w, extra, now) {
+    if (!w) return ""
+    var kind = String(w.windowKind || "")
+    if (kind === "context") return root.contextRatioLabel(extra)
+    var rem = Number(w.remaining)
+    if (isFinite(rem) && rem >= 100) return "Full"
+    var iso = w.resetsAt
+    if (!iso) return "?"
+    var d = new Date(iso)
+    if (isNaN(d.getTime())) return "?"
+    var diffMs = d.getTime() - now.getTime()
+    var dur = diffMs > 0 ? root.fmtDuration(diffMs) : "0h 00m"
+    return dur + " · " + root.fmtLocalClock(d, now)
   }
 
   function applyPayload(raw) {
@@ -165,6 +373,9 @@ BarWidget {
     enabledIds = Array.isArray(data.providerOrder) ? data.providerOrder.slice()
               : (Array.isArray(data.providers) ? data.providers.slice() : [])
     displayMode = data.displayMode === "used" ? "used" : "remaining"
+    // Ausente/omitido no payload = true — nunca desliga motion à toa num
+    // payload de config show mais velho que o campo.
+    menuAnimationsEnabled = data.menuAnimations !== false
     return true
   }
 
@@ -177,7 +388,7 @@ BarWidget {
         providerOrder: (data.providerOrder || data.providers || []).slice(),
         displayMode: displayMode,
         notifyEnabled: !!(data.notify && data.notify.enabled),
-        refreshIntervalSec: Math.min(3600, Math.max(30, Number(setting("refreshIntervalSec", 60)) || 60))
+        refreshIntervalSec: root.clampRefreshInterval(Number(setting("refreshIntervalSec", 60)) || 60)
       }
       settingsStatusText = ""
     } catch (e) {
@@ -261,7 +472,7 @@ BarWidget {
       return
     }
     // interval → shell.json (só se apply OK)
-    var interval = Math.min(3600, Math.max(30, Number(draftSettings.refreshIntervalSec) || 60))
+    var interval = root.clampRefreshInterval(Number(draftSettings.refreshIntervalSec) || 60)
     var intervalPersisted = false
     if (bar && bar.shell && typeof bar.shell.updateEntryInline === "function") {
       try {
@@ -284,7 +495,7 @@ BarWidget {
     if (on && idx < 0) p.push(id)
     if (!on) {
       if (p.length <= 1 && idx >= 0) {
-        settingsStatusText = "Keep at least one provider"
+        settingsStatusText = "Mantenha ao menos 1 provider ativo"
         return
       }
       if (idx >= 0) p.splice(idx, 1)
@@ -316,8 +527,7 @@ BarWidget {
   }
 
   function setRefreshInterval(sec) {
-    var n = Math.min(3600, Math.max(30, Number(sec) || 60))
-    draftSettings = Object.assign({}, draftSettings, { refreshIntervalSec: n })
+    draftSettings = Object.assign({}, draftSettings, { refreshIntervalSec: root.clampRefreshInterval(sec) })
   }
 
   // enabled first (draft order), then disabled known ids
@@ -407,6 +617,15 @@ BarWidget {
     onTriggered: root.refresh(false)
   }
 
+  // Só força reavaliação de texto ("há Xm", countdown) — nunca dispara
+  // fetch nem I/O.
+  Timer {
+    interval: 30000
+    running: true
+    repeat: true
+    onTriggered: root.clockTick++
+  }
+
   Grid {
     id: chips
     anchors.centerIn: parent
@@ -493,21 +712,18 @@ BarWidget {
     owner: root
     bar: root.bar
     open: root.popupOpen
-    contentWidth: Style.space(370)
+    contentWidth: Style.space(540)
     contentHeight: Math.min(popupCol.implicitHeight + Style.space(20), Style.space(560))
 
-    // PanelKeyCatcher (qs.Ui): esc → close, s/S → save ou openSettings.
+    // PanelKeyCatcher (qs.Ui): esc → close. Salvar só pelo botão (atalho s
+    // removido — decisão travada do mockup settings-v2).
     // PopupCard não expõe focusTarget; ver onPopupOpenChanged no root.
     PanelKeyCatcher {
       id: keyCatcher
       anchors.fill: parent
-      blocked: root.settingsMode && refreshIntervalField.field.activeFocus
+      blocked: false
 
       onCloseRequested: root.close()
-      onTextKey: function(t) {
-        if (t === "s" || t === "S")
-          root.settingsMode ? root.saveSettings() : root.openSettings()
-      }
 
     Flickable {
       anchors.fill: parent
@@ -519,14 +735,70 @@ BarWidget {
         width: parent.width
         spacing: 10
 
-        // ── Settings header ──────────────────────────────────────────
+        // ── Titlebar de uso (B1: título à esquerda, ações à direita) ───
+        RowLayout {
+          visible: !root.settingsMode
+          Layout.fillWidth: true
+          spacing: 6
+
+          Text {
+            text: "agent-bar"
+            color: root.fg
+            font.family: root.fontFamily
+            font.pixelSize: 12.5
+            font.bold: true
+          }
+          Text {
+            text: (root.clockTick, root.payload ? "· " + root.fmtAgo(root.payload.fetchedAt, new Date()) : "")
+            color: root.dim
+            font.family: root.fontFamily
+            font.pixelSize: 10.5
+          }
+
+          Item { Layout.fillWidth: true }
+
+          IconButton {
+            glyph: "↻"
+            tooltip: "Atualizar"
+            spinning: fetchProc.running
+            onClicked: root.refresh(true)
+          }
+          IconButton {
+            glyph: "⚙︎"
+            tooltip: "Settings"
+            onClicked: root.openSettings()
+          }
+          IconButton {
+            glyph: "❯"
+            tooltip: "Abrir TUI"
+            onClicked: root.openTui()
+          }
+        }
+
+        // ── Titlebar de settings ────────────────────────────────────────
         RowLayout {
           visible: root.settingsMode
           Layout.fillWidth: true
           spacing: 8
 
+          Text {
+            text: "agent-bar"
+            color: root.fg
+            font.family: root.fontFamily
+            font.pixelSize: 12.5
+            font.bold: true
+          }
+          Text {
+            text: "· Settings"
+            color: root.dim
+            font.family: root.fontFamily
+            font.pixelSize: 12.5
+          }
+
+          Item { Layout.fillWidth: true }
+
           Button {
-            text: "← Usage"
+            text: "← Uso"
             foreground: root.fg
             fontFamily: root.fontFamily
             fontSize: 10
@@ -534,19 +806,8 @@ BarWidget {
             verticalPadding: 4
             onClicked: root.showUsage()
           }
-
-          Text {
-            text: "Settings"
-            color: root.fg
-            font.family: root.fontFamily
-            font.pixelSize: 13
-            font.bold: true
-            Layout.fillWidth: true
-            Layout.alignment: Qt.AlignVCenter
-          }
-
           Button {
-            text: root.settingsBusy ? "Saving…" : "Save"
+            text: root.settingsBusy ? "Salvando…" : "Salvar"
             foreground: root.fg
             accent: Color.accent
             fontFamily: root.fontFamily
@@ -559,294 +820,468 @@ BarWidget {
           }
         }
 
-        PanelSeparator {
-          visible: root.settingsMode
-          Layout.fillWidth: true
-          foreground: root.fg
-          strength: 0.18
-        }
-
-        // ── Usage sections ───────────────────────────────────────────
+        // ── Usage: um painel elevado por provider (Estilo 2 — Painéis) ──
         Repeater {
           model: root.settingsMode ? [] : root.visibleProviders()
 
           ColumnLayout {
-            id: section
+            id: panelWrap
             required property var modelData
             Layout.fillWidth: true
-            spacing: 4
+            spacing: 0
+
+            Rectangle {
+              Layout.fillWidth: true
+              implicitHeight: panelContent.implicitHeight + 20
+              radius: 9
+              // Tint semi-transparente de root.fg — os hex do mockup são só
+              // do protótipo HTML; a cor real do tema do shell entra via fg.
+              color: Qt.rgba(root.fg.r, root.fg.g, root.fg.b, 0.05)
+              border.width: 1
+              border.color: Qt.rgba(root.fg.r, root.fg.g, root.fg.b, 0.14)
+              opacity: panelWrap.modelData.staleReason ? 0.55 : 1.0
+
+              ColumnLayout {
+                id: panelContent
+                anchors.fill: parent
+                anchors.margins: 10
+                spacing: 4
+
+                RowLayout {
+                  Layout.fillWidth: true
+                  spacing: 6
+
+                  Image {
+                    source: root.iconFile(panelWrap.modelData.provider) ? Qt.resolvedUrl(root.iconFile(panelWrap.modelData.provider)) : ""
+                    visible: source !== ""
+                    width: 15; height: 15
+                    sourceSize.width: 15; sourceSize.height: 15
+                    fillMode: Image.PreserveAspectFit
+                  }
+                  Text {
+                    text: panelWrap.modelData.displayName
+                    color: root.fg
+                    font.family: root.fontFamily
+                    font.pixelSize: 13
+                    font.bold: true
+                  }
+                  Text {
+                    Layout.fillWidth: true
+                    text: String(panelWrap.modelData.plan || panelWrap.modelData.account || "")
+                    color: root.dim
+                    font.family: root.fontFamily
+                    font.pixelSize: 11
+                    elide: Text.ElideRight
+                  }
+                  // Hero % — mesmo valor e severidade do chip da barra.
+                  Text {
+                    visible: panelWrap.modelData.available
+                    text: root.chipLabel(panelWrap.modelData)
+                    color: root.severityColor(root.severityBucket(panelWrap.modelData.primary))
+                    font.family: root.fontFamily
+                    font.pixelSize: 15
+                    font.bold: true
+                  }
+                }
+
+                Text {
+                  visible: !panelWrap.modelData.available
+                  text: String(panelWrap.modelData.error || "Unavailable")
+                  color: Qt.darker(root.fg, 1.3)
+                  font.family: root.fontFamily
+                  font.pixelSize: 11
+                  wrapMode: Text.WordWrap
+                  Layout.fillWidth: true
+                }
+
+                Text {
+                  visible: !!panelWrap.modelData.staleReason
+                  text: "stale — " + String(panelWrap.modelData.staleReason || "")
+                  color: root.dim
+                  font.family: root.fontFamily
+                  font.pixelSize: 10
+                  wrapMode: Text.WordWrap
+                  Layout.fillWidth: true
+                }
+
+                Repeater {
+                  model: panelWrap.modelData.available ? root.providerRows(panelWrap.modelData) : []
+
+                  QuotaRow {
+                    window: modelData.window
+                    extra: panelWrap.modelData.extra
+                    name: modelData.name
+                    isSub: modelData.isSub
+                    rowIndex: index
+                  }
+                }
+
+                Repeater {
+                  model: panelWrap.modelData.available ? root.extraInfoRows(panelWrap.modelData) : []
+
+                  InfoRow {
+                    label: modelData.label
+                    info: modelData.info
+                  }
+                }
+              }
+            }
+          }
+        }
+
+        // ── Settings body v2: 3 painéis (Providers / Exibição / Alertas &
+        // atualização), prévia ao vivo da barra, sem rodapé de dicas ──────
+        Rectangle {
+          visible: root.settingsMode
+          Layout.fillWidth: true
+          implicitHeight: providersCol.implicitHeight + 20
+          radius: 9
+          color: Qt.rgba(root.fg.r, root.fg.g, root.fg.b, 0.05)
+          border.width: 1
+          border.color: Qt.rgba(root.fg.r, root.fg.g, root.fg.b, 0.14)
+
+          ColumnLayout {
+            id: providersCol
+            anchors.fill: parent
+            anchors.margins: 10
+            spacing: 8
+
+            PanelSectionHeader {
+              Layout.fillWidth: true
+              text: "Providers"
+              foreground: root.fg
+              fontFamily: root.fontFamily
+              fontSize: 11
+            }
+
+            Repeater {
+              model: root.settingsMode ? root.settingsProviderRows() : []
+
+              ColumnLayout {
+                id: provRow
+                required property var modelData
+                Layout.fillWidth: true
+                spacing: 4
+
+                RowLayout {
+                  Layout.fillWidth: true
+                  spacing: 8
+
+                  Image {
+                    source: root.iconFile(provRow.modelData.id) ? Qt.resolvedUrl(root.iconFile(provRow.modelData.id)) : ""
+                    visible: source !== ""
+                    width: 15; height: 15
+                    sourceSize.width: 15; sourceSize.height: 15
+                    fillMode: Image.PreserveAspectFit
+                  }
+                  Toggle {
+                    Layout.fillWidth: true
+                    label: root.providerLabel(provRow.modelData.id)
+                    description: checked ? "Visível na barra" : "Oculto da barra"
+                    checked: provRow.modelData.on
+                    foreground: root.fg
+                    accent: Color.accent
+                    fontFamily: root.fontFamily
+                    onClicked: root.setProviderEnabled(provRow.modelData.id, !checked)
+                  }
+                }
+
+                RowLayout {
+                  visible: provRow.modelData.on
+                  Layout.fillWidth: true
+                  spacing: 6
+
+                  Item { Layout.fillWidth: true }
+
+                  IconButton {
+                    glyph: "↑"
+                    tooltip: "Mover para cima"
+                    enabled: provRow.modelData.index > 0
+                    onClicked: root.moveProvider(provRow.modelData.id, -1)
+                  }
+                  IconButton {
+                    glyph: "↓"
+                    tooltip: "Mover para baixo"
+                    enabled: provRow.modelData.index >= 0 && provRow.modelData.index < provRow.modelData.count - 1
+                    onClicked: root.moveProvider(provRow.modelData.id, 1)
+                  }
+                }
+              }
+            }
+          }
+        }
+
+        Rectangle {
+          visible: root.settingsMode
+          Layout.fillWidth: true
+          implicitHeight: exibicaoCol.implicitHeight + 20
+          radius: 9
+          color: Qt.rgba(root.fg.r, root.fg.g, root.fg.b, 0.05)
+          border.width: 1
+          border.color: Qt.rgba(root.fg.r, root.fg.g, root.fg.b, 0.14)
+
+          ColumnLayout {
+            id: exibicaoCol
+            anchors.fill: parent
+            anchors.margins: 10
+            spacing: 8
+
+            PanelSectionHeader {
+              Layout.fillWidth: true
+              text: "Exibição"
+              foreground: root.fg
+              fontFamily: root.fontFamily
+              fontSize: 11
+            }
 
             RowLayout {
               Layout.fillWidth: true
               spacing: 6
 
-              Image {
-                source: root.iconFile(section.modelData.provider) ? Qt.resolvedUrl(root.iconFile(section.modelData.provider)) : ""
-                visible: source !== ""
-                width: 14; height: 14
-                sourceSize.width: 14; sourceSize.height: 14
-                fillMode: Image.PreserveAspectFit
-              }
               Text {
-                text: section.modelData.displayName
+                text: "Número do chip"
                 color: root.fg
                 font.family: root.fontFamily
-                font.pixelSize: 13
-                font.bold: true
-              }
-              Text {
+                font.pixelSize: 12
                 Layout.fillWidth: true
-                text: String(section.modelData.plan || section.modelData.account || "")
-                color: root.dim
-                font.family: root.fontFamily
-                font.pixelSize: 11
-                elide: Text.ElideRight
               }
-            }
-
-            Text {
-              visible: !section.modelData.available
-              text: String(section.modelData.error || "Unavailable")
-              color: Qt.darker(root.fg, 1.3)
-              font.family: root.fontFamily
-              font.pixelSize: 11
-              wrapMode: Text.WordWrap
-              Layout.fillWidth: true
-            }
-
-            QuotaRow { window: section.modelData.primary; name: root.windowLabel(section.modelData.primary, "Session") }
-            QuotaRow { window: section.modelData.secondary; name: root.windowLabel(section.modelData.secondary, "Weekly") }
-
-            Repeater {
-              // delegate sem required properties → `modelData` implícito do
-              // contexto é a chave (nome do modelo)
-              model: section.modelData.models ? Object.keys(section.modelData.models) : []
-              QuotaRow {
-                window: section.modelData.models[modelData]
-                name: modelData
-              }
-            }
-
-            PanelSeparator { Layout.fillWidth: true; foreground: root.fg; strength: 0.18 }
-          }
-        }
-
-        // ── Settings body ────────────────────────────────────────────
-        ColumnLayout {
-          visible: root.settingsMode
-          Layout.fillWidth: true
-          spacing: 12
-
-          PanelSectionHeader {
-            Layout.fillWidth: true
-            text: "Providers"
-            foreground: root.fg
-            fontFamily: root.fontFamily
-            fontSize: 11
-          }
-
-          Repeater {
-            model: root.settingsMode ? root.settingsProviderRows() : []
-
-            ColumnLayout {
-              id: provRow
-              required property var modelData
-              Layout.fillWidth: true
-              spacing: 4
-
-              Toggle {
-                Layout.fillWidth: true
-                label: root.providerLabel(provRow.modelData.id)
-                description: checked ? "Shown in bar chips" : "Hidden from the bar"
-                checked: provRow.modelData.on
+              Button {
+                text: "Restante"
                 foreground: root.fg
                 accent: Color.accent
                 fontFamily: root.fontFamily
-                onClicked: root.setProviderEnabled(provRow.modelData.id, !checked)
+                fontSize: 11
+                horizontalPadding: 10
+                verticalPadding: 5
+                active: (root.draftSettings.displayMode || "remaining") !== "used"
+                onClicked: root.setDisplayMode("remaining")
               }
-
-              RowLayout {
-                visible: provRow.modelData.on
-                Layout.fillWidth: true
-                spacing: 6
-
-                Item { Layout.fillWidth: true }
-
-                Button {
-                  text: "↑"
-                  enabled: provRow.modelData.index > 0
-                  foreground: root.fg
-                  fontFamily: root.fontFamily
-                  fontSize: 11
-                  horizontalPadding: 8
-                  verticalPadding: 3
-                  onClicked: root.moveProvider(provRow.modelData.id, -1)
-                }
-                Button {
-                  text: "↓"
-                  enabled: provRow.modelData.index >= 0 && provRow.modelData.index < provRow.modelData.count - 1
-                  foreground: root.fg
-                  fontFamily: root.fontFamily
-                  fontSize: 11
-                  horizontalPadding: 8
-                  verticalPadding: 3
-                  onClicked: root.moveProvider(provRow.modelData.id, 1)
-                }
+              Button {
+                text: "Usado"
+                foreground: root.fg
+                accent: Color.accent
+                fontFamily: root.fontFamily
+                fontSize: 11
+                horizontalPadding: 10
+                verticalPadding: 5
+                active: root.draftSettings.displayMode === "used"
+                onClicked: root.setDisplayMode("used")
               }
             }
-          }
 
-          PanelSectionHeader {
-            Layout.fillWidth: true
-            text: "Display"
-            foreground: root.fg
-            fontFamily: root.fontFamily
-            fontSize: 11
-          }
-
-          RowLayout {
-            Layout.fillWidth: true
-            spacing: 6
-
-            Button {
-              text: "Remaining"
+            // Prévia ao vivo: usa o modo em RASCUNHO contra os dados reais
+            // já carregados — o usuário vê o efeito antes de clicar Salvar.
+            RowLayout {
               Layout.fillWidth: true
-              foreground: root.fg
-              accent: Color.accent
-              fontFamily: root.fontFamily
-              fontSize: 11
-              horizontalPadding: 8
-              verticalPadding: 5
-              active: (root.draftSettings.displayMode || "remaining") !== "used"
-              onClicked: root.setDisplayMode("remaining")
+              spacing: 14
+
+              Text {
+                text: "Prévia"
+                color: Qt.darker(root.fg, 1.6)
+                font.family: root.fontFamily
+                font.pixelSize: 10
+              }
+
+              Repeater {
+                model: root.settingsMode ? root.visibleProviders() : []
+
+                RowLayout {
+                  required property var modelData
+                  spacing: 5
+
+                  Image {
+                    source: root.iconFile(modelData.provider) ? Qt.resolvedUrl(root.iconFile(modelData.provider)) : ""
+                    visible: source !== ""
+                    width: 13; height: 13
+                    sourceSize.width: 13; sourceSize.height: 13
+                    fillMode: Image.PreserveAspectFit
+                  }
+                  Text {
+                    text: root.previewChipLabel(modelData)
+                    color: root.severityColor(root.severityBucket(modelData.primary))
+                    font.family: root.fontFamily
+                    font.pixelSize: 11.5
+                  }
+                }
+              }
             }
-            Button {
-              text: "Used"
-              Layout.fillWidth: true
-              foreground: root.fg
-              accent: Color.accent
-              fontFamily: root.fontFamily
-              fontSize: 11
-              horizontalPadding: 8
-              verticalPadding: 5
-              active: root.draftSettings.displayMode === "used"
-              onClicked: root.setDisplayMode("used")
-            }
-          }
-
-          PanelSectionHeader {
-            Layout.fillWidth: true
-            text: "Alerts"
-            foreground: root.fg
-            fontFamily: root.fontFamily
-            fontSize: 11
-          }
-
-          Toggle {
-            Layout.fillWidth: true
-            label: "Desktop notifications"
-            description: checked ? "notify-send on quota thresholds" : "Notifications off"
-            checked: !!root.draftSettings.notifyEnabled
-            foreground: root.fg
-            accent: Color.accent
-            fontFamily: root.fontFamily
-            onClicked: root.setNotifyEnabled(!checked)
-          }
-
-          PanelSectionHeader {
-            Layout.fillWidth: true
-            text: "Refresh"
-            foreground: root.fg
-            fontFamily: root.fontFamily
-            fontSize: 11
-          }
-
-          NumberField {
-            id: refreshIntervalField
-            Layout.fillWidth: true
-            label: "Interval (seconds)"
-            value: Number(root.draftSettings.refreshIntervalSec || 60)
-            from: 30
-            to: 3600
-            stepSize: 30
-            fieldWidth: parent.width
-            foreground: root.fg
-            accent: Color.accent
-            fontFamily: root.fontFamily
-            onModified: function(value) { root.setRefreshInterval(value) }
-          }
-
-          Text {
-            visible: root.settingsStatusText !== ""
-            Layout.fillWidth: true
-            text: root.settingsStatusText
-            color: root.dim
-            font.family: root.fontFamily
-            font.pixelSize: 10
-            horizontalAlignment: Text.AlignHCenter
-            wrapMode: Text.WordWrap
-          }
-
-          Text {
-            Layout.fillWidth: true
-            text: "s saves · esc closes"
-            color: root.dim
-            font.family: root.fontFamily
-            font.pixelSize: 10
-            horizontalAlignment: Text.AlignHCenter
           }
         }
 
-        // ── Usage footer ─────────────────────────────────────────────
+        Rectangle {
+          visible: root.settingsMode
+          Layout.fillWidth: true
+          implicitHeight: alertasCol.implicitHeight + 20
+          radius: 9
+          color: Qt.rgba(root.fg.r, root.fg.g, root.fg.b, 0.05)
+          border.width: 1
+          border.color: Qt.rgba(root.fg.r, root.fg.g, root.fg.b, 0.14)
+
+          ColumnLayout {
+            id: alertasCol
+            anchors.fill: parent
+            anchors.margins: 10
+            spacing: 8
+
+            PanelSectionHeader {
+              Layout.fillWidth: true
+              text: "Alertas & atualização"
+              foreground: root.fg
+              fontFamily: root.fontFamily
+              fontSize: 11
+            }
+
+            Toggle {
+              Layout.fillWidth: true
+              label: "Notificações desktop"
+              description: checked ? "notify-send nos limites de quota" : "Notificações desligadas"
+              checked: !!root.draftSettings.notifyEnabled
+              foreground: root.fg
+              accent: Color.accent
+              fontFamily: root.fontFamily
+              onClicked: root.setNotifyEnabled(!checked)
+            }
+
+            RowLayout {
+              Layout.fillWidth: true
+              spacing: 8
+
+              ColumnLayout {
+                Layout.fillWidth: true
+                spacing: 0
+                Text {
+                  text: "Intervalo"
+                  color: root.fg
+                  font.family: root.fontFamily
+                  font.pixelSize: 12
+                }
+                Text {
+                  text: "segundos entre atualizações"
+                  color: Qt.darker(root.fg, 1.6)
+                  font.family: root.fontFamily
+                  font.pixelSize: 10.5
+                }
+              }
+
+              IconButton {
+                glyph: "−"
+                tooltip: "Diminuir 30s"
+                enabled: root.draftSettings.refreshIntervalSec > 30
+                onClicked: root.setRefreshInterval(root.draftSettings.refreshIntervalSec - 30)
+              }
+              Text {
+                text: root.draftSettings.refreshIntervalSec + "s"
+                color: root.fg
+                font.family: root.fontFamily
+                font.pixelSize: 11.5
+                horizontalAlignment: Text.AlignHCenter
+                Layout.preferredWidth: 46
+              }
+              IconButton {
+                glyph: "+"
+                tooltip: "Aumentar 30s"
+                enabled: root.draftSettings.refreshIntervalSec < 3600
+                onClicked: root.setRefreshInterval(root.draftSettings.refreshIntervalSec + 30)
+              }
+            }
+          }
+        }
+
         Text {
-          visible: !root.settingsMode
-          text: root.stale ? "stale — last fetch failed" : (root.payload ? "fetched " + root.fmtReset(root.payload.fetchedAt) : "loading…")
+          visible: root.settingsMode && root.settingsStatusText !== ""
+          Layout.fillWidth: true
+          text: root.settingsStatusText
           color: root.dim
           font.family: root.fontFamily
           font.pixelSize: 10
-        }
-
-        Text {
-          visible: !root.settingsMode
-          text: "right-click: settings · middle: refresh"
-          color: Qt.darker(root.fg, 1.6)
-          font.family: root.fontFamily
-          font.pixelSize: 10
-        }
-
-        Text {
-          visible: !root.settingsMode
-          text: "Abrir menu (TUI)"
-          color: Color.accent
-          font.family: root.fontFamily
-          font.pixelSize: 11
-          font.underline: true
-
-          MouseArea {
-            anchors.fill: parent
-            cursorShape: Qt.PointingHandCursor
-            onClicked: root.openTui()
-          }
+          horizontalAlignment: Text.AlignHCenter
+          wrapMode: Text.WordWrap
         }
       }
     }
     } // PanelKeyCatcher
   }
 
+  // Botão quadrado só-ícone (↻ ⚙︎ ❯, e reusado para ↑/↓/−/+).
+  // Unicode puro — sem dependência de Nerd Font (spec).
+  component IconButton: Item {
+    id: btn
+    property string glyph: ""
+    property string tooltip: ""
+    property bool spinning: false
+    signal clicked()
+
+    implicitWidth: 28
+    implicitHeight: 25
+    opacity: btn.enabled ? 1.0 : 0.4
+
+    Rectangle {
+      anchors.fill: parent
+      radius: 6
+      color: mouse.containsMouse && btn.enabled
+        ? Qt.rgba(root.fg.r, root.fg.g, root.fg.b, 0.14)
+        : Qt.rgba(root.fg.r, root.fg.g, root.fg.b, 0.08)
+      border.width: 1
+      border.color: mouse.containsMouse && btn.enabled
+        ? Color.accent
+        : Qt.rgba(root.fg.r, root.fg.g, root.fg.b, 0.20)
+
+      Behavior on color { enabled: root.menuAnimationsEnabled; ColorAnimation { duration: 160 } }
+      Behavior on border.color { enabled: root.menuAnimationsEnabled; ColorAnimation { duration: 160 } }
+    }
+
+    Text {
+      id: glyphText
+      anchors.centerIn: parent
+      text: btn.glyph
+      color: mouse.containsMouse && btn.enabled ? Color.accent : root.fg
+      font.family: root.fontFamily
+      font.pixelSize: 13
+
+      RotationAnimation {
+        target: glyphText
+        property: "rotation"
+        running: btn.spinning && root.menuAnimationsEnabled
+        from: 0; to: 360
+        duration: 900
+        loops: Animation.Infinite
+        onRunningChanged: if (!running) glyphText.rotation = 0
+      }
+    }
+
+    MouseArea {
+      id: mouse
+      anchors.fill: parent
+      enabled: btn.enabled
+      hoverEnabled: true
+      cursorShape: btn.enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
+      onEntered: if (root.bar && btn.tooltip) root.bar.showTooltip(btn, btn.tooltip)
+      onExited: if (root.bar) root.bar.hideTooltip(btn)
+      onClicked: btn.clicked()
+    }
+  }
+
+  // Colunas fixas (spec): rótulo 82 · barra flex · % 44 · reset/eta 132.
+  // Toda barra idêntica, % e reset sempre na mesma coluna independente do
+  // provider — é o que mata a assimetria da versão antiga.
   component QuotaRow: RowLayout {
     id: row
     property var window: null
+    property var extra: null
     property string name: ""
+    property bool isSub: false
+    property int rowIndex: 0
     visible: !!window
     Layout.fillWidth: true
     spacing: 6
 
     Text {
       text: row.name
-      color: Qt.darker(root.fg, 1.3)
+      color: row.isSub ? Qt.darker(root.fg, 1.6) : Qt.darker(root.fg, 1.3)
       font.family: root.fontFamily
       font.pixelSize: 11
-      Layout.preferredWidth: 64
+      leftPadding: row.isSub ? 12 : 0
+      Layout.preferredWidth: 82
       elide: Text.ElideRight
     }
 
@@ -865,15 +1300,70 @@ BarWidget {
         height: parent.height
         radius: 3
         color: root.severityColor(root.severityBucket(row.window))
+
+        // M1: só anima durante a janela de abertura do popup (barsAnimating);
+        // fora dela o valor só salta, sem transição — refresh de fundo não
+        // deve re-disparar o preenchimento. Gotcha: Behavior on width não
+        // anima a atribuição inicial na construção do item — se na prova
+        // ao vivo as barras não animarem no 1º open, fallback é width:0 +
+        // Component.onCompleted (Task 6 do plano).
+        Behavior on width {
+          enabled: root.barsAnimating && root.menuAnimationsEnabled
+          SequentialAnimation {
+            PauseAnimation { duration: Math.min(row.rowIndex, 8) * 60 }
+            NumberAnimation { duration: 320; easing.type: Easing.OutCubic }
+          }
+        }
       }
     }
 
     Text {
-      readonly property string resetText: root.fmtReset(row.window ? row.window.resetsAt : "")
-      text: (row.window && isFinite(Number(row.window.remaining)) ? Math.round(Number(row.window.remaining)) + "% left" : "") + (resetText ? " · " + resetText : "")
+      text: root.formatDisplayPct(root.windowDisplayValue(row.window, root.displayMode))
       color: Qt.darker(root.fg, 1.3)
       font.family: root.fontFamily
-      font.pixelSize: 10
+      font.pixelSize: 11
+      Layout.preferredWidth: 44
+      horizontalAlignment: Text.AlignRight
+    }
+
+    Text {
+      text: (root.clockTick, root.fmtEta(row.window, row.extra, new Date()))
+      color: root.dim
+      font.family: root.fontFamily
+      font.pixelSize: 10.5
+      Layout.preferredWidth: 132
+      horizontalAlignment: Text.AlignRight
+      elide: Text.ElideRight
+    }
+  }
+
+  // Linha de `extra` (Créditos/Hoje/Extra usage) — mesma coluna de rótulo
+  // (82) do QuotaRow; o valor ocupa o resto da largura (aproxima o
+  // `grid-column: 2/5` do mockup sem depender da grade CSS que QML não tem).
+  component InfoRow: RowLayout {
+    id: infoRow
+    property string label: ""
+    property string info: ""
+    visible: info !== ""
+    Layout.fillWidth: true
+    spacing: 6
+
+    Text {
+      text: infoRow.label
+      color: Qt.darker(root.fg, 1.3)
+      font.family: root.fontFamily
+      font.pixelSize: 11
+      Layout.preferredWidth: 82
+      elide: Text.ElideRight
+    }
+    Text {
+      text: infoRow.info
+      textFormat: Text.RichText
+      color: root.dim
+      font.family: root.fontFamily
+      font.pixelSize: 11
+      Layout.fillWidth: true
+      wrapMode: Text.WordWrap
     }
   }
 }


### PR DESCRIPTION
## Resumo

Reescreve `assets/omarchy/Widget.qml` para o popup "Painéis" e o settings v2 aprovados nos mockups, consumindo o contrato do plano 02 (`windowKind`, `menuAnimations`).

### Usage (popup)
- Largura `Style.space(540)`, titlebar `agent-bar` + "há Xm" + botões Unicode ↻ ⚙︎ ❯
- Painel elevado por provider com hero %
- Grade fixa: rótulo 82 / barra flex / % 44 / reset 132
- Rótulos só por `windowKind` (Sessão 5h / Semana / Diário / Contexto / Janela de …)
- Dedup display-level espelhando `is_duplicate_window`
- Countdown local `1h 46m · 18:30` / weekday quando outro dia
- `extra` na tela (Créditos Amp, Hoje Grok, Extra usage Claude)
- `staleReason` textual; `displayMode used` nas linhas e no chip

### Settings v2
- 3 painéis: Providers / Exibição (+prévia ao vivo) / Alertas & atualização
- Salvar **só pelo botão** (atalho `s` removido)
- Sem rodapé de dicas
- Intervalo com − / valor / + (sem NumberField)

### Motion
- M1 barras (320ms OutCubic, stagger 60ms, só na abertura)
- M2 ↻ gira no fetch
- M4 hover 160ms
- Gate: `menuAnimations` de `config show`

### Workarounds preservados
- `function close()` (binding `popupOpen`)
- Barrier `_haveStdout`/`_haveExit` no apply
- Apply via `mktemp`
- `Util.shellQuote` (nunca `bar.shellQuote`)

## Plano / mockups
- Plano: `docs/superpowers/plans/2026-07-21-v9-03-widget-qml.md`
- Mockups: `.superpowers/brainstorm/.../popup-b1-styles.html` (estilo 2) e `settings-v2.html`
- Base: `f7c6c4e` (PR #21 mergeado)

## Test plan
- [x] `qmllint assets/omarchy/Widget.qml` (exit 0)
- [x] Checklist: sem `fmtReset`/`NumberField`/`onTextKey`/`Style.space(370)`
- [x] `agent-bar setup --omarchy-plugins-dir <tmp>` — Widget.qml byte-identical
- [ ] **Validação ao vivo no desktop do dono** (3 provas: funcional + screenshot vs mockup + dado real vs `agent-bar --format json`) — **não rodei `agent-bar setup` no desktop real**
- [ ] Review + merge do dono