### PR TITLE
UI polish: window labels, chip tooltip, popup height

### DIFF
--- a/assets/omarchy/CoreView.js
+++ b/assets/omarchy/CoreView.js
@@ -128,22 +128,16 @@ function chipDimmed(provider) {
   return state !== "ready"
 }
 
-// UX-011: provider, displayed percentage, state, reset summary.
-function chipTooltip(provider, metric, nowMs) {
+// UX-011: provider and displayed percentage; typed state only when it is
+// actionable (anything but ready). Reset detail lives in the popup.
+function chipTooltip(provider, metric) {
   if (!provider)
     return ""
   var name = provider.name ? String(provider.name) : providerDisplayName(provider.id)
-  var pct = chipPercentText(provider, metric)
+  var parts = [name, chipPercentText(provider, metric)]
   var state = provider.state ? String(provider.state) : "unknown"
-  var parts = [name, pct, state]
-  var w = primaryWindow(provider)
-  if (w && w.resetsAt) {
-    var resetText = formatResetText(String(w.resetsAt), nowMs === undefined ? Date.now() : nowMs)
-    if (resetText) {
-      var label = w.label ? String(w.label) : String(w.id || "window")
-      parts.push("resets " + label + " " + resetText)
-    }
-  }
+  if (state !== "ready")
+    parts.push(state)
   return parts.join(" \u00b7 ")
 }
 

--- a/assets/omarchy/Popup.qml
+++ b/assets/omarchy/Popup.qml
@@ -84,8 +84,11 @@ KeyboardPanel {
 
   open: isOpen
   contentWidth: maxContentWidth
+  // verticalContentInset (padding + borders), not padding alone: KeyboardPanel
+  // subtracts the border from the inner area, so sizing without it left the
+  // border as phantom overflow and enabled a few-pixel scroll.
   contentHeight: Scroll.fittedPopupContentHeight(
-    measuredBodyHeight + padding * 2,
+    measuredBodyHeight + verticalContentInset,
     minContentHeight,
     maxContentHeight
   )

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -37,7 +37,7 @@ Representative response:
       "windows": [
         {
           "id": "session",
-          "label": "5h Reset",
+          "label": "Session (5h)",
           "usedPercent": 42.0,
           "remainingPercent": 58.0,
           "resetsAt": "2026-07-26T22:00:00Z"

--- a/docs/specs/v10/03-cli-and-json-contract.md
+++ b/docs/specs/v10/03-cli-and-json-contract.md
@@ -116,7 +116,7 @@ Representative response:
       "windows": [
         {
           "id": "session",
-          "label": "5h Reset",
+          "label": "Session (5h)",
           "usedPercent": 42.0,
           "remainingPercent": 58.0,
           "resetsAt": "2026-07-26T22:00:00Z"

--- a/docs/superpowers/specs/2026-07-29-v11-ui-fixes-design.md
+++ b/docs/superpowers/specs/2026-07-29-v11-ui-fixes-design.md
@@ -1,0 +1,62 @@
+# v11 UI polish fixes — design
+
+Date: 2026-07-29. Approved by the owner after live use of the Fase 2 popup.
+Amends the locked visual decisions of
+`2026-07-28-v11-recovery-quattro-parity-design.md` (label format A) at the
+owner's request.
+
+## Problems observed in live use
+
+1. Chip hover tooltip reads `Claude · 14% · ready · resets 5h Reset 1m ·
+   12:50`. The raw `ready` state is noise, and the window label (`5h Reset`)
+   concatenated with the humanized reset text repeats "Reset"/"resets".
+2. The provider popup opens with a scrollbar and a few pixels of scroll even
+   though content fits. Root cause: `Popup.qml` sizes the card as
+   `content + padding * 2`, but `KeyboardPanel` subtracts
+   `verticalContentInset` (padding **plus** top/bottom border) from the inner
+   area. The ~4px border becomes overflow, `flickableInteractive` turns on.
+3. Amp window labels `1d Reset` / `7d Reset` are cryptic; the owner wants
+   `Daily` / `Weekly`. The same scheme generalizes to every provider and
+   removes the duplicated "RESET" kicker in the popup.
+
+## Decisions
+
+### A. Window labels (Rust-owned, all providers)
+
+Labels keep being born in `src/providers/v2_map.rs`; QML still never
+re-derives them. New naming, duration kept in parentheses (owner's request):
+
+| window id            | old label   | new label      |
+| -------------------- | ----------- | -------------- |
+| `session`            | `5h Reset`  | `Session (5h)` |
+| `daily`              | `1d Reset`  | `Daily (1d)`   |
+| `weekly`             | `7d Reset`  | `Weekly (7d)`  |
+| Codex `other:{n}:…`  | `{n}m Reset`| `{n}m`         |
+
+Popup kicker renders uppercase: `SESSION (5H)`, `WEEKLY (7D)`.
+
+### B. Chip tooltip (CoreView.js)
+
+`chipTooltip` returns `Name · pct`. The typed state is appended only when it
+is not `ready` (stale/error states are actionable; `ready` is noise). The
+reset segment is removed entirely — reset detail lives in the popup.
+
+Examples: `Claude · 99%` · `Claude · 99% · stale` · `Grok · — · network_error`.
+
+### C. Popup height (Popup.qml)
+
+`contentHeight` uses the panel's own `verticalContentInset`
+(`padding * 2 + Border.top + Border.bottom`) instead of `padding * 2`, so the
+border no longer eats viewport and short content never scrolls.
+
+## Testing
+
+- Rust: existing tests pinning old labels updated; label table asserted per
+  provider adapter.
+- QML: `chipTooltip` unit cases (ready / stale / error); source-inspection
+  test asserting the `contentHeight` binding uses `verticalContentInset`.
+- Full gate: cargo fmt/test/clippy, qmllint, `omarchy plugin validate`,
+  Qt6 `qmltestrunner`.
+
+Out of scope: any other visual change; popup structure stays as shipped in
+Fase 2.

--- a/src/providers/adapters.rs
+++ b/src/providers/adapters.rs
@@ -979,7 +979,7 @@ mod tests {
             } => {
                 assert_eq!(windows.len(), 1);
                 assert_eq!(windows[0].id(), "weekly");
-                assert_eq!(windows[0].label(), "7d Reset");
+                assert_eq!(windows[0].label(), "Weekly (7d)");
                 assert!(windows.iter().all(|w| w.id() != "context"));
                 assert_eq!(account.as_ref().map(|a| a.label.as_str()), Some("Ada"));
             }

--- a/src/providers/v2_map.rs
+++ b/src/providers/v2_map.rs
@@ -17,6 +17,12 @@ use crate::support::redact::strip_ansi_and_controls;
 
 use super::catalog::{AMP, CLAUDE, CODEX, GROK};
 
+/// Display labels for the shared window ids. Every provider mapper uses these;
+/// QML renders them verbatim and never re-derives.
+const LABEL_SESSION: &str = "Session (5h)";
+const LABEL_DAILY: &str = "Daily (1d)";
+const LABEL_WEEKLY: &str = "Weekly (7d)";
+
 // ---------------------------------------------------------------------------
 // Amp
 // ---------------------------------------------------------------------------
@@ -61,7 +67,7 @@ pub fn amp_from_usage_text(stdout: &str, now: OffsetDateTime) -> ProviderResult 
         } else {
             None
         };
-        if let Ok(window) = UsageWindow::try_new("daily", "1d Reset", used, rem, resets) {
+        if let Ok(window) = UsageWindow::try_new("daily", LABEL_DAILY, used, rem, resets) {
             windows.push(window);
         }
     }
@@ -163,7 +169,7 @@ pub fn grok_from_billing_json(
             let used = used_raw.clamp(0.0, 100.0);
             let remaining = (100.0 - used).clamp(0.0, 100.0);
             let resets = grok_billing_resets_at(&doc);
-            if let Ok(w) = UsageWindow::try_new("weekly", "7d Reset", used, remaining, resets) {
+            if let Ok(w) = UsageWindow::try_new("weekly", LABEL_WEEKLY, used, remaining, resets) {
                 windows.push(w);
             }
         }
@@ -345,14 +351,14 @@ pub fn codex_from_rate_limits_json(bytes: &[u8], now: OffsetDateTime) -> Provide
 /// → session, secondary → weekly) for incomplete payloads.
 fn codex_window_identity(window_minutes: Option<i64>, ordinal: usize) -> (String, String) {
     match window_minutes {
-        Some(10080) => ("weekly".into(), "7d Reset".into()),
-        Some(300) => ("session".into(), "5h Reset".into()),
-        Some(n) if n > 0 => (format!("other:{n}:{ordinal}"), format!("{n}m Reset")),
+        Some(10080) => ("weekly".into(), LABEL_WEEKLY.into()),
+        Some(300) => ("session".into(), LABEL_SESSION.into()),
+        Some(n) if n > 0 => (format!("other:{n}:{ordinal}"), format!("{n}m")),
         _ => {
             if ordinal == 1 {
-                ("session".into(), "5h Reset".into())
+                ("session".into(), LABEL_SESSION.into())
             } else {
-                ("weekly".into(), "7d Reset".into())
+                ("weekly".into(), LABEL_WEEKLY.into())
             }
         }
     }
@@ -489,13 +495,13 @@ pub fn claude_from_usage_json(
 
     let mut windows = Vec::new();
     if let Some(w) = doc.five_hour.as_ref() {
-        if let Some(window) = claude_window("session", "5h Reset", w) {
+        if let Some(window) = claude_window("session", LABEL_SESSION, w) {
             push_window_unique(&mut windows, window);
         }
     }
     // OAuth tokens report the weekly bucket as seven_day_oauth_apps; prefer it.
     if let Some(w) = doc.seven_day_oauth_apps.as_ref().or(doc.seven_day.as_ref()) {
-        if let Some(window) = claude_window("weekly", "7d Reset", w) {
+        if let Some(window) = claude_window("weekly", LABEL_WEEKLY, w) {
             push_window_unique(&mut windows, window);
         }
     }
@@ -656,6 +662,7 @@ mod tests {
             ProviderResult::Ready { windows, .. } => {
                 assert_eq!(windows.len(), 1);
                 assert_eq!(windows[0].id(), "daily");
+                assert_eq!(windows[0].label(), "Daily (1d)");
                 assert!((windows[0].remaining_percent() - 97.0).abs() < 0.01);
             }
             other => panic!("expected ready, got {other:?}"),
@@ -732,6 +739,7 @@ mod tests {
         match result {
             ProviderResult::Ready { windows, .. } => {
                 assert_eq!(windows.len(), 1);
+                assert_eq!(windows[0].label(), "Session (5h)");
                 assert!(
                     windows[0].resets_at().is_some(),
                     "epoch resets_at was dropped"
@@ -825,9 +833,23 @@ mod tests {
             ProviderResult::Ready { windows, plan, .. } => {
                 assert_eq!(windows.len(), 1);
                 assert_eq!(windows[0].id(), "weekly");
-                assert_eq!(windows[0].label(), "7d Reset");
+                assert_eq!(windows[0].label(), "Weekly (7d)");
                 assert!((windows[0].used_percent() - 1.0).abs() < 0.01);
                 assert!(plan.is_some());
+            }
+            other => panic!("expected ready, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn codex_other_duration_labels_minutes_only() {
+        let body =
+            br#"{"primary":{"used_percent":10.0,"window_minutes":45,"resets_at":1785628013}}"#;
+        let result = codex_from_rate_limits_json(body, datetime!(2026-07-26 18:00:00 UTC));
+        match result {
+            ProviderResult::Ready { windows, .. } => {
+                assert_eq!(windows[0].id(), "other:45:1");
+                assert_eq!(windows[0].label(), "45m");
             }
             other => panic!("expected ready, got {other:?}"),
         }
@@ -842,10 +864,10 @@ mod tests {
             ProviderResult::Ready { windows, .. } => {
                 assert_eq!(windows.len(), 2);
                 assert_eq!(windows[0].id(), "session");
-                assert_eq!(windows[0].label(), "5h Reset");
+                assert_eq!(windows[0].label(), "Session (5h)");
                 assert!((windows[0].used_percent() - 30.0).abs() < 0.01);
                 assert_eq!(windows[1].id(), "weekly");
-                assert_eq!(windows[1].label(), "7d Reset");
+                assert_eq!(windows[1].label(), "Weekly (7d)");
                 assert!((windows[1].used_percent() - 40.0).abs() < 0.01);
             }
             other => panic!("expected ready, got {other:?}"),
@@ -860,7 +882,7 @@ mod tests {
             ProviderResult::Ready { windows, plan, .. } => {
                 assert_eq!(windows.len(), 1);
                 assert_eq!(windows[0].id(), "weekly");
-                assert_eq!(windows[0].label(), "7d Reset");
+                assert_eq!(windows[0].label(), "Weekly (7d)");
                 assert!((windows[0].used_percent() - 33.0).abs() < 0.01);
                 assert!((windows[0].remaining_percent() - 67.0).abs() < 0.01);
                 assert!(windows[0].resets_at().is_some());

--- a/tests/fixtures/status-v2/money-field.json
+++ b/tests/fixtures/status-v2/money-field.json
@@ -22,7 +22,7 @@
       "windows": [
         {
           "id": "session",
-          "label": "5h Reset",
+          "label": "Session (5h)",
           "usedPercent": 42.0,
           "remainingPercent": 58.0,
           "resetsAt": "2026-07-26T22:00:00Z",

--- a/tests/fixtures/status-v2/percent-over-100.json
+++ b/tests/fixtures/status-v2/percent-over-100.json
@@ -22,7 +22,7 @@
       "windows": [
         {
           "id": "session",
-          "label": "5h Reset",
+          "label": "Session (5h)",
           "usedPercent": 101.0,
           "remainingPercent": 0.0,
           "resetsAt": "2026-07-26T22:00:00Z"

--- a/tests/fixtures/status-v2/ready.json
+++ b/tests/fixtures/status-v2/ready.json
@@ -22,7 +22,7 @@
       "windows": [
         {
           "id": "session",
-          "label": "5h Reset",
+          "label": "Session (5h)",
           "usedPercent": 42.0,
           "remainingPercent": 58.0,
           "resetsAt": "2026-07-26T22:00:00Z"

--- a/tests/fixtures/status-v2/valid-multi-provider.json
+++ b/tests/fixtures/status-v2/valid-multi-provider.json
@@ -22,14 +22,14 @@
       "windows": [
         {
           "id": "session",
-          "label": "5h Reset",
+          "label": "Session (5h)",
           "usedPercent": 10.0,
           "remainingPercent": 90.0,
           "resetsAt": "2026-07-26T22:00:00Z"
         },
         {
           "id": "weekly",
-          "label": "7d Reset",
+          "label": "Weekly (7d)",
           "usedPercent": 25.5,
           "remainingPercent": 74.5,
           "resetsAt": "2026-08-01T00:00:00Z"

--- a/tests/fixtures/status-v2/valid-stale.json
+++ b/tests/fixtures/status-v2/valid-stale.json
@@ -22,7 +22,7 @@
       "windows": [
         {
           "id": "session",
-          "label": "5h Reset",
+          "label": "Session (5h)",
           "usedPercent": 90.0,
           "remainingPercent": 10.0,
           "resetsAt": null

--- a/tests/qml/tst_BarWidget.qml
+++ b/tests/qml/tst_BarWidget.qml
@@ -253,15 +253,17 @@ TestCase {
     verify(!Core.chipDimmed(makeProvider("claude", "ready", 1, 99)))
   }
 
-  function test_tooltip_includes_provider_percent_state_reset() {
+  function test_tooltip_ready_is_name_and_percent_only() {
     var p = makeProvider("claude", "ready", 42, 58, "2026-07-26T22:00:00Z")
     var tip = Core.chipTooltip(p, "remaining", Date.parse("2026-07-26T20:00:00Z"))
-    verify(tip.indexOf("Claude") >= 0)
-    verify(tip.indexOf("58%") >= 0)
-    verify(tip.indexOf("ready") >= 0)
-    verify(tip.indexOf("resets") >= 0)
-    verify(tip.indexOf("2h 0m") >= 0)
-    verify(tip.indexOf("2026-07-26T22:00:00Z") === -1)
+    compare(tip, "Claude · 58%")
+  }
+
+  function test_tooltip_appends_state_only_when_not_ready() {
+    var stale = makeProvider("claude", "stale", 42, 58, "2026-07-26T22:00:00Z")
+    compare(Core.chipTooltip(stale, "remaining"), "Claude · 58% · stale")
+    var err = makeProvider("grok", "network_error")
+    compare(Core.chipTooltip(err, "remaining"), "Grok · — · network_error")
   }
 
   // ---- Task 10: click routing ----

--- a/tests/qml/tst_Popup.qml
+++ b/tests/qml/tst_Popup.qml
@@ -107,6 +107,15 @@ TestCase {
     }
   }
 
+  function test_card_height_accounts_for_border_inset() {
+    // KeyboardPanel subtracts verticalContentInset (padding + top/bottom
+    // border) from the inner area; sizing the card with padding alone leaves
+    // the border as phantom overflow that enables a few-pixel scroll.
+    var src = read("assets/omarchy/Popup.qml")
+    verify(src.indexOf("verticalContentInset") >= 0)
+    verify(src.indexOf("padding * 2") < 0)
+  }
+
   function test_popup_open_owner_gate() {
     var ownerA = { id: "a" }
     var ownerB = { id: "b" }

--- a/tests/qml/tst_ProviderStates.qml
+++ b/tests/qml/tst_ProviderStates.qml
@@ -172,9 +172,9 @@ TestCase {
     var provider = {
       id: "claude", name: "Claude", state: "ready",
       windows: [
-        { id: "session", label: "5h Reset", usedPercent: 31, remainingPercent: 69,
+        { id: "session", label: "Session (5h)", usedPercent: 31, remainingPercent: 69,
           resetsAt: "2026-07-28T17:59:59Z" },
-        { id: "weekly", label: "7d Reset", usedPercent: 6, remainingPercent: 94,
+        { id: "weekly", label: "Weekly (7d)", usedPercent: 6, remainingPercent: 94,
           resetsAt: "2026-07-31T11:59:59Z" },
         { id: "weekly-model:opus", label: "Opus", usedPercent: 2, remainingPercent: 98,
           resetsAt: "2026-07-31T11:59:59Z" }
@@ -184,7 +184,7 @@ TestCase {
     var groups = Core.windowGroups(provider, "remaining", now)
     compare(groups.primary.length, 2)
     compare(groups.secondary.length, 1)
-    compare(groups.primary[0].label, "5h Reset")
+    compare(groups.primary[0].label, "Session (5h)")
     verify(groups.primary[0].resetText.indexOf("2h 59m") === 0, groups.primary[0].resetText)
     compare(groups.secondary[0].label, "Opus")
   }

--- a/tests/qml/tst_Screenshots.qml
+++ b/tests/qml/tst_Screenshots.qml
@@ -96,14 +96,14 @@ TestCase {
       applyTheme("light")
       stage.titleText = "Claude"
       stage.badgeText = "Connected"
-      stage.bodyText = "5h Reset 58% left · Max plan"
+      stage.bodyText = "Session (5h) 58% left · Max plan"
       return
     }
     applyTheme("dark")
     if (name.indexOf("ready-dark") === 0) {
       stage.titleText = "Claude"
       stage.badgeText = "Connected"
-      stage.bodyText = "5h Reset 58% left · Max plan"
+      stage.bodyText = "Session (5h) 58% left · Max plan"
     } else if (name.indexOf("loading-dark") === 0) {
       stage.titleText = "Loading"
       stage.badgeText = "Loading"
@@ -111,7 +111,7 @@ TestCase {
     } else if (name.indexOf("refreshing-with-data-dark") === 0) {
       stage.titleText = "Codex"
       stage.badgeText = "Connected · refreshing"
-      stage.bodyText = "7d Reset 74% left (prior data kept)"
+      stage.bodyText = "Weekly (7d) 74% left (prior data kept)"
     } else if (name.indexOf("stale-dark") === 0) {
       stage.titleText = "Grok"
       stage.badgeText = "Stale"


### PR DESCRIPTION
Three fixes the owner spotted using the Fase 2 popup, spec in
`docs/superpowers/specs/2026-07-29-v11-ui-fixes-design.md`.

## Window labels (all providers)

Labels stay Rust-owned in `v2_map.rs`; new naming keeps the duration in
parentheses:

| window id | old | new |
|---|---|---|
| `session` | `5h Reset` | `Session (5h)` |
| `daily` | `1d Reset` | `Daily (1d)` |
| `weekly` | `7d Reset` | `Weekly (7d)` |
| Codex `other:{n}:…` | `{n}m Reset` | `{n}m` |

Removes the duplicated "RESET" between the popup kicker and the humanized
reset line. Amends the label decision of the v11 recovery spec at the
owner's request.

## Chip tooltip

`chipTooltip` now returns `Name · pct`, appending the typed state only when
it is not `ready`. The reset segment is gone — that detail lives in the
popup. Was: `Claude · 14% · ready · resets 5h Reset 1m · 12:50`.

## Popup phantom scroll

`Popup.qml` sized the card with `padding * 2`, but `KeyboardPanel` subtracts
`verticalContentInset` (padding **plus** borders) from the inner area, so the
~4px border became overflow and enabled a few-pixel scroll on every open.
The card height now uses `verticalContentInset`.

## Verification

Full gate green: `cargo fmt --check`, 281 Rust tests, clippy `-D warnings`,
qmllint, `omarchy plugin validate`, 176 QML tests (Qt6 runner). Live QA on
the owner's bar: new labels confirmed in live status data and popup/tooltip
visually approved by the owner.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **User Interface**
  * Updated usage window labels to clearer formats such as “Session (5h),” “Daily (1d),” and “Weekly (7d).”
  * Simplified provider tooltips by removing reset timing details and hiding the “ready” state when applicable.
  * Improved popup sizing to prevent unwanted scrolling caused by borders and insets.

* **Documentation**
  * Updated JSON examples and specifications to reflect the new window labels.

* **Tests**
  * Updated UI, provider, and fixture coverage for the revised labels, tooltips, and popup sizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->