### PR TITLE
fix: Codex rate limits and Grok weekly

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -65,9 +65,10 @@ state, settings persistence, or cache.
 | `support` | Atomic files, clock, filesystem, redaction |
 
 Provider adapters receive a narrow context for process, HTTP, filesystem,
-clock, and redaction. Claude may collect through HTTP, Grok through filesystem,
-Codex through a composite process/fallback flow, and Amp through its CLI.
-Adapters are not forced into a command-only abstraction.
+clock, and redaction. Claude may collect through HTTP, Grok through
+authenticated billing HTTP, Codex through a composite app-server/session-log
+flow, and Amp through its CLI. Adapters are not forced into a command-only
+abstraction.
 
 ## Data contract
 

--- a/docs/handoff-v10-post-merge.md
+++ b/docs/handoff-v10-post-merge.md
@@ -23,7 +23,7 @@ Default branch is **`master`** (not `main`).
   - Chips with real percents/states on dual monitors.
   - Popup opens on left/right click.
   - Rail option-A stack, bordered strip, neutral selection, settings slot.
-  - Usage progress tracks (Amp Daily, Grok Context, etc.).
+  - Usage progress tracks (Amp Daily, Grok Weekly, etc.).
   - Content-fit height; Flickable only when overflowing.
   - Foreign-monitor dismiss layer + `Service.dismissPopup()`.
   - Same-monitor outside-click via KeyboardPanel (platform pattern).

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -72,7 +72,7 @@ last good data as stale.
 - Claude may use local credentials plus provider HTTP.
 - Codex may use app-server with a bounded local fallback.
 - Amp uses its official usage command.
-- Grok may use provider-owned local auth/session data.
+- Grok may use local auth for an authenticated billing HTTPS request.
 
 Collection discovery is separate from interactive login-CLI discovery.
 

--- a/docs/specs/v10/02-target-architecture.md
+++ b/docs/specs/v10/02-target-architecture.md
@@ -152,7 +152,7 @@ pub trait ProviderAdapter: Send + Sync {
 availability. A provider may collect without an installed login CLI; this must
 not become `cli_missing`.
 `CollectionContext` exposes narrow process, HTTP, filesystem, clock, and
-redaction capabilities. This supports Claude HTTP collection, Grok filesystem
+redaction capabilities. This supports Claude HTTP collection, Grok HTTP billing
 collection, Codex composite app-server/session-log collection, and Amp process
 collection without forcing them into a fake command abstraction.
 `ProviderResult` is a typed domain result, not serialized provider JSON.
@@ -201,17 +201,15 @@ Locked collection policy:
 | `claude` | `$HOME/.claude/.credentials.json`, then authenticated `GET https://api.anthropic.com/api/oauth/usage` | `session`, `weekly`, then provider-scoped `weekly-model:<sanitized-id>` | 300 s | 10 s | one network/timeout retry |
 | `codex` | resolved `codex app-server` JSON-RPC `rateLimits/read`, then newest valid rate-limit event below `$HOME/.codex/sessions` | `session`, `weekly`, then `other:<duration-minutes>:<ordinal>` | 90 s | 10 s | one app-server timeout retry before filesystem fallback |
 | `amp` | resolved `amp usage` with `NO_COLOR=1`, `TERM=dumb` | `daily`, or no windows when the account exposes no percentage | 90 s | 10 s | one timeout/process-I/O retry |
-| `grok` | `$GROK_HOME/auth.json`, then bounded walk of `$GROK_HOME/sessions/**/signals.json` | `context`, or no windows when no valid context percentage exists | 90 s | 10 s | none |
+| `grok` | `$GROK_HOME/auth.json`, then authenticated GET `https://cli-chat-proxy.grok.com/v1/billing?format=credits` (literal; headers Authorization Bearer + x-grok-client-mode) | `weekly` | 90 s | 10 s | one network/timeout retry |
 
 Collection concurrency is at most four adapters. Every process stdout, process
 stderr, HTTP response, and individual provider file is capped at 1 MiB before
-parsing. The Grok walk does not follow links, descends at most eight levels,
-visits at most 4096 directory entries, and reads at most 256 candidate
-`signals.json` files. Codex filesystem fallback applies the same 1 MiB
-per-file limit, does not follow links, descends at most eight levels, and
-visits at most 4096 directory entries. Codex candidate files sort by mtime
-descending then raw path bytes ascending before taking 256; valid events sort
-by parsed UTC event timestamp descending, then candidate path and line number.
+parsing. Codex filesystem fallback applies the same 1 MiB per-file limit, does
+not follow links, descends at most eight levels, and visits at most 4096
+directory entries. Codex candidate files sort by mtime descending then raw
+path bytes ascending before taking 256; valid events sort by parsed UTC event
+timestamp descending, then candidate path and line number.
 
 `GROK_HOME`, when set, must be a nonempty absolute path; an invalid set value
 is a typed provider configuration error. When unset, it resolves to
@@ -225,7 +223,7 @@ nonzero usage-command results are never retried. Adapter source fallback is
 not counted as a retry.
 
 Provider labels are fixed English copy: Claude `Session`/`Weekly`, Codex
-`Session`/`Weekly`, Amp `Daily`, and Grok `Context`. Dynamic model labels are
+`Session`/`Weekly`, Amp `Daily`, and Grok `Weekly`. Dynamic model labels are
 sanitized plain text. A dynamic Claude model ID is lowercased, limited to
 ASCII letters/digits/hyphens, and prefixed with `weekly-model:`; collisions
 receive the deterministic source-order suffix `:2`, `:3`, and so on. Monetary

--- a/docs/superpowers/plans/2026-07-27-codex-retry-grok-weekly.md
+++ b/docs/superpowers/plans/2026-07-27-codex-retry-grok-weekly.md
@@ -1,0 +1,695 @@
+# Codex Retry + Grok Weekly Usage Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Codex Retry return real Session/Weekly rate limits when the CLI is authenticated, and make Grok show SuperGrok weekly usage with reset instead of session Context.
+
+**Architecture:** Complete the stubbed v10 `CodexAdapter` with app-server JSON-RPC plus bounded session-log fallback (restore pre-v10 behavior into current seams). Switch `GrokAdapter` from `signals.json` context to authenticated HTTPS billing (`/billing?format=credits`) producing a single `weekly` window. Pure parsers live in `v2_map`; adapters orchestrate I/O only.
+
+**Tech Stack:** Rust 2021, tokio process/HTTP, serde_json, time, existing `CollectionContext` / `HttpClient` / `FileSystem` seams, cargo test.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-27-codex-retry-grok-weekly-design.md`
+- v10 catalog policy: `docs/specs/v10/02-target-architecture.md` (Codex row already correct; Grok row must be updated in Task 6)
+- No production `unwrap()` / `expect()`
+- No monetary fields in `ProviderResult` / cache / logs / UI
+- Never log credentials, JWTs, Authorization headers, or account emails
+- QML must not parse raw provider payloads (no QML change required if schema-v2 is correct)
+- Status stdout remains one schema-v2 object + newline
+- Conventional Commits English, subject ≤ 50 characters
+- Zero AI attribution in commits
+- Tests: fake process/HTTP/filesystem/clock only; no live network in unit tests
+- Do not mutate live Omarchy/Hyprland paths
+- Read each file before Edit; re-Read after other agents/git changes
+- Implementers: after git pull/checkout, previous Read is dead
+
+## File map
+
+```text
+src/providers/v2_map.rs              # Codex duration-based windows; Grok billing parser; drop Context primary
+src/providers/codex_session_log.rs   # NEW: bounded walk + extract rate_limits from token_count events
+src/providers/codex_app_server.rs    # NEW: JSON-RPC protocol + spawn app-server (bidirectional stdio)
+src/providers/adapters.rs            # Wire Codex/Grok collect order; Grok token extraction for HTTP
+src/providers/catalog.rs             # GROK.retry_policy → OneTransient; constants if needed
+src/providers/mod.rs                 # mod codex_session_log; mod codex_app_server
+tests/fixtures/providers/codex/      # session-log jsonl + appserver-shaped JSON samples
+tests/fixtures/providers/grok/       # billing-weekly.json (no secrets)
+docs/specs/v10/02-target-architecture.md
+docs/troubleshooting.md              # Codex retry / Grok weekly notes
+README.md / PRODUCT.md               # only if they still claim Grok context-only
+```
+
+Optional: keep all Codex helpers in one file if under ~400 LOC; prefer the two new modules above for reviewability.
+
+---
+
+### Task 1: Codex window normalization by duration
+
+**Files:**
+- Modify: `src/providers/v2_map.rs` (`codex_from_rate_limits_json`, `codex_window`, helpers)
+- Test: unit tests in `src/providers/v2_map.rs` (`#[cfg(test)]`)
+- Fixture (optional): `tests/fixtures/providers/codex/primary-weekly-only.json`
+
+**Interfaces:**
+- Consumes: existing `UsageWindow::try_new`, `ProviderResult::Ready`
+- Produces: `codex_from_rate_limits_json(bytes, now) -> ProviderResult` where each raw window is labeled by `window_minutes`, not by primary/secondary slot order
+- Produces: helper `fn codex_window_identity(window_minutes: Option<i64>, ordinal: usize) -> (String, String)`  
+  - `Some(10080)` → `("weekly", "Weekly")`  
+  - `Some(300)` → `("session", "Session")`  
+  - `Some(n)` other → `(format!("other:{n}:{ordinal}"), format!("{n}m"))`  
+  - `None` on primary slot → treat as session; on secondary → weekly (compat with incomplete payloads)
+
+- [ ] **Step 1: Write the failing test for primary-only weekly**
+
+Add to `v2_map` tests:
+
+```rust
+#[test]
+fn codex_primary_only_weekly_is_labeled_weekly() {
+    let body = br#"{
+      "primary": {"used_percent": 1.0, "window_minutes": 10080, "resets_at": 1785628013},
+      "plan_type": "plus"
+    }"#;
+    let now = time::macros::datetime!(2026-07-26 18:00:00 UTC);
+    let result = codex_from_rate_limits_json(body, now);
+    match result {
+        ProviderResult::Ready { windows, plan, .. } => {
+            assert_eq!(windows.len(), 1);
+            assert_eq!(windows[0].id(), "weekly");
+            assert_eq!(windows[0].label(), "Weekly");
+            assert!((windows[0].used_percent() - 1.0).abs() < 0.01);
+            assert!(plan.is_some());
+        }
+        other => panic!("expected ready, got {other:?}"),
+    }
+}
+```
+
+Also update/extend the existing camelCase fixture test so dual windows still map session + weekly when durations are 300 / 10080.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cargo test codex_primary_only_weekly_is_labeled_weekly -- --nocapture
+```
+
+Expected: FAIL — current code labels primary as `session`.
+
+- [ ] **Step 3: Implement duration-based labeling**
+
+In `codex_from_rate_limits_json`:
+
+1. Build windows from `primary` and `secondary` independently.
+2. Call `codex_window_identity` for each (ordinal 1, then 2; if collision on `other:…` bump ordinal).
+3. Keep camelCase + snake_case aliases already on `CodexWindowRaw`.
+4. Continue discarding `credits`.
+
+Minimal helper:
+
+```rust
+fn codex_window_identity(window_minutes: Option<i64>, ordinal: usize) -> (String, String) {
+    match window_minutes {
+        Some(10080) => ("weekly".into(), "Weekly".into()),
+        Some(300) => ("session".into(), "Session".into()),
+        Some(n) if n > 0 => (format!("other:{n}:{ordinal}"), format!("{n}m")),
+        _ => {
+            if ordinal == 1 {
+                ("session".into(), "Session".into())
+            } else {
+                ("weekly".into(), "Weekly".into())
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cargo test codex_ -- --nocapture
+```
+
+Expected: PASS for all codex parser tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/providers/v2_map.rs tests/fixtures/providers/codex
+git commit -m "fix: label Codex windows by duration"
+```
+
+---
+
+### Task 2: Codex session-log fallback
+
+**Files:**
+- Create: `src/providers/codex_session_log.rs`
+- Modify: `src/providers/mod.rs` (`mod codex_session_log;`)
+- Modify: `src/providers/adapters.rs` (`CodexAdapter::collect` order)
+- Create: `tests/fixtures/providers/codex/session-token-count.jsonl`
+- Test: unit tests in `codex_session_log.rs`
+
+**Interfaces:**
+- Consumes: `FileSystem` (for optional direct reads in tests) + std walk for directory listing (same pattern as Grok signals walk)
+- Produces:
+  - `pub fn extract_rate_limits_from_jsonl(bytes: &[u8]) -> Option<Vec<u8>>`  
+    reverse-scan lines; first `payload.type == "token_count"` with `payload.rate_limits` object → re-serialize that object as JSON bytes for `codex_from_rate_limits_json`
+  - `pub fn find_latest_rate_limits(sessions_dir: &Path) -> Option<Vec<u8>>`  
+    bounded walk: no symlinks, depth ≤ 8, visits ≤ 4096, candidates ≤ 256 jsonl files, sort mtime desc then path asc; scan each candidate reverse for token_count; return first hit’s rate_limits JSON bytes
+
+**Adapter order after this task (still without app-server):**
+
+1. `rate-limits.json` if present  
+2. `find_latest_rate_limits(home.join(".codex/sessions"))`  
+3. else if no collection exe → `cli_missing`  
+4. else retryable `provider_error` (“Codex rate limits were not available.”)
+
+- [ ] **Step 1: Write fixture + failing tests**
+
+`tests/fixtures/providers/codex/session-token-count.jsonl` (synthetic, no secrets):
+
+```json
+{"timestamp":"2026-07-25T23:00:00.000Z","type":"event","payload":{"type":"message"}}
+{"timestamp":"2026-07-25T23:01:00.000Z","type":"event","payload":{"type":"token_count","rate_limits":{"primary":{"used_percent":12.5,"window_minutes":10080,"resets_at":1785628013},"plan_type":"plus"}}}
+```
+
+Test:
+
+```rust
+#[test]
+fn extract_token_count_rate_limits_from_jsonl() {
+    let bytes = include_bytes!("../../tests/fixtures/providers/codex/session-token-count.jsonl");
+    let raw = extract_rate_limits_from_jsonl(bytes).expect("limits");
+    let now = time::macros::datetime!(2026-07-26 18:00:00 UTC);
+    match crate::providers::v2_map::codex_from_rate_limits_json(&raw, now) {
+        ProviderResult::Ready { windows, .. } => {
+            assert_eq!(windows[0].id(), "weekly");
+            assert!((windows[0].used_percent() - 12.5).abs() < 0.01);
+        }
+        other => panic!("{other:?}"),
+    }
+}
+```
+
+Add a temp-dir walk test that writes the fixture under `sessions/2026/07/25/rollout.jsonl` and asserts `find_latest_rate_limits` returns the same weekly window.
+
+- [ ] **Step 2: Run tests — expect FAIL**
+
+```bash
+cargo test codex_session_log -- --nocapture
+```
+
+Expected: FAIL (module missing).
+
+- [ ] **Step 3: Implement `codex_session_log.rs` and wire adapter**
+
+Implementation notes:
+
+- Parse each non-empty line as `serde_json::Value`.
+- Match `payload.type == "token_count"` and `payload.rate_limits` is object.
+- Scan reverse so the latest line wins inside a file.
+- Walk mirrors Grok’s bounds in `adapters.rs` (`find_latest_signals` / `walk_signals_std`).
+- Prefer newest candidate that yields extractable limits (not merely newest file without limits).
+
+Wire in `CodexAdapter::collect` after `rate-limits.json` miss.
+
+- [ ] **Step 4: Run tests — expect PASS**
+
+```bash
+cargo test codex_session_log -- --nocapture
+cargo test providers::adapters -- --nocapture
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/providers/codex_session_log.rs src/providers/mod.rs src/providers/adapters.rs tests/fixtures/providers/codex
+git commit -m "feat: Codex session-log rate limits"
+```
+
+---
+
+### Task 3: Codex app-server JSON-RPC collection
+
+**Files:**
+- Create: `src/providers/codex_app_server.rs`
+- Modify: `src/providers/mod.rs`
+- Modify: `src/providers/adapters.rs` (prefer app-server before session-log when exe present)
+- Test: unit tests with in-memory duplex / scripted lines in `codex_app_server.rs`
+
+**Interfaces:**
+- Consumes: resolved `codex` executable path, version string for `clientInfo.version` (use crate version / `app_identity` if available; else `"agent-bar"`)
+- Produces:
+  - `pub async fn run_appserver_protocol<R, W>(reader: R, writer: W, version: &str, timeout: Duration) -> Option<Vec<u8>>`  
+    where `R: AsyncRead + Unpin`, `W: AsyncWrite + Unpin`  
+    Returns JSON bytes of a document acceptable to `codex_from_rate_limits_json` (primary/secondary/plan_type), or `None`
+  - `pub async fn fetch_rate_limits_via_appserver(exe: &Path, version: &str, timeout: Duration) -> Option<Vec<u8>>`  
+    spawns `exe app-server` with piped stdio, stderr null, kill_on_drop, runs protocol, kills child
+
+**Protocol (from pre-v10, method names verified in history):**
+
+1. Write `{"method":"initialize","id":0,"params":{"clientInfo":{"name":…,"title":…,"version":…}}}`
+2. On id=0 result → write `initialized` notification, then  
+   `account/read` id=1 `{refreshToken:false}`, then  
+   `account/rateLimits/read` id=2 `{}`
+3. On id=2 error → return `None` immediately (do not wait hard timeout)
+4. On id=2 result → parse rate limits; merge plan_type from id=1 when present
+5. Normalize app-server camelCase windows into the same shape as session-log / `codex_from_rate_limits_json`
+
+**Adapter final order:**
+
+1. If collection exe present: try app-server once; on **timeout only**, sleep 250ms and try once more; then fall through  
+2. `rate-limits.json`  
+3. session-log fallback  
+4. typed miss / cli_missing
+
+Note: `ProcessRunner::run` is one-shot without interactive stdin — **do not** force app-server through it. Dedicated spawn in `codex_app_server` is correct (matches architecture: “composite process”, not fake command abstraction).
+
+- [ ] **Step 1: Write protocol unit test with scripted reader/writer**
+
+```rust
+#[tokio::test]
+async fn appserver_protocol_reads_rate_limits() {
+    use tokio::io::{duplex, AsyncWriteExt};
+    let (client, mut server) = duplex(64 * 1024);
+    let (client_read, client_write) = tokio::io::split(client);
+
+    let server_task = tokio::spawn(async move {
+        // Read initialize line, respond id=0, then serve id=1/2 after requests
+        // (implement with BufReader line loop; keep fixture compact)
+    });
+
+    let out = run_appserver_protocol(
+        client_read,
+        client_write,
+        "10.0.0",
+        std::time::Duration::from_secs(2),
+    )
+    .await
+    .expect("limits json");
+    let now = time::macros::datetime!(2026-07-26 18:00:00 UTC);
+    match crate::providers::v2_map::codex_from_rate_limits_json(&out, now) {
+        ProviderResult::Ready { windows, .. } => assert!(!windows.is_empty()),
+        other => panic!("{other:?}"),
+    }
+    let _ = server_task.await;
+}
+```
+
+Include a second test: id=2 error object → `None` quickly (no hang).
+
+- [ ] **Step 2: Run test — expect FAIL**
+
+```bash
+cargo test appserver_protocol -- --nocapture
+```
+
+- [ ] **Step 3: Port protocol from v9 + wire adapter**
+
+Source to port (read-only reference, do not restore whole v9 tree):
+
+```bash
+git show 7556db3:src/providers/codex/app_server.rs
+```
+
+Adapt types to return `Vec<u8>` for `codex_from_rate_limits_json` instead of old `CodexRateLimits` domain.
+
+Wire `CodexAdapter::collect`:
+
+```rust
+if let Some(exe) = collection_exe(discovery) {
+    let timeout = CODEX.timeout;
+    let version = env!("CARGO_PKG_VERSION");
+    let mut attempt = fetch_rate_limits_via_appserver(exe, version, timeout).await;
+    if attempt.is_none() {
+        // Only the adapter-level "one transient retry" for timeout is required by
+        // catalog; if fetch cannot distinguish timeout vs auth miss, skip second
+        // attempt when error path was immediate JSON-RPC error. Prefer having
+        // fetch return an enum { Timeout, Failed, Ok(bytes) } if cheap.
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+        attempt = fetch_rate_limits_via_appserver(exe, version, timeout).await;
+    }
+    if let Some(bytes) = attempt {
+        return codex_from_rate_limits_json(&bytes, context.clock.now_utc());
+    }
+}
+// then rate-limits.json, session-log, typed miss
+```
+
+Refine retry: only second attempt on timeout if you introduce `AppServerOutcome::{Ok, TimedOut, Failed}`.
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cargo test codex_ -- --nocapture
+cargo test providers:: -- --nocapture
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/providers/codex_app_server.rs src/providers/mod.rs src/providers/adapters.rs
+git commit -m "feat: Codex app-server rate limits"
+```
+
+---
+
+### Task 4: Grok billing parser (weekly only)
+
+**Files:**
+- Modify: `src/providers/v2_map.rs`
+- Create: `tests/fixtures/providers/grok/billing-weekly.json`
+- Test: `v2_map` unit tests
+- Remove/replace: `grok_signals_context_window` expectations that require `context` as product primary
+
+**Interfaces:**
+- Produces: `pub fn grok_from_billing_json(bytes: &[u8], account_label: Option<String>, now: OffsetDateTime, login_available: bool) -> ProviderResult`
+- Mapping:
+  - `creditUsagePercent` → used
+  - remaining = `(100.0 - used).clamp(0.0, 100.0)`
+  - `currentPeriod.end` or `billingPeriodEnd` (RFC3339) → `resetsAt`
+  - window id/label always `weekly` / `Weekly`
+  - `subscriptionTiers` string → optional `Plan`
+- Discards: prepaid/onDemand balances and any money-like objects
+- On missing/invalid percent: `Ready` with **empty** windows (not Context)
+- Does **not** read signals / emit `context`
+
+Fixture `tests/fixtures/providers/grok/billing-weekly.json`:
+
+```json
+{
+  "creditUsagePercent": 33.0,
+  "currentPeriod": {
+    "type": "USAGE_PERIOD_TYPE_WEEKLY",
+    "start": "2026-07-24T21:10:59.543182+00:00",
+    "end": "2026-07-31T21:10:59.543182+00:00"
+  },
+  "billingPeriodStart": "2026-07-24T21:10:59.543182+00:00",
+  "billingPeriodEnd": "2026-07-31T21:10:59.543182+00:00",
+  "prepaidBalance": { "val": 99 },
+  "onDemandCap": { "val": 0 },
+  "onDemandUsed": { "val": 0 },
+  "isUnifiedBillingUser": true,
+  "subscriptionTiers": "SuperGrok"
+}
+```
+
+- [ ] **Step 1: Write failing tests**
+
+```rust
+#[test]
+fn grok_billing_weekly_window_discards_money() {
+    let body = include_bytes!("../../tests/fixtures/providers/grok/billing-weekly.json");
+    let now = time::macros::datetime!(2026-07-27 12:00:00 UTC);
+    match grok_from_billing_json(body, Some("Ada".into()), now, true) {
+        ProviderResult::Ready { windows, plan, .. } => {
+            assert_eq!(windows.len(), 1);
+            assert_eq!(windows[0].id(), "weekly");
+            assert_eq!(windows[0].label(), "Weekly");
+            assert!((windows[0].used_percent() - 33.0).abs() < 0.01);
+            assert!((windows[0].remaining_percent() - 67.0).abs() < 0.01);
+            assert!(windows[0].resets_at().is_some());
+            assert_eq!(plan.as_ref().map(|p| p.label.as_str()), Some("SuperGrok"));
+        }
+        other => panic!("{other:?}"),
+    }
+}
+
+#[test]
+fn grok_billing_ready_never_emits_context() {
+    let body = include_bytes!("../../tests/fixtures/providers/grok/billing-weekly.json");
+    let now = time::macros::datetime!(2026-07-27 12:00:00 UTC);
+    match grok_from_billing_json(body, None, now, true) {
+        ProviderResult::Ready { windows, .. } => {
+            assert!(windows.iter().all(|w| w.id() != "context"));
+        }
+        other => panic!("{other:?}"),
+    }
+}
+```
+
+Keep `grok_from_auth_and_signals` only if still needed for unauthenticated helper tests; otherwise delete Context path and update `grok_ready_from_auth_and_signals_fixture` adapter tests in Task 5.
+
+- [ ] **Step 2: Run — expect FAIL**
+
+```bash
+cargo test grok_billing -- --nocapture
+```
+
+- [ ] **Step 3: Implement parser**
+
+```rust
+pub fn grok_from_billing_json(
+    bytes: &[u8],
+    account_label: Option<String>,
+    now: OffsetDateTime,
+    login_available: bool,
+) -> ProviderResult {
+    // parse; on total JSON failure → ProviderError non-retryable
+    // build single weekly window when creditUsagePercent finite
+    // never include context
+}
+```
+
+- [ ] **Step 4: Run — expect PASS**
+
+```bash
+cargo test grok_billing -- --nocapture
+cargo test grok_ -- --nocapture
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/providers/v2_map.rs tests/fixtures/providers/grok/billing-weekly.json
+git commit -m "feat: parse Grok weekly billing JSON"
+```
+
+---
+
+### Task 5: Grok adapter HTTP billing collect
+
+**Files:**
+- Modify: `src/providers/adapters.rs` (`GrokAdapter`, auth token extract)
+- Modify: `src/providers/catalog.rs` (`GROK.retry_policy = RetryPolicy::OneTransient`)
+- Modify: adapter tests that expect `context` window
+- Export constant: `pub const GROK_BILLING_URL: &str = "https://cli-chat-proxy.grok.com/v1/billing?format=credits";`  
+  (If a controlled offline probe during implementation shows a different host/path used by the installed CLI, **update the constant and this plan’s equality tests** in the same commit — do not leave a soft default.)
+
+**Headers (literals for equality tests):**
+
+```text
+Authorization: Bearer <key>
+x-grok-client-mode: cli
+```
+
+If the installed CLI uses a different `x-grok-client-mode` value, pin the observed value and document it in the commit body. Do not send tokens to logs.
+
+**Interfaces:**
+- Consumes: `context.http.get(url, headers, max_body)`
+- Consumes: auth.json key via `parse_grok_auth_token(bytes) -> Option<(String /*token*/, Option<String> /*label*/)>`  
+  (extend current `parse_grok_auth` — token used only for the request, never stored in `ProviderResult`)
+- Produces: domain result from `grok_from_billing_json`
+- Retry: on `HttpError::Network` / timeout-class failure only, one extra attempt after 250ms when `GROK.retry_policy` is `OneTransient`
+
+**Collect algorithm:**
+
+1. Resolve absolute `grok_home` (existing).
+2. Read `auth.json`; if missing/invalid/no key → unauthenticated.
+3. GET `GROK_BILLING_URL` with Bearer key.
+4. Status 401/403 → unauthenticated.
+5. Status non-success → provider_error or network_error (retryable for 5xx/timeout).
+6. Success body → `grok_from_billing_json`.
+7. Do not call signals walk for windows.
+
+- [ ] **Step 1: Write failing adapter test with ScriptedHttpClient**
+
+Pattern from Claude/Grok existing adapter tests in `adapters.rs`:
+
+```rust
+#[tokio::test]
+async fn grok_ready_from_billing_http() {
+    // home with auth.json (synthetic key string, not a real JWT)
+    // ScriptedHttpClient returns 200 + billing-weekly.json body
+    // assert last_url == GROK_BILLING_URL
+    // assert Authorization header present with Bearer prefix
+    // assert Ready weekly window; no context
+}
+```
+
+Also:
+
+- `grok_billing_401_unauthenticated`
+- `grok_billing_timeout_network_error` (if ScriptedHttpClient can return `HttpError::Network`)
+
+Update/remove `grok_ready_from_auth_and_signals_fixture` that expects `windows[0].id() == "context"`.
+
+- [ ] **Step 2: Run — expect FAIL**
+
+```bash
+cargo test grok_ready_from_billing -- --nocapture
+```
+
+- [ ] **Step 3: Implement adapter + catalog retry**
+
+```rust
+// catalog.rs
+retry_policy: RetryPolicy::OneTransient, // was None for GROK
+
+// adapters.rs GrokAdapter::collect
+let token = /* from auth */;
+let headers = [
+    ("Authorization", bearer.as_str()),
+    ("x-grok-client-mode", "cli"),
+];
+match context.http.get(GROK_BILLING_URL, &headers, GROK.max_output_bytes).await {
+    Ok(resp) if resp.status == 200 => grok_from_billing_json(&resp.body, account, now, login_available(discovery)),
+    Ok(resp) if resp.status == 401 || resp.status == 403 => unauthenticated(...),
+    Ok(_) => ProviderResult::ProviderError { retryable: true, ... },
+    Err(HttpError::Network(_)) => { /* optional one retry */ ProviderResult::NetworkError { ... } },
+    Err(_) => ProviderResult::NetworkError { ... },
+}
+```
+
+Never put `token` into error messages.
+
+- [ ] **Step 4: Run suite**
+
+```bash
+cargo test providers:: -- --nocapture
+cargo test grok_ -- --nocapture
+```
+
+Expected: PASS; no test asserts Grok `context` as the ready primary.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/providers/adapters.rs src/providers/catalog.rs src/providers/v2_map.rs src/providers/mod.rs
+git commit -m "feat: Grok weekly via billing HTTP"
+```
+
+---
+
+### Task 6: Docs + active contract alignment
+
+**Files:**
+- Modify: `docs/specs/v10/02-target-architecture.md` (Grok collection row)
+- Modify: `docs/troubleshooting.md` (Codex rate limits / Grok weekly)
+- Modify if needed: `README.md`, `PRODUCT.md`, `docs/architecture.md`, `docs/new-provider.md`
+- Modify: any active-doc test that freezes the old Grok “context” string (`tests/active_docs.rs` if present)
+
+**Grok table row target text:**
+
+```text
+| `grok` | `$GROK_HOME/auth.json`, then authenticated GET
+  `https://cli-chat-proxy.grok.com/v1/billing?format=credits`
+  (literal; headers Authorization Bearer + x-grok-client-mode)
+  | `weekly` | 90 s | 10 s | one network/timeout retry |
+```
+
+Labels line: Grok `Weekly` (not Context).
+
+Troubleshooting bullets:
+
+- Codex Retry loops with “rate limits not available” → ensure CLI logged in; agent-bar uses app-server then session logs under `~/.codex/sessions`; not `rate-limits.json` alone.
+- Grok shows `—` when billing returns no percent; Weekly reset comes from billing period end; Context is no longer a product window.
+
+- [ ] **Step 1: Update docs**
+
+Apply the table/label/troubleshooting edits. Grep active docs for “Context” + Grok product claims:
+
+```bash
+rg -n "Grok.*[Cc]ontext|context de sessão|Context\`" README.md PRODUCT.md docs/architecture.md docs/new-provider.md docs/specs/v10 docs/troubleshooting.md
+```
+
+- [ ] **Step 2: Run active doc tests**
+
+```bash
+cargo test --test active_docs -- --nocapture
+cargo test --test active_legacy_scan -- --nocapture
+```
+
+Expected: PASS (or update freezes if they intentionally locked old Grok copy).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs README.md PRODUCT.md tests
+git commit -m "docs: Codex collection and Grok weekly"
+```
+
+---
+
+### Task 7: Full verification gate
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Format / test / clippy / diff**
+
+```bash
+cargo fmt --check
+cargo test
+cargo clippy --all-targets -- -D warnings
+git diff --check
+```
+
+Expected: all green.
+
+- [ ] **Step 2: Optional authorized live smoke (host with CLIs)**
+
+```bash
+PLUGIN="$HOME/.config/omarchy/plugins/agent-bar.usage/bin/agent-bar"
+# After local `cargo build` install/replace only if user authorized plugin write.
+./target/debug/agent-bar status provider codex format human cache bypass
+./target/debug/agent-bar status provider grok format human cache bypass
+```
+
+Expected:
+
+- Codex: `ready` with Session and/or Weekly **or** a non-stub typed state after real collection attempt (not instant stub-only without reading sessions).
+- Grok: `Weekly` used/remaining + reset; label not `Context`.
+
+Sanitize any logs before pasting (no tokens).
+
+- [ ] **Step 3: Final commit only if smoke required code tweaks; otherwise stop**
+
+Do not push/merge unless explicitly authorized.
+
+---
+
+## Self-review (plan vs spec)
+
+| Spec requirement | Task |
+| --- | --- |
+| Codex app-server `rateLimits/read` | Task 3 |
+| Codex session-log fallback + bounds | Task 2 |
+| Duration-based Session/Weekly labels | Task 1 |
+| Optional rate-limits.json | Task 2/3 order |
+| Retry meaningful with local data | Task 2 alone already; Task 3 improves live |
+| Grok weekly from billing HTTPS | Tasks 4–5 |
+| No Context window | Tasks 4–5 |
+| Discard money fields | Tasks 1, 4 |
+| Catalog/docs update Grok | Tasks 5–6 |
+| Privacy / no token logs | Tasks 3, 5 notes |
+| Verification gate | Task 7 |
+
+No TBD placeholders remain. URL/header literals are pinned with an explicit “update constant if probe differs” rule inside Task 5 (not an open product decision).
+
+---
+
+## Execution handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-07-27-codex-retry-grok-weekly.md`.
+
+**Two execution options:**
+
+1. **Subagent-Driven (recommended)** — fresh subagent per task, review between tasks  
+2. **Inline Execution** — same session with executing-plans checkpoints  
+
+Which approach?

--- a/docs/superpowers/specs/2026-07-27-codex-retry-grok-weekly-design.md
+++ b/docs/superpowers/specs/2026-07-27-codex-retry-grok-weekly-design.md
@@ -1,0 +1,340 @@
+# Design — Codex retry + Grok weekly usage
+
+Date: 2026-07-27  
+Status: approved (brainstorming)  
+Scope: fix Codex collection so Retry works when CLI-authenticated; replace Grok
+Context window with SuperGrok weekly usage + reset.
+
+## 1. Problem statement
+
+### 1.1 Codex Retry appears to do nothing
+
+Observed on a host with Codex CLI logged in (`codex login status` → ChatGPT;
+`~/.codex/auth.json` present):
+
+- `agent-bar status provider codex` → `provider_error`:
+  `Codex rate limits were not available.` + action `Retry`
+- `~/.codex/rate-limits.json` does **not** exist
+- `~/.codex/sessions/**/*.jsonl` **does** contain `token_count` events with
+  `rate_limits` (`used_percent`, `window_minutes`, `resets_at`)
+
+Root cause: the v10 `CodexAdapter` is a stub. It only reads
+`$HOME/.codex/rate-limits.json`. If missing, it ignores the resolved `codex`
+executable (`let _ = exe`) and returns a retryable provider error. Retry in
+QML correctly force-refreshes, but re-runs the same incomplete path.
+
+This contradicts the locked v10 collection policy in
+`docs/specs/v10/02-target-architecture.md`:
+
+> Codex: `codex app-server` JSON-RPC `rateLimits/read`, then newest valid
+> rate-limit event below `$HOME/.codex/sessions`
+
+The pre-v10 implementation (`src/providers/codex/{app_server,session_log}.rs`)
+already implemented that pipeline and was removed during the v10 legacy cut.
+
+### 1.2 Grok shows Context instead of weekly usage
+
+Current behavior is intentional under the 2026-07-17 Grok provider design:
+primary metric is session **context** remaining from `signals.json`.
+
+Product request: show SuperGrok **weekly usage limit** with correct reset.
+
+Evidence that the weekly metric exists for the Build CLI OAuth path:
+
+- Grok CLI logs `billing: fetched credits config` with:
+  - `creditUsagePercent` (used %)
+  - `currentPeriod.type = USAGE_PERIOD_TYPE_WEEKLY`
+  - `currentPeriod.start` / `currentPeriod.end` (reset bound)
+  - `billingPeriodStart` / `billingPeriodEnd`
+  - `subscriptionTiers` (e.g. SuperGrok)
+- Binary strings include path `/billing?format=credits`, Bearer auth, and
+  `x-grok-client-mode`
+- Local signals.json has no plan-quota fields (only context tokens)
+
+So Context is not a UI bug; it is the wrong product metric. Weekly must come
+from the same billing surface the CLI already calls, not from inventing a
+percentage from session signals.
+
+## 2. Goals and non-goals
+
+### Goals
+
+1. **Codex:** when CLI-authenticated and any live source can supply rate
+   limits, status is `ready` with Session/Weekly (or `other:*`) windows and
+   correct `resetsAt`. Retry force-refreshes and surfaces updated data or a
+   clear typed failure.
+2. **Grok:** chip and popup show a single **Weekly** window (not Context),
+   with used/remaining percent and reset at period end.
+3. Preserve v10 hard rules: no monetary fields in status/cache/UI/logs; never
+   log credentials/tokens; provider failures stay typed inside schema-v2;
+   QML does not parse raw provider payloads.
+
+### Non-goals
+
+- SuperGrok chat-web limits as a separate source
+- Amp/Claude collection changes
+- Emitting prepaid/on-demand balances or dollar amounts
+- Keeping Context as a parallel Grok window
+- Reading Grok weekly from `unified.jsonl` (not a contract)
+- QML redesign beyond what status data already drives
+- Live desktop mutation during unit tests
+
+## 3. Approach (selected)
+
+**Approach A — restore Codex composite collection + Grok billing HTTPS.**
+
+Rejected alternatives:
+
+| Approach | Why not |
+| --- | --- |
+| B — Grok weekly from `unified.jsonl` only | Stale unless CLI recently ran; log is not a public contract |
+| C — Codex session-log only (no app-server) | Stale without recent sessions; weaker than v10; Retry can still look dead |
+
+## 4. Architecture
+
+### 4.1 Data flow
+
+```text
+Service.qml (Retry / poll)
+  → agent-bar status [force bypass when Retry]
+      → CodexAdapter
+          1) codex app-server JSON-RPC rateLimits/read
+          2) fallback session-log walk under ~/.codex/sessions
+          3) optional ~/.codex/rate-limits.json if present (fixtures/tests)
+          → ProviderResult → schema v2
+      → GrokAdapter
+          1) auth.json gate (key present; same login semantics as today)
+          2) HTTPS GET /billing?format=credits (CLI-equivalent)
+          → weekly UsageWindow only
+```
+
+### 4.2 Codex collection
+
+**Source order (mandatory):**
+
+1. **App-server (preferred live)**  
+   - Resolve `codex` via catalog discovery.  
+   - Spawn app-server over stdio; run JSON-RPC handshake + `rateLimits/read`
+     (port v9 `run_appserver_protocol` into current process seams).  
+   - Timeout: catalog timeout (10s).  
+   - One additional attempt only on app-server **timeout**, then filesystem
+     fallback (v10 retry table).  
+   - Auth / malformed / non-timeout failures do not count as that retry.
+
+2. **Session-log fallback**  
+   - Bounded walk under `$HOME/.codex/sessions` matching v10 limits:
+     no link follow, depth ≤ 8, ≤ 4096 directory entries, 1 MiB per file,
+     ≤ 256 candidates, sort mtime desc then path bytes asc.  
+   - Valid event: `payload.type == "token_count"` with `rate_limits`.  
+   - Prefer newest by event timestamp, then path/line tie-break as in ARCH.
+
+3. **Optional static file**  
+   - If `$HOME/.codex/rate-limits.json` exists and parses, may be used as a
+     source (tests/fixtures). Must not be the only production path.
+
+**Normalization:**
+
+- Accept camelCase and snake_case window fields
+  (`usedPercent`/`used_percent`, `windowDurationMins`/`window_minutes`,
+  `resetsAt`/`resets_at`).
+- Label by duration, **not** by primary/secondary slot:
+
+  | window_minutes | id | label |
+  | --- | --- | --- |
+  | 300 (or session-like primary when duration matches catalog norms) | `session` | Session |
+  | 10080 | `weekly` | Weekly |
+  | other finite | `other:<mins>:<ordinal>` | short plain label (`{mins}m`) |
+
+- Critical regression: host samples show **primary** with
+  `window_minutes = 10080` and `secondary = null`. Mapping primary always to
+  Session is wrong.
+- Discard `credits` / balance / monetary fields.
+- `plan_type` → optional `Plan { id, label }` as plain text when present.
+
+**States:**
+
+| Situation | Result |
+| --- | --- |
+| Not authenticated (no usable auth / app-server auth failure) | `unauthenticated` + login when available |
+| Transient network/timeout after policy | `network_error` retryable |
+| All sources miss rate limits | `provider_error` retryable, clear message |
+| Malformed payload | `provider_error` non-retryable |
+| Success | `ready` with windows |
+
+**Why Retry works after the fix:** force refresh re-runs app-server (live) or
+re-reads session logs that already contain weekly/session buckets on this host.
+
+### 4.3 Grok collection (Weekly replaces Context)
+
+**Source order:**
+
+1. Auth gate from `$GROK_HOME/auth.json` (or `$HOME/.grok`): require non-empty
+   `key` under the selected entry (existing multi-entry selection rules).
+2. Authenticated HTTPS GET to the CLI billing endpoint:
+   - Path: `/billing?format=credits` (literal from Grok CLI binary).
+   - Host base: CLI proxy host (`cli-chat-proxy.grok.com` family).  
+     **Implementation must pin the exact absolute URL via equality tests**
+     after a controlled discovery probe; no free-form URL construction at
+     runtime beyond that constant.
+   - Headers: `Authorization: Bearer <key>`, plus the CLI’s
+     `x-grok-client-mode` header (literal value fixed in tests).
+   - Transport: existing `HttpClient` (HTTPS only, no redirects, body cap
+     1 MiB, timeout from catalog).
+3. Do **not** emit a Context window from `signals.json` in the ready path.
+4. Do **not** parse `~/.grok/logs/unified.jsonl`.
+
+**Mapping (from observed CLI billing config):**
+
+```text
+creditUsagePercent              → used_percent
+remaining                       → (100 - used).clamp(0, 100)
+currentPeriod.type == WEEKLY
+  (or period span ≈ 7 days)     → window id weekly
+currentPeriod.end
+  or billingPeriodEnd           → resetsAt
+subscriptionTiers / plan label  → Plan plain text when safe
+```
+
+Discard: `prepaidBalance`, `onDemandCap`, `onDemandUsed`, any currency fields.
+
+**Single window product decision (approved):**
+
+| id | label | resets |
+| --- | --- | --- |
+| `weekly` | Weekly | period end |
+
+**States:**
+
+| Situation | Result |
+| --- | --- |
+| No/invalid auth | `unauthenticated` + Connect when login available |
+| HTTP timeout / transport failure | `network_error` retryable (one retry) |
+| 401/403 after auth file present | `unauthenticated` or typed provider error; never silent Context fallback |
+| 5xx / unparseable body | `provider_error` retryable where appropriate |
+| Success without usable percent | `ready` with **empty** windows (chip `—`), not Context |
+
+### 4.4 Catalog / contract updates
+
+Update locked collection table for Grok in `docs/specs/v10/02-target-architecture.md`
+and any active docs that claim Grok primary is context:
+
+| Field | Before | After |
+| --- | --- | --- |
+| Grok sources | auth + signals walk | auth + billing HTTPS |
+| Window IDs | `context` | `weekly` |
+| Labels | Context | Weekly |
+| Retry | none | one network/timeout retry |
+| TTL | 90s | 90s |
+
+Codex row stays as already specified; implementation must match it.
+
+### 4.5 UI layer
+
+No QML contract change required if schema-v2 windows update correctly.
+
+- Retry continues to call `retryProvider` → `refreshProvider(id, true)`.
+- Chip primary metric follows existing remaining/used display settings.
+- Optional loading affordance on Retry is out of scope (YAGNI unless an
+  existing spinner pattern is trivial to reuse).
+
+### 4.6 Privacy and security
+
+- Never log Authorization headers, JWT/`key`, refresh tokens, account emails.
+- Cache only normalized schema-v2 (percentages, resetsAt, sanitized plan).
+- Fixtures synthetic only.
+- Redaction on HTTP errors must strip URL query auth and header echoes
+  (existing Claude HTTP client rules apply to Grok billing).
+
+## 5. Module sketch
+
+Keep adapters thin; parsers pure.
+
+```text
+src/providers/adapters.rs     # Codex/Grok collect orchestration
+src/providers/v2_map.rs       # pure parsers (codex windows by duration;
+                              # grok_from_billing_json; remove context-primary path)
+src/providers/codex/          # optional split if app-server+session_log grow:
+                              #   app_server.rs, session_log.rs
+src/providers/http.rs         # reuse GET; no secrets in errors
+src/providers/catalog.rs      # Grok timeout/retry metadata if needed
+tests/fixtures/providers/codex/
+tests/fixtures/providers/grok/  # billing-weekly.json, billing-unauth shapes
+```
+
+Prefer porting proven v9 Codex protocol code over inventing a new RPC dialect.
+
+## 6. Testing and acceptance
+
+### Codex unit/integration
+
+- Scripted app-server success → Session + Weekly with resets.
+- Session-log snake_case `token_count.rate_limits` fallback.
+- Primary-only weekly (`window_minutes=10080`) → id `weekly` (mislabel regression).
+- All sources missing → retryable provider_error.
+- Auth failure → unauthenticated when applicable.
+- Walk bounds (depth/entry caps) enforced.
+- Credits absent from domain result.
+
+### Grok unit/integration
+
+- Billing fixture → single `weekly` window; remaining = 100 − used; resetsAt = end.
+- No `context` window in ready result.
+- Monetary fields discarded.
+- 401 → unauthenticated path.
+- Timeout → network_error retryable.
+- Literal URL + required headers equality tests (ARCH-018 style).
+- Auth missing → unauthenticated without HTTP call.
+
+### Manual / QA smoke (authorized host only)
+
+1. `status provider codex cache bypass` while CLI logged in → ready with windows
+   or a non-stub typed state that changes after a real Codex session event.
+2. Popup Retry on Codex updates `lastSuccessAt` / windows when data available.
+3. `status provider grok cache bypass` → Weekly % near CLI-observed
+   `creditUsagePercent`, reset matching period end.
+4. Chip Grok shows weekly remaining/used, not Context label.
+
+### Verification gate
+
+```bash
+cargo fmt --check
+cargo test
+cargo clippy --all-targets -- -D warnings
+git diff --check
+```
+
+QML suite only if assets change.
+
+### Docs to update in the same implementation plan
+
+- `docs/specs/v10/02-target-architecture.md` (Grok collection row)
+- `docs/new-provider.md` / `docs/troubleshooting.md` as needed
+- `README.md` / `PRODUCT.md` if they still claim Grok context-only
+- Historical Grok design (2026-07-17) remains historical; this doc supersedes
+  the product metric decision for v10 follow-up
+
+## 7. Risks
+
+| Risk | Mitigation |
+| --- | --- |
+| Codex app-server protocol drift vs CLI 0.145+ | Port v9, fixture against current CLI strings; session-log fallback |
+| Grok billing URL/header drift | Literal constants + equality tests; fail typed on parse/HTTP change |
+| Undocumented billing API | Same surface the official CLI uses; no credential install; degrade typed |
+| Primary weekly mislabel | Duration-based window ids + explicit regression fixture |
+| Silent Context fallback reintroduced | Tests assert zero `context` windows on Grok ready path |
+
+## 8. Implementation order (plan seed)
+
+1. Codex parsers + session-log fallback (unblocks Retry using local data).
+2. Codex app-server path + timeout retry policy.
+3. Grok billing parser + HTTP collect; remove Context primary path.
+4. Catalog/docs contract updates.
+5. Full verification gate + optional live smoke.
+
+## 9. Success criteria
+
+- Codex Retry no longer loops on the stub-only message when rate limits exist
+  via app-server or session log.
+- Grok chip/popup show Weekly usage with correct reset, not Context.
+- No money fields, no token leakage, schema-v2 only on stdout.
+- Tests and clippy gate green.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -39,6 +39,18 @@ The provider is connected but exposes no normalized percentage quota for that
 account. Agent Bar intentionally does not show spend, balance, or credits as a
 substitute percentage.
 
+## Codex Retry loops with “rate limits not available”
+
+Ensure the Codex CLI is logged in. Agent Bar collects Codex rate limits through
+`codex app-server` JSON-RPC `rateLimits/read`, then newest valid rate-limit
+events under `~/.codex/sessions`. It does not rely on `rate-limits.json` alone.
+
+## Grok shows `—` or missing Weekly
+
+When billing returns no usable percentage, Grok is connected with empty windows
+and the chip shows `—`. Weekly reset comes from the billing period end.
+Context is no longer a product window.
+
 ## Popup does not appear
 
 Check:

--- a/src/providers/adapters.rs
+++ b/src/providers/adapters.rs
@@ -11,6 +11,7 @@ use super::adapter::{
     CollectionContext, ProviderAdapter,
 };
 use super::catalog::{AMP, CLAUDE, CODEX, GROK};
+use super::codex_session_log::find_latest_rate_limits;
 use super::process::ProcessSpec;
 use super::v2_map::{
     amp_from_usage_text, claude_from_usage_json, codex_from_rate_limits_json,
@@ -268,11 +269,18 @@ impl ProviderAdapter for CodexAdapter {
                     retryable: false,
                 };
             }
+            // 1. Explicit rate-limits.json if present
             let rates_path = home.join(".codex/rate-limits.json");
             if let Ok(bytes) = context.fs.read(&rates_path) {
                 return codex_from_rate_limits_json(&bytes, context.clock.now_utc());
             }
 
+            // 2. Bounded session-log fallback (~/.codex/sessions/**/*.jsonl)
+            if let Some(bytes) = find_latest_rate_limits(&home.join(".codex/sessions")) {
+                return codex_from_rate_limits_json(&bytes, context.clock.now_utc());
+            }
+
+            // 3. No collection exe → cli_missing
             let Some(exe) = collection_exe(discovery) else {
                 return missing_collection(
                     ProviderId::Codex,
@@ -280,7 +288,7 @@ impl ProviderAdapter for CodexAdapter {
                     CODEX.installation_url,
                 );
             };
-            // Without a live app-server in unit tests, missing rates is a typed miss.
+            // 4. App-server not wired yet (Task 3); typed retryable miss.
             let _ = exe;
             ProviderResult::ProviderError {
                 id: ProviderId::Codex,

--- a/src/providers/adapters.rs
+++ b/src/providers/adapters.rs
@@ -11,6 +11,7 @@ use super::adapter::{
     CollectionContext, ProviderAdapter,
 };
 use super::catalog::{AMP, CLAUDE, CODEX, GROK};
+use super::codex_app_server::{fetch_rate_limits_via_appserver, AppServerOutcome};
 use super::codex_session_log::find_latest_rate_limits;
 use super::process::ProcessSpec;
 use super::v2_map::{
@@ -259,7 +260,6 @@ impl ProviderAdapter for CodexAdapter {
         discovery: &'a Discovery,
     ) -> BoxFuture<'a, ProviderResult> {
         Box::pin(async move {
-            // Prefer filesystem session-log fixture path under $HOME/.codex
             let home = &context.env.home;
             if !home.is_absolute() {
                 return ProviderResult::ProviderError {
@@ -269,27 +269,40 @@ impl ProviderAdapter for CodexAdapter {
                     retryable: false,
                 };
             }
-            // 1. Explicit rate-limits.json if present
+
+            // 1. App-server when collection exe is present (one timeout retry).
+            if let Some(exe) = collection_exe(discovery) {
+                let version = crate::app_identity::VERSION;
+                let timeout = CODEX.timeout;
+                let mut outcome = fetch_rate_limits_via_appserver(exe, version, timeout).await;
+                if matches!(outcome, AppServerOutcome::TimedOut) {
+                    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+                    outcome = fetch_rate_limits_via_appserver(exe, version, timeout).await;
+                }
+                if let AppServerOutcome::Ok(bytes) = outcome {
+                    return codex_from_rate_limits_json(&bytes, context.clock.now_utc());
+                }
+            }
+
+            // 2. Explicit rate-limits.json if present
             let rates_path = home.join(".codex/rate-limits.json");
             if let Ok(bytes) = context.fs.read(&rates_path) {
                 return codex_from_rate_limits_json(&bytes, context.clock.now_utc());
             }
 
-            // 2. Bounded session-log fallback (~/.codex/sessions/**/*.jsonl)
+            // 3. Bounded session-log fallback (~/.codex/sessions/**/*.jsonl)
             if let Some(bytes) = find_latest_rate_limits(&home.join(".codex/sessions")) {
                 return codex_from_rate_limits_json(&bytes, context.clock.now_utc());
             }
 
-            // 3. No collection exe → cli_missing
-            let Some(exe) = collection_exe(discovery) else {
+            // 4. Typed miss / cli_missing
+            if collection_exe(discovery).is_none() {
                 return missing_collection(
                     ProviderId::Codex,
                     CODEX.display_name,
                     CODEX.installation_url,
                 );
-            };
-            // 4. App-server not wired yet (Task 3); typed retryable miss.
-            let _ = exe;
+            }
             ProviderResult::ProviderError {
                 id: ProviderId::Codex,
                 name: CODEX.display_name.to_owned(),
@@ -768,7 +781,9 @@ mod tests {
             http: &http,
             plugin_root: None,
         };
-        let discovery = discovery_with_exe(Path::new("/usr/bin/codex"));
+        // Non-existent exe so app-server spawn fails immediately and collection
+        // falls through to rate-limits.json (no live Codex dependency).
+        let discovery = discovery_with_exe(Path::new("/nonexistent/codex"));
         let result = CODEX_ADAPTER.collect(&ctx, &discovery).await;
         assert_no_money(&result);
         match result {

--- a/src/providers/adapters.rs
+++ b/src/providers/adapters.rs
@@ -1,10 +1,7 @@
 //! Concrete [`ProviderAdapter`] implementations for the four locked providers.
 
-use std::path::Path;
-
 use crate::cli::ProviderId;
 use crate::status::schema::{Account, Plan, ProviderResult};
-use crate::support::FileSystem;
 
 use super::adapter::{
     collection_exe, login_available, missing_collection, unauthenticated, BoxFuture,
@@ -16,7 +13,7 @@ use super::codex_session_log::find_latest_rate_limits;
 use super::process::ProcessSpec;
 use super::v2_map::{
     amp_from_usage_text, claude_from_usage_json, codex_from_rate_limits_json,
-    grok_from_auth_and_signals,
+    grok_from_billing_json,
 };
 use super::{Discovery, ProviderDescriptor};
 
@@ -88,6 +85,9 @@ impl ProviderAdapter for AmpAdapter {
 // Grok
 // ---------------------------------------------------------------------------
 
+/// Authenticated billing endpoint (literal; equality-tested).
+pub const GROK_BILLING_URL: &str = "https://cli-chat-proxy.grok.com/v1/billing?format=credits";
+
 pub struct GrokAdapter;
 
 pub static GROK_ADAPTER: GrokAdapter = GrokAdapter;
@@ -137,108 +137,125 @@ impl ProviderAdapter for GrokAdapter {
                 }
             };
 
-            let (logged_in, account) = parse_grok_auth(&auth_bytes);
-            if !logged_in {
-                return unauthenticated(
-                    ProviderId::Grok,
-                    GROK.display_name,
-                    "Grok is not authenticated.",
-                    login_available(discovery),
-                    GROK.installation_url,
-                );
-            }
+            // Token is used only for the Authorization header — never stored in
+            // ProviderResult, logs, or error messages.
+            let (token, account) = match parse_grok_auth_token(&auth_bytes) {
+                Some(v) => v,
+                None => {
+                    return unauthenticated(
+                        ProviderId::Grok,
+                        GROK.display_name,
+                        "Grok is not authenticated.",
+                        login_available(discovery),
+                        GROK.installation_url,
+                    );
+                }
+            };
 
-            let signals = find_latest_signals(context.fs, &grok_home.join("sessions"));
-            let _ = collection_exe(discovery); // login/collection independence
-            grok_from_auth_and_signals(
-                true,
-                account,
-                signals.as_deref(),
-                context.clock.now_utc(),
-                login_available(discovery),
-            )
+            let bearer = format!("Bearer {token}");
+            let headers = [
+                ("Authorization", bearer.as_str()),
+                ("x-grok-client-mode", "cli"),
+            ];
+            let max_body = GROK.max_output_bytes;
+            let login = login_available(discovery);
+            let now = context.clock.now_utc();
+
+            let mut attempts: u8 = 0;
+            loop {
+                attempts = attempts.saturating_add(1);
+                match context.http.get(GROK_BILLING_URL, &headers, max_body).await {
+                    Ok(resp) if resp.status == 401 || resp.status == 403 => {
+                        return unauthenticated(
+                            ProviderId::Grok,
+                            GROK.display_name,
+                            "Grok authentication was rejected.",
+                            login,
+                            GROK.installation_url,
+                        );
+                    }
+                    Ok(resp) if (200..300).contains(&resp.status) => {
+                        let _ = resp.final_url;
+                        return grok_from_billing_json(&resp.body, account, now, login);
+                    }
+                    Ok(resp) if resp.status >= 500 => {
+                        return ProviderResult::ProviderError {
+                            id: ProviderId::Grok,
+                            name: GROK.display_name.to_owned(),
+                            message: "Grok billing request failed.".into(),
+                            retryable: true,
+                        };
+                    }
+                    Ok(_) => {
+                        return ProviderResult::ProviderError {
+                            id: ProviderId::Grok,
+                            name: GROK.display_name.to_owned(),
+                            message: "Grok billing request failed.".into(),
+                            retryable: false,
+                        };
+                    }
+                    Err(super::adapter::HttpError::Network(_)) => {
+                        if attempts == 1 {
+                            if let Some(delay) = GROK.retry_delay() {
+                                tokio::time::sleep(delay).await;
+                                continue;
+                            }
+                        }
+                        return ProviderResult::NetworkError {
+                            id: ProviderId::Grok,
+                            name: GROK.display_name.to_owned(),
+                            message: "Network error while contacting Grok.".into(),
+                        };
+                    }
+                    Err(super::adapter::HttpError::RedirectRefused(_)) => {
+                        return ProviderResult::ProviderError {
+                            id: ProviderId::Grok,
+                            name: GROK.display_name.to_owned(),
+                            message: "Grok billing redirect refused.".into(),
+                            retryable: false,
+                        };
+                    }
+                    Err(super::adapter::HttpError::BodyTooLarge) => {
+                        return ProviderResult::ProviderError {
+                            id: ProviderId::Grok,
+                            name: GROK.display_name.to_owned(),
+                            message: "Grok billing response exceeded size limit.".into(),
+                            retryable: false,
+                        };
+                    }
+                    Err(super::adapter::HttpError::InvalidResponse(_)) => {
+                        return ProviderResult::ProviderError {
+                            id: ProviderId::Grok,
+                            name: GROK.display_name.to_owned(),
+                            message: "Invalid Grok billing response.".into(),
+                            retryable: false,
+                        };
+                    }
+                }
+            }
         })
     }
 }
 
-fn parse_grok_auth(bytes: &[u8]) -> (bool, Option<String>) {
-    let Ok(value) = serde_json::from_slice::<serde_json::Value>(bytes) else {
-        return (false, None);
-    };
-    let Some(map) = value.as_object() else {
-        return (false, None);
-    };
+/// Extract API key + optional first_name label from Grok `auth.json`.
+///
+/// Returns `None` when no non-empty `key` is present. The token must only be
+/// used for the HTTP Authorization header and must never enter `ProviderResult`.
+fn parse_grok_auth_token(bytes: &[u8]) -> Option<(String, Option<String>)> {
+    let value: serde_json::Value = serde_json::from_slice(bytes).ok()?;
+    let map = value.as_object()?;
     for (_k, entry) in map {
         let key = entry.get("key").and_then(|v| v.as_str()).unwrap_or("");
-        if !key.is_empty() {
-            let name = entry
-                .get("first_name")
-                .and_then(|v| v.as_str())
-                .map(str::to_owned);
-            return (true, name);
-        }
-    }
-    (false, None)
-}
-
-/// Bounded walk: no follow links, max depth 8, max 4096 entries, max 256 signals.
-fn find_latest_signals(fs: &dyn FileSystem, sessions: &Path) -> Option<Vec<u8>> {
-    // Prefer a simple known file if present (tests); otherwise walk via std for
-    // directory listing (FileSystem seam is read/metadata only).
-    let direct = sessions.join("recent/signals.json");
-    if let Ok(bytes) = fs.read(&direct) {
-        return Some(bytes);
-    }
-    walk_signals_std(sessions)
-}
-
-fn walk_signals_std(sessions: &Path) -> Option<Vec<u8>> {
-    use std::cmp::Ordering;
-    use std::fs;
-
-    if !sessions.is_dir() {
-        return None;
-    }
-    let mut candidates: Vec<(std::time::SystemTime, std::path::PathBuf)> = Vec::new();
-    let mut stack = vec![(sessions.to_path_buf(), 0u32)];
-    let mut visits = 0u32;
-    while let Some((dir, depth)) = stack.pop() {
-        if visits >= 4096 || depth > 8 {
+        if key.is_empty() {
             continue;
         }
-        visits += 1;
-        let Ok(entries) = fs::read_dir(&dir) else {
-            continue;
-        };
-        for entry in entries.flatten() {
-            visits += 1;
-            if visits >= 4096 {
-                break;
-            }
-            let path = entry.path();
-            let Ok(meta) = entry.metadata() else {
-                continue;
-            };
-            if meta.file_type().is_symlink() {
-                continue;
-            }
-            if meta.is_dir() && depth < 8 {
-                stack.push((path, depth + 1));
-            } else if meta.is_file()
-                && path.file_name().and_then(|s| s.to_str()) == Some("signals.json")
-            {
-                let mtime = meta.modified().unwrap_or(std::time::UNIX_EPOCH);
-                candidates.push((mtime, path));
-            }
-        }
+        let name = entry
+            .get("first_name")
+            .and_then(|v| v.as_str())
+            .map(str::to_owned);
+        return Some((key.to_owned(), name));
     }
-    candidates.sort_by(|a, b| match b.0.cmp(&a.0) {
-        Ordering::Equal => a.1.as_os_str().cmp(b.1.as_os_str()),
-        other => other,
-    });
-    candidates.truncate(256);
-    let path = &candidates.first()?.1;
-    fs::read(path).ok()
+    None
 }
 
 // ---------------------------------------------------------------------------
@@ -467,15 +484,15 @@ pub struct MapFileSystem {
 }
 
 #[cfg(test)]
-impl FileSystem for MapFileSystem {
-    fn read(&self, path: &Path) -> std::io::Result<Vec<u8>> {
+impl crate::support::FileSystem for MapFileSystem {
+    fn read(&self, path: &std::path::Path) -> std::io::Result<Vec<u8>> {
         self.files
             .get(path)
             .cloned()
             .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::NotFound, "missing"))
     }
 
-    fn metadata(&self, path: &Path) -> std::io::Result<crate::support::FileMetadata> {
+    fn metadata(&self, path: &std::path::Path) -> std::io::Result<crate::support::FileMetadata> {
         let bytes = self.read(path)?;
         Ok(crate::support::FileMetadata {
             len: bytes.len() as u64,
@@ -496,6 +513,7 @@ mod tests {
     use crate::providers::http::ScriptedHttpClient;
     use crate::providers::process::{ProcessError, ProcessOutput, ProcessRunner, ProcessSpec};
     use crate::providers::v2_map::assert_no_money;
+    use std::path::Path;
     use std::sync::Mutex;
     use time::macros::datetime;
 
@@ -698,33 +716,43 @@ mod tests {
         assert!(matches!(result, ProviderResult::ProviderError { .. }));
     }
 
-    #[tokio::test]
-    async fn grok_ready_from_auth_and_signals_fixture() {
-        let process = ScriptedProcess::one(ProcessOutput {
+    fn grok_test_env_and_auth(fs: &mut MapFileSystem) -> ExecutionEnvironment {
+        let home = std::path::PathBuf::from("/home/u");
+        let grok_home = home.join(".grok");
+        fs.files.insert(
+            grok_home.join("auth.json"),
+            // Synthetic key — not a real JWT or credential.
+            br#"{"acct":{"key":"SYNTH_GROK_KEY_NOT_REAL","first_name":"Ada"}}"#.to_vec(),
+        );
+        ExecutionEnvironment {
+            home,
+            path_dirs: vec![],
+            grok_home: None,
+        }
+    }
+
+    fn empty_process() -> ScriptedProcess {
+        ScriptedProcess::one(ProcessOutput {
             exit_code: Some(0),
             stdout: String::new(),
             stderr: String::new(),
             timed_out: false,
             stdout_truncated: false,
             stderr_truncated: false,
-        });
-        let http = ScriptedHttpClient::default();
+        })
+    }
+
+    #[tokio::test]
+    async fn grok_ready_from_billing_http() {
+        let body = include_bytes!("../../tests/fixtures/providers/grok/billing-weekly.json");
+        let http = ScriptedHttpClient::single(Ok(HttpResponse {
+            status: 200,
+            final_url: GROK_BILLING_URL.into(),
+            body: body.to_vec(),
+        }));
+        let process = empty_process();
         let mut fs = MapFileSystem::default();
-        let home = std::path::PathBuf::from("/home/u");
-        let grok_home = home.join(".grok");
-        fs.files.insert(
-            grok_home.join("auth.json"),
-            br#"{"acct":{"key":"k","first_name":"Ada"}}"#.to_vec(),
-        );
-        fs.files.insert(
-            grok_home.join("sessions/recent/signals.json"),
-            include_bytes!("../../tests/fixtures/grok/signals-recent.json").to_vec(),
-        );
-        let env = ExecutionEnvironment {
-            home,
-            path_dirs: vec![],
-            grok_home: None,
-        };
+        let env = grok_test_env_and_auth(&mut fs);
         let clock = FixedClock(datetime!(2026-07-26 18:00:00 UTC));
         let ctx = CollectionContext {
             env: &env,
@@ -742,12 +770,95 @@ mod tests {
         };
         let result = GROK_ADAPTER.collect(&ctx, &discovery).await;
         assert_no_money(&result);
+        let dbg = format!("{result:?}");
+        assert!(
+            !dbg.contains("SYNTH_GROK_KEY_NOT_REAL"),
+            "token must not appear in domain result"
+        );
+        assert_eq!(
+            http.last_url.lock().unwrap().as_deref(),
+            Some(GROK_BILLING_URL)
+        );
+        let headers = http.last_headers.lock().unwrap().clone();
+        assert!(
+            headers.iter().any(|(k, v)| {
+                k == "Authorization" && v.starts_with("Bearer ") && v.contains("SYNTH_GROK_KEY")
+            }),
+            "Authorization Bearer header missing: {headers:?}"
+        );
+        assert!(
+            headers
+                .iter()
+                .any(|(k, v)| k == "x-grok-client-mode" && v == "cli"),
+            "x-grok-client-mode header missing: {headers:?}"
+        );
         match result {
-            ProviderResult::Ready { windows, .. } => {
-                assert_eq!(windows[0].id(), "context");
+            ProviderResult::Ready {
+                windows, account, ..
+            } => {
+                assert_eq!(windows.len(), 1);
+                assert_eq!(windows[0].id(), "weekly");
+                assert_eq!(windows[0].label(), "Weekly");
+                assert!(windows.iter().all(|w| w.id() != "context"));
+                assert_eq!(account.as_ref().map(|a| a.label.as_str()), Some("Ada"));
             }
             other => panic!("{other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn grok_billing_401_unauthenticated() {
+        let http = ScriptedHttpClient::single(Ok(HttpResponse {
+            status: 401,
+            final_url: GROK_BILLING_URL.into(),
+            body: br#"{"error":"unauthorized"}"#.to_vec(),
+        }));
+        let process = empty_process();
+        let mut fs = MapFileSystem::default();
+        let env = grok_test_env_and_auth(&mut fs);
+        let clock = FixedClock(datetime!(2026-07-26 18:00:00 UTC));
+        let ctx = CollectionContext {
+            env: &env,
+            clock: &clock,
+            fs: &fs,
+            process: &process,
+            http: &http,
+            plugin_root: None,
+        };
+        let discovery = Discovery {
+            collection: CollectionAvailability::Missing,
+            login: LoginAvailability::Available {
+                executable: std::path::PathBuf::from("/usr/bin/grok"),
+            },
+        };
+        let result = GROK_ADAPTER.collect(&ctx, &discovery).await;
+        let dbg = format!("{result:?}");
+        assert!(!dbg.contains("SYNTH_GROK_KEY_NOT_REAL"));
+        assert!(matches!(result, ProviderResult::Unauthenticated { .. }));
+    }
+
+    #[tokio::test]
+    async fn grok_billing_timeout_network_error() {
+        let http = ScriptedHttpClient::single(Err(crate::providers::adapter::HttpError::Network(
+            "timeout".into(),
+        )));
+        let process = empty_process();
+        let mut fs = MapFileSystem::default();
+        let env = grok_test_env_and_auth(&mut fs);
+        let clock = FixedClock(datetime!(2026-07-26 18:00:00 UTC));
+        let ctx = CollectionContext {
+            env: &env,
+            clock: &clock,
+            fs: &fs,
+            process: &process,
+            http: &http,
+            plugin_root: None,
+        };
+        let discovery = discovery_with_exe(Path::new("/usr/bin/grok"));
+        let result = GROK_ADAPTER.collect(&ctx, &discovery).await;
+        let dbg = format!("{result:?}");
+        assert!(!dbg.contains("SYNTH_GROK_KEY_NOT_REAL"));
+        assert!(matches!(result, ProviderResult::NetworkError { .. }));
     }
 
     #[tokio::test]

--- a/src/providers/catalog.rs
+++ b/src/providers/catalog.rs
@@ -257,7 +257,7 @@ pub static GROK: ProviderDescriptor = ProviderDescriptor {
     cache_ttl: Duration::from_secs(90),
     timeout: Duration::from_secs(10),
     max_output_bytes: ONE_MIB,
-    retry_policy: RetryPolicy::None,
+    retry_policy: RetryPolicy::OneTransient,
 };
 
 /// Look up a descriptor by closed provider id.
@@ -435,7 +435,7 @@ mod tests {
         assert_eq!(GROK.icon_key, "grok");
         assert_eq!(GROK.login_argv, &["grok", "login"]);
         assert_eq!(GROK.installation_url, "https://x.ai/cli");
-        assert_eq!(GROK.retry_policy, RetryPolicy::None);
+        assert_eq!(GROK.retry_policy, RetryPolicy::OneTransient);
         assert_eq!(GROK.fallback_executable_paths[0].root, PathRoot::GrokHome);
     }
 

--- a/src/providers/codex_app_server.rs
+++ b/src/providers/codex_app_server.rs
@@ -210,7 +210,16 @@ where
 
     loop {
         tokio::select! {
-            _ = &mut hard => return AppServerOutcome::TimedOut,
+            _ = &mut hard => {
+                // Prefer already-parsed rate limits over classifying as timeout.
+                return match rate_limits.as_ref().and_then(|r| {
+                    let plan = account_plan.as_ref().and_then(|o| o.as_deref());
+                    normalize_to_rate_limits_json(r, plan)
+                }) {
+                    Some(bytes) => AppServerOutcome::Ok(bytes),
+                    None => AppServerOutcome::TimedOut,
+                };
+            }
             _ = &mut grace, if grace_armed => {
                 return match rate_limits.as_ref().and_then(|r| {
                     let plan = account_plan.as_ref().and_then(|o| o.as_deref());
@@ -230,7 +239,14 @@ where
                     Err(_) => continue,
                 };
                 match msg.id {
-                    Some(0) if msg.result.is_some() => {
+                    Some(0) => {
+                        // Initialize response: error or missing result → fail now.
+                        if msg.error.is_some() || msg.result.is_none() {
+                            log::debug!(
+                                "Codex app-server initialize returned error or no result"
+                            );
+                            return AppServerOutcome::Failed;
+                        }
                         if write_json_line(
                             &mut writer,
                             &serde_json::json!({"method": "initialized", "params": {}}),
@@ -511,5 +527,139 @@ mod tests {
         )
         .await;
         assert!(matches!(outcome, AppServerOutcome::TimedOut));
+    }
+
+    #[tokio::test]
+    async fn appserver_hard_timeout_returns_ok_when_rate_limits_already_parsed() {
+        let (client, server) = duplex(64 * 1024);
+        let (client_read, client_write) = tokio::io::split(client);
+
+        let server_task = tokio::spawn(async move {
+            let (read_half, mut write_half) = tokio::io::split(server);
+            let mut lines = BufReader::new(read_half).lines();
+            let _ = lines.next_line().await; // initialize
+            write_half
+                .write_all(br#"{"id":0,"result":{}}"#)
+                .await
+                .expect("init");
+            write_half.write_all(b"\n").await.expect("nl");
+
+            // Send rate limits (id=2) but never account/read (id=1), so the
+            // client arms grace and then hits hard timeout with limits held.
+            let mut saw_limits = false;
+            while !saw_limits {
+                let line = match lines.next_line().await {
+                    Ok(Some(l)) => l,
+                    _ => break,
+                };
+                if line.contains("account/rateLimits/read") {
+                    saw_limits = true;
+                    write_half
+                        .write_all(
+                            br#"{"id":2,"result":{"rateLimits":{"primary":{"usedPercent":12.5,"windowDurationMins":300,"resetsAt":1700000000}}}}"#,
+                        )
+                        .await
+                        .expect("limits");
+                    write_half.write_all(b"\n").await.expect("nl");
+                }
+                // Deliberately ignore account/read so account_plan stays None.
+            }
+            // Hold the stream open past hard timeout.
+            tokio::time::sleep(Duration::from_secs(2)).await;
+        });
+
+        let outcome = run_appserver_protocol_outcome(
+            client_read,
+            client_write,
+            "10.0.0",
+            Duration::from_millis(300),
+        )
+        .await;
+        match outcome {
+            AppServerOutcome::Ok(bytes) => {
+                let now = datetime!(2026-07-26 18:00:00 UTC);
+                match codex_from_rate_limits_json(&bytes, now) {
+                    ProviderResult::Ready { windows, .. } => {
+                        assert!(!windows.is_empty());
+                        assert!((windows[0].used_percent() - 12.5).abs() < 0.01);
+                    }
+                    other => panic!("normalize failed: {other:?}"),
+                }
+            }
+            other => panic!("expected Ok with parsed limits, got {other:?}"),
+        }
+        let _ = server_task.await;
+    }
+
+    #[tokio::test]
+    async fn appserver_initialize_error_returns_failed_immediately() {
+        let (client, server) = duplex(64 * 1024);
+        let (client_read, client_write) = tokio::io::split(client);
+
+        let server_task = tokio::spawn(async move {
+            let (read_half, mut write_half) = tokio::io::split(server);
+            let mut lines = BufReader::new(read_half).lines();
+            let _ = lines.next_line().await; // initialize
+            write_half
+                .write_all(br#"{"id":0,"error":{"code":-32000,"message":"init failed"}}"#)
+                .await
+                .expect("err");
+            write_half.write_all(b"\n").await.expect("nl");
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        });
+
+        let started = std::time::Instant::now();
+        let outcome = run_appserver_protocol_outcome(
+            client_read,
+            client_write,
+            "10.0.0",
+            Duration::from_secs(5),
+        )
+        .await;
+        let elapsed = started.elapsed();
+        assert!(
+            matches!(outcome, AppServerOutcome::Failed),
+            "expected Failed on id=0 error, got {outcome:?}"
+        );
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "must not wait hard timeout, elapsed={elapsed:?}"
+        );
+        let _ = server_task.await;
+    }
+
+    #[tokio::test]
+    async fn appserver_initialize_missing_result_returns_failed_immediately() {
+        let (client, server) = duplex(64 * 1024);
+        let (client_read, client_write) = tokio::io::split(client);
+
+        let server_task = tokio::spawn(async move {
+            let (read_half, mut write_half) = tokio::io::split(server);
+            let mut lines = BufReader::new(read_half).lines();
+            let _ = lines.next_line().await; // initialize
+                                             // id=0 with neither result nor error → treat as failed.
+            write_half.write_all(br#"{"id":0}"#).await.expect("empty");
+            write_half.write_all(b"\n").await.expect("nl");
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        });
+
+        let started = std::time::Instant::now();
+        let outcome = run_appserver_protocol_outcome(
+            client_read,
+            client_write,
+            "10.0.0",
+            Duration::from_secs(5),
+        )
+        .await;
+        let elapsed = started.elapsed();
+        assert!(
+            matches!(outcome, AppServerOutcome::Failed),
+            "expected Failed on id=0 without result, got {outcome:?}"
+        );
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "must not wait hard timeout, elapsed={elapsed:?}"
+        );
+        let _ = server_task.await;
     }
 }

--- a/src/providers/codex_app_server.rs
+++ b/src/providers/codex_app_server.rs
@@ -1,0 +1,515 @@
+//! Codex `app-server` JSON-RPC collection over bidirectional stdio.
+//!
+//! Spawns `codex app-server`, runs initialize → account/read →
+//! account/rateLimits/read, and normalizes the camelCase payload into JSON
+//! accepted by [`crate::providers::v2_map::codex_from_rate_limits_json`].
+
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::process::Stdio;
+use std::time::Duration;
+
+use serde::Deserialize;
+use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader};
+
+use crate::app_identity::APP_NAME;
+
+/// Result of one app-server attempt. Distinguishes timeout so the adapter can
+/// apply the catalog's single transient retry only on hard timeout.
+#[derive(Debug)]
+pub enum AppServerOutcome {
+    Ok(Vec<u8>),
+    TimedOut,
+    Failed,
+}
+
+// ---- App-server wire types (camelCase) ----
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CodexAppServerWindow {
+    used_percent: f64,
+    #[serde(default)]
+    window_duration_mins: Option<i64>,
+    #[serde(default)]
+    resets_at: Option<i64>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CodexAppServerLimitBucket {
+    #[serde(default)]
+    primary: Option<CodexAppServerWindow>,
+    #[serde(default)]
+    secondary: Option<CodexAppServerWindow>,
+    #[serde(default)]
+    plan_type: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CodexAppServerRateLimitsReadResult {
+    #[serde(default)]
+    rate_limits: Option<CodexAppServerLimitBucket>,
+    #[serde(default)]
+    rate_limits_by_limit_id: Option<BTreeMap<String, CodexAppServerLimitBucket>>,
+    #[serde(default)]
+    plan_type: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CodexAppServerAccount {
+    #[serde(default)]
+    plan_type: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+struct CodexAppServerAccountReadResult {
+    #[serde(default)]
+    account: Option<CodexAppServerAccount>,
+}
+
+#[derive(Deserialize)]
+struct AppServerResponse {
+    #[serde(default)]
+    id: Option<i64>,
+    #[serde(default)]
+    result: Option<serde_json::Value>,
+    #[serde(default)]
+    error: Option<serde_json::Value>,
+}
+
+// ---- Normalization → codex_from_rate_limits_json shape ----
+
+fn window_to_json(raw: &CodexAppServerWindow, fallback_minutes: i64) -> serde_json::Value {
+    serde_json::json!({
+        "usedPercent": raw.used_percent,
+        "windowDurationMins": raw.window_duration_mins.unwrap_or(fallback_minutes),
+        "resetsAt": raw.resets_at.unwrap_or(0),
+    })
+}
+
+/// Build JSON bytes with `primary` / `secondary` / `plan_type` for
+/// [`crate::providers::v2_map::codex_from_rate_limits_json`].
+fn normalize_to_rate_limits_json(
+    raw: &CodexAppServerRateLimitsReadResult,
+    account_plan_type: Option<&str>,
+) -> Option<Vec<u8>> {
+    let root = raw.rate_limits.as_ref();
+    let mut primary = root.and_then(|r| r.primary.as_ref());
+    let mut secondary = root.and_then(|r| r.secondary.as_ref());
+
+    if primary.is_none() && secondary.is_none() {
+        if let Some(by_id) = raw.rate_limits_by_limit_id.as_ref() {
+            for bucket in by_id.values() {
+                if primary.is_none() {
+                    primary = bucket.primary.as_ref();
+                }
+                if secondary.is_none() {
+                    secondary = bucket.secondary.as_ref();
+                }
+                if primary.is_some() || secondary.is_some() {
+                    break;
+                }
+            }
+        }
+    }
+
+    if primary.is_none() && secondary.is_none() {
+        return None;
+    }
+
+    let plan_type = account_plan_type
+        .map(str::to_string)
+        .or_else(|| raw.plan_type.clone())
+        .or_else(|| root.and_then(|r| r.plan_type.clone()));
+
+    let mut doc = serde_json::Map::new();
+    if let Some(p) = primary {
+        doc.insert("primary".into(), window_to_json(p, 300));
+    }
+    if let Some(s) = secondary {
+        doc.insert("secondary".into(), window_to_json(s, 10080));
+    }
+    if let Some(pt) = plan_type {
+        doc.insert("plan_type".into(), serde_json::Value::String(pt));
+    }
+    serde_json::to_vec(&serde_json::Value::Object(doc)).ok()
+}
+
+fn has_rate_limit_data(raw: &CodexAppServerRateLimitsReadResult) -> bool {
+    raw.rate_limits.is_some() || raw.rate_limits_by_limit_id.is_some()
+}
+
+async fn write_json_line<W: AsyncWrite + Unpin>(
+    w: &mut W,
+    v: &serde_json::Value,
+) -> std::io::Result<()> {
+    let mut s = serde_json::to_string(v)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    s.push('\n');
+    w.write_all(s.as_bytes()).await
+}
+
+/// Run the JSON-RPC handshake on generic streams. Returns normalized rate-limits
+/// JSON bytes, or `None` on timeout / EOF / protocol error.
+pub async fn run_appserver_protocol<R, W>(
+    reader: R,
+    writer: W,
+    version: &str,
+    timeout: Duration,
+) -> Option<Vec<u8>>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    match run_appserver_protocol_outcome(reader, writer, version, timeout).await {
+        AppServerOutcome::Ok(bytes) => Some(bytes),
+        AppServerOutcome::TimedOut | AppServerOutcome::Failed => None,
+    }
+}
+
+/// Same as [`run_appserver_protocol`] but preserves timeout vs hard failure.
+pub async fn run_appserver_protocol_outcome<R, W>(
+    reader: R,
+    mut writer: W,
+    version: &str,
+    timeout: Duration,
+) -> AppServerOutcome
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    let init = serde_json::json!({
+        "method": "initialize",
+        "id": 0,
+        "params": {
+            "clientInfo": {
+                "name": APP_NAME,
+                "title": APP_NAME,
+                "version": version
+            }
+        }
+    });
+    if write_json_line(&mut writer, &init).await.is_err() {
+        return AppServerOutcome::Failed;
+    }
+
+    let mut lines = BufReader::new(reader).lines();
+    // None = not yet; Some(None) = received without plan_type; Some(Some) = plan.
+    let mut account_plan: Option<Option<String>> = None;
+    let mut rate_limits: Option<CodexAppServerRateLimitsReadResult> = None;
+
+    let hard = tokio::time::sleep(timeout);
+    tokio::pin!(hard);
+    // Grace starts far enough that it cannot fire before armed.
+    let grace = tokio::time::sleep(timeout + Duration::from_secs(1));
+    tokio::pin!(grace);
+    let mut grace_armed = false;
+
+    loop {
+        tokio::select! {
+            _ = &mut hard => return AppServerOutcome::TimedOut,
+            _ = &mut grace, if grace_armed => {
+                return match rate_limits.as_ref().and_then(|r| {
+                    let plan = account_plan.as_ref().and_then(|o| o.as_deref());
+                    normalize_to_rate_limits_json(r, plan)
+                }) {
+                    Some(bytes) => AppServerOutcome::Ok(bytes),
+                    None => AppServerOutcome::Failed,
+                };
+            }
+            line = lines.next_line() => {
+                let line = match line {
+                    Ok(Some(l)) => l,
+                    Ok(None) | Err(_) => return AppServerOutcome::Failed,
+                };
+                let msg: AppServerResponse = match serde_json::from_str(&line) {
+                    Ok(m) => m,
+                    Err(_) => continue,
+                };
+                match msg.id {
+                    Some(0) if msg.result.is_some() => {
+                        if write_json_line(
+                            &mut writer,
+                            &serde_json::json!({"method": "initialized", "params": {}}),
+                        )
+                        .await
+                        .is_err()
+                        {
+                            return AppServerOutcome::Failed;
+                        }
+                        if write_json_line(
+                            &mut writer,
+                            &serde_json::json!({
+                                "method": "account/read",
+                                "id": 1,
+                                "params": {"refreshToken": false}
+                            }),
+                        )
+                        .await
+                        .is_err()
+                        {
+                            return AppServerOutcome::Failed;
+                        }
+                        if write_json_line(
+                            &mut writer,
+                            &serde_json::json!({
+                                "method": "account/rateLimits/read",
+                                "id": 2,
+                                "params": {}
+                            }),
+                        )
+                        .await
+                        .is_err()
+                        {
+                            return AppServerOutcome::Failed;
+                        }
+                    }
+                    Some(1) => {
+                        let plan = msg
+                            .result
+                            .as_ref()
+                            .and_then(|v| {
+                                serde_json::from_value::<CodexAppServerAccountReadResult>(
+                                    v.clone(),
+                                )
+                                .ok()
+                            })
+                            .and_then(|a| a.account)
+                            .and_then(|a| a.plan_type);
+                        account_plan = Some(plan);
+                        if let Some(r) = rate_limits.as_ref() {
+                            let plan_ref = account_plan.as_ref().and_then(|o| o.as_deref());
+                            return match normalize_to_rate_limits_json(r, plan_ref) {
+                                Some(bytes) => AppServerOutcome::Ok(bytes),
+                                None => AppServerOutcome::Failed,
+                            };
+                        }
+                    }
+                    Some(2) => {
+                        if msg.error.is_some() {
+                            // Immediate failure (e.g. auth); do not wait for hard timeout.
+                            log::debug!(
+                                "Codex app-server account/rateLimits/read returned error"
+                            );
+                            return AppServerOutcome::Failed;
+                        }
+                        let parsed = msg.result.as_ref().and_then(|v| {
+                            serde_json::from_value::<CodexAppServerRateLimitsReadResult>(
+                                v.clone(),
+                            )
+                            .ok()
+                        });
+                        if let Some(r) = parsed {
+                            if has_rate_limit_data(&r) {
+                                rate_limits = Some(r);
+                                if account_plan.is_some() {
+                                    if let Some(rr) = rate_limits.as_ref() {
+                                        let plan_ref = account_plan
+                                            .as_ref()
+                                            .and_then(|o| o.as_deref());
+                                        return match normalize_to_rate_limits_json(
+                                            rr, plan_ref,
+                                        ) {
+                                            Some(bytes) => AppServerOutcome::Ok(bytes),
+                                            None => AppServerOutcome::Failed,
+                                        };
+                                    }
+                                } else {
+                                    grace.as_mut().reset(
+                                        tokio::time::Instant::now()
+                                            + Duration::from_millis(200),
+                                    );
+                                    grace_armed = true;
+                                }
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+}
+
+/// Spawn `exe app-server` with piped stdio, run the protocol, kill the child.
+pub async fn fetch_rate_limits_via_appserver(
+    exe: &Path,
+    version: &str,
+    timeout: Duration,
+) -> AppServerOutcome {
+    let mut child = match tokio::process::Command::new(exe)
+        .arg("app-server")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .kill_on_drop(true)
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(_) => return AppServerOutcome::Failed,
+    };
+    let stdout = match child.stdout.take() {
+        Some(s) => s,
+        None => {
+            let _ = child.start_kill();
+            return AppServerOutcome::Failed;
+        }
+    };
+    let stdin = match child.stdin.take() {
+        Some(s) => s,
+        None => {
+            let _ = child.start_kill();
+            return AppServerOutcome::Failed;
+        }
+    };
+    let result = run_appserver_protocol_outcome(stdout, stdin, version, timeout).await;
+    let _ = child.start_kill();
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::providers::v2_map::codex_from_rate_limits_json;
+    use crate::status::schema::ProviderResult;
+    use time::macros::datetime;
+    use tokio::io::{duplex, AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+    async fn scripted_appserver_ok(server: tokio::io::DuplexStream) {
+        let (read_half, mut write_half) = tokio::io::split(server);
+        let mut lines = BufReader::new(read_half).lines();
+
+        // initialize
+        let init = lines.next_line().await.expect("init").expect("line");
+        assert!(init.contains("initialize"), "{init}");
+        write_half
+            .write_all(br#"{"id":0,"result":{"protocolVersion":1}}"#)
+            .await
+            .expect("write init result");
+        write_half.write_all(b"\n").await.expect("nl");
+
+        // initialized + account/read + rateLimits/read (order may vary across lines)
+        let mut saw_account = false;
+        let mut saw_limits = false;
+        while !(saw_account && saw_limits) {
+            let line = lines.next_line().await.expect("req").expect("line");
+            if line.contains("account/read") {
+                saw_account = true;
+                write_half
+                    .write_all(br#"{"id":1,"result":{"account":{"planType":"plus"}}}"#)
+                    .await
+                    .expect("account");
+                write_half.write_all(b"\n").await.expect("nl");
+            } else if line.contains("account/rateLimits/read") {
+                saw_limits = true;
+                write_half
+                    .write_all(
+                        br#"{"id":2,"result":{"rateLimits":{"primary":{"usedPercent":12.5,"windowDurationMins":300,"resetsAt":1700000000},"secondary":{"usedPercent":40.0,"windowDurationMins":10080,"resetsAt":1700000000}}}}"#,
+                    )
+                    .await
+                    .expect("limits");
+                write_half.write_all(b"\n").await.expect("nl");
+            }
+            // ignore "initialized" notification
+        }
+        // Keep the stream open briefly so the client can finish.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    #[tokio::test]
+    async fn appserver_protocol_reads_rate_limits() {
+        let (client, server) = duplex(64 * 1024);
+        let (client_read, client_write) = tokio::io::split(client);
+
+        let server_task = tokio::spawn(async move {
+            scripted_appserver_ok(server).await;
+        });
+
+        let out =
+            run_appserver_protocol(client_read, client_write, "10.0.0", Duration::from_secs(2))
+                .await
+                .expect("limits json");
+        let now = datetime!(2026-07-26 18:00:00 UTC);
+        match codex_from_rate_limits_json(&out, now) {
+            ProviderResult::Ready { windows, plan, .. } => {
+                assert!(!windows.is_empty());
+                assert_eq!(windows[0].id(), "session");
+                assert_eq!(windows[1].id(), "weekly");
+                assert_eq!(plan.as_ref().map(|p| p.id.as_str()), Some("plus"));
+            }
+            other => panic!("{other:?}"),
+        }
+        let _ = server_task.await;
+    }
+
+    #[tokio::test]
+    async fn appserver_protocol_id2_error_returns_none_quickly() {
+        let (client, server) = duplex(64 * 1024);
+        let (client_read, client_write) = tokio::io::split(client);
+
+        let server_task = tokio::spawn(async move {
+            let (read_half, mut write_half) = tokio::io::split(server);
+            let mut lines = BufReader::new(read_half).lines();
+            let _ = lines.next_line().await; // initialize
+            write_half
+                .write_all(br#"{"id":0,"result":{}}"#)
+                .await
+                .expect("init");
+            write_half.write_all(b"\n").await.expect("nl");
+
+            // Drain client follow-ups; respond id=2 with error immediately.
+            let mut saw_limits = false;
+            while !saw_limits {
+                let line = match lines.next_line().await {
+                    Ok(Some(l)) => l,
+                    _ => break,
+                };
+                if line.contains("account/read") {
+                    write_half
+                        .write_all(br#"{"id":1,"result":{"account":{}}}"#)
+                        .await
+                        .expect("account");
+                    write_half.write_all(b"\n").await.expect("nl");
+                } else if line.contains("account/rateLimits/read") {
+                    saw_limits = true;
+                    write_half
+                        .write_all(br#"{"id":2,"error":{"code":401,"message":"unauthorized"}}"#)
+                        .await
+                        .expect("err");
+                    write_half.write_all(b"\n").await.expect("nl");
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        });
+
+        let started = std::time::Instant::now();
+        let out =
+            run_appserver_protocol(client_read, client_write, "10.0.0", Duration::from_secs(5))
+                .await;
+        let elapsed = started.elapsed();
+        assert!(out.is_none(), "expected None on id=2 error");
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "must not wait hard timeout, elapsed={elapsed:?}"
+        );
+        let _ = server_task.await;
+    }
+
+    #[tokio::test]
+    async fn appserver_protocol_timeout_is_timed_out_outcome() {
+        let (client, _server) = duplex(64 * 1024);
+        let (client_read, client_write) = tokio::io::split(client);
+        // No server responses → hard timeout.
+        let outcome = run_appserver_protocol_outcome(
+            client_read,
+            client_write,
+            "10.0.0",
+            Duration::from_millis(80),
+        )
+        .await;
+        assert!(matches!(outcome, AppServerOutcome::TimedOut));
+    }
+}

--- a/src/providers/codex_session_log.rs
+++ b/src/providers/codex_session_log.rs
@@ -37,9 +37,13 @@ pub fn extract_rate_limits_from_jsonl(bytes: &[u8]) -> Option<Vec<u8>> {
     None
 }
 
+/// Per-file read cap for session JSONL candidates (1 MiB).
+const MAX_SESSION_JSONL_BYTES: u64 = 1024 * 1024;
+
 /// Bounded walk of `sessions_dir`: no symlinks, depth ≤ 8, visits ≤ 4096,
-/// candidates ≤ 256 jsonl files. Sort mtime desc then path asc; scan each
-/// candidate reverse for token_count; return first hit's rate_limits JSON.
+/// candidates ≤ 256 jsonl files, each file ≤ 1 MiB. Sort mtime desc then path
+/// asc; scan each candidate reverse for token_count; return first hit's
+/// rate_limits JSON.
 pub fn find_latest_rate_limits(sessions_dir: &Path) -> Option<Vec<u8>> {
     use std::cmp::Ordering;
     use std::fs;
@@ -93,8 +97,14 @@ pub fn find_latest_rate_limits(sessions_dir: &Path) -> Option<Vec<u8>> {
     candidates.truncate(256);
 
     // Prefer newest candidate that yields extractable limits (not merely
-    // newest file without limits).
+    // newest file without limits). Skip files larger than 1 MiB.
     for (_mtime, path) in &candidates {
+        let Ok(meta) = fs::metadata(path) else {
+            continue;
+        };
+        if meta.len() > MAX_SESSION_JSONL_BYTES {
+            continue;
+        }
         let Ok(bytes) = fs::read(path) else {
             continue;
         };
@@ -185,6 +195,52 @@ mod tests {
         std::fs::write(sessions.join("good.jsonl"), fixture).expect("write good");
 
         let raw = find_latest_rate_limits(&sessions).expect("skip empty, use good");
+        let now = datetime!(2026-07-26 18:00:00 UTC);
+        match codex_from_rate_limits_json(&raw, now) {
+            ProviderResult::Ready { windows, .. } => {
+                assert_eq!(windows[0].id(), "weekly");
+                assert!((windows[0].used_percent() - 12.5).abs() < 0.01);
+            }
+            other => panic!("{other:?}"),
+        }
+    }
+
+    #[test]
+    fn find_latest_skips_files_over_1_mib_in_favor_of_smaller_valid() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sessions = dir.path().join("sessions");
+        std::fs::create_dir_all(&sessions).expect("mkdir");
+
+        // Oversized candidate sorts first by path ("a-huge.jsonl" < "z-good.jsonl")
+        // when mtimes match; must be skipped due to 1 MiB cap.
+        let huge_path = sessions.join("a-huge.jsonl");
+        {
+            use std::io::Write;
+            let mut f = std::fs::File::create(&huge_path).expect("create huge");
+            // Write just over 1 MiB of JSONL-shaped content with a fake rate_limits
+            // so a size-blind reader would succeed — size cap must prevent that.
+            let line = concat!(
+                r#"{"payload":{"type":"token_count","rate_limits":{"primary":{"used_percent":1.0,"window_minutes":10080}}}}"#,
+                "\n"
+            );
+            let mut written = 0usize;
+            let target = (MAX_SESSION_JSONL_BYTES as usize) + 1;
+            while written < target {
+                f.write_all(line.as_bytes()).expect("write chunk");
+                written += line.len();
+            }
+            f.flush().expect("flush");
+        }
+        assert!(
+            std::fs::metadata(&huge_path).expect("meta").len() > MAX_SESSION_JSONL_BYTES,
+            "fixture must exceed 1 MiB"
+        );
+
+        let fixture =
+            include_bytes!("../../tests/fixtures/providers/codex/session-token-count.jsonl");
+        std::fs::write(sessions.join("z-good.jsonl"), fixture).expect("write good");
+
+        let raw = find_latest_rate_limits(&sessions).expect("skip huge, use good");
         let now = datetime!(2026-07-26 18:00:00 UTC);
         match codex_from_rate_limits_json(&raw, now) {
             ProviderResult::Ready { windows, .. } => {

--- a/src/providers/codex_session_log.rs
+++ b/src/providers/codex_session_log.rs
@@ -1,0 +1,197 @@
+//! Bounded Codex session-log extraction for rate limits fallback.
+//!
+//! Scans `.codex/sessions/**/*.jsonl` for the latest `token_count` event that
+//! carries a `rate_limits` object, then re-serializes that object for
+//! [`crate::providers::v2_map::codex_from_rate_limits_json`].
+
+use std::path::Path;
+
+/// Reverse-scan JSONL bytes; first `payload.type == "token_count"` with a
+/// `payload.rate_limits` object wins. Returns re-serialized rate_limits JSON.
+pub fn extract_rate_limits_from_jsonl(bytes: &[u8]) -> Option<Vec<u8>> {
+    let text = std::str::from_utf8(bytes).ok()?;
+    for line in text.lines().rev() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let value: serde_json::Value = match serde_json::from_str(line) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        let Some(payload) = value.get("payload") else {
+            continue;
+        };
+        let payload_type = payload.get("type").and_then(|v| v.as_str());
+        if payload_type != Some("token_count") {
+            continue;
+        }
+        let Some(rate_limits) = payload.get("rate_limits") else {
+            continue;
+        };
+        if !rate_limits.is_object() {
+            continue;
+        }
+        return serde_json::to_vec(rate_limits).ok();
+    }
+    None
+}
+
+/// Bounded walk of `sessions_dir`: no symlinks, depth ≤ 8, visits ≤ 4096,
+/// candidates ≤ 256 jsonl files. Sort mtime desc then path asc; scan each
+/// candidate reverse for token_count; return first hit's rate_limits JSON.
+pub fn find_latest_rate_limits(sessions_dir: &Path) -> Option<Vec<u8>> {
+    use std::cmp::Ordering;
+    use std::fs;
+
+    if !sessions_dir.is_dir() {
+        return None;
+    }
+
+    let mut candidates: Vec<(std::time::SystemTime, std::path::PathBuf)> = Vec::new();
+    let mut stack = vec![(sessions_dir.to_path_buf(), 0u32)];
+    let mut visits = 0u32;
+
+    while let Some((dir, depth)) = stack.pop() {
+        if visits >= 4096 || depth > 8 {
+            continue;
+        }
+        visits += 1;
+        let Ok(entries) = fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            visits += 1;
+            if visits >= 4096 {
+                break;
+            }
+            let path = entry.path();
+            let Ok(meta) = entry.metadata() else {
+                continue;
+            };
+            if meta.file_type().is_symlink() {
+                continue;
+            }
+            if meta.is_dir() && depth < 8 {
+                stack.push((path, depth + 1));
+            } else if meta.is_file()
+                && path
+                    .extension()
+                    .and_then(|s| s.to_str())
+                    .is_some_and(|ext| ext.eq_ignore_ascii_case("jsonl"))
+            {
+                let mtime = meta.modified().unwrap_or(std::time::UNIX_EPOCH);
+                candidates.push((mtime, path));
+            }
+        }
+    }
+
+    candidates.sort_by(|a, b| match b.0.cmp(&a.0) {
+        Ordering::Equal => a.1.as_os_str().cmp(b.1.as_os_str()),
+        other => other,
+    });
+    candidates.truncate(256);
+
+    // Prefer newest candidate that yields extractable limits (not merely
+    // newest file without limits).
+    for (_mtime, path) in &candidates {
+        let Ok(bytes) = fs::read(path) else {
+            continue;
+        };
+        if let Some(raw) = extract_rate_limits_from_jsonl(&bytes) {
+            return Some(raw);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::providers::v2_map::codex_from_rate_limits_json;
+    use crate::status::schema::ProviderResult;
+    use time::macros::datetime;
+
+    #[test]
+    fn extract_token_count_rate_limits_from_jsonl() {
+        let bytes =
+            include_bytes!("../../tests/fixtures/providers/codex/session-token-count.jsonl");
+        let raw = extract_rate_limits_from_jsonl(bytes).expect("limits");
+        let now = datetime!(2026-07-26 18:00:00 UTC);
+        match codex_from_rate_limits_json(&raw, now) {
+            ProviderResult::Ready { windows, .. } => {
+                assert_eq!(windows[0].id(), "weekly");
+                assert!((windows[0].used_percent() - 12.5).abs() < 0.01);
+            }
+            other => panic!("{other:?}"),
+        }
+    }
+
+    #[test]
+    fn find_latest_rate_limits_from_temp_sessions_tree() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sessions = dir.path().join("sessions");
+        let nested = sessions.join("2026/07/25");
+        std::fs::create_dir_all(&nested).expect("mkdir");
+        let fixture =
+            include_bytes!("../../tests/fixtures/providers/codex/session-token-count.jsonl");
+        std::fs::write(nested.join("rollout.jsonl"), fixture).expect("write");
+
+        let raw = find_latest_rate_limits(&sessions).expect("limits from walk");
+        let now = datetime!(2026-07-26 18:00:00 UTC);
+        match codex_from_rate_limits_json(&raw, now) {
+            ProviderResult::Ready { windows, .. } => {
+                assert_eq!(windows[0].id(), "weekly");
+                assert!((windows[0].used_percent() - 12.5).abs() < 0.01);
+            }
+            other => panic!("{other:?}"),
+        }
+    }
+
+    #[test]
+    fn extract_skips_non_token_count_and_prefers_last_match() {
+        let jsonl = concat!(
+            r#"{"payload":{"type":"token_count","rate_limits":{"primary":{"used_percent":1.0,"window_minutes":10080}}}}"#,
+            "\n",
+            r#"{"payload":{"type":"message"}}"#,
+            "\n",
+            r#"{"payload":{"type":"token_count","rate_limits":{"primary":{"used_percent":99.0,"window_minutes":10080}}}}"#,
+            "\n",
+        );
+        let raw = extract_rate_limits_from_jsonl(jsonl.as_bytes()).expect("limits");
+        let now = datetime!(2026-07-26 18:00:00 UTC);
+        match codex_from_rate_limits_json(&raw, now) {
+            ProviderResult::Ready { windows, .. } => {
+                // Reverse scan → last token_count line wins.
+                assert!((windows[0].used_percent() - 99.0).abs() < 0.01);
+            }
+            other => panic!("{other:?}"),
+        }
+    }
+
+    #[test]
+    fn find_latest_skips_jsonl_without_rate_limits() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sessions = dir.path().join("sessions");
+        std::fs::create_dir_all(&sessions).expect("mkdir");
+        // File without usable limits (sorts first by path when mtimes match).
+        std::fs::write(
+            sessions.join("empty.jsonl"),
+            b"{\"payload\":{\"type\":\"message\"}}\n",
+        )
+        .expect("write empty");
+        let fixture =
+            include_bytes!("../../tests/fixtures/providers/codex/session-token-count.jsonl");
+        std::fs::write(sessions.join("good.jsonl"), fixture).expect("write good");
+
+        let raw = find_latest_rate_limits(&sessions).expect("skip empty, use good");
+        let now = datetime!(2026-07-26 18:00:00 UTC);
+        match codex_from_rate_limits_json(&raw, now) {
+            ProviderResult::Ready { windows, .. } => {
+                assert_eq!(windows[0].id(), "weekly");
+                assert!((windows[0].used_percent() - 12.5).abs() < 0.01);
+            }
+            other => panic!("{other:?}"),
+        }
+    }
+}

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -3,6 +3,7 @@
 pub mod adapter;
 pub mod adapters;
 pub mod catalog;
+pub mod codex_app_server;
 pub mod codex_session_log;
 pub mod http;
 pub mod process;

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -15,7 +15,7 @@ pub use adapter::{
 };
 pub use adapters::{
     AmpAdapter, ClaudeAdapter, CodexAdapter, GrokAdapter, AMP_ADAPTER, CLAUDE_ADAPTER,
-    CLAUDE_USAGE_URL, CODEX_ADAPTER, GROK_ADAPTER,
+    CLAUDE_USAGE_URL, CODEX_ADAPTER, GROK_ADAPTER, GROK_BILLING_URL,
 };
 pub use catalog::{
     descriptor, discover, login_process_argv, CatalogError, CollectionAvailability, Discovery,

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -3,6 +3,7 @@
 pub mod adapter;
 pub mod adapters;
 pub mod catalog;
+pub mod codex_session_log;
 pub mod http;
 pub mod process;
 pub mod v2_map;

--- a/src/providers/v2_map.rs
+++ b/src/providers/v2_map.rs
@@ -766,7 +766,8 @@ mod tests {
 
     #[test]
     fn grok_billing_accepts_cli_config_envelope() {
-        let body = include_bytes!("../../tests/fixtures/providers/grok/billing-weekly-wrapped.json");
+        let body =
+            include_bytes!("../../tests/fixtures/providers/grok/billing-weekly-wrapped.json");
         let now = datetime!(2026-07-27 12:00:00 UTC);
         let result = grok_from_billing_json(body, None, now, true);
         assert_no_money(&result);

--- a/src/providers/v2_map.rs
+++ b/src/providers/v2_map.rs
@@ -202,8 +202,8 @@ fn grok_billing_resets_at(doc: &GrokBillingDoc) -> Option<OffsetDateTime> {
 
 /// Build Grok result from auth flag + optional signals JSON bytes.
 ///
-/// Kept until Task 5 rewires the adapter to billing HTTP. Product window is
-/// weekly via [`grok_from_billing_json`]; do not treat context as primary.
+/// Legacy helper retained for unauthenticated/auth fixtures. Product collect
+/// uses [`grok_from_billing_json`] (weekly only); do not treat context as primary.
 pub fn grok_from_auth_and_signals(
     logged_in: bool,
     account_label: Option<String>,

--- a/src/providers/v2_map.rs
+++ b/src/providers/v2_map.rs
@@ -100,7 +100,110 @@ struct GrokSignals {
     context_window_tokens: Option<u64>,
 }
 
+#[derive(Debug, Deserialize, Default)]
+struct GrokBillingDoc {
+    #[serde(default, rename = "creditUsagePercent")]
+    credit_usage_percent: Option<f64>,
+    #[serde(default, rename = "currentPeriod")]
+    current_period: Option<GrokPeriodRaw>,
+    #[serde(default, rename = "billingPeriodEnd")]
+    billing_period_end: Option<String>,
+    #[serde(default, rename = "subscriptionTiers")]
+    subscription_tiers: Option<String>,
+    /// Discarded monetary fields.
+    #[serde(default, rename = "prepaidBalance")]
+    prepaid_balance: Option<Value>,
+    #[serde(default, rename = "onDemandCap")]
+    on_demand_cap: Option<Value>,
+    #[serde(default, rename = "onDemandUsed")]
+    on_demand_used: Option<Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GrokPeriodRaw {
+    #[serde(default)]
+    end: Option<String>,
+}
+
+/// Parse Grok billing JSON into a single weekly percentage window.
+///
+/// - `creditUsagePercent` → used; remaining = 100 − used
+/// - `currentPeriod.end` or `billingPeriodEnd` → resetsAt
+/// - money-like fields discarded; never emits a `context` window
+/// - missing/invalid percent → Ready with empty windows
+pub fn grok_from_billing_json(
+    bytes: &[u8],
+    account_label: Option<String>,
+    now: OffsetDateTime,
+    _login_available: bool,
+) -> ProviderResult {
+    let doc: GrokBillingDoc = match serde_json::from_slice(bytes) {
+        Ok(doc) => doc,
+        Err(_) => {
+            return ProviderResult::ProviderError {
+                id: ProviderId::Grok,
+                name: GROK.display_name.to_owned(),
+                message: "Grok returned an invalid billing payload.".into(),
+                retryable: false,
+            };
+        }
+    };
+
+    // prepaid_balance / on_demand_* are deserialized only to document discard.
+    let _ = (
+        &doc.prepaid_balance,
+        &doc.on_demand_cap,
+        &doc.on_demand_used,
+    );
+
+    let mut windows = Vec::new();
+    if let Some(used_raw) = doc.credit_usage_percent {
+        if used_raw.is_finite() {
+            let used = used_raw.clamp(0.0, 100.0);
+            let remaining = (100.0 - used).clamp(0.0, 100.0);
+            let resets = grok_billing_resets_at(&doc);
+            if let Ok(w) = UsageWindow::try_new("weekly", "Weekly", used, remaining, resets) {
+                windows.push(w);
+            }
+        }
+    }
+
+    let plan = doc
+        .subscription_tiers
+        .filter(|s| !s.is_empty())
+        .map(|id| Plan {
+            label: id.clone(),
+            id,
+        });
+
+    ProviderResult::Ready {
+        id: ProviderId::Grok,
+        name: GROK.display_name.to_owned(),
+        source: DataSource::Live,
+        plan,
+        account: account_label.map(|label| Account {
+            label: sanitize_account_label(&label),
+        }),
+        windows,
+        last_success_at: now,
+    }
+}
+
+fn grok_billing_resets_at(doc: &GrokBillingDoc) -> Option<OffsetDateTime> {
+    let end = doc
+        .current_period
+        .as_ref()
+        .and_then(|p| p.end.as_deref())
+        .or(doc.billing_period_end.as_deref())?;
+    OffsetDateTime::parse(end, &Rfc3339)
+        .ok()
+        .map(|ts| ts.to_offset(UtcOffset::UTC))
+}
+
 /// Build Grok result from auth flag + optional signals JSON bytes.
+///
+/// Kept until Task 5 rewires the adapter to billing HTTP. Product window is
+/// weekly via [`grok_from_billing_json`]; do not treat context as primary.
 pub fn grok_from_auth_and_signals(
     logged_in: bool,
     account_label: Option<String>,
@@ -619,20 +722,30 @@ mod tests {
     }
 
     #[test]
-    fn grok_signals_context_window() {
-        let signals = include_bytes!("../../tests/fixtures/grok/signals-recent.json");
-        let result = grok_from_auth_and_signals(
-            true,
-            Some("user".into()),
-            Some(signals.as_slice()),
-            datetime!(2026-07-26 18:00:00 UTC),
-            true,
-        );
-        assert_no_money(&result);
-        match result {
+    fn grok_billing_weekly_window_discards_money() {
+        let body = include_bytes!("../../tests/fixtures/providers/grok/billing-weekly.json");
+        let now = datetime!(2026-07-27 12:00:00 UTC);
+        match grok_from_billing_json(body, Some("Ada".into()), now, true) {
+            ProviderResult::Ready { windows, plan, .. } => {
+                assert_eq!(windows.len(), 1);
+                assert_eq!(windows[0].id(), "weekly");
+                assert_eq!(windows[0].label(), "Weekly");
+                assert!((windows[0].used_percent() - 33.0).abs() < 0.01);
+                assert!((windows[0].remaining_percent() - 67.0).abs() < 0.01);
+                assert!(windows[0].resets_at().is_some());
+                assert_eq!(plan.as_ref().map(|p| p.label.as_str()), Some("SuperGrok"));
+            }
+            other => panic!("{other:?}"),
+        }
+    }
+
+    #[test]
+    fn grok_billing_ready_never_emits_context() {
+        let body = include_bytes!("../../tests/fixtures/providers/grok/billing-weekly.json");
+        let now = datetime!(2026-07-27 12:00:00 UTC);
+        match grok_from_billing_json(body, None, now, true) {
             ProviderResult::Ready { windows, .. } => {
-                assert_eq!(windows[0].id(), "context");
-                assert!((windows[0].used_percent() - 10.0).abs() < 0.01);
+                assert!(windows.iter().all(|w| w.id() != "context"));
             }
             other => panic!("{other:?}"),
         }

--- a/src/providers/v2_map.rs
+++ b/src/providers/v2_map.rs
@@ -137,7 +137,8 @@ pub fn grok_from_billing_json(
     now: OffsetDateTime,
     _login_available: bool,
 ) -> ProviderResult {
-    let doc: GrokBillingDoc = match serde_json::from_slice(bytes) {
+    // Live CLI proxy wraps fields in `{ "config": { ... } }`; fixtures may be flat.
+    let doc: GrokBillingDoc = match parse_grok_billing_doc(bytes) {
         Ok(doc) => doc,
         Err(_) => {
             return ProviderResult::ProviderError {
@@ -187,6 +188,18 @@ pub fn grok_from_billing_json(
         windows,
         last_success_at: now,
     }
+}
+
+fn parse_grok_billing_doc(bytes: &[u8]) -> Result<GrokBillingDoc, serde_json::Error> {
+    let value: Value = serde_json::from_slice(bytes)?;
+    let payload = match &value {
+        Value::Object(map) => match map.get("config") {
+            Some(cfg) if cfg.is_object() => cfg.clone(),
+            _ => value,
+        },
+        _ => value,
+    };
+    serde_json::from_value(payload)
 }
 
 fn grok_billing_resets_at(doc: &GrokBillingDoc) -> Option<OffsetDateTime> {
@@ -746,6 +759,24 @@ mod tests {
         match grok_from_billing_json(body, None, now, true) {
             ProviderResult::Ready { windows, .. } => {
                 assert!(windows.iter().all(|w| w.id() != "context"));
+            }
+            other => panic!("{other:?}"),
+        }
+    }
+
+    #[test]
+    fn grok_billing_accepts_cli_config_envelope() {
+        let body = include_bytes!("../../tests/fixtures/providers/grok/billing-weekly-wrapped.json");
+        let now = datetime!(2026-07-27 12:00:00 UTC);
+        let result = grok_from_billing_json(body, None, now, true);
+        assert_no_money(&result);
+        match result {
+            ProviderResult::Ready { windows, .. } => {
+                assert_eq!(windows.len(), 1);
+                assert_eq!(windows[0].id(), "weekly");
+                assert!((windows[0].used_percent() - 96.0).abs() < 0.01);
+                assert!((windows[0].remaining_percent() - 4.0).abs() < 0.01);
+                assert!(windows[0].resets_at().is_some());
             }
             other => panic!("{other:?}"),
         }

--- a/src/providers/v2_map.rs
+++ b/src/providers/v2_map.rs
@@ -176,6 +176,9 @@ struct CodexRateLimitsDoc {
 }
 
 /// Parse Codex rate-limit JSON. Credits are discarded.
+///
+/// Window IDs/labels come from `window_minutes` duration, not primary/secondary
+/// slot order. Primary with 10080 minutes is weekly; 300 is session.
 pub fn codex_from_rate_limits_json(bytes: &[u8], now: OffsetDateTime) -> ProviderResult {
     let doc: CodexRateLimitsDoc = match serde_json::from_slice(bytes) {
         Ok(doc) => doc,
@@ -190,30 +193,15 @@ pub fn codex_from_rate_limits_json(bytes: &[u8], now: OffsetDateTime) -> Provide
     };
 
     let mut windows = Vec::new();
-    if let Some(primary) = doc.primary.as_ref() {
-        if let Some(w) = codex_window("session", "Session", primary) {
-            windows.push(w);
-        }
-    }
-    if let Some(secondary) = doc.secondary.as_ref() {
-        let (id, label) = if secondary.window_minutes == Some(10080) {
-            ("weekly", "Weekly")
-        } else if secondary.window_minutes.is_some() {
-            ("other", "Other")
-        } else {
-            ("weekly", "Weekly")
+    for (ordinal, raw) in [
+        (1usize, doc.primary.as_ref()),
+        (2usize, doc.secondary.as_ref()),
+    ] {
+        let Some(raw) = raw else {
+            continue;
         };
-        let id = if id == "other" {
-            format!("other:{}:1", secondary.window_minutes.unwrap_or(0))
-        } else {
-            id.to_owned()
-        };
-        let label = if id.starts_with("other:") {
-            format!("{}m", secondary.window_minutes.unwrap_or(0))
-        } else {
-            label.to_owned()
-        };
-        if let Some(w) = codex_window(&id, &label, secondary) {
+        let (id, label) = codex_window_identity(raw.window_minutes, ordinal);
+        if let Some(w) = codex_window(&id, &label, raw) {
             windows.push(w);
         }
     }
@@ -230,6 +218,26 @@ pub fn codex_from_rate_limits_json(bytes: &[u8], now: OffsetDateTime) -> Provide
         account: None,
         windows,
         last_success_at: now,
+    }
+}
+
+/// Map a Codex rate-limit duration to window id and display label.
+///
+/// Known durations: 300 → session, 10080 → weekly. Other positive minutes use
+/// `other:{n}:{ordinal}`. Missing duration falls back by slot ordinal (primary
+/// → session, secondary → weekly) for incomplete payloads.
+fn codex_window_identity(window_minutes: Option<i64>, ordinal: usize) -> (String, String) {
+    match window_minutes {
+        Some(10080) => ("weekly".into(), "Weekly".into()),
+        Some(300) => ("session".into(), "Session".into()),
+        Some(n) if n > 0 => (format!("other:{n}:{ordinal}"), format!("{n}m")),
+        _ => {
+            if ordinal == 1 {
+                ("session".into(), "Session".into())
+            } else {
+                ("weekly".into(), "Weekly".into())
+            }
+        }
     }
 }
 
@@ -568,6 +576,45 @@ mod tests {
                 assert!((windows[0].used_percent() - 30.0).abs() < 0.01);
             }
             other => panic!("{other:?}"),
+        }
+    }
+
+    #[test]
+    fn codex_primary_only_weekly_is_labeled_weekly() {
+        let body = br#"{
+      "primary": {"used_percent": 1.0, "window_minutes": 10080, "resets_at": 1785628013},
+      "plan_type": "plus"
+    }"#;
+        let now = datetime!(2026-07-26 18:00:00 UTC);
+        let result = codex_from_rate_limits_json(body, now);
+        match result {
+            ProviderResult::Ready { windows, plan, .. } => {
+                assert_eq!(windows.len(), 1);
+                assert_eq!(windows[0].id(), "weekly");
+                assert_eq!(windows[0].label(), "Weekly");
+                assert!((windows[0].used_percent() - 1.0).abs() < 0.01);
+                assert!(plan.is_some());
+            }
+            other => panic!("expected ready, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn codex_dual_windows_map_session_and_weekly_by_duration() {
+        let body = include_bytes!("../../tests/fixtures/providers/codex/rate-limits-ready.json");
+        let result = codex_from_rate_limits_json(body, datetime!(2026-07-26 18:00:00 UTC));
+        assert_no_money(&result);
+        match result {
+            ProviderResult::Ready { windows, .. } => {
+                assert_eq!(windows.len(), 2);
+                assert_eq!(windows[0].id(), "session");
+                assert_eq!(windows[0].label(), "Session");
+                assert!((windows[0].used_percent() - 30.0).abs() < 0.01);
+                assert_eq!(windows[1].id(), "weekly");
+                assert_eq!(windows[1].label(), "Weekly");
+                assert!((windows[1].used_percent() - 40.0).abs() < 0.01);
+            }
+            other => panic!("expected ready, got {other:?}"),
         }
     }
 

--- a/tests/fixtures/providers/codex/session-token-count.jsonl
+++ b/tests/fixtures/providers/codex/session-token-count.jsonl
@@ -1,0 +1,2 @@
+{"timestamp":"2026-07-25T23:00:00.000Z","type":"event","payload":{"type":"message"}}
+{"timestamp":"2026-07-25T23:01:00.000Z","type":"event","payload":{"type":"token_count","rate_limits":{"primary":{"used_percent":12.5,"window_minutes":10080,"resets_at":1785628013},"plan_type":"plus"}}}

--- a/tests/fixtures/providers/grok/billing-weekly-wrapped.json
+++ b/tests/fixtures/providers/grok/billing-weekly-wrapped.json
@@ -1,0 +1,16 @@
+{
+  "config": {
+    "creditUsagePercent": 96.0,
+    "currentPeriod": {
+      "type": "USAGE_PERIOD_TYPE_WEEKLY",
+      "start": "2026-07-24T21:10:59.543182+00:00",
+      "end": "2026-07-31T21:10:59.543182+00:00"
+    },
+    "billingPeriodStart": "2026-07-24T21:10:59.543182+00:00",
+    "billingPeriodEnd": "2026-07-31T21:10:59.543182+00:00",
+    "prepaidBalance": { "val": 0 },
+    "onDemandCap": { "val": 0 },
+    "onDemandUsed": { "val": 0 },
+    "isUnifiedBillingUser": true
+  }
+}

--- a/tests/fixtures/providers/grok/billing-weekly.json
+++ b/tests/fixtures/providers/grok/billing-weekly.json
@@ -1,0 +1,15 @@
+{
+  "creditUsagePercent": 33.0,
+  "currentPeriod": {
+    "type": "USAGE_PERIOD_TYPE_WEEKLY",
+    "start": "2026-07-24T21:10:59.543182+00:00",
+    "end": "2026-07-31T21:10:59.543182+00:00"
+  },
+  "billingPeriodStart": "2026-07-24T21:10:59.543182+00:00",
+  "billingPeriodEnd": "2026-07-31T21:10:59.543182+00:00",
+  "prepaidBalance": { "val": 99 },
+  "onDemandCap": { "val": 0 },
+  "onDemandUsed": { "val": 0 },
+  "isUnifiedBillingUser": true,
+  "subscriptionTiers": "SuperGrok"
+}


### PR DESCRIPTION
## Summary

- Restore full Codex collection (app-server JSON-RPC, session-log fallback, duration-based Session/Weekly labels) so Retry works when the CLI is logged in instead of looping on a stub that only read a missing `rate-limits.json`.
- Switch Grok from session Context to SuperGrok weekly usage via the CLI billing HTTPS path (`/billing?format=credits`), including the live `{config:…}` envelope, with period-end reset and no monetary fields.
- Align v10 architecture, runtime, troubleshooting, and catalog retry policy with the new sources.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo test --lib` (219 passed)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] Live smoke: `agent-bar status provider codex|grok format human cache bypass` shows Weekly ready with % and reset data
- [ ] Optional: install debug helper into the plugin and confirm bar chips + Retry after `omarchy plugin rescan`
- [ ] Note: `binary_interactive_update_rejects_non_tty` still fails on master (exit 5 vs 3); unrelated to this branch