### PR TITLE
fix: Claude monitoring and UI overhaul (v11 p1-2)

### DIFF
--- a/docs/superpowers/plans/2026-07-28-fase1-claude-completo.md
+++ b/docs/superpowers/plans/2026-07-28-fase1-claude-completo.md
@@ -1,0 +1,1204 @@
+# Fase 1 — Claude Completo — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restaurar o monitoramento das janelas 5h/semanal do Claude ponta a ponta: header de auth correto, buckets completos, IDs sem colisão, resets tolerantes, retry compartilhado, expiry acionável e tier real.
+
+**Architecture:** Toda a Fase 1 vive no helper Rust (`src/providers/`, `src/status/`). O adapter Claude (`adapters.rs`) coleta via HTTP OAuth; `v2_map.rs` faz o parse puro para `ProviderResult`; `collect.rs` mapeia para `ProviderStatus`; o coordinator aplica cache/retenção. Zero mudança de QML nesta fase — a UI já renderiza `windows`/`resetsAt` corretamente quando o dado chega.
+
+**Tech Stack:** Rust (tokio, serde, time, reqwest via seam injetável), testes com fakes (`ScriptedHttpClient`, `MapFileSystem`, `FixedClock`).
+
+## Global Constraints
+
+- Rust/Cargo e QML apenas. Sem Node/npm/Bun/etc.
+- Proibido `unwrap()`/`expect()` em código de produção (clippy deny já ativo no crate; escreva `match`/`?`/`is_some_and`).
+- Stdout do status é exatamente um objeto JSON schema-v2 + newline; logs vão para stderr.
+- Falha operacional de provider é dado tipado (`ProviderResult`), nunca falha de processo.
+- Token/credencial NUNCA entra em `ProviderResult`, logs, mensagens de erro ou asserts de Debug (asserts devem provar a AUSÊNCIA do token).
+- Testes usam fakes; zero rede viva, zero credencial real.
+- Não mutar paths vivos do Omarchy/Hyprland fora do gate final autorizado (Task 10 para e pergunta).
+- Commits: Conventional Commit com subject em INGLÊS, ≤50 caracteres.
+- Gate de cada checkpoint: `cargo fmt --check && cargo test && cargo clippy --all-targets -- -D warnings && git diff --check`.
+- Branch de trabalho: `claude-ajustes`.
+- Read cada arquivo antes de Edit; se Edit falhar com "string not found", re-Read antes de re-tentar.
+
+## File Structure
+
+- `src/providers/adapters.rs` — adapters concretos; Claude em ~330-470, testes em ~506-919. Tasks 1, 5, 7.
+- `src/providers/v2_map.rs` — parsers puros; Claude em ~374-598, testes em ~616-794. Tasks 2, 3, 4, 8, 9.
+- `src/providers/retry.rs` — NOVO: helper de retry transiente compartilhado. Task 5.
+- `src/providers/mod.rs` — declara o novo módulo. Task 5.
+- `src/providers/adapter.rs` — helper `unauthenticated()` (linha ~211). Task 6.
+- `src/status/schema.rs` — variante `ProviderResult::Unauthenticated` (~948) e `is_temporary_failure` (~449). Task 6.
+- `src/status/collect.rs` — mapeamento `ProviderResult` → `ProviderStatus` (~48-66). Task 6.
+- `src/status/coordinator.rs` — testes de retenção stale (~527-558). Task 6 (só teste novo).
+
+---
+
+### Task 1: Header `Bearer` no Claude
+
+O adapter Claude envia o token OAuth cru no header `Authorization` (`adapters.rs:382`); a API responde 401 e o provider aparece "unauthenticated" com credencial válida. O Grok já faz certo (`adapters.rs:155`: `let bearer = format!("Bearer {token}");`).
+
+**Files:**
+- Modify: `src/providers/adapters.rs` (Claude collect ~linha 380-384; teste `claude_http_exact_url_and_redacts_auth_from_domain` ~linha 634)
+
+**Interfaces:**
+- Consumes: `ScriptedHttpClient.last_headers` (já existe, `providers/http.rs:80`).
+- Produces: nada novo — corrige comportamento.
+
+- [ ] **Step 1: Escrever o assert que falha**
+
+No teste `claude_http_exact_url_and_redacts_auth_from_domain` (em `src/providers/adapters.rs`, módulo `tests`), logo após o assert de `http.last_url`, adicionar (espelhando o padrão do teste `grok_ready_from_billing_http`, linhas ~782-794):
+
+```rust
+        let headers = http.last_headers.lock().unwrap().clone();
+        assert!(
+            headers.iter().any(|(k, v)| {
+                k == "Authorization"
+                    && v.starts_with("Bearer ")
+                    && v.contains("SECRET_TOKEN_VALUE")
+            }),
+            "Authorization Bearer header missing: got keys {:?}",
+            headers.iter().map(|(k, _)| k.as_str()).collect::<Vec<_>>()
+        );
+        assert!(
+            headers
+                .iter()
+                .any(|(k, v)| k == "anthropic-beta" && v == "oauth-2025-04-20"),
+            "anthropic-beta header missing"
+        );
+```
+
+Atenção: o segundo argumento do assert imprime só as CHAVES dos headers, nunca os valores — o token de teste não deve vazar na saída de falha.
+
+- [ ] **Step 2: Rodar e confirmar a falha**
+
+Run: `cargo test claude_http_exact_url_and_redacts_auth_from_domain`
+Expected: FAIL com "Authorization Bearer header missing" (o header atual é o token cru, sem prefixo).
+
+- [ ] **Step 3: Corrigir o header de produção**
+
+Em `src/providers/adapters.rs`, no `impl ProviderAdapter for ClaudeAdapter`, trocar:
+
+```rust
+            // Never log the token. Pass only as Authorization header value.
+            let headers = [
+                ("Authorization", token.as_str()),
+                ("anthropic-beta", "oauth-2025-04-20"),
+            ];
+```
+
+por:
+
+```rust
+            // Never log the token. Pass only as Authorization header value.
+            let bearer = format!("Bearer {token}");
+            let headers = [
+                ("Authorization", bearer.as_str()),
+                ("anthropic-beta", "oauth-2025-04-20"),
+            ];
+```
+
+- [ ] **Step 4: Rodar e confirmar que passa**
+
+Run: `cargo test claude_http`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/providers/adapters.rs
+git commit -m 'fix: send Bearer prefix on Claude usage auth'
+```
+
+---
+
+### Task 2: Bucket `seven_day_oauth_apps`
+
+A API OAuth retorna a janela semanal no bucket `seven_day_oauth_apps` para tokens OAuth (o widget nativo do Quattro o trata como fonte primária, com fallback para `seven_day`). Nossa struct `ClaudeUsageDoc` não declara o campo, então o serde o descarta em silêncio — semanal vazio mesmo com auth correto.
+
+**Files:**
+- Modify: `src/providers/v2_map.rs` (struct `ClaudeUsageDoc` ~378; `claude_from_usage_json` ~492 e ~503; testes no módulo `tests`)
+
+**Interfaces:**
+- Consumes: `ClaudeWindowRaw` (já existe, `v2_map.rs:399`).
+- Produces: campo `seven_day_oauth_apps: Option<ClaudeWindowRaw>` em `ClaudeUsageDoc`.
+
+- [ ] **Step 1: Escrever os testes que falham**
+
+No módulo `tests` de `src/providers/v2_map.rs`:
+
+```rust
+    #[test]
+    fn claude_reads_seven_day_oauth_apps_bucket() {
+        let body = br#"{"five_hour":{"utilization":10.0,"resets_at":"2026-07-28T20:00:00Z"},"seven_day_oauth_apps":{"utilization":37.0,"resets_at":"2026-08-01T00:00:00Z"}}"#;
+        let result =
+            claude_from_usage_json(body, datetime!(2026-07-28 18:00:00 UTC), None, None, true);
+        match result {
+            ProviderResult::Ready { windows, .. } => {
+                assert_eq!(windows.len(), 2);
+                assert_eq!(windows[1].id(), "weekly");
+                assert!((windows[1].used_percent() - 37.0).abs() < 0.01);
+                assert!(windows[1].resets_at().is_some());
+            }
+            other => panic!("expected ready, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn claude_prefers_oauth_apps_bucket_over_seven_day() {
+        let body = br#"{"seven_day_oauth_apps":{"utilization":30.0},"seven_day":{"utilization":60.0}}"#;
+        let result =
+            claude_from_usage_json(body, datetime!(2026-07-28 18:00:00 UTC), None, None, true);
+        match result {
+            ProviderResult::Ready { windows, .. } => {
+                assert_eq!(windows.len(), 1);
+                assert_eq!(windows[0].id(), "weekly");
+                assert!((windows[0].used_percent() - 30.0).abs() < 0.01);
+            }
+            other => panic!("expected ready, got {other:?}"),
+        }
+    }
+```
+
+- [ ] **Step 2: Rodar e confirmar as falhas**
+
+Run: `cargo test claude_reads_seven_day_oauth_apps claude_prefers_oauth_apps`
+Expected: FAIL — no primeiro, `windows.len()` é 1 (bucket descartado); no segundo, `used_percent` é 60 (usa `seven_day`).
+
+- [ ] **Step 3: Implementar**
+
+Em `ClaudeUsageDoc`, adicionar o campo após `seven_day`:
+
+```rust
+    #[serde(default)]
+    seven_day_oauth_apps: Option<ClaudeWindowRaw>,
+```
+
+Em `claude_from_usage_json`, trocar o bloco da janela semanal:
+
+```rust
+    if let Some(w) = doc.seven_day.as_ref() {
+        if let Some(window) = claude_window("weekly", "Weekly", w) {
+            windows.push(window);
+        }
+    }
+```
+
+por:
+
+```rust
+    // OAuth tokens report the weekly bucket as seven_day_oauth_apps; prefer it.
+    if let Some(w) = doc.seven_day_oauth_apps.as_ref().or(doc.seven_day.as_ref()) {
+        if let Some(window) = claude_window("weekly", "Weekly", w) {
+            windows.push(window);
+        }
+    }
+```
+
+E no loop de `limits[]`, estender o skip de kinds dedicados:
+
+```rust
+        if kind == "five_hour" || kind == "seven_day" || kind == "seven_day_oauth_apps" {
+            continue; // handled via dedicated fields when present
+        }
+```
+
+- [ ] **Step 4: Rodar e confirmar que passa**
+
+Run: `cargo test claude_ -p agent-bar` (ou `cargo test claude_` se single-crate)
+Expected: PASS em todos os testes com prefixo `claude_`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/providers/v2_map.rs
+git commit -m 'feat: read Claude seven_day_oauth_apps bucket'
+```
+
+---
+
+### Task 3: Dedup de IDs de janela
+
+`weekly_model_id(model_id, idx)` no caminho de `limits[]` e `weekly_model_id(suffix, 0)` no caminho legado (`seven_day_opus`/`seven_day_sonnet`) produzem o MESMO id (ex.: `weekly-model:opus`) quando `ordinal <= 1`. Payload com ambos → duas janelas com id repetido → `ensure_unique_window_ids` (`status/schema.rs:996`) rejeita → o coordinator rebaixa a linha INTEIRA do Claude para `provider_error`, apagando 5h/semanal válidos. A validação downstream está certa; o fix é a montante: nunca inserir id duplicado.
+
+**Files:**
+- Modify: `src/providers/v2_map.rs` (`claude_from_usage_json`; novo helper `push_window_unique`; testes)
+
+**Interfaces:**
+- Consumes: `UsageWindow::id()` (getter público, `status/schema.rs:300`).
+- Produces: `fn push_window_unique(windows: &mut Vec<UsageWindow>, window: UsageWindow)` (privado de `v2_map.rs`).
+
+- [ ] **Step 1: Escrever o teste que falha**
+
+```rust
+    #[test]
+    fn claude_dedupes_model_window_ids_across_sources() {
+        // limits[] entry AND legacy seven_day_opus for the same model must not
+        // produce duplicate window ids (schema rejects the whole row otherwise).
+        let body = br#"{
+            "five_hour": {"utilization": 10.0},
+            "limits": [{"kind": "seven_day_model", "utilization": 20.0,
+                        "scope": {"model": {"id": "opus", "display_name": "Opus"}}}],
+            "seven_day_opus": {"utilization": 55.0}
+        }"#;
+        let result =
+            claude_from_usage_json(body, datetime!(2026-07-28 18:00:00 UTC), None, None, true);
+        // The whole row must survive schema validation downstream (duplicate
+        // window ids make ensure_unique_window_ids reject the entire status).
+        let status = crate::status::collect::provider_status_from_result(result.clone());
+        assert!(status.is_ok(), "row failed schema validation: {status:?}");
+        match result {
+            ProviderResult::Ready { windows, .. } => {
+                let opus: Vec<_> = windows
+                    .iter()
+                    .filter(|w| w.id() == "weekly-model:opus")
+                    .collect();
+                assert_eq!(opus.len(), 1, "duplicate weekly-model:opus windows");
+                // limits[] (dynamic) wins over the legacy field.
+                assert!((opus[0].used_percent() - 20.0).abs() < 0.01);
+            }
+            other => panic!("expected ready, got {other:?}"),
+        }
+    }
+```
+
+- [ ] **Step 2: Rodar e confirmar a falha**
+
+Run: `cargo test claude_dedupes_model_window_ids`
+Expected: FAIL — hoje nascem 2 janelas `weekly-model:opus`.
+
+- [ ] **Step 3: Implementar o helper e aplicar**
+
+Adicionar em `v2_map.rs` (perto de `claude_window`):
+
+```rust
+/// Insert keeping window ids unique; first occurrence wins (dynamic limits[]
+/// entries are pushed before legacy seven_day_* fields on purpose).
+fn push_window_unique(windows: &mut Vec<UsageWindow>, window: UsageWindow) {
+    if windows.iter().any(|w| w.id() == window.id()) {
+        return;
+    }
+    windows.push(window);
+}
+```
+
+Em `claude_from_usage_json`, trocar TODOS os `windows.push(window);` por `push_window_unique(&mut windows, window);` (4 sites: five_hour, weekly, loop de limits[], loop legado opus/sonnet).
+
+- [ ] **Step 4: Rodar e confirmar que passa**
+
+Run: `cargo test claude_`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/providers/v2_map.rs
+git commit -m 'fix: dedupe Claude usage window ids'
+```
+
+---
+
+### Task 4: `resets_at` tolerante (RFC3339 + epoch)
+
+`claude_window` só aceita RFC3339 estrito; o endpoint real também emite epoch (o widget nativo trata epoch explicitamente, e nosso próprio Codex já parseia `resets_at` como `i64`). Timestamp não-ISO hoje derruba silenciosamente só o reset, deixando percentual sem horário.
+
+**Files:**
+- Modify: `src/providers/v2_map.rs` (novo helper `parse_reset_timestamp`; `claude_window`; testes)
+
+**Interfaces:**
+- Consumes: `time::OffsetDateTime`, `Rfc3339`, `UtcOffset` (já importados no arquivo).
+- Produces: `fn parse_reset_timestamp(raw: &str) -> Option<OffsetDateTime>` (privado; Fases 3/4 poderão promovê-lo).
+
+- [ ] **Step 1: Escrever os testes que falham**
+
+```rust
+    #[test]
+    fn parse_reset_timestamp_accepts_iso_and_epoch() {
+        let iso = parse_reset_timestamp("2026-08-01T00:00:00Z");
+        assert!(iso.is_some());
+        // Epoch seconds (10 digits).
+        let secs = parse_reset_timestamp("1785272823");
+        assert_eq!(secs.map(|t| t.unix_timestamp()), Some(1_785_272_823));
+        // Epoch milliseconds (13 digits).
+        let millis = parse_reset_timestamp("1785272823412");
+        assert_eq!(millis.map(|t| t.unix_timestamp()), Some(1_785_272_823));
+        // Garbage and non-positive are rejected.
+        assert!(parse_reset_timestamp("soon").is_none());
+        assert!(parse_reset_timestamp("0").is_none());
+        assert!(parse_reset_timestamp("-5").is_none());
+        assert!(parse_reset_timestamp("").is_none());
+    }
+
+    #[test]
+    fn claude_window_accepts_epoch_resets_at() {
+        let body = br#"{"five_hour":{"utilization":42.0,"resets_at":"1785272823"}}"#;
+        let result =
+            claude_from_usage_json(body, datetime!(2026-07-28 18:00:00 UTC), None, None, true);
+        match result {
+            ProviderResult::Ready { windows, .. } => {
+                assert_eq!(windows.len(), 1);
+                assert!(windows[0].resets_at().is_some(), "epoch resets_at was dropped");
+            }
+            other => panic!("expected ready, got {other:?}"),
+        }
+    }
+```
+
+- [ ] **Step 2: Rodar e confirmar as falhas**
+
+Run: `cargo test parse_reset_timestamp claude_window_accepts_epoch`
+Expected: FAIL — `parse_reset_timestamp` não existe (erro de compilação). Isso conta como falha vermelha de TDD para função nova.
+
+- [ ] **Step 3: Implementar**
+
+Adicionar em `v2_map.rs`:
+
+```rust
+/// Parse a reset timestamp that may be RFC3339, epoch seconds, or epoch millis.
+///
+/// The documented contract is RFC3339-only, but the live OAuth endpoint and
+/// sibling providers also emit epochs; be liberal on input, strict on output.
+fn parse_reset_timestamp(raw: &str) -> Option<OffsetDateTime> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if let Ok(ts) = OffsetDateTime::parse(trimmed, &Rfc3339) {
+        return Some(ts.to_offset(UtcOffset::UTC));
+    }
+    let numeric: i128 = trimmed.parse().ok()?;
+    if numeric <= 0 {
+        return None;
+    }
+    // < 1e12 → seconds; otherwise milliseconds (mirrors the reference widget).
+    let nanos = if numeric < 1_000_000_000_000 {
+        numeric.checked_mul(1_000_000_000)?
+    } else {
+        numeric.checked_mul(1_000_000)?
+    };
+    OffsetDateTime::from_unix_timestamp_nanos(nanos)
+        .ok()
+        .map(|ts| ts.to_offset(UtcOffset::UTC))
+}
+```
+
+Em `claude_window`, trocar:
+
+```rust
+    let resets = raw
+        .resets_at
+        .as_deref()
+        .and_then(|s| OffsetDateTime::parse(s, &Rfc3339).ok())
+        .map(|ts| ts.to_offset(UtcOffset::UTC));
+```
+
+por:
+
+```rust
+    let resets = raw.resets_at.as_deref().and_then(parse_reset_timestamp);
+```
+
+- [ ] **Step 4: Rodar e confirmar que passa**
+
+Run: `cargo test parse_reset_timestamp claude_`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/providers/v2_map.rs
+git commit -m 'fix: accept epoch resets_at in Claude usage'
+```
+
+---
+
+### Task 5: Retry transiente compartilhado
+
+O catálogo declara `RetryPolicy::OneTransient` para os 4 providers e o spec promete "one network/timeout retry", mas o loop de retry só existe manuscrito dentro do `GrokAdapter` (`adapters.rs:164-235`). Claude é single-shot. Extrair o loop para um helper e usar em Claude e Grok (Amp/Codex adotam nas Fases 3/4).
+
+**Files:**
+- Create: `src/providers/retry.rs`
+- Modify: `src/providers/mod.rs` (declarar `mod retry;`)
+- Modify: `src/providers/adapters.rs` (Claude: usar helper; Grok: substituir loop inline)
+
+**Interfaces:**
+- Consumes: `HttpClient`, `HttpError`, `HttpResponse` (`providers/adapter.rs`), `ProviderDescriptor::retry_delay()` (`catalog.rs:61`, retorna `Some(250ms)` para `OneTransient`).
+- Produces: `pub(crate) async fn http_get_with_retry(http: &dyn HttpClient, descriptor: &ProviderDescriptor, url: &str, headers: &[(&str, &str)], max_body_bytes: usize) -> Result<HttpResponse, HttpError>` em `src/providers/retry.rs`.
+
+- [ ] **Step 1: Criar o módulo com os testes que falham**
+
+Criar `src/providers/retry.rs`:
+
+```rust
+//! Shared one-transient-retry loop for HTTP collection.
+//!
+//! The catalog declares [`RetryPolicy::OneTransient`] for every provider; this
+//! is the single implementation of that promise. Only network errors retry.
+
+use super::adapter::{HttpClient, HttpError, HttpResponse};
+use super::catalog::ProviderDescriptor;
+
+/// GET with at most one extra attempt after a transient network error,
+/// honoring the descriptor's retry policy and delay.
+pub(crate) async fn http_get_with_retry(
+    http: &dyn HttpClient,
+    descriptor: &ProviderDescriptor,
+    url: &str,
+    headers: &[(&str, &str)],
+    max_body_bytes: usize,
+) -> Result<HttpResponse, HttpError> {
+    match http.get(url, headers, max_body_bytes).await {
+        Err(HttpError::Network(first)) => {
+            let Some(delay) = descriptor.retry_delay() else {
+                return Err(HttpError::Network(first));
+            };
+            tokio::time::sleep(delay).await;
+            http.get(url, headers, max_body_bytes).await
+        }
+        other => other,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::providers::catalog::CLAUDE;
+    use crate::providers::http::ScriptedHttpClient;
+
+    fn ok_response() -> HttpResponse {
+        HttpResponse {
+            status: 200,
+            final_url: "https://example.invalid/".into(),
+            body: b"{}".to_vec(),
+        }
+    }
+
+    #[tokio::test]
+    async fn retries_once_after_network_error() {
+        // ScriptedHttpClient pops from the END: last entry is served first.
+        let http = ScriptedHttpClient {
+            responses: std::sync::Mutex::new(vec![
+                Ok(ok_response()),
+                Err(HttpError::Network("transient".into())),
+            ]),
+            last_url: std::sync::Mutex::new(None),
+            last_headers: std::sync::Mutex::new(Vec::new()),
+        };
+        let result = http_get_with_retry(&http, &CLAUDE, "https://x/", &[], 1024).await;
+        assert!(result.is_ok(), "expected retry to succeed: {result:?}");
+        assert!(
+            http.responses.lock().unwrap().is_empty(),
+            "both scripted responses must be consumed (two attempts)"
+        );
+    }
+
+    #[tokio::test]
+    async fn non_network_errors_do_not_retry() {
+        let http = ScriptedHttpClient {
+            responses: std::sync::Mutex::new(vec![
+                Ok(ok_response()),
+                Err(HttpError::RedirectRefused("https://evil/".into())),
+            ]),
+            last_url: std::sync::Mutex::new(None),
+            last_headers: std::sync::Mutex::new(Vec::new()),
+        };
+        let result = http_get_with_retry(&http, &CLAUDE, "https://x/", &[], 1024).await;
+        assert!(matches!(result, Err(HttpError::RedirectRefused(_))));
+        assert_eq!(
+            http.responses.lock().unwrap().len(),
+            1,
+            "second scripted response must remain unconsumed (single attempt)"
+        );
+    }
+
+    #[tokio::test]
+    async fn second_network_error_is_returned() {
+        let http = ScriptedHttpClient {
+            responses: std::sync::Mutex::new(vec![
+                Err(HttpError::Network("second".into())),
+                Err(HttpError::Network("first".into())),
+            ]),
+            last_url: std::sync::Mutex::new(None),
+            last_headers: std::sync::Mutex::new(Vec::new()),
+        };
+        let result = http_get_with_retry(&http, &CLAUDE, "https://x/", &[], 1024).await;
+        assert!(matches!(result, Err(HttpError::Network(_))));
+    }
+}
+```
+
+Em `src/providers/mod.rs`, adicionar `mod retry;` junto às outras declarações de módulo (ler o arquivo primeiro para seguir a ordem existente).
+
+- [ ] **Step 2: Rodar e confirmar que compilam e passam**
+
+Run: `cargo test retry`
+Expected: PASS (helper novo com testes próprios — o vermelho de TDD aqui é o passo 3, onde os adapters ainda não usam o helper).
+
+- [ ] **Step 3: Escrever o teste de adoção no Claude que falha**
+
+No módulo `tests` de `src/providers/adapters.rs`:
+
+```rust
+    #[tokio::test]
+    async fn claude_retries_once_on_network_error() {
+        let body = br#"{"five_hour":{"utilization":10.0,"resets_at":"2026-07-28T22:00:00Z"}}"#;
+        let http = ScriptedHttpClient {
+            responses: Mutex::new(vec![
+                Ok(HttpResponse {
+                    status: 200,
+                    final_url: CLAUDE_USAGE_URL.into(),
+                    body: body.to_vec(),
+                }),
+                Err(crate::providers::adapter::HttpError::Network("blip".into())),
+            ]),
+            last_url: Mutex::new(None),
+            last_headers: Mutex::new(Vec::new()),
+        };
+        let process = empty_process();
+        let mut fs = MapFileSystem::default();
+        fs.files.insert(
+            std::path::PathBuf::from("/home/u/.claude/.credentials.json"),
+            br#"{"claudeAiOauth":{"accessToken":"tok"}}"#.to_vec(),
+        );
+        let env = ExecutionEnvironment {
+            home: std::path::PathBuf::from("/home/u"),
+            path_dirs: vec![],
+            grok_home: None,
+        };
+        let clock = FixedClock(datetime!(2026-07-28 18:00:00 UTC));
+        let ctx = CollectionContext {
+            env: &env,
+            clock: &clock,
+            fs: &fs,
+            process: &process,
+            http: &http,
+            plugin_root: None,
+        };
+        let discovery = discovery_with_exe(Path::new("/usr/bin/claude"));
+        let result = CLAUDE_ADAPTER.collect(&ctx, &discovery).await;
+        assert!(
+            matches!(result, ProviderResult::Ready { .. }),
+            "one transient network error must be retried: {result:?}"
+        );
+    }
+```
+
+- [ ] **Step 4: Rodar e confirmar a falha**
+
+Run: `cargo test claude_retries_once_on_network_error`
+Expected: FAIL — hoje o Claude retorna `NetworkError` na primeira falha, sem retry.
+
+- [ ] **Step 5: Adotar o helper no Claude e no Grok**
+
+No `ClaudeAdapter::collect`, trocar:
+
+```rust
+            match context
+                .http
+                .get(CLAUDE_USAGE_URL, &headers, CLAUDE.max_output_bytes)
+                .await
+```
+
+por:
+
+```rust
+            match super::retry::http_get_with_retry(
+                context.http,
+                &CLAUDE,
+                CLAUDE_USAGE_URL,
+                &headers,
+                CLAUDE.max_output_bytes,
+            )
+            .await
+```
+
+No `GrokAdapter::collect`, remover o loop manuscrito (`let mut attempts: u8 = 0; loop { ... }`) e o braço `Err(HttpError::Network)` com sleep interno, substituindo por uma única chamada + match plano (mesmos braços de status, sem `continue`):
+
+```rust
+            match super::retry::http_get_with_retry(
+                context.http,
+                &GROK,
+                GROK_BILLING_URL,
+                &headers,
+                max_body,
+            )
+            .await
+            {
+                Ok(resp) if resp.status == 401 || resp.status == 403 => unauthenticated(
+                    ProviderId::Grok,
+                    GROK.display_name,
+                    "Grok authentication was rejected.",
+                    login,
+                    GROK.installation_url,
+                ),
+                Ok(resp) if (200..300).contains(&resp.status) => {
+                    let _ = resp.final_url;
+                    grok_from_billing_json(&resp.body, account, now, login)
+                }
+                Ok(resp) if resp.status >= 500 => ProviderResult::ProviderError {
+                    id: ProviderId::Grok,
+                    name: GROK.display_name.to_owned(),
+                    message: "Grok billing request failed.".into(),
+                    retryable: true,
+                },
+                Ok(_) => ProviderResult::ProviderError {
+                    id: ProviderId::Grok,
+                    name: GROK.display_name.to_owned(),
+                    message: "Grok billing request failed.".into(),
+                    retryable: false,
+                },
+                Err(super::adapter::HttpError::Network(_)) => ProviderResult::NetworkError {
+                    id: ProviderId::Grok,
+                    name: GROK.display_name.to_owned(),
+                    message: "Network error while contacting Grok.".into(),
+                },
+                Err(super::adapter::HttpError::RedirectRefused(_)) => {
+                    ProviderResult::ProviderError {
+                        id: ProviderId::Grok,
+                        name: GROK.display_name.to_owned(),
+                        message: "Grok billing redirect refused.".into(),
+                        retryable: false,
+                    }
+                }
+                Err(super::adapter::HttpError::BodyTooLarge) => ProviderResult::ProviderError {
+                    id: ProviderId::Grok,
+                    name: GROK.display_name.to_owned(),
+                    message: "Grok billing response exceeded size limit.".into(),
+                    retryable: false,
+                },
+                Err(super::adapter::HttpError::InvalidResponse(_)) => {
+                    ProviderResult::ProviderError {
+                        id: ProviderId::Grok,
+                        name: GROK.display_name.to_owned(),
+                        message: "Invalid Grok billing response.".into(),
+                        retryable: false,
+                    }
+                }
+            }
+```
+
+Atenção: os `return` do loop antigo viram expressões do match (sem `return`), pois o match agora é a expressão final do bloco async. Ajuste conforme o corpo real após ler o arquivo.
+
+- [ ] **Step 6: Rodar a suíte inteira e confirmar**
+
+Run: `cargo test`
+Expected: PASS — incluindo `claude_retries_once_on_network_error` e os testes existentes do Grok (`grok_ready_from_billing_http`, `grok_billing_timeout_network_error` — este continua vendo `NetworkError` porque o client roteirizado exaure e o segundo attempt também falha).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/providers/retry.rs src/providers/mod.rs src/providers/adapters.rs
+git commit -m 'refactor: share one-transient HTTP retry helper'
+```
+
+---
+
+### Task 6: `retryable` em Unauthenticated + retenção stale
+
+Token expirado é transitório (o Claude Code renova sozinho na próxima abertura) — mas hoje qualquer `Unauthenticated` apaga as janelas e NÃO retém cache (invariante correto para token revogado, errado para expirado). Distinguir via `retryable` no erro: expirado → `retryable: true` → elegível a retenção stale; rejeitado → `retryable: false` → comportamento atual intacto.
+
+**Files:**
+- Modify: `src/status/schema.rs` (variante `ProviderResult::Unauthenticated` ~948; `is_temporary_failure` ~449)
+- Modify: `src/providers/adapter.rs` (helper `unauthenticated()` ~211)
+- Modify: `src/status/collect.rs` (mapeamento ~48-66)
+- Modify: `src/providers/v2_map.rs` (2 construções literais: ~228 e ~468)
+- Modify: `src/providers/adapters.rs` (7 chamadas do helper — o compilador lista todas)
+- Modify: `src/status/coordinator.rs` (teste novo de retenção)
+
+**Interfaces:**
+- Consumes: `apply_stale_retention` (`coordinator.rs:245`) e `retain_as_stale` (`schema.rs:427`) — nenhuma mudança nelas.
+- Produces: `ProviderResult::Unauthenticated` ganha campo `retryable: bool`; helper vira `unauthenticated(id, name, message, login_available, url, retryable)`.
+
+- [ ] **Step 1: Escrever o teste de retenção que falha (não compila ainda)**
+
+No módulo `tests` de `src/status/coordinator.rs`, ao lado de `auth_failure_does_not_retain_stale_usage`:
+
+```rust
+    #[tokio::test]
+    async fn retryable_auth_failure_retains_prior_ready_as_stale() {
+        // Expired-token style failure (retryable) keeps last good windows.
+        let now = datetime!(2026-07-28 18:42:00 UTC);
+        let prior = ready_claude(now);
+        let live = ProviderStatus::unauthenticated(
+            ProviderId::Claude,
+            "Claude",
+            ProviderError::new(ErrorCode::AuthenticationRequired, "expired", true),
+            ProviderAction::login("Log in"),
+        )
+        .unwrap();
+        let out = apply_stale_retention(live, Some(&prior)).unwrap();
+        assert_eq!(out.state(), ProviderState::Stale);
+        assert_eq!(out.windows().len(), 1, "prior windows must be retained");
+        assert!(out.error().is_some_and(|e| e.retryable));
+    }
+```
+
+- [ ] **Step 2: Rodar e confirmar a falha**
+
+Run: `cargo test retryable_auth_failure_retains`
+Expected: FAIL — `out.state()` é `Unauthenticated` (retenção não se aplica a auth hoje).
+
+- [ ] **Step 3: Estender `is_temporary_failure`**
+
+Em `src/status/schema.rs`, trocar:
+
+```rust
+    /// Temporary failures eligible for stale retention (not auth / missing CLI).
+    pub fn is_temporary_failure(&self) -> bool {
+        match self.state {
+            ProviderState::NetworkError | ProviderState::RateLimited => true,
+            ProviderState::ProviderError => self.error.as_ref().is_some_and(|e| e.retryable),
+            _ => false,
+        }
+    }
+```
+
+por:
+
+```rust
+    /// Temporary failures eligible for stale retention. Rejected auth and
+    /// missing CLI never retain; an expired session (retryable auth) does.
+    pub fn is_temporary_failure(&self) -> bool {
+        match self.state {
+            ProviderState::NetworkError | ProviderState::RateLimited => true,
+            ProviderState::ProviderError | ProviderState::Unauthenticated => {
+                self.error.as_ref().is_some_and(|e| e.retryable)
+            }
+            _ => false,
+        }
+    }
+```
+
+- [ ] **Step 4: Rodar os dois testes de retenção**
+
+Run: `cargo test retryable_auth_failure_retains auth_failure_does_not_retain`
+Expected: PASS nos dois — o teste antigo usa `retryable: false` e continua não retendo.
+
+- [ ] **Step 5: Adicionar `retryable` à variante e propagar**
+
+Em `src/status/schema.rs`, na variante:
+
+```rust
+    Unauthenticated {
+        id: ProviderId,
+        name: String,
+        message: String,
+        login_available: bool,
+        installation_url: String,
+        retryable: bool,
+    },
+```
+
+Em `src/providers/adapter.rs`, helper:
+
+```rust
+pub(crate) fn unauthenticated(
+    id: ProviderId,
+    name: &str,
+    message: impl Into<String>,
+    login_available: bool,
+    url: &str,
+    retryable: bool,
+) -> ProviderResult {
+    ProviderResult::Unauthenticated {
+        id,
+        name: name.to_owned(),
+        message: message.into(),
+        login_available,
+        installation_url: url.to_owned(),
+        retryable,
+    }
+}
+```
+
+Em `src/status/collect.rs`, no braço `Unauthenticated`, destructure o campo novo e use-o:
+
+```rust
+        ProviderResult::Unauthenticated {
+            id,
+            name,
+            message,
+            login_available,
+            installation_url,
+            retryable,
+        } => {
+            let action = if login_available {
+                ProviderAction::login("Log in")
+            } else {
+                ProviderAction::view_installation("View installation", installation_url)?
+            };
+            ProviderStatus::unauthenticated(
+                id,
+                name,
+                ProviderError::new(ErrorCode::AuthenticationRequired, message, retryable),
+                action,
+            )
+        }
+```
+
+Compilar (`cargo build`) e corrigir TODOS os erros de campo/aridade que o compilador listar, passando `retryable: false` (ou `false` como 6º argumento do helper) em cada site existente — `adapters.rs` (Amp 1×, Grok 3×, Claude 3×) e `v2_map.rs` (2 construções literais). NENHUM site existente muda de comportamento nesta task.
+
+- [ ] **Step 6: Rodar a suíte inteira**
+
+Run: `cargo test`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/status/schema.rs src/status/collect.rs src/providers/adapter.rs src/providers/adapters.rs src/providers/v2_map.rs src/status/coordinator.rs
+git commit -m 'feat: retryable unauthenticated retains stale'
+```
+
+---
+
+### Task 7: Expiry client-side no Claude
+
+O adapter lê `accessToken` mas ignora `expiresAt`. Com token vencido (Claude Code fechado há horas), dispara um HTTP condenado e mostra o genérico "authentication was rejected". Fix: checar expiry antes do HTTP; vencido → `Unauthenticated` com mensagem própria e `retryable: true` (Task 6 garante retenção do último dado como Stale quando houver cache).
+
+**Files:**
+- Modify: `src/providers/adapters.rs` (`parse_claude_credentials` ~451 e `ClaudeAdapter::collect`; testes)
+
+**Interfaces:**
+- Consumes: helper `unauthenticated(..., retryable)` da Task 6; `context.clock.now_utc()`.
+- Produces: `struct ClaudeCredentials { token: String, plan: Option<Plan>, account: Option<Account>, expires_at_ms: Option<i64> }` (privada de `adapters.rs`); `parse_claude_credentials(bytes) -> Option<ClaudeCredentials>`. A Task 8 consome esta struct.
+
+- [ ] **Step 1: Escrever o teste que falha**
+
+No módulo `tests` de `src/providers/adapters.rs`:
+
+```rust
+    #[tokio::test]
+    async fn claude_expired_token_skips_http_and_is_retryable() {
+        let http = ScriptedHttpClient::default(); // any HTTP call would error
+        let process = empty_process();
+        let mut fs = MapFileSystem::default();
+        fs.files.insert(
+            std::path::PathBuf::from("/home/u/.claude/.credentials.json"),
+            // expiresAt in the past relative to the fixed clock below.
+            br#"{"claudeAiOauth":{"accessToken":"tok","expiresAt":1690000000000}}"#.to_vec(),
+        );
+        let env = ExecutionEnvironment {
+            home: std::path::PathBuf::from("/home/u"),
+            path_dirs: vec![],
+            grok_home: None,
+        };
+        let clock = FixedClock(datetime!(2026-07-28 18:00:00 UTC));
+        let ctx = CollectionContext {
+            env: &env,
+            clock: &clock,
+            fs: &fs,
+            process: &process,
+            http: &http,
+            plugin_root: None,
+        };
+        let discovery = discovery_with_exe(Path::new("/usr/bin/claude"));
+        let result = CLAUDE_ADAPTER.collect(&ctx, &discovery).await;
+        assert!(
+            http.last_url.lock().unwrap().is_none(),
+            "expired token must not trigger an HTTP request"
+        );
+        match result {
+            ProviderResult::Unauthenticated {
+                message, retryable, ..
+            } => {
+                assert!(message.contains("expired"), "message: {message}");
+                assert!(retryable, "expired session must be retryable");
+            }
+            other => panic!("expected unauthenticated, got {other:?}"),
+        }
+    }
+```
+
+- [ ] **Step 2: Rodar e confirmar a falha**
+
+Run: `cargo test claude_expired_token_skips_http`
+Expected: FAIL — hoje o HTTP dispara (client roteirizado vazio → `NetworkError`).
+
+- [ ] **Step 3: Implementar**
+
+Em `src/providers/adapters.rs`, substituir `parse_claude_credentials` (retorno em tupla) por:
+
+```rust
+struct ClaudeCredentials {
+    token: String,
+    plan: Option<Plan>,
+    account: Option<Account>,
+    expires_at_ms: Option<i64>,
+}
+
+fn parse_claude_credentials(bytes: &[u8]) -> Option<ClaudeCredentials> {
+    let value: serde_json::Value = serde_json::from_slice(bytes).ok()?;
+    let oauth = value.get("claudeAiOauth")?;
+    let token = oauth.get("accessToken")?.as_str()?.to_owned();
+    if token.is_empty() {
+        return None;
+    }
+    let plan = oauth
+        .get("subscriptionType")
+        .and_then(|v| v.as_str())
+        .map(|id| Plan {
+            id: id.to_owned(),
+            label: id.to_owned(),
+        });
+    let expires_at_ms = oauth.get("expiresAt").and_then(|v| v.as_i64());
+    Some(ClaudeCredentials {
+        token,
+        plan,
+        account: None,
+        expires_at_ms,
+    })
+}
+```
+
+No `ClaudeAdapter::collect`, trocar o destructure em tupla pelo uso da struct e inserir a checagem ANTES da montagem dos headers:
+
+```rust
+            let creds = match parse_claude_credentials(&cred_bytes) {
+                Some(v) => v,
+                None => {
+                    return unauthenticated(
+                        ProviderId::Claude,
+                        CLAUDE.display_name,
+                        "Claude is not authenticated.",
+                        login_available(discovery),
+                        CLAUDE.installation_url,
+                        false,
+                    );
+                }
+            };
+
+            // An expired session self-heals when Claude Code refreshes the
+            // token; report it as retryable so prior data is retained as stale.
+            let now_ms = context.clock.now_utc().unix_timestamp().saturating_mul(1000);
+            if creds.expires_at_ms.is_some_and(|exp| exp <= now_ms) {
+                return unauthenticated(
+                    ProviderId::Claude,
+                    CLAUDE.display_name,
+                    "Claude session expired. Open Claude Code to refresh it.",
+                    login_available(discovery),
+                    CLAUDE.installation_url,
+                    true,
+                );
+            }
+```
+
+Referências seguintes trocam `token`/`plan`/`account` por `creds.token`/`creds.plan`/`creds.account` (o `format!("Bearer {token}")` da Task 1 vira `format!("Bearer {}", creds.token)`).
+
+- [ ] **Step 4: Rodar e confirmar que passa**
+
+Run: `cargo test claude_`
+Expected: PASS em todos.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/providers/adapters.rs
+git commit -m 'feat: detect expired Claude token before HTTP'
+```
+
+---
+
+### Task 8: Tier real (`rateLimitTier`)
+
+O plano/badge usa só `subscriptionType` cru ("max"). O arquivo de credenciais também traz `rateLimitTier` (ex.: `max_20x`), que o widget nativo formata como "Max 20x". Preferir o tier; fallback para o subscription capitalizado.
+
+**Files:**
+- Modify: `src/providers/adapters.rs` (`parse_claude_credentials` da Task 7; novo helper `claude_plan`; testes)
+
+**Interfaces:**
+- Consumes: `ClaudeCredentials` (Task 7), `Plan { id, label }` (`status/schema.rs`).
+- Produces: `fn claude_plan(subscription_type: Option<&str>, rate_limit_tier: Option<&str>) -> Option<Plan>` (privada de `adapters.rs`).
+
+- [ ] **Step 1: Escrever o teste que falha**
+
+```rust
+    #[test]
+    fn claude_plan_formats_rate_limit_tier() {
+        let plan = claude_plan(Some("max"), Some("max_20x"));
+        assert_eq!(plan.as_ref().map(|p| p.label.as_str()), Some("Max 20x"));
+        assert_eq!(plan.as_ref().map(|p| p.id.as_str()), Some("max_20x"));
+
+        let fallback = claude_plan(Some("pro"), None);
+        assert_eq!(fallback.as_ref().map(|p| p.label.as_str()), Some("Pro"));
+        assert_eq!(fallback.as_ref().map(|p| p.id.as_str()), Some("pro"));
+
+        assert!(claude_plan(None, None).is_none());
+    }
+```
+
+- [ ] **Step 2: Rodar e confirmar a falha**
+
+Run: `cargo test claude_plan_formats`
+Expected: FAIL — `claude_plan` não existe (erro de compilação; vermelho de TDD para função nova).
+
+- [ ] **Step 3: Implementar**
+
+Em `src/providers/adapters.rs`:
+
+```rust
+/// Prefer the granular rate-limit tier ("max_20x" → "Max 20x"); fall back to
+/// the capitalized subscription type. Mirrors the native widget's formatTier.
+fn claude_plan(subscription_type: Option<&str>, rate_limit_tier: Option<&str>) -> Option<Plan> {
+    if let Some(tier) = rate_limit_tier.filter(|t| !t.is_empty()) {
+        if let Some(suffix) = tier.strip_prefix("max_") {
+            return Some(Plan {
+                id: tier.to_owned(),
+                label: format!("Max {suffix}"),
+            });
+        }
+        return Some(Plan {
+            id: tier.to_owned(),
+            label: capitalize_ascii(tier),
+        });
+    }
+    let sub = subscription_type.filter(|s| !s.is_empty())?;
+    Some(Plan {
+        id: sub.to_owned(),
+        label: capitalize_ascii(sub),
+    })
+}
+
+fn capitalize_ascii(raw: &str) -> String {
+    let mut chars = raw.chars();
+    match chars.next() {
+        Some(first) => first.to_ascii_uppercase().to_string() + chars.as_str(),
+        None => String::new(),
+    }
+}
+```
+
+Em `parse_claude_credentials`, trocar a construção de `plan` por:
+
+```rust
+    let plan = claude_plan(
+        oauth.get("subscriptionType").and_then(|v| v.as_str()),
+        oauth.get("rateLimitTier").and_then(|v| v.as_str()),
+    );
+```
+
+- [ ] **Step 4: Rodar e confirmar que passa**
+
+Run: `cargo test claude_`
+Expected: PASS. Atenção: se algum teste existente assertar o label antigo cru (ex.: "pro"), atualize o assert para o label capitalizado — mudança intencional.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/providers/adapters.rs
+git commit -m 'feat: format Claude rate limit tier label'
+```
+
+---
+
+### Task 9: Remover o guard morto de percentual
+
+`claude_window` tem um `if/else` cujos dois ramos computam a expressão idêntica — o comentário alega proteção contra payload fracionário que não existe. Remover o código morto e fixar o comportamento correto por teste (1.0 = 1%, não 100%).
+
+**Files:**
+- Modify: `src/providers/v2_map.rs` (`claude_window` ~550-563; teste novo)
+
+**Interfaces:**
+- Consumes/Produces: nada novo — refactor interno.
+
+- [ ] **Step 1: Escrever o teste de caracterização**
+
+```rust
+    #[test]
+    fn claude_utilization_one_means_one_percent() {
+        // The endpoint reports percent scale: 1.0 is 1%, never 100%.
+        let body = br#"{"five_hour":{"utilization":1.0,"resets_at":"2026-07-28T22:00:00Z"}}"#;
+        let result =
+            claude_from_usage_json(body, datetime!(2026-07-28 18:00:00 UTC), None, None, true);
+        match result {
+            ProviderResult::Ready { windows, .. } => {
+                assert!((windows[0].used_percent() - 1.0).abs() < 0.01);
+                assert!((windows[0].remaining_percent() - 99.0).abs() < 0.01);
+            }
+            other => panic!("expected ready, got {other:?}"),
+        }
+    }
+```
+
+- [ ] **Step 2: Rodar — este teste JÁ PASSA (é rede de segurança do refactor)**
+
+Run: `cargo test claude_utilization_one`
+Expected: PASS (os dois ramos do guard morto são idênticos; o teste protege o refactor seguinte).
+
+- [ ] **Step 3: Remover o código morto**
+
+Em `claude_window`, trocar:
+
+```rust
+    // Guard double-division: values are already percent, not 0..=1 fractions.
+    let used = if raw.utilization > 0.0 && raw.utilization <= 1.0 {
+        // Ambiguous tiny values: treat as percent only when clearly percent-like
+        // API always sends 0..=100; if someone passes 0.42 meaning 42%, that
+        // was the historical bug — we intentionally treat <=1 as percent only
+        // when the fixture marks it via >100 impossible; keep as-is clamp.
+        raw.utilization.clamp(0.0, 100.0)
+    } else {
+        raw.utilization.clamp(0.0, 100.0)
+    };
+```
+
+por:
+
+```rust
+    // Utilization is already percent scale (1.0 == 1%); clamp only.
+    let used = raw.utilization.clamp(0.0, 100.0);
+```
+
+- [ ] **Step 4: Rodar e confirmar que segue passando**
+
+Run: `cargo test claude_`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/providers/v2_map.rs
+git commit -m 'refactor: drop dead percent guard in Claude map'
+```
+
+---
+
+### Task 10: Gate completo + baseline QML + checkpoint de QA ao vivo
+
+Fecha a fase: gate integral do repo, baseline da suíte QML (nunca executada de fato segundo a auditoria — Fase 1 não toca QML, então ela DEVE passar) e parada obrigatória antes de tocar o plugin instalado.
+
+**Files:**
+- Nenhuma modificação esperada (só correções se o gate acusar).
+
+- [ ] **Step 1: Gate Rust completo**
+
+Run:
+```bash
+cargo fmt --check && cargo test && cargo clippy --all-targets -- -D warnings && git diff --check
+```
+Expected: tudo verde. Qualquer falha: corrigir, re-rodar, e emendar no commit da task correspondente (`git commit --fixup` NÃO — commit normal com subject descritivo).
+
+- [ ] **Step 2: Baseline QML (sem mudanças QML nesta fase)**
+
+Run:
+```bash
+find assets/omarchy -type f -name '*.qml' -exec qmllint -I /usr/share/omarchy/shell {} +
+omarchy plugin validate assets/omarchy
+QT_QPA_PLATFORM=offscreen qmltestrunner -input tests/qml -import /usr/share/omarchy/shell -import assets/omarchy -o -,txt
+```
+Expected: PASS. Se falhar em algo pré-existente, NÃO corrigir aqui — registrar o resultado literal no relatório da fase (é insumo da Fase 2).
+
+- [ ] **Step 3: PARAR — checkpoint com o usuário para QA ao vivo**
+
+Reportar: resultado do gate, baseline QML e o diff total da fase (`git log --oneline master..claude-ajustes`). Pedir autorização explícita para o QA ao vivo (build do bundle + atualização do plugin instalado em `~/.config/omarchy/plugins/agent-bar.usage` + verificação na barra real com credencial real). O contrato proíbe mutar paths vivos sem esse gate autorizado. NÃO prosseguir sem resposta.
+
+---
+
+## Fora deste plano (registrado para as próximas fases)
+
+- Humanização de `resets_at` na UI ("em 2h 14m") — Fase 2 (está pinado por teste QML hoje).
+- Enum sync JS/Rust, split do ServiceCore.js, `error.retryable` na UI — Fase 2.
+- Codex freshness/sandbox/cap, dedup de schemas — Fase 3.
+- Amp classifier, Grok period type/expiry, dead code Grok — Fase 4.
+- Paridade com o widget nativo + emenda de contrato — Fase 5.

--- a/docs/superpowers/specs/2026-07-28-v11-recovery-quattro-parity-design.md
+++ b/docs/superpowers/specs/2026-07-28-v11-recovery-quattro-parity-design.md
@@ -1,0 +1,232 @@
+# Agent Bar v11 — Recuperação + paridade Quattro (design)
+
+Data: 2026-07-28 · Status: aprovado pelo mantenedor · Base: `master`/`claude-ajustes` @ `4cb7407` (v10.0.0)
+
+## Contexto
+
+A v10.0.0 (PR #25) e o PR #28 entregaram o plugin Quickshell-nativo, mas a auditoria
+de 2026-07-28 (6 áreas, workflow multi-agente, achados reverificados por leitura
+direta) encontrou bugs empilhados que impedem o objetivo central do produto:
+monitorar as janelas de 5h/semanal e os horários de reset dos providers.
+O Omarchy Quattro (4.0.0.alpha, PR basecamp/omarchy#6231) agora traz um widget
+nativo `model-usage` (Claude+Codex) que serve de implementação de referência —
+funciona nesta máquina contra o mesmo endpoint com a mesma credencial.
+
+Sintomas confirmados pelo usuário: Claude sem dados (401), Codex com dados
+errados, Grok/Amp quebrados, popup ruim (denso, timestamps ilegíveis,
+hierarquia confusa, chip da barra fraco), refresh/notificações não confiáveis.
+
+Decisão de estratégia (usuário): **manter o Agent Bar e buscar paridade total
+com o widget nativo**, corrigindo com fix + refactor juntos, em fases verticais
+por provider — Claude primeiro.
+
+## Objetivo
+
+1. Monitoramento funcional dos 4 providers (Claude, Codex, Amp, Grok).
+2. Eliminar as classes de bug da auditoria (auth, parsing, freshness, retry).
+3. Desmontar o god-module `ServiceCore.js` e sincronizar enums com o schema.
+4. Redesign do popup/chip orientado por mockups aprovados visualmente.
+5. Paridade funcional com o widget nativo, com emenda formal do contrato.
+
+## Fora de escopo (decisões explícitas)
+
+- Refactor de `src/plugin/maintenance.rs` (4.070 linhas): dívida registrada;
+  alto risco, nenhum benefício para os sintomas atuais.
+- Qualquer dado monetário (spend/balance/credits/currency): continua banido.
+- Reintroduzir TUI/Waybar/Pango/schema-v1: continua banido.
+
+## Arquitetura
+
+**Intacto**: topologia Quattro — helper Rust privado (`bin/agent-bar`) emite um
+único objeto JSON schema-v2 no stdout; `Service.qml` é o único dono de
+polling/processos; `BarWidget.qml` resolve o serviço via
+`bar.shell.serviceFor(moduleName)`. A auditoria confirmou zero drift de
+contrato com o alpha instalado (r1429) — mecânica de manifest, enable/rescan e
+registro de widget corretos.
+
+**Muda**:
+
+- **Retry compartilhado**: extrair o loop hoje exclusivo do `GrokAdapter`
+  (`adapters.rs:199`) para um helper usado pelos 4 adapters. O spec v10 já
+  promete "one transient retry" para todos (`catalog.rs` declara
+  `RetryPolicy::OneTransient` uniforme); o código nunca cumpriu para
+  Claude/Amp.
+- **Parsing tolerante de `resets_at`** em helper único no `v2_map`: RFC3339 +
+  epoch em segundos e millis. Evidência de necessidade: o Codex já trata epoch
+  `i64` (`v2_map.rs:277-278`) e o widget nativo trata epoch explicitamente
+  (`Claude.qml:327-345`) — o endpoint real é menos uniforme que o contrato
+  documentado (JSON-014).
+- **Schema v2 aditivo, não v3**: campos novos da Fase 5 entram como opcionais.
+  QML antigo ignora; QML novo renderiza. Nenhuma quebra para consumidores.
+- **`ServiceCore.js` fatiado** por responsabilidade: envelope/estado, chip,
+  popup, settings, maintenance, a11y. Enums (`PROVIDER_STATES`/`ACTION_KINDS`)
+  deixam de ser cópias manuais: gerados ou verificados por teste contra
+  `status-v2.schema.json`, eliminando o congelamento silencioso do popup
+  quando o Rust ganha um state novo.
+
+## Fase 1 — Claude completo
+
+Critério de pronto: a barra real do mantenedor mostrando 5h + semanal +
+resets do Claude com dado vivo (prova funcional + perceptual + de dados).
+
+TDD por item; o teste de header nasce antes do fix (é o teste que teria
+impedido o bug de shippar — o irmão do Grok já o faz em `adapters.rs:785`):
+
+1. **Header `Bearer`** — `adapters.rs:382` envia o token OAuth cru; a API
+   responde 401 e a UI mostra "unauthenticated" com credencial válida.
+   Fix: prefixar `"Bearer "` (padrão do Grok, `adapters.rs:155`) + assert de
+   `last_headers` no teste do Claude.
+2. **Bucket `seven_day_oauth_apps`** — `ClaudeUsageDoc` (`v2_map.rs:378-397`)
+   não declara o campo; serde descarta em silêncio. Fix: adicionar campo e
+   preferi-lo sobre `seven_day` (precedência do widget nativo,
+   `Claude.qml:406`).
+3. **Dedup de IDs de janela** — `limits[]` dinâmico e campos legados
+   `seven_day_opus`/`seven_day_sonnet` geram o mesmo id
+   (`weekly_model_id`, `v2_map.rs:512` vs `:532`);
+   `ensure_unique_window_ids` (`status/schema.rs:996-1007`) rejeita e o
+   coordinator (`status/coordinator.rs:240`) rebaixa a linha inteira do Claude
+   para `provider_error`, apagando 5h/semanal válidos. Fix: deduplicar por id
+   na montagem (`limits[]` vence; legado só preenche ausências).
+4. **`resets_at` tolerante** — helper compartilhado (ver Arquitetura),
+   aplicado ao Claude nesta fase.
+5. **Retry compartilhado** — helper extraído do Grok, aplicado ao Claude
+   nesta fase (Amp adota na Fase 4).
+6. **Expiry client-side** — token vencido vira estado próprio ("expirado",
+   com último dado em cache exibido e hint de login), não o genérico
+   "authentication was rejected". Sem refresh de token: o contrato "não
+   manuseia credenciais" permanece.
+7. **Tier real** — `parse_claude_credentials` passa a ler `rateLimitTier`
+   (`max_20x` → "Max 20x"), com fallback para `subscriptionType`.
+8. **Código morto** — remover o falso "double-division guard"
+   (`v2_map.rs:554-563`, ramos idênticos) e cobrir com teste o caso
+   percentual real (1.0 renderiza 1%, não 100%).
+
+## Fase 2 — UI transversal + redesign do popup
+
+O usuário confirmou os quatro problemas visuais: denso/poluído, timestamps
+ilegíveis, hierarquia confusa, chip da barra fraco.
+
+1. **Humanização de tempo** — helper único (`formatWhen`): resets como
+   "em 2h 14m", atualização como "há 3 min". Atualizar o teste que hoje
+   **fixa** a string ISO crua (`tst_BarWidget.qml:257-263`).
+2. **Redesign do popup e do chip** — GATE OBRIGATÓRIO: mockups visuais
+   (HTML/companion) comparando opções de hierarquia e densidade, aprovados
+   pelo mantenedor ANTES de tocar QML de layout. O redesign ataca os quatro
+   problemas confirmados; o chip passa a comunicar estado de relance
+   (pior janela/percentual mais crítico entre providers habilitados).
+3. **`error.retryable` de verdade** — QML passa a ler o boolean do schema em
+   vez da lista hardcoded paralela de states.
+4. **Split do `ServiceCore.js`** + enum sync por teste/geração (ver
+   Arquitetura). Funções test-only (`requiredScreenshotNames`,
+   `themePalette`) saem do bundle shipado.
+5. **Limpeza rust-core** — remover os 4 `let _ =` vestigiais
+   (`status/coordinator.rs:221`, `cache/store.rs:121`, `cli/mod.rs:651`,
+   `notifications/mod.rs:193`), o subsistema forced-targets nunca invocado
+   (`cache/coordinator.rs:87`) e a dependência dormante apontada pela
+   auditoria; endurecer o teste anti-dormant para checar uso real, não
+   comentário.
+
+## Fase 3 — Codex
+
+1. **Freshness honesta** — dado de session-log (potencialmente de horas
+   atrás) deixa de ser reportado como `DataSource::Live` com
+   `last_success_at: now`; passa a carregar fonte e timestamp reais.
+2. **Sandbox no spawn** — `codex app-server` ganha `-s read-only -a
+   untrusted` (paridade com o scanner nativo; princípio do menor
+   privilégio).
+3. **3º estágio legalizado** — a leitura de `~/.codex/rate-limits.json`
+   (`adapters.rs:304-308`) ganha cap de 1 MiB + rejeição de symlink (mesmas
+   proteções do session-log) e entra no spec (hoje o contrato documenta só
+   2 estágios).
+4. **Dedup de schemas** — eliminar os tipos paralelos de
+   `codex_app_server.rs:28-58` e o round-trip parse→build→serialize→reparse
+   (`normalize_to_rate_limits_json` → `codex_from_rate_limits_json`);
+   deserializar uma vez nos tipos do `v2_map`.
+5. **Remover `rate_limits_by_limit_id`** — caminho especulativo sem fixture,
+   sem teste e sem contraparte no spec ou na referência.
+6. **Retry no Codex** — adotar o helper compartilhado nos estágios
+   transitórios (RPC/timeout), honrando o `RetryPolicy::OneTransient` que o
+   catalog já declara para o provider.
+
+## Fase 4 — Amp/Grok
+
+1. **Amp: classificador de auth específico** — fim do substring `"auth"`
+   (`adapters.rs:54-56`); matching por frases/padrões conhecidos do CLI.
+2. **Amp: parse-miss visível** — saída do `amp usage` que não casa nenhum
+   padrão conhecido vira `provider_error` "formato não reconhecido"
+   (retryable), distinto do estado válido "conectado sem janela" (`—`).
+3. **Grok: `currentPeriod.type` respeitado** — rótulo da janela deixa de ser
+   "weekly" hardcoded (`v2_map.rs:166`).
+4. **Grok: expiry local** — checar `expires_at` do `auth.json` antes do HTTP;
+   vencido → estado "expirado" acionável (mesmo padrão da Fase 1 item 6).
+5. **Dead code** — remover `grok_from_auth_and_signals`/`GrokSignals`
+   (implementação pré-#28) e as 4 fixtures órfãs.
+6. **Retry no Amp** — adotar o helper compartilhado (fecha a promessa do
+   spec para os 4 providers).
+
+## Fase 5 — Paridade com o nativo + emenda de contrato
+
+A emenda vem ANTES do código desta fase:
+
+1. **Emenda v11 do contrato** (`CLAUDE.md` + spec): permitir histórico e
+   stats locais não-monetários (o v10 os proíbe: "v10 removes: session
+   history and charts"); documentar os headers do Claude na linha do spec
+   (a assimetria de documentação — Grok com headers explícitos, Claude sem —
+   plausivelmente deixou o bug do Bearer passar); atualizar a menção à
+   branch de implementação.
+2. **Coexistência com o widget nativo documentada** — ambos consultam
+   `api.anthropic.com/api/oauth/usage`; rodar os dois duplica polling no
+   mesmo endpoint rate-limitado (risco de 429). Documentar em
+   `docs/runtime.md` com recomendação de habilitar um só.
+3. **Stats locais via Rust** — subcomando do helper (sem Python, contrato
+   Rust/QML) lendo `~/.claude/stats-cache.json`, `history.jsonl` e
+   `~/.claude/projects` com os mesmos caps/anti-symlink de arquivo;
+   equivalente ao scanner Python do nativo. Campos aditivos no schema v2.
+4. **UI de paridade** — tokens/dia por modelo, prompts/sessões de hoje,
+   atividade recente no popup — com mockup aprovado antes (mesmo gate da
+   Fase 2).
+5. **Settings schema declarativo do Quattro** — decidir na fase: adotar
+   (scriptável via `omarchy bar plugin set`) ou registrar em
+   `docs/runtime.md` por que a surface própria permanece. Critério: se o
+   redesign da Fase 2 reduzir a settings surface a tipos flat, adotar.
+
+## Tratamento de erros
+
+Inalterado no princípio: falha operacional de provider é **dado tipado**,
+nunca falha de processo. As mudanças refinam a taxonomia: "expirado" distinto
+de "rejeitado" (Fases 1/4), parse-miss distinto de "sem janela" (Fase 4),
+freshness real na fonte (Fase 3). Nenhum item relaxa redação de
+segredos/tokens em logs, cache, screenshots ou UI.
+
+## Testes e verificação
+
+- TDD por item: teste falhando → fix mínimo → verde (regra do repo).
+- Gate de cada fase: `cargo fmt --check` + `cargo test` + `cargo clippy
+  --all-targets -- -D warnings` + `git diff --check`; mudanças QML rodam
+  `qmllint` + `qmltestrunner` offscreen (a auditoria constatou que a suíte
+  QML nunca foi executada de fato — ela roda como baseline já na Fase 1);
+  ShellCheck para scripts.
+- Fim de fase = QA ao vivo autorizado na barra real do mantenedor: prova
+  funcional (testes), perceptual (screenshot lado a lado) e de dados (valores
+  reais conferidos contra `claude.ai`/fontes).
+- Fixtures novas por provider cobrindo os shapes reais observados
+  (percent-scale 1.0, epoch vs ISO, buckets OAuth, period types do Grok).
+
+## Riscos e mitigação
+
+- **API da Anthropic sem contrato público** — mitigado seguindo o widget
+  nativo como referência viva e com parsing tolerante; divergência futura
+  cai em `provider_error` tipado, nunca crash.
+- **Refactor QML grande (Fase 2)** — mitigado pelo split incremental com a
+  suíte `qmltestrunner` rodando de verdade e screenshots comparativos.
+- **Alpha do Quattro em movimento** (r1429, atualiza com frequência) —
+  mitigado pela checagem de drift no início de cada fase (barata: a
+  auditoria já mapeou os pontos de contato).
+
+## Referências
+
+- Auditoria 2026-07-28 (workflow `agent-bar-deep-audit`, 6 áreas + síntese).
+- Widget nativo: `/usr/share/omarchy/shell/plugins/model-usage/` (referência
+  de endpoint, precedência de buckets e sandbox flags).
+- PR basecamp/omarchy#6231 (Quattro), PRs locais #25 e #28.
+- `docs/specs/v10/` — contrato v10 vigente até a emenda da Fase 5.

--- a/src/providers/adapter.rs
+++ b/src/providers/adapter.rs
@@ -214,6 +214,7 @@ pub(crate) fn unauthenticated(
     message: impl Into<String>,
     login_available: bool,
     url: &str,
+    retryable: bool,
 ) -> ProviderResult {
     ProviderResult::Unauthenticated {
         id,
@@ -221,6 +222,7 @@ pub(crate) fn unauthenticated(
         message: message.into(),
         login_available,
         installation_url: url.to_owned(),
+        retryable,
     }
 }
 

--- a/src/providers/adapters.rs
+++ b/src/providers/adapters.rs
@@ -161,75 +161,63 @@ impl ProviderAdapter for GrokAdapter {
             let login = login_available(discovery);
             let now = context.clock.now_utc();
 
-            let mut attempts: u8 = 0;
-            loop {
-                attempts = attempts.saturating_add(1);
-                match context.http.get(GROK_BILLING_URL, &headers, max_body).await {
-                    Ok(resp) if resp.status == 401 || resp.status == 403 => {
-                        return unauthenticated(
-                            ProviderId::Grok,
-                            GROK.display_name,
-                            "Grok authentication was rejected.",
-                            login,
-                            GROK.installation_url,
-                        );
+            match super::retry::http_get_with_retry(
+                context.http,
+                &GROK,
+                GROK_BILLING_URL,
+                &headers,
+                max_body,
+            )
+            .await
+            {
+                Ok(resp) if resp.status == 401 || resp.status == 403 => unauthenticated(
+                    ProviderId::Grok,
+                    GROK.display_name,
+                    "Grok authentication was rejected.",
+                    login,
+                    GROK.installation_url,
+                ),
+                Ok(resp) if (200..300).contains(&resp.status) => {
+                    let _ = resp.final_url;
+                    grok_from_billing_json(&resp.body, account, now, login)
+                }
+                Ok(resp) if resp.status >= 500 => ProviderResult::ProviderError {
+                    id: ProviderId::Grok,
+                    name: GROK.display_name.to_owned(),
+                    message: "Grok billing request failed.".into(),
+                    retryable: true,
+                },
+                Ok(_) => ProviderResult::ProviderError {
+                    id: ProviderId::Grok,
+                    name: GROK.display_name.to_owned(),
+                    message: "Grok billing request failed.".into(),
+                    retryable: false,
+                },
+                Err(super::adapter::HttpError::Network(_)) => ProviderResult::NetworkError {
+                    id: ProviderId::Grok,
+                    name: GROK.display_name.to_owned(),
+                    message: "Network error while contacting Grok.".into(),
+                },
+                Err(super::adapter::HttpError::RedirectRefused(_)) => {
+                    ProviderResult::ProviderError {
+                        id: ProviderId::Grok,
+                        name: GROK.display_name.to_owned(),
+                        message: "Grok billing redirect refused.".into(),
+                        retryable: false,
                     }
-                    Ok(resp) if (200..300).contains(&resp.status) => {
-                        let _ = resp.final_url;
-                        return grok_from_billing_json(&resp.body, account, now, login);
-                    }
-                    Ok(resp) if resp.status >= 500 => {
-                        return ProviderResult::ProviderError {
-                            id: ProviderId::Grok,
-                            name: GROK.display_name.to_owned(),
-                            message: "Grok billing request failed.".into(),
-                            retryable: true,
-                        };
-                    }
-                    Ok(_) => {
-                        return ProviderResult::ProviderError {
-                            id: ProviderId::Grok,
-                            name: GROK.display_name.to_owned(),
-                            message: "Grok billing request failed.".into(),
-                            retryable: false,
-                        };
-                    }
-                    Err(super::adapter::HttpError::Network(_)) => {
-                        if attempts == 1 {
-                            if let Some(delay) = GROK.retry_delay() {
-                                tokio::time::sleep(delay).await;
-                                continue;
-                            }
-                        }
-                        return ProviderResult::NetworkError {
-                            id: ProviderId::Grok,
-                            name: GROK.display_name.to_owned(),
-                            message: "Network error while contacting Grok.".into(),
-                        };
-                    }
-                    Err(super::adapter::HttpError::RedirectRefused(_)) => {
-                        return ProviderResult::ProviderError {
-                            id: ProviderId::Grok,
-                            name: GROK.display_name.to_owned(),
-                            message: "Grok billing redirect refused.".into(),
-                            retryable: false,
-                        };
-                    }
-                    Err(super::adapter::HttpError::BodyTooLarge) => {
-                        return ProviderResult::ProviderError {
-                            id: ProviderId::Grok,
-                            name: GROK.display_name.to_owned(),
-                            message: "Grok billing response exceeded size limit.".into(),
-                            retryable: false,
-                        };
-                    }
-                    Err(super::adapter::HttpError::InvalidResponse(_)) => {
-                        return ProviderResult::ProviderError {
-                            id: ProviderId::Grok,
-                            name: GROK.display_name.to_owned(),
-                            message: "Invalid Grok billing response.".into(),
-                            retryable: false,
-                        };
+                }
+                Err(super::adapter::HttpError::BodyTooLarge) => ProviderResult::ProviderError {
+                    id: ProviderId::Grok,
+                    name: GROK.display_name.to_owned(),
+                    message: "Grok billing response exceeded size limit.".into(),
+                    retryable: false,
+                },
+                Err(super::adapter::HttpError::InvalidResponse(_)) => {
+                    ProviderResult::ProviderError {
+                        id: ProviderId::Grok,
+                        name: GROK.display_name.to_owned(),
+                        message: "Invalid Grok billing response.".into(),
+                        retryable: false,
                     }
                 }
             }
@@ -383,10 +371,14 @@ impl ProviderAdapter for ClaudeAdapter {
                 ("Authorization", bearer.as_str()),
                 ("anthropic-beta", "oauth-2025-04-20"),
             ];
-            match context
-                .http
-                .get(CLAUDE_USAGE_URL, &headers, CLAUDE.max_output_bytes)
-                .await
+            match super::retry::http_get_with_retry(
+                context.http,
+                &CLAUDE,
+                CLAUDE_USAGE_URL,
+                &headers,
+                CLAUDE.max_output_bytes,
+            )
+            .await
             {
                 Ok(resp) if resp.status == 401 || resp.status == 403 => unauthenticated(
                     ProviderId::Claude,
@@ -729,6 +721,49 @@ mod tests {
         let discovery = discovery_with_exe(Path::new("/usr/bin/claude"));
         let result = CLAUDE_ADAPTER.collect(&ctx, &discovery).await;
         assert!(matches!(result, ProviderResult::ProviderError { .. }));
+    }
+
+    #[tokio::test]
+    async fn claude_retries_once_on_network_error() {
+        let body = br#"{"five_hour":{"utilization":10.0,"resets_at":"2026-07-28T22:00:00Z"}}"#;
+        let http = ScriptedHttpClient {
+            responses: Mutex::new(vec![
+                Ok(HttpResponse {
+                    status: 200,
+                    final_url: CLAUDE_USAGE_URL.into(),
+                    body: body.to_vec(),
+                }),
+                Err(crate::providers::adapter::HttpError::Network("blip".into())),
+            ]),
+            last_url: Mutex::new(None),
+            last_headers: Mutex::new(Vec::new()),
+        };
+        let process = empty_process();
+        let mut fs = MapFileSystem::default();
+        fs.files.insert(
+            std::path::PathBuf::from("/home/u/.claude/.credentials.json"),
+            br#"{"claudeAiOauth":{"accessToken":"tok"}}"#.to_vec(),
+        );
+        let env = ExecutionEnvironment {
+            home: std::path::PathBuf::from("/home/u"),
+            path_dirs: vec![],
+            grok_home: None,
+        };
+        let clock = FixedClock(datetime!(2026-07-28 18:00:00 UTC));
+        let ctx = CollectionContext {
+            env: &env,
+            clock: &clock,
+            fs: &fs,
+            process: &process,
+            http: &http,
+            plugin_root: None,
+        };
+        let discovery = discovery_with_exe(Path::new("/usr/bin/claude"));
+        let result = CLAUDE_ADAPTER.collect(&ctx, &discovery).await;
+        assert!(
+            matches!(result, ProviderResult::Ready { .. }),
+            "one transient network error must be retried: {result:?}"
+        );
     }
 
     fn grok_test_env_and_auth(fs: &mut MapFileSystem) -> ExecutionEnvironment {

--- a/src/providers/adapters.rs
+++ b/src/providers/adapters.rs
@@ -357,7 +357,7 @@ impl ProviderAdapter for ClaudeAdapter {
                     );
                 }
             };
-            let (token, plan, account) = match parse_claude_credentials(&cred_bytes) {
+            let creds = match parse_claude_credentials(&cred_bytes) {
                 Some(v) => v,
                 None => {
                     return unauthenticated(
@@ -371,8 +371,26 @@ impl ProviderAdapter for ClaudeAdapter {
                 }
             };
 
+            // An expired session self-heals when Claude Code refreshes the
+            // token; report it as retryable so prior data is retained as stale.
+            let now_ms = context
+                .clock
+                .now_utc()
+                .unix_timestamp()
+                .saturating_mul(1000);
+            if creds.expires_at_ms.is_some_and(|exp| exp <= now_ms) {
+                return unauthenticated(
+                    ProviderId::Claude,
+                    CLAUDE.display_name,
+                    "Claude session expired. Open Claude Code to refresh it.",
+                    login_available(discovery),
+                    CLAUDE.installation_url,
+                    true,
+                );
+            }
+
             // Never log the token. Pass only as Authorization header value.
-            let bearer = format!("Bearer {token}");
+            let bearer = format!("Bearer {}", creds.token);
             let headers = [
                 ("Authorization", bearer.as_str()),
                 ("anthropic-beta", "oauth-2025-04-20"),
@@ -411,8 +429,8 @@ impl ProviderAdapter for ClaudeAdapter {
                     claude_from_usage_json(
                         &resp.body,
                         context.clock.now_utc(),
-                        plan,
-                        account,
+                        creds.plan,
+                        creds.account,
                         login_available(discovery),
                     )
                 }
@@ -448,7 +466,14 @@ impl ProviderAdapter for ClaudeAdapter {
     }
 }
 
-fn parse_claude_credentials(bytes: &[u8]) -> Option<(String, Option<Plan>, Option<Account>)> {
+struct ClaudeCredentials {
+    token: String,
+    plan: Option<Plan>,
+    account: Option<Account>,
+    expires_at_ms: Option<i64>,
+}
+
+fn parse_claude_credentials(bytes: &[u8]) -> Option<ClaudeCredentials> {
     let value: serde_json::Value = serde_json::from_slice(bytes).ok()?;
     let oauth = value.get("claudeAiOauth")?;
     let token = oauth.get("accessToken")?.as_str()?.to_owned();
@@ -462,7 +487,13 @@ fn parse_claude_credentials(bytes: &[u8]) -> Option<(String, Option<Plan>, Optio
             id: id.to_owned(),
             label: id.to_owned(),
         });
-    Some((token, plan, None))
+    let expires_at_ms = oauth.get("expiresAt").and_then(|v| v.as_i64());
+    Some(ClaudeCredentials {
+        token,
+        plan,
+        account: None,
+        expires_at_ms,
+    })
 }
 
 /// Test-only fixed clock.
@@ -771,6 +802,47 @@ mod tests {
             matches!(result, ProviderResult::Ready { .. }),
             "one transient network error must be retried: {result:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn claude_expired_token_skips_http_and_is_retryable() {
+        let http = ScriptedHttpClient::default(); // any HTTP call would error
+        let process = empty_process();
+        let mut fs = MapFileSystem::default();
+        fs.files.insert(
+            std::path::PathBuf::from("/home/u/.claude/.credentials.json"),
+            // expiresAt in the past relative to the fixed clock below.
+            br#"{"claudeAiOauth":{"accessToken":"tok","expiresAt":1690000000000}}"#.to_vec(),
+        );
+        let env = ExecutionEnvironment {
+            home: std::path::PathBuf::from("/home/u"),
+            path_dirs: vec![],
+            grok_home: None,
+        };
+        let clock = FixedClock(datetime!(2026-07-28 18:00:00 UTC));
+        let ctx = CollectionContext {
+            env: &env,
+            clock: &clock,
+            fs: &fs,
+            process: &process,
+            http: &http,
+            plugin_root: None,
+        };
+        let discovery = discovery_with_exe(Path::new("/usr/bin/claude"));
+        let result = CLAUDE_ADAPTER.collect(&ctx, &discovery).await;
+        assert!(
+            http.last_url.lock().unwrap().is_none(),
+            "expired token must not trigger an HTTP request"
+        );
+        match result {
+            ProviderResult::Unauthenticated {
+                message, retryable, ..
+            } => {
+                assert!(message.contains("expired"), "message: {message}");
+                assert!(retryable, "expired session must be retryable");
+            }
+            other => panic!("expected unauthenticated, got {other:?}"),
+        }
     }
 
     fn grok_test_env_and_auth(fs: &mut MapFileSystem) -> ExecutionEnvironment {

--- a/src/providers/adapters.rs
+++ b/src/providers/adapters.rs
@@ -378,8 +378,9 @@ impl ProviderAdapter for ClaudeAdapter {
             };
 
             // Never log the token. Pass only as Authorization header value.
+            let bearer = format!("Bearer {token}");
             let headers = [
-                ("Authorization", token.as_str()),
+                ("Authorization", bearer.as_str()),
                 ("anthropic-beta", "oauth-2025-04-20"),
             ];
             match context
@@ -674,6 +675,20 @@ mod tests {
         assert_eq!(
             http.last_url.lock().unwrap().as_deref(),
             Some(CLAUDE_USAGE_URL)
+        );
+        let headers = http.last_headers.lock().unwrap().clone();
+        assert!(
+            headers.iter().any(|(k, v)| {
+                k == "Authorization" && v.starts_with("Bearer ") && v.contains("SECRET_TOKEN_VALUE")
+            }),
+            "Authorization Bearer header missing: got keys {:?}",
+            headers.iter().map(|(k, _)| k.as_str()).collect::<Vec<_>>()
+        );
+        assert!(
+            headers
+                .iter()
+                .any(|(k, v)| k == "anthropic-beta" && v == "oauth-2025-04-20"),
+            "anthropic-beta header missing"
         );
         assert!(matches!(result, ProviderResult::Ready { .. }));
         assert_no_money(&result);

--- a/src/providers/adapters.rs
+++ b/src/providers/adapters.rs
@@ -497,11 +497,15 @@ fn parse_claude_credentials(bytes: &[u8]) -> Option<ClaudeCredentials> {
 /// the capitalized subscription type. Mirrors the native widget's formatTier.
 fn claude_plan(subscription_type: Option<&str>, rate_limit_tier: Option<&str>) -> Option<Plan> {
     if let Some(tier) = rate_limit_tier.filter(|t| !t.is_empty()) {
-        if let Some(suffix) = tier.strip_prefix("max_") {
-            return Some(Plan {
-                id: tier.to_owned(),
-                label: format!("Max {suffix}"),
-            });
+        if let Some(pos) = tier.find("max_") {
+            let suffix = &tier[pos + 4..];
+            let digits = suffix.strip_suffix('x').unwrap_or("");
+            if !digits.is_empty() && digits.chars().all(|c| c.is_ascii_digit()) {
+                return Some(Plan {
+                    id: tier.to_owned(),
+                    label: format!("Max {suffix}"),
+                });
+            }
         }
         return Some(Plan {
             id: tier.to_owned(),
@@ -877,6 +881,14 @@ mod tests {
         let plan = claude_plan(Some("max"), Some("max_20x"));
         assert_eq!(plan.as_ref().map(|p| p.label.as_str()), Some("Max 20x"));
         assert_eq!(plan.as_ref().map(|p| p.id.as_str()), Some("max_20x"));
+
+        // Real-world tier shape observed live: prefix before max_.
+        let real = claude_plan(Some("max"), Some("default_claude_max_20x"));
+        assert_eq!(real.as_ref().map(|p| p.label.as_str()), Some("Max 20x"));
+        assert_eq!(
+            real.as_ref().map(|p| p.id.as_str()),
+            Some("default_claude_max_20x")
+        );
 
         let fallback = claude_plan(Some("pro"), None);
         assert_eq!(fallback.as_ref().map(|p| p.label.as_str()), Some("Pro"));

--- a/src/providers/adapters.rs
+++ b/src/providers/adapters.rs
@@ -480,13 +480,10 @@ fn parse_claude_credentials(bytes: &[u8]) -> Option<ClaudeCredentials> {
     if token.is_empty() {
         return None;
     }
-    let plan = oauth
-        .get("subscriptionType")
-        .and_then(|v| v.as_str())
-        .map(|id| Plan {
-            id: id.to_owned(),
-            label: id.to_owned(),
-        });
+    let plan = claude_plan(
+        oauth.get("subscriptionType").and_then(|v| v.as_str()),
+        oauth.get("rateLimitTier").and_then(|v| v.as_str()),
+    );
     let expires_at_ms = oauth.get("expiresAt").and_then(|v| v.as_i64());
     Some(ClaudeCredentials {
         token,
@@ -494,6 +491,36 @@ fn parse_claude_credentials(bytes: &[u8]) -> Option<ClaudeCredentials> {
         account: None,
         expires_at_ms,
     })
+}
+
+/// Prefer the granular rate-limit tier ("max_20x" → "Max 20x"); fall back to
+/// the capitalized subscription type. Mirrors the native widget's formatTier.
+fn claude_plan(subscription_type: Option<&str>, rate_limit_tier: Option<&str>) -> Option<Plan> {
+    if let Some(tier) = rate_limit_tier.filter(|t| !t.is_empty()) {
+        if let Some(suffix) = tier.strip_prefix("max_") {
+            return Some(Plan {
+                id: tier.to_owned(),
+                label: format!("Max {suffix}"),
+            });
+        }
+        return Some(Plan {
+            id: tier.to_owned(),
+            label: capitalize_ascii(tier),
+        });
+    }
+    let sub = subscription_type.filter(|s| !s.is_empty())?;
+    Some(Plan {
+        id: sub.to_owned(),
+        label: capitalize_ascii(sub),
+    })
+}
+
+fn capitalize_ascii(raw: &str) -> String {
+    let mut chars = raw.chars();
+    match chars.next() {
+        Some(first) => first.to_ascii_uppercase().to_string() + chars.as_str(),
+        None => String::new(),
+    }
 }
 
 /// Test-only fixed clock.
@@ -843,6 +870,19 @@ mod tests {
             }
             other => panic!("expected unauthenticated, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn claude_plan_formats_rate_limit_tier() {
+        let plan = claude_plan(Some("max"), Some("max_20x"));
+        assert_eq!(plan.as_ref().map(|p| p.label.as_str()), Some("Max 20x"));
+        assert_eq!(plan.as_ref().map(|p| p.id.as_str()), Some("max_20x"));
+
+        let fallback = claude_plan(Some("pro"), None);
+        assert_eq!(fallback.as_ref().map(|p| p.label.as_str()), Some("Pro"));
+        assert_eq!(fallback.as_ref().map(|p| p.id.as_str()), Some("pro"));
+
+        assert!(claude_plan(None, None).is_none());
     }
 
     fn grok_test_env_and_auth(fs: &mut MapFileSystem) -> ExecutionEnvironment {

--- a/src/providers/adapters.rs
+++ b/src/providers/adapters.rs
@@ -60,6 +60,7 @@ impl ProviderAdapter for AmpAdapter {
                             "Amp is not authenticated.",
                             login_available(discovery),
                             AMP.installation_url,
+                            false,
                         )
                     } else {
                         ProviderResult::ProviderError {
@@ -133,6 +134,7 @@ impl ProviderAdapter for GrokAdapter {
                         "Grok is not authenticated.",
                         login_available(discovery),
                         GROK.installation_url,
+                        false,
                     );
                 }
             };
@@ -148,6 +150,7 @@ impl ProviderAdapter for GrokAdapter {
                         "Grok is not authenticated.",
                         login_available(discovery),
                         GROK.installation_url,
+                        false,
                     );
                 }
             };
@@ -176,6 +179,7 @@ impl ProviderAdapter for GrokAdapter {
                     "Grok authentication was rejected.",
                     login,
                     GROK.installation_url,
+                    false,
                 ),
                 Ok(resp) if (200..300).contains(&resp.status) => {
                     let _ = resp.final_url;
@@ -349,6 +353,7 @@ impl ProviderAdapter for ClaudeAdapter {
                         "Claude is not authenticated.",
                         login_available(discovery),
                         CLAUDE.installation_url,
+                        false,
                     );
                 }
             };
@@ -361,6 +366,7 @@ impl ProviderAdapter for ClaudeAdapter {
                         "Claude is not authenticated.",
                         login_available(discovery),
                         CLAUDE.installation_url,
+                        false,
                     );
                 }
             };
@@ -386,6 +392,7 @@ impl ProviderAdapter for ClaudeAdapter {
                     "Claude authentication was rejected.",
                     login_available(discovery),
                     CLAUDE.installation_url,
+                    false,
                 ),
                 Ok(resp) if resp.status == 429 => ProviderResult::RateLimited {
                     id: ProviderId::Claude,

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -7,6 +7,7 @@ pub mod codex_app_server;
 pub mod codex_session_log;
 pub mod http;
 pub mod process;
+mod retry;
 pub mod v2_map;
 
 pub use adapter::{

--- a/src/providers/retry.rs
+++ b/src/providers/retry.rs
@@ -1,0 +1,95 @@
+//! Shared one-transient-retry loop for HTTP collection.
+//!
+//! The catalog declares [`RetryPolicy::OneTransient`] for every provider; this
+//! is the single implementation of that promise. Only network errors retry.
+
+use super::adapter::{HttpClient, HttpError, HttpResponse};
+use super::catalog::ProviderDescriptor;
+
+/// GET with at most one extra attempt after a transient network error,
+/// honoring the descriptor's retry policy and delay.
+pub(crate) async fn http_get_with_retry(
+    http: &dyn HttpClient,
+    descriptor: &ProviderDescriptor,
+    url: &str,
+    headers: &[(&str, &str)],
+    max_body_bytes: usize,
+) -> Result<HttpResponse, HttpError> {
+    match http.get(url, headers, max_body_bytes).await {
+        Err(HttpError::Network(first)) => {
+            let Some(delay) = descriptor.retry_delay() else {
+                return Err(HttpError::Network(first));
+            };
+            tokio::time::sleep(delay).await;
+            http.get(url, headers, max_body_bytes).await
+        }
+        other => other,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::providers::catalog::CLAUDE;
+    use crate::providers::http::ScriptedHttpClient;
+
+    fn ok_response() -> HttpResponse {
+        HttpResponse {
+            status: 200,
+            final_url: "https://example.invalid/".into(),
+            body: b"{}".to_vec(),
+        }
+    }
+
+    #[tokio::test]
+    async fn retries_once_after_network_error() {
+        // ScriptedHttpClient pops from the END: last entry is served first.
+        let http = ScriptedHttpClient {
+            responses: std::sync::Mutex::new(vec![
+                Ok(ok_response()),
+                Err(HttpError::Network("transient".into())),
+            ]),
+            last_url: std::sync::Mutex::new(None),
+            last_headers: std::sync::Mutex::new(Vec::new()),
+        };
+        let result = http_get_with_retry(&http, &CLAUDE, "https://x/", &[], 1024).await;
+        assert!(result.is_ok(), "expected retry to succeed: {result:?}");
+        assert!(
+            http.responses.lock().unwrap().is_empty(),
+            "both scripted responses must be consumed (two attempts)"
+        );
+    }
+
+    #[tokio::test]
+    async fn non_network_errors_do_not_retry() {
+        let http = ScriptedHttpClient {
+            responses: std::sync::Mutex::new(vec![
+                Ok(ok_response()),
+                Err(HttpError::RedirectRefused("https://evil/".into())),
+            ]),
+            last_url: std::sync::Mutex::new(None),
+            last_headers: std::sync::Mutex::new(Vec::new()),
+        };
+        let result = http_get_with_retry(&http, &CLAUDE, "https://x/", &[], 1024).await;
+        assert!(matches!(result, Err(HttpError::RedirectRefused(_))));
+        assert_eq!(
+            http.responses.lock().unwrap().len(),
+            1,
+            "second scripted response must remain unconsumed (single attempt)"
+        );
+    }
+
+    #[tokio::test]
+    async fn second_network_error_is_returned() {
+        let http = ScriptedHttpClient {
+            responses: std::sync::Mutex::new(vec![
+                Err(HttpError::Network("second".into())),
+                Err(HttpError::Network("first".into())),
+            ]),
+            last_url: std::sync::Mutex::new(None),
+            last_headers: std::sync::Mutex::new(Vec::new()),
+        };
+        let result = http_get_with_retry(&http, &CLAUDE, "https://x/", &[], 1024).await;
+        assert!(matches!(result, Err(HttpError::Network(_))));
+    }
+}

--- a/src/providers/v2_map.rs
+++ b/src/providers/v2_map.rs
@@ -231,6 +231,7 @@ pub fn grok_from_auth_and_signals(
             message: "Grok is not authenticated.".into(),
             login_available,
             installation_url: GROK.installation_url.to_owned(),
+            retryable: false,
         };
     }
 
@@ -473,6 +474,7 @@ pub fn claude_from_usage_json(
                 message: "Claude authentication expired.".into(),
                 login_available,
                 installation_url: CLAUDE.installation_url.to_owned(),
+                retryable: false,
             };
         }
         return ProviderResult::ProviderError {

--- a/src/providers/v2_map.rs
+++ b/src/providers/v2_map.rs
@@ -592,16 +592,8 @@ fn claude_window(id: &str, label: &str, raw: &ClaudeWindowRaw) -> Option<UsageWi
     if !raw.utilization.is_finite() {
         return None;
     }
-    // Guard double-division: values are already percent, not 0..=1 fractions.
-    let used = if raw.utilization > 0.0 && raw.utilization <= 1.0 {
-        // Ambiguous tiny values: treat as percent only when clearly percent-like
-        // API always sends 0..=100; if someone passes 0.42 meaning 42%, that
-        // was the historical bug — we intentionally treat <=1 as percent only
-        // when the fixture marks it via >100 impossible; keep as-is clamp.
-        raw.utilization.clamp(0.0, 100.0)
-    } else {
-        raw.utilization.clamp(0.0, 100.0)
-    };
+    // Utilization is already percent scale (1.0 == 1%); clamp only.
+    let used = raw.utilization.clamp(0.0, 100.0);
     let remaining = (100.0 - used).clamp(0.0, 100.0);
     let resets = raw.resets_at.as_deref().and_then(parse_reset_timestamp);
     UsageWindow::try_new(id, label, used, remaining, resets).ok()
@@ -736,6 +728,21 @@ mod tests {
                     windows[0].resets_at().is_some(),
                     "epoch resets_at was dropped"
                 );
+            }
+            other => panic!("expected ready, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn claude_utilization_one_means_one_percent() {
+        // The endpoint reports percent scale: 1.0 is 1%, never 100%.
+        let body = br#"{"five_hour":{"utilization":1.0,"resets_at":"2026-07-28T22:00:00Z"}}"#;
+        let result =
+            claude_from_usage_json(body, datetime!(2026-07-28 18:00:00 UTC), None, None, true);
+        match result {
+            ProviderResult::Ready { windows, .. } => {
+                assert!((windows[0].used_percent() - 1.0).abs() < 0.01);
+                assert!((windows[0].remaining_percent() - 99.0).abs() < 0.01);
             }
             other => panic!("expected ready, got {other:?}"),
         }

--- a/src/providers/v2_map.rs
+++ b/src/providers/v2_map.rs
@@ -488,13 +488,13 @@ pub fn claude_from_usage_json(
     let mut windows = Vec::new();
     if let Some(w) = doc.five_hour.as_ref() {
         if let Some(window) = claude_window("session", "Session", w) {
-            windows.push(window);
+            push_window_unique(&mut windows, window);
         }
     }
     // OAuth tokens report the weekly bucket as seven_day_oauth_apps; prefer it.
     if let Some(w) = doc.seven_day_oauth_apps.as_ref().or(doc.seven_day.as_ref()) {
         if let Some(window) = claude_window("weekly", "Weekly", w) {
-            windows.push(window);
+            push_window_unique(&mut windows, window);
         }
     }
     // Dynamic model windows from limits[] or legacy seven_day_* fields.
@@ -524,7 +524,7 @@ pub fn claude_from_usage_json(
             resets_at: limit.resets_at.clone(),
         };
         if let Some(window) = claude_window(&id, &label, &raw) {
-            windows.push(window);
+            push_window_unique(&mut windows, window);
         }
     }
     for (suffix, field) in [
@@ -534,7 +534,7 @@ pub fn claude_from_usage_json(
         if let Some(w) = field {
             let id = weekly_model_id(suffix, 0);
             if let Some(window) = claude_window(&id, &format!("Weekly {suffix}"), w) {
-                windows.push(window);
+                push_window_unique(&mut windows, window);
             }
         }
     }
@@ -548,6 +548,15 @@ pub fn claude_from_usage_json(
         windows,
         last_success_at: now,
     }
+}
+
+/// Insert keeping window ids unique; first occurrence wins (dynamic limits[]
+/// entries are pushed before legacy seven_day_* fields on purpose).
+fn push_window_unique(windows: &mut Vec<UsageWindow>, window: UsageWindow) {
+    if windows.iter().any(|w| w.id() == window.id()) {
+        return;
+    }
+    windows.push(window);
 }
 
 fn claude_window(id: &str, label: &str, raw: &ClaudeWindowRaw) -> Option<UsageWindow> {
@@ -815,6 +824,36 @@ mod tests {
                 assert!(windows[0].resets_at().is_some());
             }
             other => panic!("{other:?}"),
+        }
+    }
+
+    #[test]
+    fn claude_dedupes_model_window_ids_across_sources() {
+        // limits[] entry AND legacy seven_day_opus for the same model must not
+        // produce duplicate window ids (schema rejects the whole row otherwise).
+        let body = br#"{
+            "five_hour": {"utilization": 10.0},
+            "limits": [{"kind": "seven_day_model", "utilization": 20.0,
+                        "scope": {"model": {"id": "opus", "display_name": "Opus"}}}],
+            "seven_day_opus": {"utilization": 55.0}
+        }"#;
+        let result =
+            claude_from_usage_json(body, datetime!(2026-07-28 18:00:00 UTC), None, None, true);
+        // The whole row must survive schema validation downstream (duplicate
+        // window ids make ensure_unique_window_ids reject the entire status).
+        let status = crate::status::collect::provider_status_from_result(result.clone());
+        assert!(status.is_ok(), "row failed schema validation: {status:?}");
+        match result {
+            ProviderResult::Ready { windows, .. } => {
+                let opus: Vec<_> = windows
+                    .iter()
+                    .filter(|w| w.id() == "weekly-model:opus")
+                    .collect();
+                assert_eq!(opus.len(), 1, "duplicate weekly-model:opus windows");
+                // limits[] (dynamic) wins over the legacy field.
+                assert!((opus[0].used_percent() - 20.0).abs() < 0.01);
+            }
+            other => panic!("expected ready, got {other:?}"),
         }
     }
 

--- a/src/providers/v2_map.rs
+++ b/src/providers/v2_map.rs
@@ -471,10 +471,10 @@ pub fn claude_from_usage_json(
             return ProviderResult::Unauthenticated {
                 id: ProviderId::Claude,
                 name: CLAUDE.display_name.to_owned(),
-                message: "Claude authentication expired.".into(),
+                message: "Claude session expired. Open Claude Code to refresh it.".into(),
                 login_available,
                 installation_url: CLAUDE.installation_url.to_owned(),
-                retryable: false,
+                retryable: true,
             };
         }
         return ProviderResult::ProviderError {
@@ -681,7 +681,15 @@ mod tests {
         let body = br#"{"error":{"error_code":"token_expired","message":"expired"}}"#;
         let result =
             claude_from_usage_json(body, datetime!(2026-07-26 18:00:00 UTC), None, None, true);
-        assert!(matches!(result, ProviderResult::Unauthenticated { .. }));
+        match result {
+            ProviderResult::Unauthenticated {
+                message, retryable, ..
+            } => {
+                assert!(retryable, "server-reported expiry must be retryable");
+                assert!(message.contains("expired"), "message: {message}");
+            }
+            other => panic!("expected unauthenticated, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/providers/v2_map.rs
+++ b/src/providers/v2_map.rs
@@ -382,6 +382,8 @@ struct ClaudeUsageDoc {
     #[serde(default)]
     seven_day: Option<ClaudeWindowRaw>,
     #[serde(default)]
+    seven_day_oauth_apps: Option<ClaudeWindowRaw>,
+    #[serde(default)]
     seven_day_opus: Option<ClaudeWindowRaw>,
     #[serde(default)]
     seven_day_sonnet: Option<ClaudeWindowRaw>,
@@ -489,7 +491,8 @@ pub fn claude_from_usage_json(
             windows.push(window);
         }
     }
-    if let Some(w) = doc.seven_day.as_ref() {
+    // OAuth tokens report the weekly bucket as seven_day_oauth_apps; prefer it.
+    if let Some(w) = doc.seven_day_oauth_apps.as_ref().or(doc.seven_day.as_ref()) {
         if let Some(window) = claude_window("weekly", "Weekly", w) {
             windows.push(window);
         }
@@ -500,7 +503,7 @@ pub fn claude_from_usage_json(
             continue;
         };
         let kind = limit.kind.as_deref().unwrap_or("");
-        if kind == "five_hour" || kind == "seven_day" {
+        if kind == "five_hour" || kind == "seven_day" || kind == "seven_day_oauth_apps" {
             continue; // handled via dedicated fields when present
         }
         let model_id = limit
@@ -678,6 +681,38 @@ mod tests {
         match result {
             ProviderResult::Ready { windows, .. } => assert!(windows.is_empty()),
             other => panic!("{other:?}"),
+        }
+    }
+
+    #[test]
+    fn claude_reads_seven_day_oauth_apps_bucket() {
+        let body = br#"{"five_hour":{"utilization":10.0,"resets_at":"2026-07-28T20:00:00Z"},"seven_day_oauth_apps":{"utilization":37.0,"resets_at":"2026-08-01T00:00:00Z"}}"#;
+        let result =
+            claude_from_usage_json(body, datetime!(2026-07-28 18:00:00 UTC), None, None, true);
+        match result {
+            ProviderResult::Ready { windows, .. } => {
+                assert_eq!(windows.len(), 2);
+                assert_eq!(windows[1].id(), "weekly");
+                assert!((windows[1].used_percent() - 37.0).abs() < 0.01);
+                assert!(windows[1].resets_at().is_some());
+            }
+            other => panic!("expected ready, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn claude_prefers_oauth_apps_bucket_over_seven_day() {
+        let body =
+            br#"{"seven_day_oauth_apps":{"utilization":30.0},"seven_day":{"utilization":60.0}}"#;
+        let result =
+            claude_from_usage_json(body, datetime!(2026-07-28 18:00:00 UTC), None, None, true);
+        match result {
+            ProviderResult::Ready { windows, .. } => {
+                assert_eq!(windows.len(), 1);
+                assert_eq!(windows[0].id(), "weekly");
+                assert!((windows[0].used_percent() - 30.0).abs() < 0.01);
+            }
+            other => panic!("expected ready, got {other:?}"),
         }
     }
 

--- a/src/providers/v2_map.rs
+++ b/src/providers/v2_map.rs
@@ -559,6 +559,33 @@ fn push_window_unique(windows: &mut Vec<UsageWindow>, window: UsageWindow) {
     windows.push(window);
 }
 
+/// Parse a reset timestamp that may be RFC3339, epoch seconds, or epoch millis.
+///
+/// The documented contract is RFC3339-only, but the live OAuth endpoint and
+/// sibling providers also emit epochs; be liberal on input, strict on output.
+fn parse_reset_timestamp(raw: &str) -> Option<OffsetDateTime> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if let Ok(ts) = OffsetDateTime::parse(trimmed, &Rfc3339) {
+        return Some(ts.to_offset(UtcOffset::UTC));
+    }
+    let numeric: i128 = trimmed.parse().ok()?;
+    if numeric <= 0 {
+        return None;
+    }
+    // < 1e12 → seconds; otherwise milliseconds (mirrors the reference widget).
+    let nanos = if numeric < 1_000_000_000_000 {
+        numeric.checked_mul(1_000_000_000)?
+    } else {
+        numeric.checked_mul(1_000_000)?
+    };
+    OffsetDateTime::from_unix_timestamp_nanos(nanos)
+        .ok()
+        .map(|ts| ts.to_offset(UtcOffset::UTC))
+}
+
 fn claude_window(id: &str, label: &str, raw: &ClaudeWindowRaw) -> Option<UsageWindow> {
     if !raw.utilization.is_finite() {
         return None;
@@ -574,11 +601,7 @@ fn claude_window(id: &str, label: &str, raw: &ClaudeWindowRaw) -> Option<UsageWi
         raw.utilization.clamp(0.0, 100.0)
     };
     let remaining = (100.0 - used).clamp(0.0, 100.0);
-    let resets = raw
-        .resets_at
-        .as_deref()
-        .and_then(|s| OffsetDateTime::parse(s, &Rfc3339).ok())
-        .map(|ts| ts.to_offset(UtcOffset::UTC));
+    let resets = raw.resets_at.as_deref().and_then(parse_reset_timestamp);
     UsageWindow::try_new(id, label, used, remaining, resets).ok()
 }
 
@@ -679,6 +702,40 @@ mod tests {
                 assert!((windows[0].remaining_percent() - 58.0).abs() < 0.01);
             }
             other => panic!("{other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_reset_timestamp_accepts_iso_and_epoch() {
+        let iso = parse_reset_timestamp("2026-08-01T00:00:00Z");
+        assert!(iso.is_some());
+        // Epoch seconds (10 digits).
+        let secs = parse_reset_timestamp("1785272823");
+        assert_eq!(secs.map(|t| t.unix_timestamp()), Some(1_785_272_823));
+        // Epoch milliseconds (13 digits).
+        let millis = parse_reset_timestamp("1785272823412");
+        assert_eq!(millis.map(|t| t.unix_timestamp()), Some(1_785_272_823));
+        // Garbage and non-positive are rejected.
+        assert!(parse_reset_timestamp("soon").is_none());
+        assert!(parse_reset_timestamp("0").is_none());
+        assert!(parse_reset_timestamp("-5").is_none());
+        assert!(parse_reset_timestamp("").is_none());
+    }
+
+    #[test]
+    fn claude_window_accepts_epoch_resets_at() {
+        let body = br#"{"five_hour":{"utilization":42.0,"resets_at":"1785272823"}}"#;
+        let result =
+            claude_from_usage_json(body, datetime!(2026-07-28 18:00:00 UTC), None, None, true);
+        match result {
+            ProviderResult::Ready { windows, .. } => {
+                assert_eq!(windows.len(), 1);
+                assert!(
+                    windows[0].resets_at().is_some(),
+                    "epoch resets_at was dropped"
+                );
+            }
+            other => panic!("expected ready, got {other:?}"),
         }
     }
 

--- a/src/status/collect.rs
+++ b/src/status/collect.rs
@@ -51,6 +51,7 @@ pub fn provider_status_from_result(result: ProviderResult) -> Result<ProviderSta
             message,
             login_available,
             installation_url,
+            retryable,
         } => {
             let action = if login_available {
                 ProviderAction::login("Log in")
@@ -60,7 +61,7 @@ pub fn provider_status_from_result(result: ProviderResult) -> Result<ProviderSta
             ProviderStatus::unauthenticated(
                 id,
                 name,
-                ProviderError::new(ErrorCode::AuthenticationRequired, message, false),
+                ProviderError::new(ErrorCode::AuthenticationRequired, message, retryable),
                 action,
             )
         }

--- a/src/status/coordinator.rs
+++ b/src/status/coordinator.rs
@@ -542,6 +542,24 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn retryable_auth_failure_retains_prior_ready_as_stale() {
+        // Expired-token style failure (retryable) keeps last good windows.
+        let now = datetime!(2026-07-28 18:42:00 UTC);
+        let prior = ready_claude(now);
+        let live = ProviderStatus::unauthenticated(
+            ProviderId::Claude,
+            "Claude",
+            ProviderError::new(ErrorCode::AuthenticationRequired, "expired", true),
+            ProviderAction::login("Log in"),
+        )
+        .unwrap();
+        let out = apply_stale_retention(live, Some(&prior)).unwrap();
+        assert_eq!(out.state(), ProviderState::Stale);
+        assert_eq!(out.windows().len(), 1, "prior windows must be retained");
+        assert!(out.error().is_some_and(|e| e.retryable));
+    }
+
+    #[tokio::test]
     async fn auth_failure_does_not_retain_stale_usage() {
         let now = datetime!(2026-07-26 18:42:00 UTC);
         let prior = ready_claude(now);

--- a/src/status/schema.rs
+++ b/src/status/schema.rs
@@ -445,11 +445,14 @@ impl ProviderStatus {
         )
     }
 
-    /// Temporary failures eligible for stale retention (not auth / missing CLI).
+    /// Temporary failures eligible for stale retention. Rejected auth and
+    /// missing CLI never retain; an expired session (retryable auth) does.
     pub fn is_temporary_failure(&self) -> bool {
         match self.state {
             ProviderState::NetworkError | ProviderState::RateLimited => true,
-            ProviderState::ProviderError => self.error.as_ref().is_some_and(|e| e.retryable),
+            ProviderState::ProviderError | ProviderState::Unauthenticated => {
+                self.error.as_ref().is_some_and(|e| e.retryable)
+            }
             _ => false,
         }
     }
@@ -951,6 +954,7 @@ pub enum ProviderResult {
         message: String,
         login_available: bool,
         installation_url: String,
+        retryable: bool,
     },
     RateLimited {
         id: ProviderId,


### PR DESCRIPTION
## Summary

Two phases of the v11 recovery design (\`docs/superpowers/specs/2026-07-28-v11-recovery-quattro-parity-design.md\`), both live-QA'd on the maintainer machine.

### Phase 1 — Claude usage monitoring restored (13 commits)

Claude rows rendered as \`unauthenticated\` since v10.0.0 even with valid credentials. Root cause chain fixed:
- Authorization header sent the raw OAuth token without the \`Bearer \` prefix → unconditional 401.
- The weekly \`seven_day_oauth_apps\` bucket was silently dropped by serde.
- Duplicate window ids (\`limits[]\` × legacy \`seven_day_opus/sonnet\`) collapsed the whole Claude row to \`provider_error\`.
- \`resets_at\` only parsed strict RFC3339 while the endpoint also emits epochs.

Plus: shared one-transient retry helper (Claude+Grok), expired sessions (client pre-check and server-reported \`token_expired\`) retain cached windows as Stale, real \`rateLimitTier\` badge ("Max 20x").

### Phase 2 — UI overhaul (12 commits)

- Duration-based window labels across all providers: "5h Reset" / "7d Reset" / "1d Reset" / "{n}m Reset" (ids unchanged).
- Humanized times: "resets 2h 30m · 14:59" (hardcoded-English weekday for ≥24h), "Updated 5m ago" footer; raw ISO banned from tooltips by test.
- Layered popup redesign (approved via mockups): large primary windows with theme-accent tracks, per-model quiet list, stale banner (⌛ + Retry gated by \`error.retryable\`), meta footer; slim header with plan pill; stale chip cue "⌛".
- \`ServiceCore.js\` (1536 lines) split into 5 concern modules with \`.import\` JS→JS (byte-verified move); JS enums locked to the Rust schema by a contract test.
- Rust cleanup: dormant \`anyhow\` removed + anti-dormant test now verifies real usage; dead forced-targets subsystem removed; \`binary_interactive_update_rejects_non_tty\` fixed (env isolation + TTY-before-network, the latter mandated by spec JSON contract §345).

## Verification

- \`cargo fmt --check\` / \`cargo test\` (280 tests, zero exceptions — the historic non-tty failure is fixed, not skipped) / \`cargo clippy --all-targets -- -D warnings\` / \`git diff --check\`: clean.
- QML suite: 174/174 via the Qt6 runner; \`qmllint\` and \`omarchy plugin validate\` clean. CLAUDE.md's documented runner invocation corrected (PATH \`qmltestrunner\` is Qt5 on Arch and fails silently).
- Live QA (both phases): installed helper + QML on the real bar; popup matches the approved mockup with live data (5H RESET 30% left · resets 46m · 12:49; 7D RESET 80% left · resets 1d 20h · Fri 09:00; Max 20x pill).

Spec: \`docs/superpowers/specs/2026-07-28-v11-recovery-quattro-parity-design.md\` · Plans: \`docs/superpowers/plans/2026-07-28-fase1-claude-completo.md\`, \`docs/superpowers/plans/2026-07-28-fase2-ui-transversal.md\`