### PR TITLE
Fix settings save deadlock and update 302 handling

### DIFF
--- a/assets/omarchy/Service.qml
+++ b/assets/omarchy/Service.qml
@@ -622,6 +622,8 @@ Item {
     settingsWriteBusy = true
     if (testMode)
       return
+    // Re-arm stdin: each save closes it after writing (EOF delivery below).
+    settingsWriteProcess.stdinEnabled = true
     settingsWriteProcess.command = Settings.settingsArgvApplyStdin(helper)
     settingsWriteProcess.running = true
   }
@@ -755,8 +757,12 @@ Item {
     stderr: StdioCollector { id: settingsWriteErr; waitForEnd: true }
     onStarted: {
       // Write the immutable captured payload; never re-read live draft (SET-018).
-      if (root.pendingSettingsPayload && root.pendingSettingsPayload.length)
+      // config apply stdin reads until EOF — write() alone does not deliver it;
+      // stdinEnabled=false closes the write channel (same as maintenance handoff).
+      if (root.pendingSettingsPayload && root.pendingSettingsPayload.length) {
         write(root.pendingSettingsPayload + "\n")
+        settingsWriteProcess.stdinEnabled = false
+      }
     }
     onExited: function (exitCode) {
       var ok = exitCode === 0

--- a/docs/superpowers/specs/2026-07-29-settings-update-fixes-design.md
+++ b/docs/superpowers/specs/2026-07-29-settings-update-fixes-design.md
@@ -1,0 +1,66 @@
+# Settings save deadlock + update metadata redirect — design
+
+Date: 2026-07-29. Approved by the owner. Fixes the two defects reported after
+live use of 10.1.0: the Settings Save button silently does nothing, and the
+update flow (issue #31) fails against real GitHub.
+
+## Defect 1 — Settings save deadlocks on stdin EOF
+
+Evidence: `~/.config/agent-bar/settings.json` mtime predates every recent save
+attempt; toggling a provider and saving changes nothing.
+
+Chain:
+
+1. `agent-bar config apply stdin` reads the payload with `read_to_string`
+   (`src/cli/mod.rs`), which blocks until **EOF**.
+2. `settingsWriteProcess` in `Service.qml` writes the payload in `onStarted`
+   but never closes the write channel, so EOF never arrives.
+3. The helper hangs forever; nothing is written; `settingsWriteBusy` stays
+   `true`, so every later save is silently rejected until the shell restarts.
+
+`maintenanceHandoffProcess` in the same file already documents the gotcha
+("write() alone does not deliver EOF; stdinEnabled=false closes the write
+channel") and applies the correct pattern.
+
+Fix (QML only; the helper is correct):
+
+- `settingsWriteProcess.onStarted`: after `write(payload)`, set
+  `stdinEnabled = false` to deliver EOF.
+- `kickSettingsWrite()`: re-arm `stdinEnabled = true` before starting the
+  process so consecutive saves work.
+
+Test: QML source-inspection (tst pattern already used for process wiring)
+asserting the settings write process closes stdin after writing and re-arms
+before start.
+
+## Defect 2 — Update check dies on GitHub's 302 (issue #31)
+
+`UpdateCheck::run` (`src/plugin/maintenance.rs`) fetches the release
+**metadata asset** with a raw `http.get` and requires status 200. GitHub
+release assets always answer 302 to the CDN, so every `update check` — and
+`update apply`, which re-runs the check — fails with
+"metadata download HTTP 302". The archive and checksum downloads already use
+`download_with_policy`, which follows ≤5 HTTPS redirects while validating
+every hop against the closed host allowlist (`github.com`,
+`*.githubusercontent.com`).
+
+Fix (Rust):
+
+- Replace the raw metadata fetch in `UpdateCheck::run` with
+  `download_with_policy(http, &meta_asset.browser_download_url)`.
+- Provider HTTP (`src/providers/http.rs`, OAuth path) keeps
+  `Policy::none` untouched.
+
+Test: fake `ReleaseHttp` where the metadata asset answers 302 with a
+`Location` on `objects.githubusercontent.com` followed by 200 — update check
+succeeds; a hop outside the allowlist still fails.
+
+## Verification
+
+Full gate (cargo fmt/test/clippy, qmllint, plugin validate, Qt6
+qmltestrunner). Live QA on the owner's setup: disable a provider → Save →
+chip disappears and `settings.json` changes on disk; `agent-bar update check`
+against real GitHub returns the machine document instead of HTTP 302.
+
+Out of scope: any other Settings behavior, the maintenance worker, and the
+sidecar-checksum leniency (`if let Ok`) — unchanged.

--- a/src/plugin/maintenance.rs
+++ b/src/plugin/maintenance.rs
@@ -520,20 +520,11 @@ impl UpdateCheck {
             validate_release_asset_url(&archive_asset.browser_download_url)?;
             validate_release_asset_url(&checksum_asset.browser_download_url)?;
 
-            let meta_resp = http.get(
-                &meta_asset.browser_download_url,
-                &[("User-Agent", RELEASE_USER_AGENT)],
-            )?;
-            if meta_resp.status != 200 {
-                return Err(MaintenanceError::msg(format!(
-                    "metadata download HTTP {} for {tag}",
-                    meta_resp.status
-                )));
-            }
-            // Reject credential leakage on redirects — scripted client already
-            // rejects Authorization headers; production uses Policy::none so
-            // callers must follow redirects explicitly via download_with_policy.
-            let meta = ReleaseMetadata::parse_json(&meta_resp.body)
+            // GitHub asset URLs always 302 to the CDN (issue #31); follow the
+            // redirect under the closed host policy like archive/checksum do.
+            let meta_body = download_with_policy(http, &meta_asset.browser_download_url)
+                .map_err(|e| MaintenanceError::msg(format!("metadata download for {tag}: {e}")))?;
+            let meta = ReleaseMetadata::parse_json(&meta_body)
                 .map_err(|e| MaintenanceError::msg(format!("malformed metadata for {tag}: {e}")))?;
 
             if meta.target != probe.target {
@@ -2542,6 +2533,125 @@ mod tests {
         let doc = UpdateCheck::run(&http, &clock, &probe).unwrap();
         assert!(doc.available);
         assert_eq!(doc.latest_compatible.as_ref().unwrap().version, "10.1.0");
+    }
+
+    // Issue #31: GitHub release assets always answer 302 to the CDN, so the
+    // metadata fetch must follow redirects under the closed policy like the
+    // archive/checksum downloads already do.
+    #[test]
+    fn update_check_follows_metadata_redirect() {
+        let meta_10_1 = ReleaseMetadata {
+            schema_version: 1,
+            plugin_id: PLUGIN_ID.into(),
+            version: "10.1.0".into(),
+            target: OFFICIAL_TARGET.into(),
+            omarchy_contract: 1,
+            minimum_quickshell_version: MINIMUM_QUICKSHELL_VERSION.into(),
+            source_commit: "0123456789abcdef0123456789abcdef01234567".into(),
+            archive: ReleaseArchiveMeta {
+                file_name: "agent-bar.usage-10.1.0-x86_64-unknown-linux-gnu.tar.zst".into(),
+                size: 10,
+                sha256: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".into(),
+            },
+            release_notes_url: "https://github.com/othavi0/agent-bar/releases/tag/v10.1.0".into(),
+        };
+        let meta_json = meta_10_1.to_pretty_json().unwrap();
+
+        let releases = serde_json::json!([{
+            "tag_name": "v10.1.0",
+            "draft": false,
+            "prerelease": false,
+            "assets": [
+                {
+                    "name": "agent-bar.usage-10.1.0-x86_64-unknown-linux-gnu.metadata.json",
+                    "browser_download_url": "https://github.com/othavi0/agent-bar/releases/download/v10.1.0/agent-bar.usage-10.1.0-x86_64-unknown-linux-gnu.metadata.json"
+                },
+                {
+                    "name": "agent-bar.usage-10.1.0-x86_64-unknown-linux-gnu.tar.zst",
+                    "browser_download_url": "https://github.com/othavi0/agent-bar/releases/download/v10.1.0/agent-bar.usage-10.1.0-x86_64-unknown-linux-gnu.tar.zst"
+                },
+                {
+                    "name": "agent-bar.usage-10.1.0-x86_64-unknown-linux-gnu.tar.zst.sha256",
+                    "browser_download_url": "https://github.com/othavi0/agent-bar/releases/download/v10.1.0/agent-bar.usage-10.1.0-x86_64-unknown-linux-gnu.tar.zst.sha256"
+                }
+            ]
+        }]);
+
+        // Calls: list (200), metadata (302 → CDN), metadata (200). Pop order
+        // = reverse push.
+        let http = ScriptedReleaseHttp::with_responses(vec![
+            Ok(ReleaseHttpResponse {
+                status: 200,
+                headers: vec![],
+                body: meta_json.into_bytes(),
+            }),
+            Ok(ReleaseHttpResponse {
+                status: 302,
+                headers: vec![(
+                    "Location".into(),
+                    "https://objects.githubusercontent.com/meta".into(),
+                )],
+                body: vec![],
+            }),
+            Ok(ReleaseHttpResponse {
+                status: 200,
+                headers: vec![],
+                body: serde_json::to_vec(&releases).unwrap(),
+            }),
+        ]);
+
+        let clock = FixedClock(OffsetDateTime::parse("2026-07-26T18:42:00Z", &Rfc3339).unwrap());
+        let probe = UpdateCheckProbe {
+            current_version: "10.0.0".into(),
+            quickshell_version: "0.3.0".into(),
+            target: OFFICIAL_TARGET.into(),
+            omarchy_contract: 1,
+        };
+        let doc = UpdateCheck::run(&http, &clock, &probe).unwrap();
+        assert!(doc.available);
+        assert_eq!(doc.latest_compatible.as_ref().unwrap().version, "10.1.0");
+    }
+
+    #[test]
+    fn update_check_rejects_metadata_redirect_outside_allowlist() {
+        let releases = serde_json::json!([{
+            "tag_name": "v10.1.0",
+            "draft": false,
+            "prerelease": false,
+            "assets": [
+                {
+                    "name": "agent-bar.usage-10.1.0-x86_64-unknown-linux-gnu.metadata.json",
+                    "browser_download_url": "https://github.com/othavi0/agent-bar/releases/download/v10.1.0/agent-bar.usage-10.1.0-x86_64-unknown-linux-gnu.metadata.json"
+                },
+                {
+                    "name": "agent-bar.usage-10.1.0-x86_64-unknown-linux-gnu.tar.zst",
+                    "browser_download_url": "https://github.com/othavi0/agent-bar/releases/download/v10.1.0/agent-bar.usage-10.1.0-x86_64-unknown-linux-gnu.tar.zst"
+                },
+                {
+                    "name": "agent-bar.usage-10.1.0-x86_64-unknown-linux-gnu.tar.zst.sha256",
+                    "browser_download_url": "https://github.com/othavi0/agent-bar/releases/download/v10.1.0/agent-bar.usage-10.1.0-x86_64-unknown-linux-gnu.tar.zst.sha256"
+                }
+            ]
+        }]);
+        let http = ScriptedReleaseHttp::with_responses(vec![
+            Ok(ReleaseHttpResponse {
+                status: 302,
+                headers: vec![("Location".into(), "https://evil.example.com/meta".into())],
+                body: vec![],
+            }),
+            Ok(ReleaseHttpResponse {
+                status: 200,
+                headers: vec![],
+                body: serde_json::to_vec(&releases).unwrap(),
+            }),
+        ]);
+        let clock = FixedClock(OffsetDateTime::now_utc());
+        let probe = UpdateCheckProbe {
+            current_version: "10.0.0".into(),
+            ..UpdateCheckProbe::default()
+        };
+        let err = UpdateCheck::run(&http, &clock, &probe).unwrap_err();
+        assert!(err.to_string().contains("not allowed"), "{err}");
     }
 
     #[test]

--- a/tests/qml/tst_Settings.qml
+++ b/tests/qml/tst_Settings.qml
@@ -176,6 +176,32 @@ TestCase {
     verify(src.indexOf("config\", \"apply\", \"stdin\"") >= 0 || src.indexOf("settingsArgvApplyStdin") >= 0)
   }
 
+  // Settings write mirrors the maintenance handoff EOF pattern: `config apply
+  // stdin` reads until EOF, so write() must be followed by stdinEnabled=false
+  // or the helper hangs forever and the save never lands.
+  function test_service_settings_stdin_closes_after_write() {
+    var src = read("assets/omarchy/Service.qml")
+    var proc = src.indexOf("id: settingsWriteProcess")
+    verify(proc >= 0)
+    var onStarted = src.indexOf("onStarted:", proc)
+    verify(onStarted >= 0)
+    var onExited = src.indexOf("onExited:", onStarted)
+    verify(onExited > onStarted)
+    var body = src.substring(onStarted, onExited)
+    verify(body.indexOf("write(") >= 0)
+    var writeAt = body.indexOf("write(")
+    var closeAt = body.indexOf("stdinEnabled = false", writeAt)
+    verify(closeAt > writeAt, "stdinEnabled=false must follow write for EOF")
+    // Re-arm before each start so consecutive saves keep a writable stdin.
+    var kick = src.indexOf("function kickSettingsWrite")
+    verify(kick >= 0)
+    var kickEnd = src.indexOf("function applySettingsWriteResult", kick)
+    verify(kickEnd > kick)
+    var kickBody = src.substring(kick, kickEnd)
+    verify(kickBody.indexOf("stdinEnabled = true") >= 0,
+           "kickSettingsWrite must re-arm stdin before start")
+  }
+
   function test_popup_hosts_settings_view() {
     var src = read("assets/omarchy/Popup.qml")
     verify(src.indexOf("SettingsView") >= 0)


### PR DESCRIPTION
Two defects reported after live use of 10.1.0. Spec:
`docs/superpowers/specs/2026-07-29-settings-update-fixes-design.md`.
Closes #31.

## Settings save deadlocked on stdin EOF

`agent-bar config apply stdin` reads the payload with `read_to_string`,
which blocks until EOF — but `settingsWriteProcess` in `Service.qml` wrote
the payload and never closed the write channel. The helper hung forever,
nothing reached disk, and `settingsWriteBusy` stayed `true`, silently
rejecting every later save until a shell restart. The sibling
`maintenanceHandoffProcess` already documents and applies the correct
pattern; settings now mirrors it: `stdinEnabled = false` after `write()`,
re-armed in `kickSettingsWrite()` so consecutive saves work.

## Update check died on GitHub's 302 (#31)

`UpdateCheck::run` fetched the release metadata asset with a raw `http.get`
requiring status 200, but GitHub asset URLs always answer 302 to the CDN —
so every `update check`/`update apply` failed before doing anything. The
metadata fetch now goes through `download_with_policy`, the same
closed-policy redirect follower (≤5 hops, `github.com` /
`*.githubusercontent.com` only) the archive and checksum downloads already
used. Provider HTTP (OAuth path) keeps `Policy::none`, untouched.

## Verification

Full gate green: `cargo fmt --check`, 283 Rust tests, clippy `-D warnings`,
qmllint, `omarchy plugin validate`, 177 QML tests (Qt6 runner). New tests:
QML source-inspection pinning the write→EOF pattern; fake-HTTP update check
following a 302 to the CDN and rejecting a redirect outside the allowlist.

Live QA on the owner's setup: disable provider → Save → chip disappears and
`settings.json` is rewritten on disk (first successful settings write since
07-26), including a second consecutive save (the previously-deadlocked
path); real `agent-bar update check` against GitHub now returns the machine
document (`available:false` on 10.1.0) instead of "metadata download HTTP
302".