### PR TITLE
fix: publish.yml checksum CWD

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -102,7 +102,8 @@ jobs:
           ARCHIVE="$OUT/agent-bar.usage-${VERSION}-x86_64-unknown-linux-gnu.tar.zst"
           SUM="$OUT/agent-bar.usage-${VERSION}-x86_64-unknown-linux-gnu.tar.zst.sha256"
           test -f "$META" && test -f "$ARCHIVE" && test -f "$SUM" && test -f "$OUT/LICENSE"
-          sha256sum -c "$SUM"
+          # Sidecar paths are basename-relative; verify from the output directory.
+          (cd "$OUT" && sha256sum -c "$(basename "$SUM")")
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Attach to release (no clobber)


### PR DESCRIPTION
## Summary

- `publish.yml` failed on v10.0.0 after `agent-bar-bundle release` succeeded: `sha256sum -c` looked for the archive in the repo root because the sidecar uses basename-only paths.
- Verify the checksum from the release output directory so future tag publishes attach artifacts via CI.

## Context

v10.0.0 was published with dual-RC artifacts uploaded manually after CI failed at the verify step. Assets on the release are valid; this only unblocks CI for later versions.

## Test plan

- [x] Dual RC + manual asset upload already live on https://github.com/othavi0/agent-bar/releases/tag/v10.0.0
- [ ] Next release tag should pass `Build release artifacts` and `Attach to release`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release artifact verification to correctly validate generated SHA-256 checksum files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->