### PR TITLE
docs: prep release 9.0.0 (Omarchy-first)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,73 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [9.0.0] - 2026-07-21
+
+Redesign completo do popup (Omarchy-shell) + Waybar rebaixada a tier
+legado. Marco de produto — sem mudança de contrato JSON.
+
+### Added
+- **Widget.qml redesenhado**: hero % por provider igual ao chip, título
+  `agent-bar` + "há Xm" relativo, ações de topo viram botões Unicode
+  reais (↻ refresh, ⚙︎ settings, ❯ abrir TUI) em vez de texto/link. Um
+  cartão por provider, grade de colunas fixas (rótulo · barra · % ·
+  reset), countdown (`1h 46m · 18:30` / `7d 0h · seg 16:43`) em toda
+  janela. Largura `540` (antes `370`), igual nos dois modos.
+- **`extra` visível no popup**: créditos do Amp (`$X · replenish`),
+  sessões/turnos/modelo do Grok, extra usage do Claude quando existir —
+  antes só existiam no `--format json`, nunca chegavam à tela.
+- **Motion no popup**: barras preenchem na abertura (M1, stagger),
+  `↻` gira durante o fetch (M2), hover nos botões (M4) — gated por
+  `menu.animations` (exposto read-only em `config show` como
+  `menuAnimations`).
+- **`windowKind`** (`"fiveHour" | "sevenDay" | "daily" | "context" |
+  "other"`) em `QuotaWindow`, decidido uma vez no Rust por cada
+  provider; dedup display-level (`(windowKind, resetsAt, remaining)`)
+  consumido pela TUI e por Widget.qml — some o "Weekly" triplicado do
+  Codex no plano Plus.
+- **Countdown e fuso local na TUI**: `fmt_reset` do Detail passa a usar
+  `format_reset_time`/`format_eta` (antes fatiava o ISO em UTC cru, sem
+  contagem regressiva).
+- Settings do popup ganham Providers (toggle + reordenar), Exibição
+  (segmentado remaining/used + prévia ao vivo da barra) e Alertas &
+  atualização (notify + intervalo) como painéis próprios.
+- **`platform::detect()`** (`src/platform.rs`) único ponto de decisão
+  Omarchy/Waybar, usado por `setup`, `update` (os dois ramos) e pelo Save
+  da TUI Config — nenhum dos três cria mais `~/.config/waybar/` do zero
+  numa máquina Omarchy-only.
+- **`agent-bar update` reinstala o plugin Omarchy** quando o shell é
+  detectado, eliminando o drift binário↔QML que antes exigia rodar
+  `setup` manualmente. `doctor` ganhou checagem de versão do manifest
+  instalado vs binário.
+- Módulo `src/waybar/` agrupando o contrato Waybar (antigo
+  `waybar_contract.rs`/`waybar_integration.rs`) como tier legado isolado.
+
+### Changed
+- **Fix do mislabeling do Codex**: `build_model_windows` não força mais
+  `primary→fiveHour`/`secondary→sevenDay` quando a classificação diverge
+  — uma janela fora de tolerância vira `other` com rótulo pela duração
+  real (ex.: "1h window").
+- **Settings mode do popup**: salvar passa a ser **só pelo botão** — o
+  atalho de teclado `s` para salvar foi removido; o rodapé de dicas em
+  texto vira botões clicáveis de verdade.
+- Migração de settings **v2 → v3**: `waybar.show_percentage` é dropada
+  silenciosamente e o arquivo é regravado na versão nova.
+- TUI Config esconde os campos exclusivos de Waybar (separadores,
+  signal, intervalo do Waybar) quando `platform::detect()` reporta
+  Omarchy-only.
+- `docs/waybar-contract.md` e `README.md` marcam Waybar como **tier
+  legado**: funciona, recebe fix, não recebe feature nova.
+
+### Removed
+- Legado morto: variante `Command::Terminal`,
+  `waybar_contract::get_all_provider_ids`, `install::ensure_amp_cli`,
+  `amp_cli::AMP_INSTALL_COMMAND` duplicada, dependência `tokio-util`,
+  `ConfigField::settings_key()`, 7 variantes órfãs de `Icon`.
+
+### Breaking
+- Nenhuma no contrato `--format json` — `windowKind` é aditivo,
+  `schemaVersion` continua `1`.
+
 ## [8.5.0] - 2026-07-21
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,7 @@ pode não aparecer. Use apenas um filtro posicional por invocação de `cargo te
 | Update flow | `cargo test update` |
 | Theme / colors / identity | `cargo test theme && cargo test app_identity` |
 | CLI locators (Amp CLI) | `cargo test providers::amp_cli` |
+| CLI locators (Grok CLI) | `cargo test providers::grok_cli` |
 | Contratos Rust | `cargo clippy --all-targets -- -D warnings` |
 | Mudanças amplas antes de handoff | `cargo test && cargo clippy --all-targets -- -D warnings` |
 
@@ -69,6 +70,12 @@ pode não aparecer. Use apenas um filtro posicional por invocação de `cargo te
 - **Nunca round-trip live Waybar config via `serde_json`.**
   Os `.jsonc` têm comentários e ordem que precisam sobreviver.
   `waybar_integration.rs` patcha in-place.
+- **Módulo `src/waybar/` agrupa o tier legado** (`src/waybar/contract.rs`,
+  `src/waybar/integration.rs`), com re-exports em `lib.rs` para
+  `crate::waybar_contract`/`crate::waybar_integration`. Os filtros
+  `cargo test waybar_contract`/`cargo test waybar_integration` da matriz
+  (§2) seguem em vigor — se um teste for movido pro módulo interno,
+  confira que o filtro ainda casa antes de commitar.
 
 ## 4. Testing Patterns
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Quick start for developers.
 
 | Tool | Minimum |
 |------|---------|
-| [Rust](https://rustup.rs) | stable (1.75+) |
+| [Rust](https://rustup.rs) | 1.88 (MSRV — `tachyonfx` via `anpa` requires it) |
 | Git | recent |
 
 Rust + Cargo is the only supported toolchain.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <img src="docs/assets/agent-bar-banner.png" alt="Banner do Agent Bar">
 </p>
 
-Monitor de quota de Claude Code, OpenAI Codex, Amp e Grok Build na Waybar. Quota de agente é aquele recurso que você só descobre que acabou quando acabou; aqui ela fica visível na barra o tempo todo. Um binário em Rust, sem daemon: a Waybar chama, ele imprime JSON e vai embora.
+Monitor de quota de Claude Code, OpenAI Codex, Amp e Grok Build — nativo no Omarchy 4 (omarchy-shell), com Waybar suportada como tier legado. Quota de agente é aquele recurso que você só descobre que acabou quando acabou; aqui ela fica visível na barra o tempo todo. Um binário em Rust, sem daemon: o shell chama, ele imprime JSON e vai embora.
 
 ## O que ele mostra
 
@@ -24,8 +24,8 @@ Tudo passa por um cache em disco (`~/.cache/agent-bar/`): 5 minutos pro Claude, 
 
 ## Requisitos
 
-- Linux x86_64 com Waybar. Uso no Hyprland, mas não tem nada específico dele aqui.
-- **Omarchy 4 (omarchy-shell)**: bar-widget plugin nativo com chips + popup — `agent-bar setup` detecta e instala. Waybar segue suportada.
+- Linux x86_64. **Omarchy 4 (omarchy-shell)** é o alvo principal: `agent-bar setup` detecta o omarchy-shell e instala o bar-widget plugin nativo (chips + popup) automaticamente.
+- **Waybar** — suportada como **tier legado**: funciona, recebe fix, não recebe feature nova. `agent-bar setup` integra com ela também, quando presente.
 - `curl`, `tar` e `sha256sum` pro instalador.
 - Um terminal que o helper reconheça: alacritty, kitty, foot, ghostty, wezterm, ou `xdg-terminal-exec`.
 - As CLIs que você quer monitorar, instaladas. O login dá pra fazer pela própria TUI.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,94 +1,130 @@
 # Architecture
 
-How a Waybar poll becomes a rendered module. This is the map of the runtime;
-`src/` is the source of truth and wins on any disagreement.
+How agent-bar turns a fetch into something on screen. Omarchy 4
+(omarchy-shell) is the primary target — `Widget.qml` renders the popup
+straight from `--format json`. Waybar remains supported as a **legacy
+tier** (works, gets fixes, no new features) via the classic Pango module
+contract. `src/` is the source of truth and wins on any disagreement.
 
 ## Data Flow
 
-Each Waybar poll spawns **one short-lived `agent-bar` process** that walks this
-pipeline and exits. There is no long-running daemon (except `--watch`, which
-keeps one process alive and emits NDJSON).
+Two consumers read the same provider/formatter pipeline; they diverge
+only at the very end.
 
 ```text
-Waybar  (interval configurable via settings, default 60s · exec-on-event · left/right click)
-   │   one process per poll
-   ▼
-agent-bar --provider <id>                          src/main.rs       entry / dispatch
-   │   parse_args                                  src/cli.rs        flags → CliOptions
-   ▼
-get_quota_for(id) / get_all_quotas()              src/providers/    fan-out + timeout/retry
-   │   parallel · 10s timeout · 1 retry on timeout
-   ▼
-Provider::get_quota()
-   ├─ ClaudeProvider   (implements Provider direct) src/providers/claude.rs
-   └─ Codex / Amp      (extends BaseProvider)       src/providers/base.rs
-   │   is_available() gate → credentials check
-   ▼
-Quota cache  (file · 5 min TTL · cross-process)    src/cache.rs
-   │   hit → cached raw      miss → fetch_raw() → provider API/CLI → cache.set()
-   ▼
-ProviderQuota  (normalized, provider-agnostic)     src/providers/types.rs
-   ▼
-Formatter
-   ├─ waybar    format_for_waybar / format_provider_for_waybar  src/formatters/waybar.rs
-   │               builders → segments → render_pango()          src/formatters/render_pango.rs  (XML escape)
-   ├─ terminal  output_terminal (ANSI)                           src/formatters/terminal.rs
-   └─ json      to_json_output (schemaVersion, no Pango)         src/formatters/json.rs
-   ▼
-stdout :  Waybar JSON {text,tooltip,class}  |  NDJSON envelope  |  ANSI terminal view
+Omarchy Widget.qml (native plugin, primary)      Waybar module (legacy tier)
+   │  polls                                          │  polls (interval from settings, default 60s)
+   ▼                                                  ▼
+agent-bar --format json                       agent-bar --provider <id>
+   │                                                  │
+   └──────────────────┬───────────────────────────────┘
+                       ▼
+        parse_args → CliOptions                  src/cli.rs
+                       ▼
+        get_quota_for(id) / get_all_quotas()      src/providers/   fan-out + timeout/retry
+                       │  parallel · 10s timeout · 1 retry on timeout
+                       ▼
+        Provider::get_quota()
+           ├─ ClaudeProvider    (implements Provider direct) src/providers/claude.rs
+           └─ Codex/Amp/Grok   (extend BaseProvider)        src/providers/base.rs
+                       │  is_available() gate → credentials check
+                       ▼
+        Quota cache  (file · 5 min TTL · cross-process)    src/cache.rs
+                       │  hit → cached raw   miss → fetch_raw() → provider API/CLI → cache.set()
+                       ▼
+        ProviderQuota  (normalized, windowKind classified) src/providers/types.rs
+                       │
+           ┌───────────┴────────────┐
+           ▼                        ▼
+    to_json_output            formatters::waybar
+    (schemaVersion, no Pango)  format_for_waybar / format_provider_for_waybar
+    src/formatters/json.rs     builders → segments → render_pango() (XML escape)
+           │                        │
+           ▼                        ▼
+    stdout NDJSON/JSON envelope    stdout Waybar JSON {text,tooltip,class}
+           │
+           ▼
+    Widget.qml applyPayload() — collapses duplicate windows
+    (same windowKind/resetsAt/remaining), renders countdown from
+    resetsAt/fetchedAt, hero %, per-provider panel, extra line.
 ```
 
-`stdout` is reserved for the machine-readable payload Waybar parses; all logging
-goes to `stderr` via `logger`. Breaking that contract breaks the bar.
+`stdout` is reserved for the machine-readable payload the shell/Waybar
+parses; all logging goes to `stderr` via `logger`. Breaking that contract
+breaks both consumers.
+
+`agent-bar menu` (the TUI) and `agent-bar status` read the exact same
+`ProviderQuota` through their own formatter (`terminal.rs`) — a third,
+interactive consumer of the same pipeline, not shown above for brevity.
 
 ## Entry And Dispatch — `src/main.rs`
 
-`parse_args` (`src/cli.rs`) turns argv into `CliOptions`. `main()` dispatches:
+`parse_args` (`src/cli.rs`) turns argv into `CliOptions`. `main()`
+dispatches:
 
-- **Subcommands** (`menu`, `setup`, `doctor`, `update`, `config show|apply`,
-  `action-right`, …) are dispatched by pattern match and handled, then the
-  process exits. `config show|apply` is implemented in `src/config_cmd.rs`
-  (editable settings subset only; no Waybar reload). `action-right` remains
-  the Waybar right-click path; Omarchy uses the native popup settings mode
-  instead (see [omarchy-shell.md](omarchy-shell.md)).
-- **`--watch`** hands off to `start_watch` (`src/watch.rs`) and streams NDJSON.
-- Otherwise it resolves quotas and prints a single payload. The default command
-  is `waybar`; `status` (`-t`/`--terminal` alias) prints the ANSI view;
-  `--format json` prints the versioned envelope.
+- **Subcommands** (`menu`, `setup`, `doctor`, `update`, `config
+  show|apply`, `action-right`, …) are dispatched by pattern match and
+  handled, then the process exits. `config show|apply` is implemented in
+  `src/config_cmd.rs` (editable settings subset only, plus the read-only
+  `menuAnimations` flag on `show`; no Waybar reload). `action-right`
+  remains the Waybar right-click path; Omarchy uses the native popup
+  settings mode instead (see [omarchy-shell.md](omarchy-shell.md)).
+- **`--watch`** hands off to `start_watch` (`src/watch.rs`) and streams
+  NDJSON.
+- Otherwise it resolves quotas and prints a single payload. The default
+  command is `waybar`; `status` (`-t`/`--terminal` alias) prints the ANSI
+  view; `--format json` prints the versioned envelope Widget.qml
+  consumes.
 
-Two Waybar render shapes share the formatter:
+`setup`, `update`, and TUI Config Save all gate their Waybar-directory
+writes behind `platform::detect()` (`src/platform.rs`) — a single
+`Platform { omarchy: bool, waybar: bool }` that composes
+`omarchy_integration::detect_omarchy_shell()` and `setup::waybar_present()`.
+On an Omarchy-only desktop, none of the three paths create
+`~/.config/waybar/` from scratch.
+
+Two Waybar render shapes share the formatter (legacy tier only):
 
 - **Single-provider module** — `agent-bar --provider <id>` →
-  `formatProviderForWaybar`. This is what generated Waybar modules call (one
-  module per provider). A provider disabled in settings never reaches the
-  formatter — `main.rs` / gate `is_hidden_module` short-circuits first and prints
-  the hidden-module payload (`class: agent-bar-hidden`) so Waybar collapses it.
+  `formatProviderForWaybar`. This is what generated Waybar modules call
+  (one module per provider). A provider disabled in settings never
+  reaches the formatter — `main.rs` / gate `is_hidden_module`
+  short-circuits first and prints the hidden-module payload (`class:
+  agent-bar-hidden`) so Waybar collapses it.
 - **Aggregate** — `agent-bar` with no provider → `outputWaybar` /
   `formatForWaybar`, joining every enabled provider into one module.
 
 After Waybar output, low/critical desktop notifications fire best-effort
-(`src/notify.rs`) — only when `notify.enabled` is set (default on) and stdout is
-piped (i.e. real Waybar polling), never on an interactive terminal run, and never
-in json/terminal/watch modes.
+(`src/notify.rs`) — only when `notify.enabled` is set (default on) and
+stdout is piped (i.e. real Waybar polling), never on an interactive
+terminal run, and never in json/terminal/watch modes.
 
 ## Provider Layer — `src/providers/`
 
-Providers are registered in `src/providers/mod.rs`. `get_all_quotas` runs every
-registered provider in parallel behind `fetch_with_retry` (10s timeout, one retry
-on timeout); a failing provider degrades to an `available: false` quota with an
-error string instead of taking down the bar. `get_quota_for` is the
-single-provider variant.
+Providers are registered in `src/providers/mod.rs`. `get_all_quotas` runs
+every registered provider in parallel behind `fetch_with_retry` (10s
+timeout, one retry on timeout); a failing provider degrades to an
+`available: false` quota with an error string instead of taking down the
+bar. `get_quota_for` is the single-provider variant.
 
-Every provider returns a normalized **`ProviderQuota`** (`src/providers/types.rs`):
-`primary`/`secondary` quota windows (each `{ remaining, resetsAt, … }`), optional
-`extra` (per-provider, pre-render data like Claude `weeklyModels` or Codex
-`modelsDetailed`), `plan`/`account`, or an `error`. Everything downstream speaks
-this shape — formatters never see provider-specific API responses.
+Every provider returns a normalized **`ProviderQuota`**
+(`src/providers/types.rs`): `primary`/`secondary` quota windows (each
+`{ remaining, resetsAt, windowKind, … }`), optional `extra` (per-provider,
+pre-render data like Claude `weeklyModels`, Codex `modelsDetailed`, Amp
+credits, or Grok session/turn counts), `plan`/`account`, or an `error`.
+Everything downstream speaks this shape — formatters never see
+provider-specific API responses.
+
+Each provider sets `windowKind` at the source instead of downstream code
+guessing from the number: Claude sets `fiveHour`/`sevenDay` directly; Amp
+sets `daily`; Grok sets `context`; Codex classifies via
+`classify_window` (below) with no fallback — a window outside tolerance
+is `other`, not force-mapped onto `fiveHour`/`sevenDay`.
 
 ### `BaseProvider` vs `ClaudeProvider`
 
-`BaseProvider` (`src/providers/base.rs`) owns the `get_quota()` orchestration so
-concrete providers implement only what differs:
+`BaseProvider` (`src/providers/base.rs`) owns the `get_quota()`
+orchestration so concrete providers implement only what differs:
 
 ```text
 get_quota():
@@ -99,70 +135,138 @@ get_quota():
   (any error)              → return ProviderQuota { error: to_user_facing_error(e), .. }
 ```
 
-`CodexProvider` and `AmpProvider` extend it — they supply `is_available`,
-`fetch_raw`, `build_quota`, and `unavailable_error`, and inherit the availability
-gate, cache wrapper, and error handling.
+`CodexProvider`, `AmpProvider`, and `GrokProvider` extend it — they
+supply `is_available`, `fetch_raw`, `build_quota`, and
+`unavailable_error`, and inherit the availability gate, cache wrapper,
+and error handling.
 
 `ClaudeProvider` **implements `Provider` directly** and does not extend
 `BaseProvider`. Its flow doesn't fit the template: it reads
-`~/.claude/.credentials.json` for the OAuth token, distinguishes "no file" /
-"invalid file" / "no token" / "token expired" as separate user-facing errors,
-calls `cache.get_or_fetch` inline, and parses several quota windows
-(`five_hour`, `seven_day`, per-model weeklies, extra usage). Forcing it into
-`BaseProvider` would mean fighting the abstraction, so it manages its own cache
-call. Do not "normalize" it back into the template (see repo `CLAUDE.md`).
+`~/.claude/.credentials.json` for the OAuth token, distinguishes "no
+file" / "invalid file" / "no token" / "token expired" as separate
+user-facing errors, calls `cache.get_or_fetch` inline, and parses several
+quota windows (`five_hour`, `seven_day`, per-model weeklies, extra
+usage). Forcing it into `BaseProvider` would mean fighting the
+abstraction, so it manages its own cache call. Do not "normalize" it back
+into the template (see repo `CLAUDE.md`).
 
 From the same credentials it also reads `expiresAt` — to short-circuit a
-locally-expired access token (the API would reject it anyway, and agent-bar must
-never refresh it: the single-use refresh token races Claude Code) — and
-`rateLimitTier`, to surface the Max multiplier in the plan label (e.g. `Max 5x`).
+locally-expired access token (the API would reject it anyway, and
+agent-bar must never refresh it: the single-use refresh token races
+Claude Code) — and `rateLimitTier`, to surface the Max multiplier in the
+plan label (e.g. `Max 5x`).
+
+## Window Classification & Display Dedup — `src/formatters/shared.rs`
+
+`classify_window(window_minutes) -> WindowKind` is the single place
+tolerance math lives (`fiveHour` = 300±90min, `sevenDay` = 10080±1440min,
+else `other`) — providers call it once at the source; QML and the TUI
+never re-derive a label from magic numbers. `format_eta`/
+`format_reset_time` render the countdown (`Xh Ym`/`Nd Nh`) and the
+localized reset clock (`Clock.local_offset`) from the same `resetsAt`
+string — the TUI's `fmt_reset` (`src/tui/render/detail/format.rs`) calls
+these instead of slicing the raw ISO string.
+
+`is_duplicate_window(a, b) -> bool` collapses two windows that share
+`(windowKind, resetsAt, remaining-rounded)` — the display-level fix for
+the Codex Plus duplicate-Weekly bug (the JSON envelope still emits
+`primary`/`secondary`/`models` untouched; only consumers that render
+multiple windows side by side dedup). The TUI consumes it directly; QML
+ports the same predicate in JS since it has no Rust runtime.
 
 ## The Quota Cache
 
 `src/cache.rs` is a file-based cache (`$XDG_CACHE_HOME/agent-bar/<key>.json`,
 default `~/.cache`) with a **5-minute TTL** (`CONFIG.cache.ttl_ms`) and
-**cross-process** lifetime — it survives between polls, which is what matters
-here: Waybar polls at the configured interval (`waybar.interval`, default 60s;
-see [Waybar contract](waybar-contract.md)) but each poll is a *separate
-process*, so an in-memory cache would never hit. The file-based cache means
-most polls within a 5-minute window read the cached response from disk and
-one triggers a fresh fetch — the provider API is hit at most once per
-5-minute window regardless of the configured poll interval. `get_or_fetch`
-reads the cache, and on a miss runs the fetcher once, writing atomically
-(temp file + `rename`) because concurrent provider processes can write the
-same key. An in-flight dedup map deduplicates concurrent fetches *within* one
-process; failed fetches are never cached (a non-200 errors before `set`);
-cache keys are validated against path traversal.
+**cross-process** lifetime — it survives between polls, which is what
+matters here: both Widget.qml and Waybar poll at their own configured
+interval but each poll is a *separate process*, so an in-memory cache
+would never hit. The file-based cache means most polls within a
+5-minute window read the cached response from disk and one triggers a
+fresh fetch — the provider API is hit at most once per 5-minute window
+regardless of the configured poll interval. `get_or_fetch` reads the
+cache, and on a miss runs the fetcher once, writing atomically (temp
+file + `rename`) because concurrent provider processes can write the
+same key. An in-flight dedup map deduplicates concurrent fetches
+*within* one process; failed fetches are never cached (a non-200 errors
+before `set`); cache keys are validated against path traversal.
 
-There is no separate settings cache — `settings::load` reads `settings.json`
-directly on every call; no in-process memoization layer exists in the Rust
-codebase (an in-memory settings cache existed in the pre-rewrite TS version,
-not here).
+There is no separate settings cache — `settings::load` reads
+`settings.json` directly on every call; no in-process memoization layer
+exists.
 
 ## Formatter Layer — `src/formatters/`
 
 Quotas are rendered three ways from the same `ProviderQuota`:
 
-- **Waybar** (`waybar.rs`) → `{ text, tooltip, class }` JSON. `text` is the bar
-  percentage; `tooltip` is multi-line Pango built per provider; `class` is a
-  provider-scoped compound carrying a health state for CSS —
-  `agent-bar-<provider> <status>` for a single module, or `agent-bar` plus
-  `<provider>-<status>` tokens in aggregate (see [Waybar contract](waybar-contract.md)).
-  States: `ok`/`low`/`warn`/`critical`/`disconnected`.
-- **Terminal** (`terminal.rs`) → ANSI view for `status`. `action-right` no
-  longer uses this path — it resolves focus and opens the TUI instead (see
-  `src/action_right.rs` below).
 - **JSON** (`json.rs`) → versioned, Pango-free envelope
-  (`{ schemaVersion, fetchedAt, providers[] }`) for non-Waybar bars. See
-  [`json-output.md`](json-output.md).
+  (`{ schemaVersion, fetchedAt, providers[] }`), the contract Widget.qml
+  and any other native bar consumes. See [`json-output.md`](json-output.md).
+- **Waybar** (`waybar.rs`) → `{ text, tooltip, class }` JSON, legacy
+  tier. `text` is the bar percentage; `tooltip` is multi-line Pango
+  built per provider; `class` is a provider-scoped compound carrying a
+  health state for CSS — `agent-bar-<provider> <status>` for a single
+  module, or `agent-bar` plus `<provider>-<status>` tokens in aggregate
+  (see [Waybar contract](waybar-contract.md)). States:
+  `ok`/`low`/`warn`/`critical`/`disconnected`.
+- **Terminal** (`terminal.rs`) → ANSI view for `status`. `action-right`
+  no longer uses this path — it resolves focus and opens the TUI instead
+  (see `src/action_right.rs` below).
 
-Builders (`formatters/builders/`) describe output as `Vec<Line>` of typed
-`Segment`s (text + color token). **`render_pango.rs` is the single XML-escape
-boundary** — `span()` / `render_pango()` are the only places provider data gets
-Pango markup, and they escape every non-`raw` segment. Builders never escape;
-a `raw` segment opts out of both color-wrap *and* escape and must already be
-safe. Routing untrusted provider strings around this boundary is a tooltip
-injection bug, so all Pango output goes through it.
+Builders (`formatters/builders/`) describe output as `Vec<Line>` of
+typed `Segment`s (text + color token). **`render_pango.rs` is the single
+XML-escape boundary** — `span()` / `render_pango()` are the only places
+provider data gets Pango markup, and they escape every non-`raw`
+segment. Builders never escape; a `raw` segment opts out of both
+color-wrap *and* escape and must already be safe. Routing untrusted
+provider strings around this boundary is a tooltip injection bug, so all
+Pango output goes through it. Since the Codex fallback mapping is gone,
+`formatters/builders/codex.rs` renders an `other`-kind window with a
+label built from its real duration (e.g. `"1h window"`) instead of
+assuming it must be the 5h or 7d bucket.
+
+## TUI — `src/tui/`
+
+`agent-bar menu` shares the provider/cache/formatter layers above; its
+own render tree (`src/tui/render/`) is a fourth consumer of
+`ProviderQuota`, independent of Waybar/Omarchy. Detail's window rows use
+the same `classify_window`/`is_duplicate_window`/`format_eta`/
+`format_reset_time` helpers as Widget.qml, so the two surfaces never
+drift on labels, dedup, or timezone. Config screens hide Waybar-only
+fields (separators, signal, interval) when `platform::detect()` reports
+Omarchy-only — the same gate `setup`/`update` use.
+
+## Omarchy Shell — `Widget.qml` (primary integration)
+
+The Omarchy 4 (omarchy-shell/Quickshell) plugin is agent-bar's
+first-class target: a native bar-widget with per-provider chips and a
+popup, driven entirely by `agent-bar --format json` and `agent-bar
+config show`/`config apply`. Titlebar actions (refresh, settings mode,
+open TUI) are real Unicode icon buttons, not text hints. Settings mode
+dual-writes: `config apply` owns `providers`/`providerOrder`/
+`displayMode`/`notify.enabled` in `settings.json`; the plugin's own
+`refreshIntervalSec` is written inline into Omarchy's `shell.json` via
+`bar.shell.updateEntryInline`. Motion (bar fill on open, refresh spin,
+hover) is gated by the read-only `menuAnimations` field `config show`
+exposes — editing it stays a `settings.json` concern. `agent-bar update`
+reinstalls the plugin whenever `detect_omarchy_shell()` is true, so the
+binary and the embedded QML never drift apart; `doctor` additionally
+checks the installed manifest version against the running binary. Full
+plugin contract, click routing, and the dual-write table:
+[omarchy-shell.md](omarchy-shell.md).
+
+## Waybar — legacy tier
+
+Waybar keeps working — it gets fixes, not new features. Its contract
+(module IDs, CSS classes, click actions, `signal`-based refresh) lives
+in [waybar-contract.md](waybar-contract.md) and is implemented by
+`src/waybar/contract.rs` and `src/waybar/integration.rs` (grouped under
+`src/waybar/`, re-exported at the crate root as `waybar_contract` /
+`waybar_integration` so the existing `cargo test waybar_contract` /
+`cargo test waybar_integration` filters in `CLAUDE.md` keep working).
+`platform::detect()` is what lets every write path (`setup`, `update`,
+TUI Config Save) skip touching `~/.config/waybar/` entirely on an
+Omarchy-only machine.
 
 ## Module Map
 
@@ -170,27 +274,30 @@ injection bug, so all Pango output goes through it.
 | --- | --- |
 | `src/main.rs` | Entry point; dispatch by command/flags. |
 | `src/cli.rs` | argv → `CliOptions`; `--help` rendering; command suggestions. |
+| `src/platform.rs` | `Platform { omarchy, waybar }` + `detect()` — the single gate `setup`/`update`/TUI-save use before touching Waybar paths. |
 | `src/config.rs` | Paths (XDG), cache TTL, API endpoints, color thresholds. |
-| `src/config_cmd.rs` | `config show` / `config apply` — editable settings subset (JSON). |
+| `src/config_cmd.rs` | `config show` / `config apply` — editable settings subset (JSON) + read-only `menuAnimations` on `show`. |
 | `src/cache.rs` | File-based quota cache (5 min, cross-process, atomic writes). |
 | `src/providers/mod.rs` | Registration, parallel fan-out, timeout/retry. |
 | `src/providers/base.rs` | `BaseProvider` `get_quota()` orchestration. |
-| `src/providers/{claude,codex,amp,grok}.rs` | Concrete providers. Claude is direct; others extend `BaseProvider`. |
-| `src/providers/types.rs` | `ProviderQuota`, `QuotaWindow`, `Provider`, `AllQuotas`. |
-| `src/formatters/waybar.rs` | Waybar JSON assembly ({text,tooltip,class}). |
+| `src/providers/{claude,codex,amp,grok}.rs` | Concrete providers. Claude is direct; others extend `BaseProvider`. Each sets `windowKind` at the source. |
+| `src/providers/types.rs` | `ProviderQuota`, `QuotaWindow` (incl. `windowKind`), `Provider`, `AllQuotas`. |
+| `src/formatters/shared.rs` | `classify_window`/`WindowKind`, `is_duplicate_window`, `format_eta`/`format_reset_time`. |
+| `src/formatters/json.rs` | Versioned JSON envelope (`schemaVersion`) — the contract Widget.qml consumes. |
+| `src/formatters/waybar.rs` | Waybar JSON assembly ({text,tooltip,class}) — legacy tier. |
 | `src/formatters/render_pango.rs` | Single XML-escape boundary for Pango. |
 | `src/formatters/terminal.rs` | ANSI terminal view. |
-| `src/formatters/json.rs` | Versioned JSON envelope (`schemaVersion`). |
-| `src/waybar_contract.rs` | Generated Waybar modules/CSS/asset install (the integration contract). |
+| `src/waybar/contract.rs` | Generated Waybar modules/CSS/asset install (re-exported as `crate::waybar_contract`). |
+| `src/waybar/integration.rs` | In-place `config.jsonc`/`style.css` patcher (re-exported as `crate::waybar_integration`). |
 | `src/notify.rs` | Best-effort low/critical desktop notifications. |
 | `src/action_right.rs` | Waybar right-click handler — resolves TUI focus (provider detail or Login) from connection state. |
-| `src/omarchy_integration.rs` | Omarchy drop-in install/remove; embeds `Widget.qml` / manifest. |
+| `src/omarchy_integration.rs` | Omarchy drop-in install/remove; embeds `Widget.qml` / manifest; `detect_omarchy_shell()`. |
 
 ## See Also
 
 - [Commands](commands.md) — public CLI surface, `config`, flags, and internals.
 - [Runtime](runtime.md) — owned paths, settings, cache, credentials.
-- [Waybar contract](waybar-contract.md) — generated modules, classes, click actions.
+- [Waybar contract](waybar-contract.md) — generated modules, classes, click actions (legacy tier).
 - [Omarchy shell](omarchy-shell.md) — plugin drop-in, settings popup, dual-write.
-- [JSON output](json-output.md) — `--format json` / `--watch` schema.
+- [JSON output](json-output.md) — `--format json` / `--watch` schema, incl. `windowKind` and `extra` shapes.
 - [New provider guide](new-provider.md) — implementing a provider on `BaseProvider`.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -39,7 +39,8 @@ Example envelope:
   "providers": ["claude", "codex", "amp", "grok"],
   "providerOrder": ["claude", "codex", "amp", "grok"],
   "displayMode": "remaining",
-  "notify": { "enabled": true }
+  "notify": { "enabled": true },
+  "menuAnimations": true
 }
 ```
 
@@ -50,6 +51,7 @@ Example envelope:
 | `providerOrder` | Effective order; unknown ids dropped. |
 | `displayMode` | `"remaining"` or `"used"`. |
 | `notify.enabled` | Desktop low/critical notifications. |
+| `menuAnimations` | Read-only; reflete `Settings.menu.animations`. Ignorado em `apply`. |
 
 Omitted fields on apply are left unchanged. Not included: separators, Waybar
 signal/interval, menu font, cache, glyphs, `refreshIntervalSec` (Omarchy

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -159,9 +159,3 @@ Process {
 ```
 
 `Process.command` is an argv array (no shell) — keep each argument separate.
-
-## Future
-
-A native Omarchy Quickshell bar-widget plugin
-(`~/.config/omarchy/plugins/agent-bar/`) is a future step once Omarchy ships its
-Quickshell release (v4).

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -97,3 +97,4 @@ them; it does not store provider tokens.
 | Claude | `~/.claude/.credentials.json` |
 | Codex | `~/.codex/auth.json`, recent `~/.codex/sessions/**` rate-limit events, or `codex app-server` |
 | Amp | official `amp` CLI |
+| Grok | `~/.grok/auth.json`; session `signals.json` under `~/.grok/sessions/**` (read-only, no network) |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -85,6 +85,20 @@ Then run:
 amp login
 ```
 
+### Grok
+
+Grok Build CLI uses OAuth in `~/.grok/auth.json`; the provider itself
+makes zero network calls — it reads session `signals.json` files under
+`~/.grok/sessions/**` for context-window data. Log in with:
+
+```bash
+grok login
+```
+
+An access token past its `expires_at` does **not** log you out: the Grok
+CLI renews it via refresh token, and agent-bar only checks for a
+non-empty `key` in `auth.json`.
+
 ## Reset Managed Waybar Entries
 
 For a normal reset:

--- a/docs/waybar-contract.md
+++ b/docs/waybar-contract.md
@@ -1,5 +1,10 @@
 # Waybar Contract
 
+> **Waybar é tier legado** a partir da 9.0.0: funciona, recebe fix, não
+> recebe feature nova. O alvo atual é o Omarchy 4 (omarchy-shell) — ver
+> [`omarchy-shell.md`](omarchy-shell.md). Este documento descreve o
+> contrato Waybar como está, para quem ainda depende dele.
+
 This is the generated contract used by setup and by the export commands.
 
 ## Providers
@@ -9,12 +14,14 @@ Built-in Waybar providers:
 - `claude`
 - `codex`
 - `amp`
+- `grok`
 
 Generated module IDs:
 
 - `custom/agent-bar-claude`
 - `custom/agent-bar-codex`
 - `custom/agent-bar-amp`
+- `custom/agent-bar-grok`
 
 CSS selectors use:
 


### PR DESCRIPTION
## Resumo

Última PR da sequência v9: documentação pública alinhada ao agent-bar 9.0.0 Omarchy-first. **Não corta o release** (sem bump de `Cargo.toml`, sem tag).

### O que entra

| Doc | Mudança |
|-----|---------|
| README | Tagline + requisitos Omarchy-first; Waybar = tier legado |
| CONTRIBUTING | MSRV 1.88 |
| waybar-contract | Grok + banner de tier legado |
| json-output | Remove seção Future (plugin já existe) |
| troubleshooting | Seção Grok (`grok login`, auth.json) |
| runtime | Linha Grok nas credenciais (schema v3 já estava) |
| architecture | Reescrito Omarchy-first (`windowKind`, `platform`, `src/waybar/`, Widget.qml) |
| CLAUDE.md | `providers::grok_cli` na matriz + nota `src/waybar/` |
| CHANGELOG | Entrada completa **9.0.0** |
| commands | `menuAnimations` no exemplo e na tabela |

### Commits

```
docs: tagline e requisitos Omarchy-first no README
docs: corrige MSRV pra 1.88 no CONTRIBUTING
docs: Grok no contrato Waybar + banner legado
docs: remove secao Future obsoleta do json-output
docs: secao Grok no troubleshooting
docs: linha Grok na tabela do runtime
docs: arquitetura reescrita Omarchy-first
docs: matriz grok_cli e nota waybar no CLAUDE
docs: entrada 9.0.0 no CHANGELOG
docs: menuAnimations no exemplo do commands
```

## Fora deste PR

- Bump `version = "9.0.0"` no Cargo.toml
- Tag/GitHub Release / AUR (runbook: `docs/releasing.md`)
- `agent-bar update` na máquina do dono

## Test plan

- [x] `git diff --check master` (sem whitespace errors)
- [x] Consistência: sem `show_percentage` / `get_all_provider_ids` / `## Future` nos docs vivos
- [x] `windowKind` + shapes de `extra` presentes em json-output (pré-req do plano 02)
- [x] `grok` em waybar-contract / runtime / troubleshooting
- [ ] Review + merge do dono