### PR TITLE
fix: bind colours to host tokens, gate language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,8 +176,8 @@ Product milestone — no JSON contract change.
 - **Native settings in omarchy-shell.** Right click on the widget opens
   the same popup in settings mode (`model-usage`-style): per-provider
   toggles, ↑↓ reordering, remaining/used display, notify on/off, and
-  refresh interval. Left = usage (wider popup); middle = refresh. "Open
-  menu (TUI)" link in the footer; the full TUI still lives at
+  refresh interval. Left = usage (wider popup); middle = refresh. A
+  “Abrir menu (TUI)” link in the footer; the full TUI still lives at
   `agent-bar menu`.
 - **`agent-bar config show` / `config apply`.** JSON mini-API for the
   editable subset (`providers`, `providerOrder`, `displayMode`, `notify`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -270,7 +270,7 @@ Product milestone — no JSON contract change.
 ## [8.2.1] - 2026-07-19
 
 ### Fixed
-- **Grok's Waybar icon** — replaced the "G" placeholder with the official
+- **Grok's Waybar icon** — replaced the “G” placeholder with the official
   `Grok_Logomark_Light` logomark from the xAI brand pack
   (`SpaceXAI_Grok_Assets.zip`). No CSS/file-contract change
   (`grok-icon.svg`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,513 +104,527 @@ Authored release notes live at `docs/releases/10.0.0.md`.
 
 ## [9.0.0] - 2026-07-21
 
-Redesign completo do popup (Omarchy-shell) + Waybar rebaixada a tier
-legado. Marco de produto — sem mudança de contrato JSON.
+Complete popup redesign (Omarchy-shell) + Waybar demoted to legacy tier.
+Product milestone — no JSON contract change.
 
 ### Added
-- **Widget.qml redesenhado**: hero % por provider igual ao chip, título
-  `agent-bar` + "há Xm" relativo, ações de topo viram botões Unicode
-  reais (↻ refresh, ⚙︎ settings, ❯ abrir TUI) em vez de texto/link. Um
-  cartão por provider, grade de colunas fixas (rótulo · barra · % ·
-  reset), countdown (`1h 46m · 18:30` / `7d 0h · seg 16:43`) em toda
-  janela. Largura `540` (antes `370`), igual nos dois modos.
-- **`extra` visível no popup**: créditos do Amp (`$X · replenish`),
-  sessões/turnos/modelo do Grok, extra usage do Claude quando existir —
-  antes só existiam no `--format json`, nunca chegavam à tela.
-- **Motion no popup**: barras preenchem na abertura (M1, stagger),
-  `↻` gira durante o fetch (M2), hover nos botões (M4) — gated por
-  `menu.animations` (exposto read-only em `config show` como
-  `menuAnimations`).
+- **Redesigned Widget.qml**: hero % per provider matching the chip,
+  `agent-bar` title + relative "Xm ago", top actions become real Unicode
+  buttons (↻ refresh, ⚙︎ settings, ❯ open TUI) instead of text/link. One
+  card per provider, fixed-column grid (label · bar · % · reset),
+  countdown (`1h 46m · 18:30` / `7d 0h · Mon 16:43`) across every window.
+  Width `540` (previously `370`), the same in both modes.
+- **`extra` visible in the popup**: Amp credits (`$X · replenish`),
+  Grok's sessions/turns/model, Claude's extra usage when present —
+  previously these only existed in `--format json`, never reaching the
+  screen.
+- **Popup motion**: bars fill on open (M1, stagger), `↻` spins during the
+  fetch (M2), button hover (M4) — gated by `menu.animations` (exposed
+  read-only in `config show` as `menuAnimations`).
 - **`windowKind`** (`"fiveHour" | "sevenDay" | "daily" | "context" |
-  "other"`) em `QuotaWindow`, decidido uma vez no Rust por cada
-  provider; dedup display-level (`(windowKind, resetsAt, remaining)`)
-  consumido pela TUI e por Widget.qml — some o "Weekly" triplicado do
-  Codex no plano Plus.
-- **Countdown e fuso local na TUI**: `fmt_reset` do Detail passa a usar
-  `format_reset_time`/`format_eta` (antes fatiava o ISO em UTC cru, sem
-  contagem regressiva).
-- Settings do popup ganham Providers (toggle + reordenar), Exibição
-  (segmentado remaining/used + prévia ao vivo da barra) e Alertas &
-  atualização (notify + intervalo) como painéis próprios.
-- **`platform::detect()`** (`src/platform.rs`) único ponto de decisão
-  Omarchy/Waybar, usado por `setup`, `update` (os dois ramos) e pelo Save
-  da TUI Config — nenhum dos três cria mais `~/.config/waybar/` do zero
-  numa máquina Omarchy-only.
-- **`agent-bar update` reinstala o plugin Omarchy** quando o shell é
-  detectado, eliminando o drift binário↔QML que antes exigia rodar
-  `setup` manualmente. `doctor` ganhou checagem de versão do manifest
-  instalado vs binário.
-- Módulo `src/waybar/` agrupando o contrato Waybar (antigo
-  `waybar_contract.rs`/`waybar_integration.rs`) como tier legado isolado.
+  "other"`) on `QuotaWindow`, decided once in Rust per provider;
+  display-level dedup (`(windowKind, resetsAt, remaining)`) consumed by
+  the TUI and by Widget.qml — makes the tripled "Weekly" on Codex's Plus
+  plan disappear.
+- **Countdown and local timezone in the TUI**: Detail's `fmt_reset` now
+  uses `format_reset_time`/`format_eta` (previously it sliced the raw
+  UTC ISO string, with no countdown).
+- Popup settings gain Providers (toggle + reorder), Display (segmented
+  remaining/used + live bar preview), and Alerts & update (notify +
+  interval) as their own panels.
+- **`platform::detect()`** (`src/platform.rs`) the single Omarchy/Waybar
+  decision point, used by `setup`, `update` (both branches), and TUI
+  Config's Save — none of the three creates `~/.config/waybar/` from
+  scratch anymore on an Omarchy-only machine.
+- **`agent-bar update` reinstalls the Omarchy plugin** when the shell is
+  detected, eliminating the binary↔QML drift that previously required
+  manually running `setup`. `doctor` gained a check of the installed
+  manifest version vs the binary.
+- `src/waybar/` module grouping the Waybar contract (formerly
+  `waybar_contract.rs`/`waybar_integration.rs`) as an isolated legacy
+  tier.
 
 ### Changed
-- **Fix do mislabeling do Codex**: `build_model_windows` não força mais
-  `primary→fiveHour`/`secondary→sevenDay` quando a classificação diverge
-  — uma janela fora de tolerância vira `other` com rótulo pela duração
-  real (ex.: "1h window").
-- **Settings mode do popup**: salvar passa a ser **só pelo botão** — o
-  atalho de teclado `s` para salvar foi removido; o rodapé de dicas em
-  texto vira botões clicáveis de verdade.
-- Migração de settings **v2 → v3**: `waybar.show_percentage` é dropada
-  silenciosamente e o arquivo é regravado na versão nova.
-- TUI Config esconde os campos exclusivos de Waybar (separadores,
-  signal, intervalo do Waybar) quando `platform::detect()` reporta
-  Omarchy-only.
-- `docs/waybar-contract.md` e `README.md` marcam Waybar como **tier
-  legado**: funciona, recebe fix, não recebe feature nova.
+- **Fixed Codex mislabeling**: `build_model_windows` no longer forces
+  `primary→fiveHour`/`secondary→sevenDay` when classification diverges
+  — a window outside tolerance becomes `other` with a label from its
+  real duration (e.g. "1h window").
+- **Popup settings mode**: saving is now **button-only** — the `s`
+  keyboard shortcut for saving was removed; the text hint footer becomes
+  real clickable buttons.
+- Settings migration **v2 → v3**: `waybar.show_percentage` is silently
+  dropped and the file is rewritten at the new version.
+- TUI Config hides the Waybar-exclusive fields (separators, signal,
+  Waybar interval) when `platform::detect()` reports Omarchy-only.
+- `docs/waybar-contract.md` and `README.md` mark Waybar as **legacy
+  tier**: it works, receives fixes, gets no new features.
 
 ### Removed
-- Legado morto: variante `Command::Terminal`,
+- Dead legacy: `Command::Terminal` variant,
   `waybar_contract::get_all_provider_ids`, `install::ensure_amp_cli`,
-  `amp_cli::AMP_INSTALL_COMMAND` duplicada, dependência `tokio-util`,
-  `ConfigField::settings_key()`, 7 variantes órfãs de `Icon`.
+  duplicated `amp_cli::AMP_INSTALL_COMMAND`, the `tokio-util` dependency,
+  `ConfigField::settings_key()`, 7 orphaned `Icon` variants.
 
 ### Breaking
-- Nenhuma no contrato `--format json` — `windowKind` é aditivo,
-  `schemaVersion` continua `1`.
+- None to the `--format json` contract — `windowKind` is additive,
+  `schemaVersion` stays `1`.
 
 ## [8.5.0] - 2026-07-21
 
 ### Added
-- **Settings nativo no omarchy-shell.** Clique direito no widget abre o
-  mesmo popup em modo settings (estilo `model-usage`): toggles por
-  provider, reordenação ↑↓, display remaining/used, notify on/off e
-  intervalo de refresh. Esquerdo = usage (popup mais largo); meio =
-  refresh. Link “Abrir menu (TUI)” no rodapé; a TUI completa continua em
+- **Native settings in omarchy-shell.** Right click on the widget opens
+  the same popup in settings mode (`model-usage`-style): per-provider
+  toggles, ↑↓ reordering, remaining/used display, notify on/off, and
+  refresh interval. Left = usage (wider popup); middle = refresh. "Open
+  menu (TUI)" link in the footer; the full TUI still lives at
   `agent-bar menu`.
-- **`agent-bar config show` / `config apply`.** Mini-API JSON do subset
-  editável (`providers`, `providerOrder`, `displayMode`, `notify`) em
-  `settings.json`, com normalização e validação. O plugin grava o
-  intervalo só via `updateEntryInline` no `shell.json` (dual-write).
-  `config apply` **não** recarrega Waybar.
+- **`agent-bar config show` / `config apply`.** JSON mini-API for the
+  editable subset (`providers`, `providerOrder`, `displayMode`, `notify`)
+  of `settings.json`, with normalization and validation. The plugin
+  writes the interval only via `updateEntryInline` in `shell.json`
+  (dual-write). `config apply` **does not** reload Waybar.
 
 ### Changed
-- **Help da CLI enxuto.** Vitrine: menu, status, config, setup, update,
-  uninstall, doctor. Internos (`action-right`, `assets`, `export`,
-  `menu-font`) continuam parseáveis mas fora do help. `remove` vira
-  alias de `uninstall --yes`; `-t`/`--terminal` vira alias de `status`.
+- **Trimmed CLI help.** Showcase: menu, status, config, setup, update,
+  uninstall, doctor. Internal commands (`action-right`, `assets`,
+  `export`, `menu-font`) remain parseable but stay out of help. `remove`
+  becomes an alias for `uninstall --yes`; `-t`/`--terminal` becomes an
+  alias for `status`.
 - **Docs** (`commands.md`, `omarchy-shell.md`, `architecture.md`, README)
-  alinhados aos clicks Omarchy e à taxonomia da CLI.
+  aligned with the Omarchy clicks and the CLI taxonomy.
 
 ### Fixed
-- Clique esquerdo com settings aberto volta ao usage sem fechar o popup.
-- Barreira de flush do stdout no `config apply` do QML (evita race
-  `onExited` vs `StdioCollector`).
+- Left click with settings open goes back to usage without closing the
+  popup.
+- stdout flush barrier in the QML `config apply` (avoids an `onExited`
+  vs `StdioCollector` race).
 
 ## [8.4.1] - 2026-07-21
 
 ### Fixed
-- **Widget omarchy-shell:** `refreshIntervalSec` agora respeita também o teto
-  do schema (3600s) quando o `shell.json` é editado à mão — antes só o piso
-  (30s) era aplicado.
+- **omarchy-shell widget:** `refreshIntervalSec` now also respects the
+  schema ceiling (3600s) when `shell.json` is edited by hand — previously
+  only the floor (30s) was applied.
 
 ### Changed
-- **Publicação automática no AUR.** O workflow de release ganhou o job
-  `publish-aur`: a cada GitHub Release, o CI preenche
-  `pkgver`/`pkgrel`/`sha256sums` e pusha o `agent-bar-bin` para o AUR
-  (versão nova → `pkgrel=1`; mesma versão com packaging alterado →
-  `pkgrel+1`; sem mudança → skip). `pkgdesc` e mensagens de
-  install/upgrade do pacote agora citam o omarchy-shell.
-- Dedup interno do scan de PATH pela CLI `omarchy`
+- **Automatic AUR publishing.** The release workflow gained a
+  `publish-aur` job: on every GitHub Release, CI fills in
+  `pkgver`/`pkgrel`/`sha256sums` and pushes `agent-bar-bin` to the AUR
+  (new version → `pkgrel=1`; same version with changed packaging →
+  `pkgrel+1`; no change → skip). The package's `pkgdesc` and
+  install/upgrade messages now mention omarchy-shell.
+- Internal dedup of the PATH scan for the `omarchy` CLI
   (`omarchy_integration::cli_on_path`).
 
 ## [8.4.0] - 2026-07-21
 
 ### Added
-- **Suporte ao Omarchy 4 (omarchy-shell/Quickshell).** O Omarchy 4 substituiu
-  a Waybar pelo omarchy-shell; o agent-bar agora se instala como bar-widget
-  plugin nativo de terceiro (`agent-bar.usage`): um chip por provider
-  (ícone + % restante, cores do tema do shell, severidade espelhando o TUI)
-  e popup nativo com janelas primária/secundária, breakdown por modelo e
-  reset times. Clique esquerdo abre o popup, direito abre o TUI, meio força
-  refresh. `agent-bar setup` detecta o bar disponível (Waybar, omarchy-shell
-  ou ambos) e escreve o plugin como drop-in em
-  `~/.config/omarchy/plugins/agent-bar.usage/` — arquivos QML embutidos no
-  binário, version-locked com o schema de `--format json`.
-  `uninstall`/`remove` desregistram e apagam o drop-in; `update` avisa para
-  re-rodar `setup` quando o drop-in existe. Flag nova
-  `--omarchy-plugins-dir <path>` (setup, para testes/CI). Docs:
+- **Omarchy 4 support (omarchy-shell/Quickshell).** Omarchy 4 replaced
+  Waybar with omarchy-shell; agent-bar now installs as a native third-party
+  bar-widget plugin (`agent-bar.usage`): one chip per provider (icon + %
+  remaining, shell-theme colors, severity mirroring the TUI) and a native
+  popup with primary/secondary windows, per-model breakdown, and reset
+  times. Left click opens the popup, right click opens the TUI, middle click
+  forces a refresh. `agent-bar setup` detects the available bar (Waybar,
+  omarchy-shell, or both) and writes the plugin as a drop-in at
+  `~/.config/omarchy/plugins/agent-bar.usage/` — QML files embedded in the
+  binary, version-locked to the `--format json` schema.
+  `uninstall`/`remove` unregister and delete the drop-in; `update` warns to
+  re-run `setup` when the drop-in exists. New flag
+  `--omarchy-plugins-dir <path>` (setup, for tests/CI). Docs:
   `docs/omarchy-shell.md`.
-- **`severity` documentado no contrato JSON** (`docs/json-output.md`): campo
-  opcional de `Window`, vindo da API do provider, com fallback de threshold
-  local (≥60/30/10) para consumidores.
+- **`severity` documented in the JSON contract** (`docs/json-output.md`):
+  optional `Window` field, coming from the provider's API, with a local
+  threshold fallback (≥60/30/10) for consumers.
 
 ### Fixed
-- Integração Waybar intocada; contrato existente segue como estava.
+- Waybar integration untouched; the existing contract stays as it was.
 
 ## [8.3.0] - 2026-07-21
 
 ### Fixed
-- **Falso "disconnected" com usuário logado.** O Grok considera logado quem
-  tem `key` no `auth.json` — o access token de 6h (renovado pelo Grok CLI via
-  refresh token) não desloga mais a barra. Timeout do `amp usage` virou erro
-  transitório em vez de "Not logged in".
+- **False "disconnected" with a logged-in user.** Grok considers a user
+  logged in when `auth.json` has a `key` — the 6h access token (renewed by
+  the Grok CLI via refresh token) no longer logs the bar out. An
+  `amp usage` timeout became a transient error instead of "Not logged in".
 
 ### Added
-- **Fallback de cache stale:** em erro transitório (timeout de rede, token
-  expirado do Claude), a barra serve o último dado bom do cache com o aviso
-  `⚠️ Cached data — {motivo}` no tooltip, em vez do ícone de desconectado.
-  `disconnected` ficou reservado a logout real. Novo campo opcional
-  `staleReason` no `--format json` (docs/json-output.md).
-- **Amp:** ETA de reset diário (meia-noite UTC, regra do frontend oficial) no
-  free tier, indicador `↻ auto-replenish` e fallback de linhas cruas do
-  servidor no tooltip para formatos futuros do `amp usage`.
+- **Stale cache fallback:** on a transient error (network timeout, expired
+  Claude token), the bar serves the last good cached data with the warning
+  `⚠️ Cached data — {motivo}` in the tooltip, instead of the disconnected
+  icon. `disconnected` is now reserved for a real logout. New optional
+  `staleReason` field in `--format json` (docs/json-output.md).
+- **Amp:** daily reset ETA (midnight UTC, the official frontend's rule) on
+  the free tier, an `↻ auto-replenish` indicator, and a fallback to the
+  server's raw lines in the tooltip for future `amp usage` formats.
 
 ## [8.2.2] - 2026-07-19
 
 ### Changed
-- **Standalone `agent-bar update`** re-copia icons e o terminal helper para os
-  paths da Waybar (`~/.config/waybar/agent-bar/icons` e `…/scripts`) após
-  baixar o release. Não re-patcha config/modules/CSS (use `setup` se a
-  integração mudou).
+- **Standalone `agent-bar update`** now re-copies icons and the terminal
+  helper to the Waybar paths (`~/.config/waybar/agent-bar/icons` and
+  `…/scripts`) after downloading the release. Does not re-patch
+  config/modules/CSS (use `setup` if the integration changed).
 
 ## [8.2.1] - 2026-07-19
 
 ### Fixed
-- **Ícone Waybar do Grok** — substituído o placeholder “G” pelo logomark
-  oficial `Grok_Logomark_Light` do pack de brand xAI
-  (`SpaceXAI_Grok_Assets.zip`). Sem mudança de CSS/contrato de arquivo
+- **Grok's Waybar icon** — replaced the "G" placeholder with the official
+  `Grok_Logomark_Light` logomark from the xAI brand pack
+  (`SpaceXAI_Grok_Assets.zip`). No CSS/file-contract change
   (`grok-icon.svg`).
 
 ## [8.2.0] - 2026-07-17
 
-Provider **Grok** (Grok Build CLI) na barra e na TUI.
+**Grok** provider (Grok Build CLI) in the bar and the TUI.
 
 ### Added
-- **Provider Grok (Grok Build CLI)** — OAuth em `~/.grok/auth.json` e
-  `signals.json` das sessões; o % da barra é **contexto restante da sessão
-  recente** (não cota de plano xAI). Login via `grok login` na TUI.
-  Módulo Waybar, ícone, builder e fixtures de regressão.
-  **Novos installs** listam `grok` por default; **settings existentes**
-  precisam habilitar em Config (não há auto-inserção).
+- **Grok provider (Grok Build CLI)** — OAuth via `~/.grok/auth.json` and
+  the sessions' `signals.json`; the bar's % is the **remaining context of
+  the recent session** (not an xAI plan quota). Login via `grok login` in
+  the TUI. Waybar module, icon, builder, and regression fixtures.
+  **New installs** list `grok` by default; **existing settings** need to
+  enable it in Config (no auto-insertion).
 
 ## [8.1.0] - 2026-07-17
 
-Fundações de código, hardening de legibilidade e polish da TUI
-(trilhas A/B/C pós-8.0.0).
+Code foundations, readability hardening, and TUI polish (tracks A/B/C
+after 8.0.0).
 
 ### Added
-- Fixtures de regressão do Amp (`tests/fixtures/amp/`) para formatos
-  legado `$X/$Y` e free-tier em `% remaining`.
-- Rótulo dual de tokens nos totais do Detail: principal = input+output,
-  sufixo `(+N cache)` quando há cache.
-- Legenda do chart com indicador `…+N` quando séries não cabem na largura.
-- Discoverability de ajuda: chip `? ajuda` no Detail e hint na borda
-  inferior da moldura.
-- Specs: fundações/confiança, hardening de produto, polish TUI.
+- Amp regression fixtures (`tests/fixtures/amp/`) for the legacy `$X/$Y`
+  format and free-tier `% remaining`.
+- Dual token label in Detail's totals: primary = input+output, suffix
+  `(+N cache)` when cache exists.
+- Chart legend with a `…+N` indicator when series don't fit the width.
+- Help discoverability: `? help` chip in Detail and a hint on the
+  frame's bottom border.
+- Specs: foundations/trust, product hardening, TUI polish.
 
 ### Changed
-- **Codex / TUI update / Detail** modularizados (sem mudança de contrato de
-  produto nos splits).
-- Config da TUI com rótulos humanos (`Provedores`, `Ordem`, `Exibição`,
-  `Câmbio R$`…); chave técnica permanece na dica do campo.
-- Sidebar colapsada usa `≡` / `→` / `⚙` em vez de H/L/C.
-- Chart no Detail usa `Min(6)` em painel estreito (&lt; 72 cols); `Min(9)` no resto.
-- Tokens de cor com contraste ≥4.5:1 sobre o fundo (`Comment`, `Red`,
-  séries do chart).
-- Pricing revalidado contra a tabela oficial Anthropic (2026-07-17).
+- **Codex / TUI update / Detail** modularized (no product-contract change
+  from the splits).
+- TUI config with human labels (`Providers`, `Order`, `Display`,
+  `Exchange rate R$`…); the technical key stays in the field's hint.
+- Collapsed sidebar uses `≡` / `→` / `⚙` instead of H/L/C.
+- Detail's chart uses `Min(6)` on narrow panels (&lt; 72 cols); `Min(9)`
+  otherwise.
+- Color tokens with ≥4.5:1 contrast against the background (`Comment`,
+  `Red`, chart series).
+- Pricing revalidated against the official Anthropic table (2026-07-17).
 
 ### Fixed
-- **Amp Free em `% remaining`** (CLI atual): parseava só o formato `$X/$Y`
-  e deixava a janela primary vazia no free tier percentual.
-- Serialização Waybar em falha de serde: nunca mais stdout vazio; payload
-  degradado com `class: agent-bar disconnected`.
-- Docs de arquitetura sem residual TypeScript (`main.rs` / `notify.rs`).
+- **Amp Free in `% remaining`** (current CLI): only parsed the `$X/$Y`
+  format and left the primary window empty in the percentage free tier.
+- Waybar serialization on serde failure: stdout is never empty again;
+  degraded payload with `class: agent-bar disconnected`.
+- Architecture docs no longer carry TypeScript residue (`main.rs` /
+  `notify.rs`).
 
 ## [8.0.0] - 2026-07-11
 
-Redesign completo da TUI (v8) + números confiáveis no usage.
+Complete TUI redesign (v8) + reliable usage numbers.
 
-> **Os números históricos exibidos MUDAM neste update**: o dedup de
-> streaming corrige a contagem de tokens do Claude (a mesma request era
-> somada N vezes — queda esperada de ~1/3 nos totais) e o pricing novo
-> corrige o custo. É correção, não perda de dado.
+> **The historical numbers shown CHANGE in this update**: streaming dedup
+> corrects Claude's token count (the same request was being summed N
+> times — an expected ~1/3 drop in totals) and the new pricing corrects
+> the cost. This is a correction, not data loss.
 
 ### Added
-- **Chart de colunas por modelo** no Detail e no Histórico (escala √,
-  série mínima sempre visível, cores One Dark Turbo validadas CVD).
-- **Histórico com dias expandíveis e sessões**: cada dia abre a lista de
-  sessões (hora, projeto, modelo, tokens, custo), derivadas dos session
-  logs.
-- **Cache persistente de parse** (`usage.redb`): warm-start do histórico
-  cai de ~8s para ~150ms; versão de cache invalida tudo quando a
-  semântica do parse muda; degradação segura em corrupção/lock.
-- **Right-click no módulo Waybar abre a TUI** focada no provider, com
-  cache invalidado antes de rotear.
-- Config da TUI com seções waybar/tui e hint do signal de reload.
-- Preços 2026-07: Fable/Mythos, Sonnet 5 com virada automática do preço
-  introdutório em 2026-09-01, Opus legado (≤4.1) separado do 4.5+, tiers
-  de cache 5m/1h, fast mode (Opus 4.7/4.8) e `inference_geo`.
-- Nomes de modelo humanizados nas telas ("Fable 5", "Opus 4.8"…).
+- **Per-model column chart** in Detail and History (√ scale, minimum
+  series always visible, CVD-validated One Dark Turbo colors).
+- **History with expandable days and sessions**: each day opens the
+  session list (time, project, model, tokens, cost), derived from the
+  session logs.
+- **Persistent parse cache** (`usage.redb`): history warm-start drops from
+  ~8s to ~150ms; the cache version invalidates everything when parse
+  semantics change; safe degradation on corruption/lock.
+- **Right-click on the Waybar module opens the TUI** focused on the
+  provider, with the cache invalidated before routing.
+- TUI config with waybar/tui sections and a reload-signal hint.
+- 2026-07 pricing: Fable/Mythos, Sonnet 5 with automatic switchover from
+  the introductory price on 2026-09-01, legacy Opus (≤4.1) separated from
+  4.5+, 5m/1h cache tiers, fast mode (Opus 4.7/4.8), and `inference_geo`.
+- Humanized model names on screen ("Fable 5", "Opus 4.8"…).
 
 ### Changed
-- **Overview removida — a TUI boota direto no provider** (navegação pela
-  sidebar; sem abas).
-- **`waybar.interval` das settings agora chega ao config do Waybar**;
-  default efetivo 60s — quem nunca configurou o valor verá o intervalo
-  mudar de 120s para 60s.
-- Paleta One Dark Turbo em toda a TUI; gauge sólido com precisão de
-  oitavos.
-- README reescrito em pt-BR; URLs migradas para `othavi0/agent-bar`.
+- **Overview removed — the TUI now boots straight into the provider**
+  (sidebar navigation; no tabs).
+- **The `waybar.interval` setting now reaches the Waybar config**;
+  effective default 60s — anyone who never configured the value will see
+  the interval change from 120s to 60s.
+- One Dark Turbo palette throughout the TUI; solid gauge with eighth-step
+  precision.
+- README rewritten in Portuguese; URLs migrated to `othavi0/agent-bar`.
 
 ### Fixed
-- **Dedup de streaming no parser do Claude**: 1 record por request
-  (a última entrada vence) — antes cada entrada parcial do streaming
-  contava de novo.
-- **Codex logado com token expirado**: resposta de erro JSON-RPC do
-  app-server agora falha rápido em vez de girar até o timeout de 4s.
-- Semana downsampled do chart cobre os 7 dias; empty-state do chart
-  centralizado; colapso limpo em terminal baixo.
-- Flake raro de testes que tocam PATH (serializados via lock comum).
+- **Streaming dedup in the Claude parser**: 1 record per request (the
+  last entry wins) — previously every partial streaming entry counted
+  again.
+- **Codex logged in with an expired token**: the app-server's JSON-RPC
+  error response now fails fast instead of spinning until the 4s timeout.
+- The chart's downsampled week covers all 7 days; chart empty-state
+  centered; clean collapse on short terminals.
+- Rare test flake touching PATH (now serialized via a shared lock).
 
 ## [7.1.0] - 2026-07-02
 
-Leva de ajustes visuais da TUI pós-teste real do redesign.
+Round of TUI visual adjustments after real hands-on testing of the redesign.
 
 ### Added
-- **Painel "Hoje (24h)" no Overview**: quando sobra altura abaixo dos cards,
-  o espaço vira o chart braille das últimas 24h (mesma visualização do
-  Histórico) com totais de hoje/7d no rodapé. Em terminal baixo o layout
-  antigo permanece intacto.
+- **"Today (24h)" panel on Overview**: when height remains below the cards,
+  the space becomes the last-24h braille chart (same visualization as
+  History) with today/7d totals in the footer. On short terminals the old
+  layout stays intact.
 
 ### Changed
-- **Animação de transição de tela (coalesce) removida** — reprovada em uso
-  real; a navegação agora troca de tela instantaneamente. Sweep no fetch,
-  pulse crítico e count-up de custo permanecem.
-- Popup de ajuda (`?`) se dimensiona pelo conteúdo (antes era 60%x70% do
-  frame e cortava as seções finais em terminais menores) e escurece a tela
-  por baixo enquanto aberto.
-- Copy da TUI revisada: acentos corrigidos ("instruções", "vírgula",
-  "inválido", "configuração"…) e "Waybar Config" → "Config do Waybar".
+- **Screen-transition animation (coalesce) removed** — it failed in real
+  use; navigation now switches screens instantly. Fetch sweep, critical
+  pulse, and cost count-up remain.
+- The help popup (`?`) now sizes itself to its content (it used to be
+  60%x70% of the frame and cut off the final sections on smaller
+  terminals) and dims the screen underneath while open.
+- TUI copy revised: fixed accent bugs in words like "instructions",
+  "comma", "invalid", "configuration"… and localized the "Waybar Config"
+  label to Portuguese.
 
 ### Fixed
-- **"hoje 0 tok" / "sem uso de tokens" durante o carregamento**: enquanto o
-  parse dos session logs não terminou, Histórico, Detail e cards agora dizem
-  "coletando…" em vez de afirmar zero sobre dado que só não chegou.
-- Parse dos session logs roda **uma vez** por refresh (rodava duas — uma pra
-  janela de hoje, outra pra de 7 dias), cortando o tempo de carregamento do
-  histórico pela metade.
-- Rodapé do painel novo usa o mesmo vocabulário de tokens da tabela do
-  Histórico (input+output), evitando totais contraditórios entre telas.
+- **"today 0 tok" / "no token usage" during loading**: while session-log
+  parsing hasn't finished, History, Detail, and the cards now say
+  "collecting…" instead of asserting zero about data that simply hasn't
+  arrived yet.
+- Session-log parsing now runs **once** per refresh (it used to run twice —
+  once for today's window, once for the 7-day one), cutting history
+  load time in half.
+- The new panel's footer uses the same token vocabulary as the History
+  table (input+output), avoiding contradictory totals between screens.
 
 ## [7.0.1] - 2026-07-02
 
-Hotfix de distribuição: `agent-bar update` e `install.sh`.
+Distribution hotfix: `agent-bar update` and `install.sh`.
 
 ### Fixed
-- **`agent-bar update` estava quebrado em todo install standalone** desde a
-  6.0.0: a detecção usava um path de compile-time (`CARGO_MANIFEST_DIR`, o
-  diretório do runner do CI) e caía num modo npm legado tentando ler
-  `package.json` inexistente. A detecção agora parte do binário real
-  (`current_exe`): checkout de dev → fluxo git; instalação de sistema/AUR →
-  orienta o gerenciador de pacotes; standalone → **self-update real** (baixa
-  a última release, verifica sha256 obrigatoriamente, substitui o binário de
-  forma atômica e espelha os assets).
-- **`agent-bar setup` avulso falhava em install standalone** — a resolução
-  de assets ganhou o candidato `~/.local/share/agent-bar` (respeitando
-  `AGENT_BAR_DATA`/`XDG_DATA_HOME`), unificada entre update e setup.
-- **`install.sh` agora migra instalações antigas sozinho**: upgrade
-  automático quando a versão difere (sem exigir `--force`), detecção sã de
-  binários da era TypeScript (que respondiam `--version` com o JSON do
-  módulo), remoção best-effort do pacote npm legado
-  (`@noctuacore/agent-bar`) e de symlinks antigos. `--force` fica só para
-  reinstalar a mesma versão.
+- **`agent-bar update` was broken on every standalone install** since
+  6.0.0: detection used a compile-time path (`CARGO_MANIFEST_DIR`, the CI
+  runner's directory) and fell into a legacy npm mode trying to read a
+  nonexistent `package.json`. Detection now starts from the real binary
+  (`current_exe`): dev checkout → git flow; system/AUR install → points to
+  the package manager; standalone → **real self-update** (downloads the
+  latest release, mandatorily verifies sha256, atomically replaces the
+  binary, and mirrors the assets).
+- **A standalone `agent-bar setup` failed on standalone installs** — asset
+  resolution gained the `~/.local/share/agent-bar` candidate (respecting
+  `AGENT_BAR_DATA`/`XDG_DATA_HOME`), unified between update and setup.
+- **`install.sh` now migrates old installations on its own**: automatic
+  upgrade when the version differs (without requiring `--force`), sound
+  detection of TypeScript-era binaries (which responded to `--version` with
+  the module's JSON), best-effort removal of the legacy npm package
+  (`@noctuacore/agent-bar`) and of old symlinks. `--force` now only serves
+  to reinstall the same version.
 
 ### Changed
-- Caminho de update npm/bun removido por completo (legado morto).
-- Diretório temporário do self-update via `tempfile` (0700, criação
-  atômica) em vez de path manual em `/tmp`.
+- The npm/bun update path removed entirely (dead legacy code).
+- Self-update temporary directory now via `tempfile` (0700, atomic
+  creation) instead of a manual path in `/tmp`.
 
 ## [7.0.0] - 2026-07-02
 
-Redesign completo da TUI do `agent-bar menu` (spec e plano em
-`docs/superpowers/`). O contrato Waybar (módulos, JSON, CSS, tooltips) está
-**intacto** — a mudança é toda no menu interativo.
+Complete redesign of the `agent-bar menu` TUI (spec and plan in
+`docs/superpowers/`). The Waybar contract (modules, JSON, CSS, tooltips) is
+**intact** — the change is entirely in the interactive menu.
 
 ### Added
-- **Navegação por sidebar única** (Geral / providers / Histórico / Login /
-  Waybar) com drill-down por provider — as 4 abas antigas foram removidas.
-- **Suporte completo a mouse**: click seleciona/ativa (sidebar, cards, chips),
-  hover destaca, wheel rola (cards e tabela do histórico).
-- **Cobertura completa do `/usage` do Claude**: provider migrado pros blocos
-  novos `limits[]` + `spend` da API OAuth — sessão, semana, limite semanal
-  por-modelo (nome vindo da API) e extra usage/créditos, com severidade
-  oficial da API e fallback transparente pros campos legados.
-- **Tela Overview** com um card denso por provider: gauges com gradiente por
-  célula, sparkline real de tokens/h (24h), custo do dia e estado de login
-  confiável; estados desenhados pra deslogado/carregando/vazio.
-- **Tela Histórico** com chart braille de área (24h/7d via tecla `t`) e
-  tabela dia × provider × tokens × custo com scroll; linha do Amp com saldo
-  real e nota de ausência de logs locais.
-- **Bucketing horário** do histórico (`usage::buckets`) — gráficos com dado
-  real por hora em vez de 7 pontos diários esticados.
-- **Motion** gated por `menu.animations`: sweep no fetch iniciado pelo
-  usuário, coalesce na troca de tela, pulse/blink em quota crítica (<10%) e
-  count-up no custo (tachyonfx).
-- **Ícones Nerd Font** com fallback Unicode via `glyphMode`.
-- **Fonte configurável do menu**: `menu.fontFamily` (default "IBM Plex Mono")
-  e `menu.fontSize`, aplicadas pelo helper via flags do terminal
-  (alacritty/kitty/foot/ghostty); comando interno `agent-bar menu-font`.
-- Settings novas: `menu.animations`, `menu.fontFamily`, `menu.fontSize`.
+- **Single sidebar navigation** (General / providers / History / Login /
+  Waybar) with per-provider drill-down — the old 4 tabs were removed.
+- **Full mouse support**: click selects/activates (sidebar, cards, chips),
+  hover highlights, wheel scrolls (cards and the history table).
+- **Full coverage of Claude's `/usage`**: provider migrated to the new
+  OAuth API blocks `limits[]` + `spend` — session, week, per-model weekly
+  limit (name from the API), and extra usage/credits, with official API
+  severity and transparent fallback to the legacy fields.
+- **Overview screen** with one dense card per provider: gauges with a
+  per-cell gradient, real tokens/h sparkline (24h), day's cost, and a
+  reliable login state; states designed for logged-out/loading/empty.
+- **History screen** with a braille area chart (24h/7d via the `t` key) and
+  a day × provider × tokens × cost table with scroll; Amp's row with a real
+  balance and a note on the absence of local logs.
+- **Hourly bucketing** for history (`usage::buckets`) — charts with real
+  hourly data instead of 7 stretched daily points.
+- **Motion** gated by `menu.animations`: user-initiated fetch sweep,
+  coalesce on screen change, pulse/blink on critical quota (<10%), and
+  cost count-up (tachyonfx).
+- **Nerd Font icons** with Unicode fallback via `glyphMode`.
+- **Configurable menu font**: `menu.fontFamily` (default "IBM Plex Mono")
+  and `menu.fontSize`, applied by the helper via terminal flags
+  (alacritty/kitty/foot/ghostty); internal command `agent-bar menu-font`.
+- New settings: `menu.animations`, `menu.fontFamily`, `menu.fontSize`.
 
 ### Changed
-- **Fetch, login e save saíram do event loop**: a TUI nunca mais congela —
-  spinner e progresso por provider aparecem de verdade, teclas respondem
-  durante o fetch, e o refetch pós-login é automático.
-- **Estado de login derivado do fetch real** (5 estados, incluindo `erro`
-  distinto de `deslogado`) — fim do `[ok]` baseado em existência de arquivo.
-- **Cascata do helper de terminal** (`agent-bar-open-terminal`): honra
-  `$TERMINAL` (lança o terminal preferido com flags de fonte quando
-  suportado; desconhecido → caminho xdg); alacritty direto vem antes do
-  caminho uwsm/xdg pra aplicar fonte preservando o float do Hyprland.
-- **MSRV corrigida para 1.88** (piso real das dependências); dependências
-  novas: `tachyonfx`, `tui-scrollview`; `tui-popup` removida.
-- "pico HHh" e labels de eixo do histórico em hora local (antes UTC).
+- **Fetch, login, and save moved off the event loop**: the TUI never freezes
+  anymore — spinner and per-provider progress genuinely appear, keys respond
+  during the fetch, and the post-login refetch is automatic.
+- **Login state derived from a real fetch** (5 states, including `error`
+  distinct from `logged-out`) — the end of `[ok]` based on file existence.
+- **Terminal helper cascade** (`agent-bar-open-terminal`): honors
+  `$TERMINAL` (launches the preferred terminal with font flags when
+  supported; unknown → xdg path); direct alacritty now comes before the
+  uwsm/xdg path to apply the font while preserving Hyprland's float.
+- **MSRV corrected to 1.88** (the dependencies' real floor); new
+  dependencies: `tachyonfx`, `tui-scrollview`; `tui-popup` removed.
+- History's "peak HHh" and axis labels are now in local time (previously UTC).
 
 ### Fixed
-- **Tecla `r` (refresh) nunca funcionou** — setava "Loading" sem disparar
-  fetch; agora dispara refetch real (com guard contra fetch duplicado).
-- **Comando de login do Codex era inválido** (`codex auth login` não existe
-  na CLI; corrigido para `codex login`).
-- **Tela corrompida ao voltar do login** — repaint completo ressincroniza o
-  buffer do terminal.
-- **Help overlay corrompia a tabela por baixo** (texto vazando "pr"/"sto") —
-  área limpa com `Clear` antes do popup.
-- Sparkline "tokens/h" do detalhe era um placeholder hardcoded idêntico para
-  todos os providers — substituído por dado real por provider.
-- Nomes truncados com corte seco ("Free Tie") — truncagem com `…`.
-- Race de ondas de fetch sobrepostas corrompendo spinner/`last_update`.
-- `abbrev` de tokens estourava a fronteira de unidade ("1000.0K" → "1.0M").
-- Extra usage habilitado sem limite configurado renderizava gauge
-  autocontraditório ("$X de $0.00") — agora "usado · sem limite".
+- **The `r` (refresh) key never worked** — it set "Loading" without
+  triggering a fetch; it now triggers a real refetch (with a guard against
+  duplicate fetches).
+- **The Codex login command was invalid** (`codex auth login` doesn't exist
+  in the CLI; fixed to `codex login`).
+- **Screen corrupted when returning from login** — a full repaint
+  resynchronizes the terminal buffer.
+- **Help overlay corrupted the table underneath** (text leaking "pr"/"sto")
+  — area cleared with `Clear` before the popup.
+- The detail's "tokens/h" sparkline was an identical hardcoded placeholder
+  for every provider — replaced with real per-provider data.
+- Truncated names with an abrupt cut ("Free Tie") — truncation now uses `…`.
+- Race between overlapping fetch waves corrupting spinner/`last_update`.
+- Token `abbrev` overflowed the unit boundary ("1000.0K" → "1.0M").
+- Extra usage enabled without a configured limit rendered a
+  self-contradictory gauge ("$X of $0.00") — now "used · no limit".
 
 ## [6.0.1] - 2026-06-21
 
 ### Fixed
-- **`install.sh` corrompia o binário no `setup`.** `create_symlink` criava um symlink
-  `~/.local/bin/agent-bar` apontando pra si mesmo (dangling) quando o binário já
-  estava nesse caminho — caso do `install.sh` —, destruindo o executável. Agora
-  detecta (via `canonicalize`) que o binário já está no destino e pula o symlink.
-  `cargo install` / `cargo binstall` (instalam em `~/.cargo/bin`) não eram afetados.
+- **`install.sh` corrupted the binary during `setup`.** `create_symlink` created
+  a symlink `~/.local/bin/agent-bar` pointing to itself (dangling) when the
+  binary was already at that path — the `install.sh` case — destroying the
+  executable. Now it detects (via `canonicalize`) that the binary is already
+  at the destination and skips the symlink. `cargo install` / `cargo binstall`
+  (which install to `~/.cargo/bin`) were unaffected.
 
 ## [6.0.0] - 2026-06-21
 
-Reescrita completa de TypeScript/Bun para **Rust** (binário único), preservando
-paridade byte-exact do contrato Waybar/Pango e da saída `--format json`.
+Complete rewrite from TypeScript/Bun to **Rust** (single binary), preserving
+byte-exact parity of the Waybar/Pango contract and the `--format json` output.
 
 ### Changed
-- **Runtime Rust.** O monitor agora é um binário Rust único (tokio + reqwest/rustls)
-  no lugar do runtime TypeScript/Bun. Comportamento de Waybar/CLI inalterado —
-  paridade byte-exact travada por golden snapshots vs a saída do TS.
-- **TUI full-screen** reescrita em ratatui (abas Dashboard / Waybar / History /
-  Login) com engine de custo via session logs locais (US$/R$). O event loop faz o
-  parse de logs em background, mantendo a UI responsiva desde o boot.
-- **Distribuição via binário musl estático.** `install.sh` baixa o tarball prebuilt
-  do GitHub Release (verificado por sha256); o AUR (`agent-bar-bin`) e
-  `cargo binstall` também instalam o binário. Build de release via `cargo-zigbuild`.
+- **Rust runtime.** The monitor is now a single Rust binary (tokio +
+  reqwest/rustls) replacing the TypeScript/Bun runtime. Waybar/CLI behavior
+  unchanged — byte-exact parity locked by golden snapshots against the TS
+  output.
+- **Full-screen TUI** rewritten in ratatui (Dashboard / Waybar / History /
+  Login tabs) with a cost engine via local session logs (US$/R$). The event
+  loop parses logs in the background, keeping the UI responsive from boot.
+- **Distribution via static musl binary.** `install.sh` downloads the
+  prebuilt tarball from the GitHub Release (sha256-verified); the AUR
+  (`agent-bar-bin`) and `cargo binstall` also install the binary. Release
+  build via `cargo-zigbuild`.
 
 ### Removed
-- **Bun / Node / npm no runtime.** Sem dependência de runtime JS. O pacote npm
-  `@noctuacore/agent-bar` foi descontinuado — a última versão TypeScript está
-  preservada na tag `v5.3.0-ts-final`.
+- **Bun / Node / npm at runtime.** No JS runtime dependency. The
+  `@noctuacore/agent-bar` npm package was discontinued — the last TypeScript
+  version is preserved at tag `v5.3.0-ts-final`.
 
-### Migração
-- Instalações npm antigas: `agent-bar doctor` detecta e limpa os resíduos;
-  reinstale via `install.sh`, AUR ou `cargo binstall`.
+### Migration
+- Old npm installations: `agent-bar doctor` detects and cleans up the
+  leftovers; reinstall via `install.sh`, AUR, or `cargo binstall`.
 
 ## [5.3.0] - 2026-06-18
 
 ### Added
-- **Pacote AUR `agent-bar-bin`** (Arch). Instala um binário standalone
-  (`bun build --compile`) baixado do GitHub Release e verificado por sha256 — sem
-  exigir Bun no runtime do usuário e **sem build no PKGBUILD** (mitigação do vetor
-  de supply-chain "Atomic Arch"). Uso: `paru -S agent-bar-bin && agent-bar setup`.
-  O workflow de release agora compila e anexa o tarball
-  `agent-bar-<ver>-x86_64.tar.gz` (+ `.sha256`) ao GitHub Release. PKGBUILD,
-  `.install` e `.SRCINFO` versionados em `packaging/aur/`.
+- **AUR package `agent-bar-bin`** (Arch). Installs a standalone binary
+  (`bun build --compile`) downloaded from the GitHub Release and sha256-verified
+  — without requiring Bun at the user's runtime and **without building in the
+  PKGBUILD** (mitigating the "Atomic Arch" supply-chain vector). Usage:
+  `paru -S agent-bar-bin && agent-bar setup`. The release workflow now builds
+  and attaches the `agent-bar-<ver>-x86_64.tar.gz` tarball (+ `.sha256`) to the
+  GitHub Release. PKGBUILD, `.install`, and `.SRCINFO` are versioned in
+  `packaging/aur/`.
 
 ### Changed
-- **Install de sistema reconhecido em todo o app.** Um binário compilado é
-  detectado por `isCompiledBinary()` (marcador `/$bunfs` do `bun --compile`):
-  `agent-bar setup` lê os assets de `/usr/share/agent-bar`, gera o módulo Waybar
-  com `exec: agent-bar` (resolvido via PATH) e **pula** o symlink `~/.local/bin`;
-  `agent-bar update` orienta o gerenciador de pacotes (ex.: `paru -Syu`) em vez de
-  tentar `bun add -g`. Os installs existentes (managed/npm/dev) ficam inalterados.
+- **System install recognized throughout the app.** A compiled binary is
+  detected by `isCompiledBinary()` (the `/$bunfs` marker from
+  `bun --compile`): `agent-bar setup` reads assets from
+  `/usr/share/agent-bar`, generates the Waybar module with
+  `exec: agent-bar` (resolved via PATH), and **skips** the `~/.local/bin`
+  symlink; `agent-bar update` points to the package manager (e.g.
+  `paru -Syu`) instead of trying `bun add -g`. Existing installs
+  (managed/npm/dev) are unchanged.
 
 ## [5.2.0] - 2026-06-18
 
 ### Added
-- **Saída Waybar single-provider expõe `percentage` e `alt`** para desbloquear
-  `format-icons`. `alt` carrega o health state (`ok` / `low` / `warn` /
-  `critical`, ou `disconnected`) para `format-icons` keyed por estado;
-  `percentage` é o valor displayMode-aware (o mesmo número do `text`), clampado
-  a `0..100`, para `{percentage}` no `format` ou `format-icons` em array. Ambos
-  são **omitidos** quando o provider está conectado mas sem dados de quota — um
-  window ausente nunca reporta `ok`. O módulo agregado e o contrato
-  `--format json` permanecem inalterados.
-- **Refresh sob demanda via `signal`** (opt-in). O novo setting `waybar.signal`
-  (`1..30`, default off) injeta `signal: N` em cada módulo gerado; o Waybar
-  re-executa o módulo ao receber `SIGRTMIN+N`. Como o `exec` do módulo lê o cache
-  de 5 min, um signal puro só re-renderiza dados cacheados — para forçar um fetch
-  **fresco** use o recipe documentado:
-  `agent-bar -p <provider> -r && pkill -RTMIN+<N> waybar` (com exemplo de Stop
-  hook do Claude Code em `docs/waybar-contract.md`).
+- **Single-provider Waybar output exposes `percentage` and `alt`** to unlock
+  `format-icons`. `alt` carries the health state (`ok` / `low` / `warn` /
+  `critical`, or `disconnected`) for `format-icons` keyed by state;
+  `percentage` is the displayMode-aware value (the same number as `text`),
+  clamped to `0..100`, for `{percentage}` in `format` or `format-icons` as an
+  array. Both are **omitted** when the provider is connected but has no
+  quota data — a missing window never reports `ok`. The aggregated module and
+  the `--format json` contract remain unchanged.
+- **On-demand refresh via `signal`** (opt-in). The new `waybar.signal` setting
+  (`1..30`, default off) injects `signal: N` into every generated module;
+  Waybar re-executes the module on receiving `SIGRTMIN+N`. Since the module's
+  `exec` reads the 5-minute cache, a plain signal only re-renders cached data —
+  to force a **fresh** fetch use the documented recipe:
+  `agent-bar -p <provider> -r && pkill -RTMIN+<N> waybar` (with a Claude Code
+  Stop-hook example in `docs/waybar-contract.md`).
 
 ### Docs
-- `docs/waybar-contract.md`: campos de saída `percentage`/`alt`, exemplos de
-  `format-icons` (por estado via `alt` e por percentual via array), e a
-  configuração + recipe de refresh do `signal`.
+- `docs/waybar-contract.md`: `percentage`/`alt` output fields, `format-icons`
+  examples (by state via `alt` and by percentage via array), and the
+  `signal` refresh configuration + recipe.
 
 ## [5.1.0] - 2026-06-17
 
 ### Added
-- **Claude: tier do plano no tooltip** (`Max 5x` / `Max 20x`). O cabeçalho do
-  tooltip do Claude agora lê `rateLimitTier` do `~/.claude/.credentials.json`
-  (ex.: `default_claude_max_5x`) e surfa o multiplicador que o `subscriptionType`
-  ("max") descartava — antes mostrava só "Max". Planos sem multiplicador (Pro,
-  Free) ficam inalterados. Lógica isolada em `deriveClaudePlan()`.
-- **`docs/architecture.md`**: data-flow completo (poll do Waybar → provider →
-  cache → formatter → saída JSON/Pango), a distinção entre os dois caches
-  (quota 5 min cross-process em `cache.ts` vs settings 5 s in-process em
-  `formatters/waybar.ts`), e `BaseProvider` vs `ClaudeProvider` direto. Passa a
-  ser publicado no pacote npm.
-- Documentação do comando interno `action-right` (right-click do Waybar) em
-  `docs/commands.md` e `docs/waybar-contract.md`, com a lógica de
-  refresh-ou-login e os campos do módulo gerado.
+- **Claude: plan tier in the tooltip** (`Max 5x` / `Max 20x`). The Claude
+  tooltip header now reads `rateLimitTier` from `~/.claude/.credentials.json`
+  (e.g. `default_claude_max_5x`) and surfaces the multiplier that
+  `subscriptionType` ("max") discarded — it previously showed just "Max".
+  Plans without a multiplier (Pro, Free) are unchanged. Logic isolated in
+  `deriveClaudePlan()`.
+- **`docs/architecture.md`**: complete data-flow (Waybar poll → provider →
+  cache → formatter → JSON/Pango output), the distinction between the two
+  caches (5 min cross-process quota cache in `cache.ts` vs 5 s in-process
+  settings cache in `formatters/waybar.ts`), and `BaseProvider` vs direct
+  `ClaudeProvider`. Now published in the npm package.
+- Documentation for the internal `action-right` command (Waybar right-click)
+  in `docs/commands.md` and `docs/waybar-contract.md`, with the
+  refresh-or-login logic and the generated module's fields.
 
 ### Changed
-- **Claude: short-circuit de token expirado.** Quando o `expiresAt` (epoch-ms
-  das credenciais) já passou, o provider devolve o erro de token expirado **sem**
-  chamar a API da Anthropic — a chamada falharia de qualquer forma e o agent-bar
-  nunca renova o token (o refresh single-use corre com o Claude Code). Mesma
-  string de erro e mesmo roteamento de login do `action-right`; apenas mais
-  rápido e funcional offline.
+- **Claude: expired-token short-circuit.** When `expiresAt` (epoch-ms from
+  the credentials) has already passed, the provider returns the expired-token
+  error **without** calling the Anthropic API — the call would fail anyway
+  and agent-bar never refreshes the token (the single-use refresh runs with
+  Claude Code). Same error string and same login routing as `action-right`;
+  just faster and works offline.
 
 ## [5.0.0] - 2026-06-17
 
 ### Removed
-- **Provider Copilot removido por inteiro** (breaking). A interface
-  `--headless --stdio` do Copilot CLI é oculta/frágil (some sem aviso em
-  auto-updates) e não estava em uso. Saíram: provider, CLI locator, builder,
-  ícone, tipos `CopilotQuota*`, paths de config, registries (tooltip/terminal/
-  TUI), entrada em `WAYBAR_PROVIDERS`, e a migração de settings v1→v2 que só
-  existia para injetar Copilot. Providers suportados agora: Claude, Codex, Amp.
+- **Copilot provider removed entirely** (breaking). The Copilot CLI's
+  `--headless --stdio` interface is hidden/fragile (disappears without notice
+  in auto-updates) and was unused. Removed: provider, CLI locator, builder,
+  icon, `CopilotQuota*` types, config paths, registries (tooltip/terminal/
+  TUI), the `WAYBAR_PROVIDERS` entry, and the v1→v2 settings migration that
+  only existed to inject Copilot. Supported providers now: Claude, Codex, Amp.
 
 ### Added
-- **Notificações desktop de quota baixa/crítica** via `notify-send`: alerta
-  quando qualquer janela de quota cruza 90% usado (low) ou 95% (critical),
-  incluindo as semanais por-modelo do Claude. Piggyback no poll do Waybar com
-  dedup por estado (`~/.cache/agent-bar/notify-<provider>.json`), re-arma ao
-  recuperar, escala low→critical. Best-effort: não faz nada se `notify-send`
-  estiver ausente e só dispara quando a saída é consumida pelo Waybar.
-  Controlado por `notify.enabled` no settings.
+- **Desktop notifications for low/critical quota** via `notify-send`: alerts
+  when any quota window crosses 90% used (low) or 95% (critical), including
+  Claude's per-model weekly windows. Piggybacks on the Waybar poll with
+  dedup by state (`~/.cache/agent-bar/notify-<provider>.json`), re-arms on
+  recovery, escalates low→critical. Best-effort: does nothing if `notify-send`
+  is absent and only fires when the output is consumed by Waybar.
+  Controlled by `notify.enabled` in settings.
 
 ### Breaking
-- O provider `copilot` não existe mais. Settings que listavam `copilot` têm a
-  entrada removida automaticamente na carga; nenhuma ação necessária.
-- **Notificações vêm ligadas por padrão** (`notify.enabled: true`). Após
-  atualizar, alertas de quota baixa passam a aparecer sem opt-in — desligue com
-  `"notify": { "enabled": false }` em `~/.config/agent-bar/settings.json`.
+- The `copilot` provider no longer exists. Settings that listed `copilot`
+  have the entry removed automatically on load; no action needed.
+- **Notifications are enabled by default** (`notify.enabled: true`). After
+  updating, low-quota alerts start appearing without opt-in — disable with
+  `"notify": { "enabled": false }` in `~/.config/agent-bar/settings.json`.
 
 ## [4.2.0] - 2026-06-17
 
@@ -688,19 +702,19 @@ paridade byte-exact do contrato Waybar/Pango e da saída `--format json`.
 
 ### Changed
 
-- `agent-bar update` agora detecta instalações npm/Bun e atualiza o pacote
-  global com `bun add -g`, em vez de tratar apenas o checkout legado
-  `~/.agent-bar`.
+- `agent-bar update` now detects npm/Bun installations and updates the
+  global package with `bun add -g`, instead of only handling the legacy
+  `~/.agent-bar` checkout.
 
 ### Fixed
 
-- Logo da TUI exibia `QBAR` (nome antigo do projeto) ao abrir o menu. Substituído pela block-art `AGENT BAR`.
+- TUI logo showed `QBAR` (the project's old name) when opening the menu. Replaced with the `AGENT BAR` block-art.
 
 ## [4.0.0] - 2026-05-15
 
 ### Added
 
-- Setting `waybar.displayMode` (`remaining` | `used`) com toggle via TUI Configure Layout. Quando `used`, percentuais e barra refletem quota consumida (0% = nada usado, 100% = esgotado); cores e classes CSS continuam baseadas em saúde. Default: `remaining` (comportamento anterior preservado).
+- Setting `waybar.displayMode` (`remaining` | `used`) with toggle via TUI Configure Layout. When `used`, percentages and the bar reflect consumed quota (0% = nothing used, 100% = exhausted); colors and CSS classes remain based on health. Default: `remaining` (previous behavior preserved).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,11 +109,12 @@ Product milestone — no JSON contract change.
 
 ### Added
 - **Redesigned Widget.qml**: hero % per provider matching the chip,
-  `agent-bar` title + relative "Xm ago", top actions become real Unicode
-  buttons (↻ refresh, ⚙︎ settings, ❯ open TUI) instead of text/link. One
-  card per provider, fixed-column grid (label · bar · % · reset),
-  countdown (`1h 46m · 18:30` / `7d 0h · Mon 16:43`) across every window.
-  Width `540` (previously `370`), the same in both modes.
+  `agent-bar` title + a relative last-updated label (elapsed minutes), top
+  actions become real Unicode buttons (↻ refresh, ⚙︎ settings, ❯ open TUI)
+  instead of text/link. One card per provider, fixed-column grid
+  (label · bar · % · reset), countdown (`1h 46m · 18:30` /
+  `7d 0h · seg 16:43`) across every window. Width `540` (previously `370`),
+  the same in both modes.
 - **`extra` visible in the popup**: Amp credits (`$X · replenish`),
   Grok's sessions/turns/model, Claude's extra usage when present —
   previously these only existed in `--format json`, never reaching the
@@ -297,15 +298,16 @@ after 8.0.0).
 - Dual token label in Detail's totals: primary = input+output, suffix
   `(+N cache)` when cache exists.
 - Chart legend with a `…+N` indicator when series don't fit the width.
-- Help discoverability: `? help` chip in Detail and a hint on the
+- Help discoverability: `? ajuda` chip in Detail and a hint on the
   frame's bottom border.
 - Specs: foundations/trust, product hardening, TUI polish.
 
 ### Changed
 - **Codex / TUI update / Detail** modularized (no product-contract change
   from the splits).
-- TUI config with human labels (`Providers`, `Order`, `Display`,
-  `Exchange rate R$`…); the technical key stays in the field's hint.
+- TUI config now shows human-readable field labels in Portuguese (at the
+  time) instead of raw setting keys; the technical key still appears in
+  the field's hint.
 - Collapsed sidebar uses `≡` / `→` / `⚙` instead of H/L/C.
 - Detail's chart uses `Min(6)` on narrow panels (&lt; 72 cols); `Min(9)`
   otherwise.
@@ -372,7 +374,7 @@ Complete TUI redesign (v8) + reliable usage numbers.
 Round of TUI visual adjustments after real hands-on testing of the redesign.
 
 ### Added
-- **"Today (24h)" panel on Overview**: when height remains below the cards,
+- **"Hoje (24h)" panel on Overview**: when height remains below the cards,
   the space becomes the last-24h braille chart (same visualization as
   History) with today/7d totals in the footer. On short terminals the old
   layout stays intact.
@@ -384,14 +386,13 @@ Round of TUI visual adjustments after real hands-on testing of the redesign.
 - The help popup (`?`) now sizes itself to its content (it used to be
   60%x70% of the frame and cut off the final sections on smaller
   terminals) and dims the screen underneath while open.
-- TUI copy revised: fixed accent bugs in words like "instructions",
-  "comma", "invalid", "configuration"… and localized the "Waybar Config"
-  label to Portuguese.
+- TUI copy revised: fixed accent bugs across several Portuguese labels,
+  and localized the "Waybar Config" label to Portuguese.
 
 ### Fixed
-- **"today 0 tok" / "no token usage" during loading**: while session-log
+- **"hoje 0 tok" / "sem uso de tokens" during loading**: while session-log
   parsing hasn't finished, History, Detail, and the cards now say
-  "collecting…" instead of asserting zero about data that simply hasn't
+  "coletando…" instead of asserting zero about data that simply hasn't
   arrived yet.
 - Session-log parsing now runs **once** per refresh (it used to run twice —
   once for today's window, once for the 7-day one), cutting history
@@ -463,15 +464,15 @@ Complete redesign of the `agent-bar menu` TUI (spec and plan in
 - **Fetch, login, and save moved off the event loop**: the TUI never freezes
   anymore — spinner and per-provider progress genuinely appear, keys respond
   during the fetch, and the post-login refetch is automatic.
-- **Login state derived from a real fetch** (5 states, including `error`
-  distinct from `logged-out`) — the end of `[ok]` based on file existence.
+- **Login state derived from a real fetch** (5 states, including `erro`
+  distinct from `deslogado`) — the end of `[ok]` based on file existence.
 - **Terminal helper cascade** (`agent-bar-open-terminal`): honors
   `$TERMINAL` (launches the preferred terminal with font flags when
   supported; unknown → xdg path); direct alacritty now comes before the
   uwsm/xdg path to apply the font while preserving Hyprland's float.
 - **MSRV corrected to 1.88** (the dependencies' real floor); new
   dependencies: `tachyonfx`, `tui-scrollview`; `tui-popup` removed.
-- History's "peak HHh" and axis labels are now in local time (previously UTC).
+- History's "pico HHh" and axis labels are now in local time (previously UTC).
 
 ### Fixed
 - **The `r` (refresh) key never worked** — it set "Loading" without
@@ -489,7 +490,7 @@ Complete redesign of the `agent-bar menu` TUI (spec and plan in
 - Race between overlapping fetch waves corrupting spinner/`last_update`.
 - Token `abbrev` overflowed the unit boundary ("1000.0K" → "1.0M").
 - Extra usage enabled without a configured limit rendered a
-  self-contradictory gauge ("$X of $0.00") — now "used · no limit".
+  self-contradictory gauge ("$X de $0.00") — now "usado · sem limite".
 
 ## [6.0.1] - 2026-06-21
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,9 +132,10 @@ ready PR. Grok may not merge.
 
 ## Documentation
 
-Active docs and public copy are English. Historical changelog entries, ADR
-bodies 0001–0003, and `docs/superpowers/**` remain historical and are excluded
-from active legacy/language scans.
+Active docs and public copy are English, enforced by
+`tests/active_language.rs`. Only `docs/superpowers/**` is excluded: it holds
+past session plans and specs, which are a build record rather than
+documentation. New files written there are English.
 
 ## Pointers
 

--- a/assets/omarchy/MaintenanceView.qml
+++ b/assets/omarchy/MaintenanceView.qml
@@ -123,10 +123,9 @@ Item {
       }
     }
 
-    Rectangle {
+    PanelSeparator {
       width: parent.width
-      height: 1
-      color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.12)
+      foreground: root.foreground
     }
 
     // Danger zone — visually separated (UX-044)

--- a/assets/omarchy/MaintenanceView.qml
+++ b/assets/omarchy/MaintenanceView.qml
@@ -34,7 +34,7 @@ Item {
 
     Text {
       text: "Maintenance"
-      color: Qt.darker(root.foreground, 1.35)
+      color: Util.alpha(root.foreground, 0.55)
       font.family: root.fontFamily
       font.pixelSize: Style.font.caption
       font.bold: true
@@ -57,7 +57,7 @@ Item {
     Text {
       width: parent.width
       text: "Installation type: " + (ui.installType || "Plugin bundle")
-      color: Qt.darker(root.foreground, 1.25)
+      color: Util.alpha(root.foreground, 0.55)
       font.family: root.fontFamily
       font.pixelSize: Style.font.caption
       textFormat: Text.PlainText
@@ -67,7 +67,7 @@ Item {
       width: parent.width
       visible: ui.message && ui.message.length > 0
       text: ui.message
-      color: ui.phase === "error" ? Color.urgent : Qt.darker(root.foreground, 1.2)
+      color: ui.phase === "error" ? Color.urgent : Util.alpha(root.foreground, 0.55)
       font.family: root.fontFamily
       font.pixelSize: Style.font.caption
       wrapMode: Text.WordWrap

--- a/assets/omarchy/ProviderRail.qml
+++ b/assets/omarchy/ProviderRail.qml
@@ -85,9 +85,9 @@ Item {
     id: frame
     anchors.fill: parent
     anchors.margins: root.outerMargin
-    color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.05)
+    color: Style.normalFill
     border.width: 1
-    border.color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.22)
+    border.color: Style.normalBorderColor
     radius: Style.cornerRadius
     clip: true
   }
@@ -143,11 +143,11 @@ Item {
           anchors.fill: parent
           radius: Style.cornerRadius
           color: railItem.selected
-              ? Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.12)
+              ? Style.selectedFill
               : "transparent"
           border.width: railItem.selected ? 1 : 0
           border.color: railItem.selected
-              ? Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.3)
+              ? Style.selectedBorderColor
               : "transparent"
         }
 
@@ -205,7 +205,7 @@ Item {
         anchors.fill: parent
         radius: Style.cornerRadius
         color: (settingsItem.activeFocus || settingsMouse.containsMouse)
-            ? Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.08)
+            ? Style.hoverFill
             : "transparent"
         border.width: settingsItem.activeFocus ? 1 : 0
         border.color: Color.accent

--- a/assets/omarchy/ProviderRail.qml
+++ b/assets/omarchy/ProviderRail.qml
@@ -145,7 +145,7 @@ Item {
           color: railItem.selected
               ? Style.selectedFill
               : "transparent"
-          border.width: railItem.selected ? 1 : 0
+          border.width: railItem.selected ? Style.selectedBorderWidth : 0
           border.color: railItem.selected
               ? Style.selectedBorderColor
               : "transparent"

--- a/assets/omarchy/ProviderView.qml
+++ b/assets/omarchy/ProviderView.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import qs.Commons
+import qs.Ui
 import "CoreView.js" as Core
 import "components"
 
@@ -66,10 +67,9 @@ Item {
       }
     }
 
-    Rectangle {
+    PanelSeparator {
       width: parent.width
-      height: 1
-      color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.12)
+      foreground: root.foreground
     }
 
     // Stale banner: glyph + typed message + Retry (never color-only).
@@ -158,10 +158,10 @@ Item {
       visible: (root.mode === "windows" || root.mode === "stale_windows")
           && root.groups.secondary.length > 0
 
-      Rectangle {
+      PanelSeparator {
         width: parent.width
-        height: 1
-        color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.08)
+        foreground: root.foreground
+        strength: 0.08
       }
 
       Repeater {

--- a/assets/omarchy/ProviderView.qml
+++ b/assets/omarchy/ProviderView.qml
@@ -219,7 +219,7 @@ Item {
             parts.push("refreshing…")
           return parts.join(" · ")
         }
-        color: Qt.darker(root.foreground, 1.4)
+        color: Util.alpha(root.foreground, 0.55)
         font.family: root.fontFamily
         font.pixelSize: Style.font.caption
         elide: Text.ElideRight
@@ -229,7 +229,7 @@ Item {
       Text {
         width: Math.max(0, parent.width - footerLeft.width)
         text: root.header.connection
-        color: Qt.darker(root.foreground, root.header.showStale ? 1.0 : 1.15)
+        color: Util.alpha(root.foreground, root.header.showStale ? 0.72 : 0.55)
         font.family: root.fontFamily
         font.pixelSize: Style.font.caption
         font.bold: root.header.showStale

--- a/assets/omarchy/SettingsView.qml
+++ b/assets/omarchy/SettingsView.qml
@@ -144,10 +144,9 @@ Item {
       }
     }
 
-    Rectangle {
+    PanelSeparator {
       width: parent.width
-      height: 1
-      color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.12)
+      foreground: root.foreground
     }
 
     // Display metric
@@ -242,10 +241,9 @@ Item {
       }
     }
 
-    Rectangle {
+    PanelSeparator {
       width: parent.width
-      height: 1
-      color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.12)
+      foreground: root.foreground
     }
 
     // Actions — English text labels (UX-036..038)
@@ -296,10 +294,9 @@ Item {
       }
     }
 
-    Rectangle {
+    PanelSeparator {
       width: parent.width
-      height: 1
-      color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.12)
+      foreground: root.foreground
     }
 
     MaintenanceView {

--- a/assets/omarchy/SettingsView.qml
+++ b/assets/omarchy/SettingsView.qml
@@ -80,7 +80,7 @@ Item {
       visible: root.loading
       width: parent.width
       text: "Loading settings\u2026"
-      color: Qt.darker(root.foreground, 1.3)
+      color: Util.alpha(root.foreground, 0.72)
       font.family: root.fontFamily
       font.pixelSize: Style.font.caption
       textFormat: Text.PlainText
@@ -90,7 +90,7 @@ Item {
       visible: root.saving
       width: parent.width
       text: "Saving\u2026"
-      color: Qt.darker(root.foreground, 1.3)
+      color: Util.alpha(root.foreground, 0.72)
       font.family: root.fontFamily
       font.pixelSize: Style.font.caption
       textFormat: Text.PlainText
@@ -105,7 +105,7 @@ Item {
 
       Text {
         text: "Providers"
-        color: Qt.darker(root.foreground, 1.35)
+        color: Util.alpha(root.foreground, 0.55)
         font.family: root.fontFamily
         font.pixelSize: Style.font.caption
         font.bold: true
@@ -159,7 +159,7 @@ Item {
 
       Text {
         text: "Chip number"
-        color: Qt.darker(root.foreground, 1.35)
+        color: Util.alpha(root.foreground, 0.55)
         font.family: root.fontFamily
         font.pixelSize: Style.font.caption
         font.bold: true

--- a/assets/omarchy/components/ConfirmDialog.qml
+++ b/assets/omarchy/components/ConfirmDialog.qml
@@ -75,7 +75,7 @@ Item {
       Text {
         width: parent.width
         text: root.message
-        color: Qt.darker(root.foreground, 1.15)
+        color: Util.alpha(root.foreground, 0.72)
         font.family: root.fontFamily
         font.pixelSize: Style.font.caption
         wrapMode: Text.WordWrap

--- a/assets/omarchy/components/ConfirmDialog.qml
+++ b/assets/omarchy/components/ConfirmDialog.qml
@@ -22,13 +22,18 @@ Item {
   signal canceled()
   signal confirmed()
 
+  // Full-screen wash behind the card. Not control chrome and not text, so it
+  // carries no host token — declared once here with the one raw alpha this
+  // file is allowed (see tst_Tokens.qml textAlphaExceptions).
+  readonly property color scrimColor: Util.alpha(Color.foreground, 0.45)
+
   anchors.fill: parent
   visible: opened
   z: 100
 
   Rectangle {
     anchors.fill: parent
-    color: Qt.rgba(0, 0, 0, 0.45)
+    color: root.scrimColor
     MouseArea {
       anchors.fill: parent
       onClicked: root.canceled()
@@ -43,9 +48,12 @@ Item {
     radius: Style.cornerRadius
     color: Color.popups.background
     border.width: 1
+    // Destructive keeps its urgent-tinted border (UX-044: danger actions stay
+    // visually separated); a Style state token would erase that signal, so
+    // only the non-destructive branch moves to the shared token.
     border.color: root.destructive
-        ? Qt.rgba(Color.urgent.r, Color.urgent.g, Color.urgent.b, 0.55)
-        : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.28)
+        ? Util.alpha(Color.urgent, 0.55)
+        : Style.normalBorderColor
 
     MouseArea {
       anchors.fill: parent

--- a/assets/omarchy/components/ConfirmDialog.qml
+++ b/assets/omarchy/components/ConfirmDialog.qml
@@ -22,10 +22,11 @@ Item {
   signal canceled()
   signal confirmed()
 
-  // Full-screen wash behind the card. Not control chrome and not text, so it
-  // carries no host token — declared once here with the one raw alpha this
-  // file is allowed (see tst_Tokens.qml textAlphaExceptions).
-  readonly property color scrimColor: Util.alpha(Color.foreground, 0.45)
+  // Full-screen dim layer behind the card. The host already exposes this
+  // exact surface — Color.menu.scrim composes the theme's background at a
+  // fixed alpha, so it dims regardless of whether foreground is light or
+  // dark. A foreground-based wash would invert on light-foreground themes.
+  readonly property color scrimColor: Color.menu.scrim
 
   anchors.fill: parent
   visible: opened

--- a/assets/omarchy/components/ProviderHeader.qml
+++ b/assets/omarchy/components/ProviderHeader.qml
@@ -49,7 +49,7 @@ Item {
       radius: height / 2
       color: "transparent"
       border.width: 1
-      border.color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.25)
+      border.color: Style.normalBorderColor
       Text {
         id: planText
         anchors.centerIn: parent

--- a/assets/omarchy/components/ProviderHeader.qml
+++ b/assets/omarchy/components/ProviderHeader.qml
@@ -54,7 +54,7 @@ Item {
         id: planText
         anchors.centerIn: parent
         text: root.plan
-        color: Qt.darker(root.foreground, 1.2)
+        color: Util.alpha(root.foreground, 0.72)
         font.family: root.fontFamily
         font.pixelSize: Style.font.caption
         textFormat: Text.PlainText

--- a/assets/omarchy/components/StateMessage.qml
+++ b/assets/omarchy/components/StateMessage.qml
@@ -68,7 +68,7 @@ Column {
       width: Math.max(0, parent.width)
       visible: root.body.length > 0
       text: root.body
-      color: Qt.darker(root.foreground, 1.25)
+      color: Util.alpha(root.foreground, 0.72)
       font.family: root.fontFamily
       font.pixelSize: Style.font.caption
       wrapMode: Text.Wrap

--- a/assets/omarchy/components/StateMessage.qml
+++ b/assets/omarchy/components/StateMessage.qml
@@ -28,19 +28,19 @@ Column {
       width: parent.width * 0.55
       height: Style.space(14)
       radius: Style.cornerRadius
-      color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.12)
+      color: Style.selectedFill
     }
     Rectangle {
       width: parent.width * 0.9
       height: Style.space(12)
       radius: Style.cornerRadius
-      color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.08)
+      color: Style.hoverFill
     }
     Rectangle {
       width: parent.width * 0.7
       height: Style.space(12)
       radius: Style.cornerRadius
-      color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.08)
+      color: Style.hoverFill
     }
   }
 

--- a/assets/omarchy/components/UsageWindow.qml
+++ b/assets/omarchy/components/UsageWindow.qml
@@ -38,7 +38,7 @@ Item {
     Text {
       width: parent.width
       text: root.label
-      color: Qt.darker(root.foreground, 1.35)
+      color: Util.alpha(root.foreground, 0.72)
       font.family: root.fontFamily
       font.pixelSize: Style.font.caption
       font.capitalization: Font.AllUppercase
@@ -62,7 +62,7 @@ Item {
       Text {
         anchors.baseline: parent.children[0].baseline
         text: root.unitText
-        color: Qt.darker(root.foreground, 1.35)
+        color: Util.alpha(root.foreground, 0.72)
         font.family: root.fontFamily
         font.pixelSize: Style.font.caption
         textFormat: Text.PlainText
@@ -95,7 +95,7 @@ Item {
       spacing: Style.space(4)
       Text {
         text: "resets"
-        color: Qt.darker(root.foreground, 1.35)
+        color: Util.alpha(root.foreground, 0.72)
         font.family: root.fontFamily
         font.pixelSize: Style.font.caption
         textFormat: Text.PlainText
@@ -123,7 +123,7 @@ Item {
       id: compactLabel
       width: Math.max(0, parent.width * 0.5)
       text: root.label
-      color: Qt.darker(root.foreground, 1.2)
+      color: Util.alpha(root.foreground, 0.72)
       font.family: root.fontFamily
       font.pixelSize: Style.font.caption
       elide: Text.ElideRight

--- a/assets/omarchy/components/UsageWindow.qml
+++ b/assets/omarchy/components/UsageWindow.qml
@@ -23,6 +23,9 @@ Item {
   readonly property real fillRatio: hasPercent
       ? Math.max(0, Math.min(1, root.percent / 100))
       : 0
+  // Data surface, not control chrome — no host token covers it. Declared
+  // once here so plan 03's compact rows tint from the same place.
+  readonly property color trackColor: Util.alpha(root.foreground, 0.12)
 
   width: parent ? parent.width : implicitWidth
   implicitHeight: root.emphasis ? bigCol.implicitHeight : compactRow.implicitHeight
@@ -74,7 +77,7 @@ Item {
       width: parent.width
       height: Style.space(5)
       radius: height / 2
-      color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.12)
+      color: root.trackColor
       Accessible.ignored: true
 
       Rectangle {

--- a/docs/adr/0001-omarchy-right-click-settings.md
+++ b/docs/adr/0001-omarchy-right-click-settings.md
@@ -1,12 +1,13 @@
-# Right-click Omarchy = settings nativo (não TUI)
+# Right-click Omarchy = native settings (not TUI)
 
-No Omarchy 4 o right-click do chip abria a TUI inteira num terminal flutuante,
-enquanto o first-party `omarchy.model-usage` usa o mesmo popup em modo settings.
-Decidimos alinhar: **só no plugin Omarchy**, right-click abre Settings mode no
-mesmo `PopupCard`; left = usage; middle = refresh. Waybar mantém left=menu e
-right=`action-right`. A TUI continua em `agent-bar menu` e no link do popup.
+On Omarchy 4 the chip's right-click opened the entire TUI in a floating
+terminal, while the first-party `omarchy.model-usage` uses the same popup in
+settings mode. We decided to align: **Omarchy plugin only**, right-click opens
+Settings mode in the same `PopupCard`; left = usage; middle = refresh. Waybar
+keeps left=menu and right=`action-right`. The TUI remains available via
+`agent-bar menu` and the popup's link.
 
-**Considered:** (B) mudar Waybar junto; (C) matar/encolher a TUI no mesmo
-release. Rejeitados: escopo e risco sem valor no desktop Omarchy-first.
+**Considered:** (B) change Waybar too; (C) kill/shrink the TUI in the same
+release. Rejected: scope and risk with no value on the Omarchy-first desktop.
 
 **Status:** accepted (v8.5.0)

--- a/docs/adr/0002-config-cli-dual-write.md
+++ b/docs/adr/0002-config-cli-dual-write.md
@@ -1,14 +1,14 @@
-# settings.json via CLI; intervalo no shell.json
+# settings.json via CLI; interval in shell.json
 
-O Settings mode precisa de providers/order/display/notify (lógica Rust) e de
-`refreshIntervalSec` (schema do plugin Omarchy). Decidimos **fonte única Rust**
-para o subset editável: `agent-bar config show` / `config apply` leem e gravam
-`~/.config/agent-bar/settings.json` com a normalização existente.
-`refreshIntervalSec` fica no entry do plugin (`updateEntryInline` →
-`shell.json`). Save do QML faz dual-write nessa ordem; apply **não** chama
-`apply_waybar_integration`.
+Settings mode needs providers/order/display/notify (Rust logic) and
+`refreshIntervalSec` (Omarchy plugin schema). We decided on a **single Rust
+source** for the editable subset: `agent-bar config show` / `config apply`
+read and write `~/.config/agent-bar/settings.json` with the existing
+normalization. `refreshIntervalSec` stays in the plugin entry
+(`updateEntryInline` → `shell.json`). QML's save performs a dual-write in
+that order; apply does **not** call `apply_waybar_integration`.
 
-**Considered:** tudo no `shell.json`; QML escrever `settings.json` direto.
-Rejeitados: segunda fonte de verdade e bypass de normalização.
+**Considered:** everything in `shell.json`; QML writing `settings.json`
+directly. Rejected: a second source of truth and bypassing normalization.
 
 **Status:** accepted (v8.5.0)

--- a/docs/adr/0003-cli-help-hide-internals.md
+++ b/docs/adr/0003-cli-help-hide-internals.md
@@ -1,13 +1,13 @@
-# Help público enxuto; internos ainda parseáveis
+# Lean public help; internals still parseable
 
-A CLI misturava primários com paths de packager/Waybar (`assets`, `export`,
-`action-right`) e aliases redundantes. Decidimos **opção A**: reorganizar o
-help (menu, status, config, setup, update, uninstall, doctor); esconder
-internos do help mas **manter o parse** (módulos Waybar e scripts dependem);
-`remove` → `uninstall --yes`; `-t` → `status`. Sem hard-cut Omarchy-only nem
-deletar `action-right`.
+The CLI mixed primary commands with packager/Waybar paths (`assets`,
+`export`, `action-right`) and redundant aliases. We decided on **option A**:
+reorganize help (menu, status, config, setup, update, uninstall, doctor);
+hide internals from help but **keep them parseable** (Waybar modules and
+scripts depend on them); `remove` → `uninstall --yes`; `-t` → `status`. No
+Omarchy-only hard cut, and `action-right` is not deleted.
 
-**Considered:** (B) unificar action-right em `menu --provider`; (C) default
-JSON e Waybar explícito. Deferidos para não quebrar contrato gerado.
+**Considered:** (B) unify action-right into `menu --provider`; (C) default
+JSON with Waybar explicit. Deferred to avoid breaking the generated contract.
 
 **Status:** accepted (v8.5.0)

--- a/docs/superpowers/plans/2026-07-30-v11-01-foundation-tokens-language.md
+++ b/docs/superpowers/plans/2026-07-30-v11-01-foundation-tokens-language.md
@@ -917,20 +917,41 @@ In `tests/qml/TestPalette.js`, delete the `muted` key from both the `light` and
 `dark` return objects. A fixture that hardcodes the value it is meant to verify
 cannot verify it.
 
-Then in `tests/qml/tst_Screenshots.qml`, add `import qs.Commons` at the top if
-it is absent, and replace `applyTheme` at line 85:
+**Do not import `qs.Commons` to reach `Util.alpha`.** The bare Qt6
+`qmltestrunner` this gate uses cannot resolve that module, and a file carrying
+the import fails to compile entirely — it does not merely lose the symbol. The
+constraint is documented at `tests/qml/tst_ProviderStates.qml:220-227` and was
+reproduced independently during Task 4. Every test in this repository reads QML
+as text for exactly this reason.
+
+Compute the same colour inline instead. `Util.alpha(c, o)` returns
+`Qt.rgba(c.r, c.g, c.b, clampAlpha(o))`, and `clampAlpha` is the identity for a
+value already inside `0..1`, so the expression below is that function's exact
+output. Replace `applyTheme` in `tests/qml/tst_Screenshots.qml` at line 85:
 
 ```qml
   function applyTheme(mode) {
     var p = Core.themePalette(mode)
     stage.color = p.background
     stage.fg = p.foreground
-    // Same expression the shipped components use, so this fixture actually
-    // exercises the token binding instead of a hand-picked stand-in.
-    stage.muted = Util.alpha(p.foreground, 0.72)
+    // Derived from this palette's own foreground at the supporting-text level,
+    // which is what the shipped components compute through Util.alpha. The
+    // literal 0.72 is pinned by tst_Tokens.qml's test_no_third_alpha_value;
+    // Util itself is unreachable here because qs.Commons will not compile
+    // under the bare Qt6 runner.
+    var fg = Qt.color(p.foreground)
+    stage.muted = Qt.rgba(fg.r, fg.g, fg.b, 0.72)
     stage.badgeColor = p.urgent
   }
 ```
+
+This is a smaller improvement than reaching the real function would be, and it
+is worth being precise about what it does and does not buy. It does not prove
+the components call `Util.alpha` — `tst_Tokens.qml` already does that. What it
+fixes is the fixture's independence from the palette: the muted colour now
+derives from the same foreground the theme supplies, so the light and white
+renders finally show the real relationship between primary and secondary text
+instead of two unrelated hand-picked hexes.
 
 - [ ] **Step 4: Render the white case**
 

--- a/docs/superpowers/plans/2026-07-30-v11-01-foundation-tokens-language.md
+++ b/docs/superpowers/plans/2026-07-30-v11-01-foundation-tokens-language.md
@@ -1031,3 +1031,53 @@ Layout, copy, assets, severity, notifications, and the CLI. Those are:
 | 03 — popup | rail alignment, header tags, footer removal, stale banner, typed-state copy |
 | 04 — severity | thresholds shared with Rust, lead-window election, `UX-017`/`UX-020A`/`UX-028`/`UX-054` amendments |
 | 05 — notifications and CLI | Rust countdown humaniser, notification metric and copy, CLI and `install.sh` copy |
+
+---
+
+## Execution record
+
+Executed 2026-07-30 on branch `feat/v11-foundation`, 23 commits, all eight tasks
+reviewed and the branch reviewed whole. Final state: `cargo test` 287 across 14
+suites, `qmltestrunner` 187 passed 0 failed, clippy and fmt clean,
+`scripts/verify-v10-ui` exit 0. Started from 283 and 177.
+
+### Deferred minors carried forward
+
+Recorded during execution, triaged at the final review, none blocking. Kept here
+because the working ledger does not survive the plan.
+
+1. The Nerd Font glyph exclusion in the language gate is correct by Unicode
+   semantics but no tracked file exercises it.
+2. `alphaArgValues` in `tst_Tokens.qml` cannot match a `Util.alpha` call whose
+   first argument nests parentheses. No call site does today.
+3. The same test's comment strip handles `//` but not `/* */`.
+4. The text-alpha exception mechanism constrains values, not growth of the list
+   itself. A later task could add a second entry with nothing flagging it —
+   **the one item plans 02 through 05 should watch.**
+5. `allowedRawAlphaFiles()` is permanently `[]` and could be removed with its
+   last caller.
+6. The Settings focus ring at `ProviderRail.qml:210-211` keeps a hardcoded width
+   and a raw `Color.accent`. Not converted deliberately:
+   `Style.focusBorderColor` resolves from the theme's `focus-color`, which is
+   the foreground, so binding it would change the ring's colour.
+7. `test_full_width_separator_present` does not actually prove `UX-019` — its
+   `width: parent.width` check matches ten unrelated sites. Pre-existing.
+8. `tests/screenshot_inventory.rs` parses both lists by line; a reformat of
+   either side degrades it. It fails loud rather than silently passing.
+9. `tst_Screenshots.qml` keeps an inert `muted` default, always overwritten.
+
+### What the plan got wrong
+
+Five defects originated in this document and were caught during execution: a
+sample sentence that was pure ASCII and could not trip the gate it demonstrated;
+an unchecked `git` exit status that let the gate pass having read nothing; a
+table row describing a ternary border as a single fill; a scrim described as
+foreground-derived when it was pure black, which inverted a modal dim into a
+brighten; a token swap that resolved to alpha 1.0 where a 0.3 literal had been;
+and an instruction to import `qs.Commons` into a test file, which makes that
+file uncompilable under this repository's runner.
+
+They share one shape: **correct-looking source that behaves differently at
+runtime, invisible to tests that read code as text.** Every one was caught by
+comparing against the original or by resolving a value, never by a test. Plans
+02 through 05 touch the same surfaces and should assume the same failure mode.

--- a/docs/superpowers/plans/2026-07-30-v11-01-foundation-tokens-language.md
+++ b/docs/superpowers/plans/2026-07-30-v11-01-foundation-tokens-language.md
@@ -281,7 +281,7 @@ Expected: PASS, 2 tests.
 - [ ] **Step 6: Verify links still resolve**
 
 Run: `cargo test --test active_docs`
-Expected: PASS, 4 tests. `active_docs_internal_links_resolve` is the one that matters — a translated heading can break an anchor link.
+Expected: PASS, 5 tests. `active_docs_internal_links_resolve` is the one that matters — a translated heading can break an anchor link.
 
 - [ ] **Step 7: Commit**
 

--- a/docs/superpowers/plans/2026-07-30-v11-01-foundation-tokens-language.md
+++ b/docs/superpowers/plans/2026-07-30-v11-01-foundation-tokens-language.md
@@ -616,6 +616,24 @@ git commit -m "fix: bind secondary text to theme alpha"
 
 The values differ slightly from the tokens — 0.12 against the theme's 0.18, 0.22 against 0.4. That is the point: the tokens track the installed theme, the literals never did.
 
+**The scrim needs an exception, and it must be declared.** Task 4 added
+`test_no_third_alpha_value`, which asserts every `Util.alpha` opacity across the
+scanned files is `0.72` or `0.55`. Those two are the *secondary text* scale. The
+modal scrim is neither text nor control chrome — it is a full-screen wash with
+no host token, which is why it gets a name of its own. Declaring it as
+`Util.alpha(Color.foreground, 0.45)` therefore fails that assertion on sight.
+
+Do not weaken the assertion to accommodate it. Give it the same shape the
+language gate uses for `src/support/redact.rs`: an explicit exception carrying
+its reason, so the strict rule keeps applying everywhere else. Extend the test
+with a per-file exception set — for example a `textAlphaExceptions()` returning
+`{"assets/omarchy/components/ConfirmDialog.qml": ["0.45"]}` with a comment
+saying why — and have `test_no_third_alpha_value` subtract a file's exceptions
+before comparing. An undeclared third value must still fail.
+
+Task 7 adds the second and final exception, `0.12` for the usage track, the
+same way.
+
 - [ ] **Step 1: Add the failing test**
 
 Append to `tests/qml/tst_Tokens.qml`, inside the `TestCase`:
@@ -784,6 +802,8 @@ git commit -m "refactor: use PanelSeparator for panel rules"
 - Produces: `UsageWindow.trackColor` — a `readonly property color`. Plan 03 reuses it for the compact rows so both track shapes tint from one place.
 
 The track background has no host token: it is not control chrome, it is a data surface. That does not license repeating the literal. It is declared once, named, and referenced.
+
+**This is the second and last text-alpha exception.** `Util.alpha(root.foreground, 0.12)` is not one of the two secondary-text levels, so `test_no_third_alpha_value` rejects it until it is declared. Add `"0.12"` to `UsageWindow.qml`'s entry in the exception set Task 5 introduced, with a comment saying it is the usage track — a data surface with no host token. After this task the exception set is closed: two entries, the scrim and the track, and any further third value is a real defect.
 
 - [ ] **Step 1: Tighten the test to its final shape**
 

--- a/docs/superpowers/plans/2026-07-30-v11-01-foundation-tokens-language.md
+++ b/docs/superpowers/plans/2026-07-30-v11-01-foundation-tokens-language.md
@@ -631,8 +631,9 @@ with a per-file exception set — for example a `textAlphaExceptions()` returnin
 saying why — and have `test_no_third_alpha_value` subtract a file's exceptions
 before comparing. An undeclared third value must still fail.
 
-Task 7 adds the second and final exception, `0.12` for the usage track, the
-same way.
+Task 7 adds the usage-track exception, `0.12`, the same way — and it turned out
+to be the only one. The scrim never needed an entry: Task 5 bound it to the host
+token `Color.menu.scrim` instead, which removed its literal entirely.
 
 - [ ] **Step 1: Add the failing test**
 
@@ -804,7 +805,7 @@ git commit -m "refactor: use PanelSeparator for panel rules"
 
 The track background has no host token: it is not control chrome, it is a data surface. That does not license repeating the literal. It is declared once, named, and referenced.
 
-**This is the second and last text-alpha exception.** `Util.alpha(root.foreground, 0.12)` is not one of the two secondary-text levels, so `test_no_third_alpha_value` rejects it until it is declared. Add `"0.12"` to `UsageWindow.qml`'s entry in the exception set Task 5 introduced, with a comment saying it is the usage track — a data surface with no host token. After this task the exception set is closed: two entries, the scrim and the track, and any further third value is a real defect.
+**This is the only text-alpha exception.** `Util.alpha(root.foreground, 0.12)` is not one of the two secondary-text levels, so `test_no_third_alpha_value` rejects it until it is declared. Add `"0.12"` to `UsageWindow.qml`'s entry in the exception set Task 5 introduced, with a comment saying it is the usage track — a data surface with no host token. Task 5 built that mechanism for the modal scrim and then emptied it again, because binding the scrim to `Color.menu.scrim` removed its literal outright; the track is what finally populates it. After this task the exception set is closed at one entry, and any further value is a real defect.
 
 - [ ] **Step 1: Tighten the test to its final shape**
 

--- a/docs/superpowers/plans/2026-07-30-v11-01-foundation-tokens-language.md
+++ b/docs/superpowers/plans/2026-07-30-v11-01-foundation-tokens-language.md
@@ -1,0 +1,947 @@
+# v11 Foundation — Host Tokens + Language Gate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Delete Agent Bar's accidental parallel design system by binding every hardcoded colour value to the Quattro tokens the host already exports, and add the language gate that no test currently provides.
+
+**Architecture:** Two independent mechanical sweeps, each ending in a test that makes the drift unrepeatable. The colour sweep replaces 16 `Qt.darker` calls and 18 of 19 hardcoded `Qt.rgba` alphas with `Util.alpha` and `Style` state tokens; the one survivor becomes a single named property. The language sweep adds a non-ASCII-letter gate with a shrinking translation backlog. No layout, copy, or behaviour changes here — those are plans 02 through 05.
+
+**Tech Stack:** Rust (std only for the gate test), QML/Qt6, Qt6 `qmltestrunner`.
+
+## Global Constraints
+
+- Rust/Cargo and QML only. No Node, npm, Bun, pnpm, Yarn, ts-node, or Deno.
+- No production `unwrap()` or `expect()` (clippy `-D warnings` is active).
+- QML never parses raw provider output; external strings render as plain text.
+- No Agent Bar-authored `Behavior`, `Transition`, `Animation` or `Animator` — `A11Y-013` and `TEST-029` must keep passing untouched.
+- No colour-only meaning (`A11Y-012`).
+- Active product copy is English. Commit subjects are English Conventional Commits, at most 50 characters.
+- Do not edit `/usr/share/omarchy`. Do not mutate live Omarchy/Hyprland paths.
+- Preserve unrelated worktree changes.
+- **Baseline to preserve:** `cargo test` 283 passing across 12 suites; `qmltestrunner` 177 passing, 0 failed.
+- `qmltestrunner` counts `initTestCase()` and `cleanupTestCase()` as passing tests, so a new `TestCase` file adds two beyond its own functions, and a data-driven function adds one per data row. Do not chase an exact total: the bar at every step is **0 failed**, plus the named tests appearing as `PASS`.
+- Rust gate, run at every task end:
+  ```bash
+  cargo fmt --check && cargo test && cargo clippy --all-targets -- -D warnings && git diff --check
+  ```
+- QML gate, run at every task that touches QML. The `qmltestrunner` on `PATH` is Qt5 and **fails silently**; the Qt6 path and both env vars are mandatory:
+  ```bash
+  find assets/omarchy -type f -name '*.qml' -exec qmllint -I /usr/share/omarchy/shell {} +
+  omarchy plugin validate assets/omarchy
+  QT_QPA_PLATFORM=offscreen QML_XHR_ALLOW_FILE_READ=1 QT_LOGGING_TO_CONSOLE=1 \
+    /usr/lib/qt6/bin/qmltestrunner -input tests/qml \
+    -import /usr/share/omarchy/shell -import assets/omarchy -o -,txt
+  ```
+- `cargo test` accepts ONE filter per invocation. Two test names means two invocations.
+- Read every file before editing it. If an `Edit` reports "string not found", re-read the file first.
+
+## Source Specs
+
+- `docs/superpowers/specs/2026-07-30-visual-update-design.md` section 4 (token binding). **Partial:** this plan takes the colour rows. The three sizing rows — icon width to `Style.bar.iconCanvas`, chip `opacity` to `WidgetButton.dimmed`, ad-hoc spacings to `Style.spacing.*` — belong to plan 02, because they only make sense once the chip sits in a host slot.
+- `docs/superpowers/specs/2026-07-30-copy-and-language-design.md` section 3 (language gate) and decision 2. **Complete:** nothing from section 3 is deferred.
+
+## File Structure
+
+| File | Responsibility | Action |
+| --- | --- | --- |
+| `tests/active_language.rs` | The language gate: scans tracked files, owns the exclusion list, allowlist, and translation backlog | create |
+| `tests/qml/tst_Tokens.qml` | Proves the token binding held: no `Qt.darker`, bounded raw alphas, and secondary text recedes in both themes | create |
+| `assets/omarchy/components/UsageWindow.qml` | Owns the usage track; after this plan it is the single declaration site for the track tint | modify |
+| `assets/omarchy/ProviderRail.qml` | Rail chrome; loses its own frame alphas in favour of `Style` state tokens | modify |
+| `assets/omarchy/{ProviderView,SettingsView,MaintenanceView}.qml` | Panes; separators become `PanelSeparator`, secondary text becomes `Util.alpha` | modify |
+| `assets/omarchy/components/{ProviderHeader,StateMessage,ConfirmDialog}.qml` | Components; same two replacements | modify |
+| `CHANGELOG.md`, `docs/adr/000{1,2,3}-*.md` | Translated to English | modify |
+| `CLAUDE.md` | The historical-language carve-out shrinks to `docs/superpowers/**` only | modify |
+
+---
+
+## Task 1: Language gate mechanism
+
+**Files:**
+- Create: `tests/active_language.rs`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `PENDING_TRANSLATION: &[&str]` — the shrinking backlog that Tasks 2 and 3 empty. Also establishes the exclusion and allowlist constants that later plans must not widen.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/active_language.rs`:
+
+```rust
+//! Active-surface language gate.
+//!
+//! Rule: no tracked text file may contain an alphabetic non-ASCII character.
+//! "Alphabetic" is load-bearing — it flags accented letters while ignoring the
+//! Nerd Font glyphs (Private Use Area) and the punctuation this project uses
+//! on purpose.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Past session artefacts. Build record, not documentation.
+const EXCLUDED_PREFIXES: &[&str] = &["docs/superpowers/"];
+
+/// Deliberate non-ASCII, with the reason it stays.
+const ALLOWLIST: &[(&str, &str)] = &[(
+    "src/support/redact.rs",
+    "accented fixture for the ANSI and control-character stripper",
+)];
+
+/// Files awaiting translation. Task 3 empties this and locks it shut.
+const PENDING_TRANSLATION: &[&str] = &[
+    "CHANGELOG.md",
+    "docs/adr/0001-omarchy-right-click-settings.md",
+    "docs/adr/0002-config-cli-dual-write.md",
+    "docs/adr/0003-cli-help-hide-internals.md",
+];
+
+const BINARY_EXTENSIONS: &[&str] = &["png", "jpg", "jpeg", "svg", "ico", "lock"];
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn tracked_files(root: &Path) -> Vec<String> {
+    let output = Command::new("git")
+        .arg("ls-files")
+        .current_dir(root)
+        .output()
+        .expect("git ls-files must run inside the repository");
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(str::to_owned)
+        .collect()
+}
+
+fn is_scannable(rel: &str) -> bool {
+    if EXCLUDED_PREFIXES.iter().any(|p| rel.starts_with(p)) {
+        return false;
+    }
+    if ALLOWLIST.iter().any(|(path, _)| *path == rel) {
+        return false;
+    }
+    if PENDING_TRANSLATION.contains(&rel) {
+        return false;
+    }
+    match Path::new(rel).extension().and_then(|e| e.to_str()) {
+        Some(ext) => !BINARY_EXTENSIONS.contains(&ext),
+        None => true,
+    }
+}
+
+/// file:line:offending characters:trimmed line
+fn offenders(root: &Path, rel: &str) -> Vec<String> {
+    let Ok(text) = std::fs::read_to_string(root.join(rel)) else {
+        return Vec::new();
+    };
+    let mut found = Vec::new();
+    for (index, line) in text.lines().enumerate() {
+        let bad: String = line
+            .chars()
+            .filter(|c| c.is_alphabetic() && !c.is_ascii())
+            .collect();
+        if !bad.is_empty() {
+            found.push(format!(
+                "{rel}:{}: [{bad}] {}",
+                index + 1,
+                line.trim()
+            ));
+        }
+    }
+    found
+}
+
+#[test]
+fn active_files_contain_no_non_english_letters() {
+    let root = workspace_root();
+    let mut all = Vec::new();
+    for rel in tracked_files(&root) {
+        if !is_scannable(&rel) {
+            continue;
+        }
+        all.extend(offenders(&root, &rel));
+    }
+    assert!(
+        all.is_empty(),
+        "alphabetic non-ASCII characters in active files:\n{}",
+        all.join("\n")
+    );
+}
+
+#[test]
+fn allowlisted_files_still_need_their_exemption() {
+    let root = workspace_root();
+    for (rel, reason) in ALLOWLIST {
+        assert!(
+            !offenders(&root, rel).is_empty(),
+            "{rel} is allowlisted for '{reason}' but no longer contains \
+             non-ASCII letters; remove the entry"
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests and confirm they pass**
+
+Run: `cargo test --test active_language`
+Expected: PASS, 2 tests. The gate proves the mechanism against everything that is already English; the backlog is quarantined, not yet solved.
+
+- [ ] **Step 3: Confirm the gate actually bites**
+
+Temporarily append a Portuguese line to `README.md`:
+
+```bash
+printf '\nEsta linha existe apenas para validar o gate de idioma.\n' >> README.md
+cargo test --test active_language 2>&1 | tail -20
+```
+
+Expected: FAIL naming `README.md`, the line number, and the offending characters. Then revert:
+
+```bash
+git checkout -- README.md
+cargo test --test active_language
+```
+
+Expected: PASS again. A gate that has never failed on purpose is not a gate.
+
+- [ ] **Step 4: Run the full Rust gate**
+
+Run: `cargo fmt --check && cargo test && cargo clippy --all-targets -- -D warnings && git diff --check`
+Expected: 285 passing (283 baseline + 2 new), clippy clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/active_language.rs
+git commit -m "test: add active-surface language gate"
+```
+
+---
+
+## Task 2: Translate the three ADRs
+
+**Files:**
+- Modify: `docs/adr/0001-omarchy-right-click-settings.md` (12 lines)
+- Modify: `docs/adr/0002-config-cli-dual-write.md` (14 lines)
+- Modify: `docs/adr/0003-cli-help-hide-internals.md` (13 lines)
+- Modify: `tests/active_language.rs` — remove the three ADR entries from `PENDING_TRANSLATION`
+
+**Interfaces:**
+- Consumes: `PENDING_TRANSLATION` from Task 1.
+- Produces: a backlog containing only `CHANGELOG.md`.
+
+- [ ] **Step 1: Read all three ADRs in full**
+
+```bash
+cat docs/adr/0001-omarchy-right-click-settings.md
+cat docs/adr/0002-config-cli-dual-write.md
+cat docs/adr/0003-cli-help-hide-internals.md
+```
+
+These are decision records. Translate the meaning exactly. Do not re-decide anything, do not add rationale that is not there, and do not modernise a decision that has since changed — an ADR records what was decided at the time.
+
+- [ ] **Step 2: Remove the ADRs from the backlog first, so the test fails**
+
+Edit `tests/active_language.rs`, leaving only `CHANGELOG.md`:
+
+```rust
+const PENDING_TRANSLATION: &[&str] = &["CHANGELOG.md"];
+```
+
+- [ ] **Step 3: Run the test and verify it fails**
+
+Run: `cargo test --test active_language`
+Expected: FAIL, listing the three ADR files with their offending lines.
+
+- [ ] **Step 4: Translate each ADR to English**
+
+Preserve heading structure, links, code spans, and file paths verbatim. Only prose changes.
+
+- [ ] **Step 5: Run the tests and verify they pass**
+
+Run: `cargo test --test active_language`
+Expected: PASS, 2 tests.
+
+- [ ] **Step 6: Verify links still resolve**
+
+Run: `cargo test --test active_docs`
+Expected: PASS, 4 tests. `active_docs_internal_links_resolve` is the one that matters — a translated heading can break an anchor link.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add docs/adr tests/active_language.rs
+git commit -m "docs: translate ADRs 0001-0003 to English"
+```
+
+---
+
+## Task 3: Translate the changelog and close the gate
+
+**Files:**
+- Modify: `CHANGELOG.md` (804 lines, 206 with accented characters)
+- Modify: `tests/active_language.rs` — empty `PENDING_TRANSLATION` and assert it stays empty
+- Modify: `CLAUDE.md` — shrink the carve-out
+
+**Interfaces:**
+- Consumes: `PENDING_TRANSLATION` from Task 2.
+- Produces: an empty backlog and a test asserting it. After this task no active file may contain a non-English letter.
+
+- [ ] **Step 1: Empty the backlog and add the lock, so the test fails**
+
+Edit `tests/active_language.rs`:
+
+```rust
+/// Empty, and it stays empty. See `translation_backlog_is_empty`.
+const PENDING_TRANSLATION: &[&str] = &[];
+```
+
+Add at the end of the file:
+
+```rust
+#[test]
+fn translation_backlog_is_empty() {
+    assert!(
+        PENDING_TRANSLATION.is_empty(),
+        "translation backlog must stay empty; still pending: {PENDING_TRANSLATION:?}"
+    );
+}
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run: `cargo test --test active_language`
+Expected: FAIL on `active_files_contain_no_non_english_letters`, listing the `CHANGELOG.md` lines. `translation_backlog_is_empty` passes already; it is the tripwire for the future, not for now.
+
+- [ ] **Step 3: Translate `CHANGELOG.md`**
+
+Work release by release, oldest first, so a partial run is still coherent. Rules:
+
+- Version headings, dates, links, code spans, file paths, command names and commit-type prefixes stay byte-identical.
+- Translate only the prose describing what changed.
+- Do not merge, reorder, reword-for-brevity, or delete entries. This is a published record; the meaning must survive, and nothing else may.
+- After each release section, re-run the scan to see the remaining count fall:
+  ```bash
+  cargo test --test active_language 2>&1 | rg -c 'CHANGELOG.md:'
+  ```
+
+- [ ] **Step 4: Run the tests and verify they pass**
+
+Run: `cargo test --test active_language`
+Expected: PASS, 3 tests.
+
+- [ ] **Step 5: Update the contract in `CLAUDE.md`**
+
+The Documentation section currently reads:
+
+```
+Active docs and public copy are English. Historical changelog entries, ADR
+bodies 0001–0003, and `docs/superpowers/**` remain historical and are excluded
+from active legacy/language scans.
+```
+
+Replace with:
+
+```
+Active docs and public copy are English, enforced by
+`tests/active_language.rs`. Only `docs/superpowers/**` is excluded: it holds
+past session plans and specs, which are a build record rather than
+documentation. New files written there are English.
+```
+
+Note the en dash in `0001–0003` disappears with the old sentence. That is fine; en dash is punctuation, not a letter, and the gate never flagged it.
+
+- [ ] **Step 6: Run the full Rust gate**
+
+Run: `cargo fmt --check && cargo test && cargo clippy --all-targets -- -D warnings && git diff --check`
+Expected: 286 passing, clippy clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add CHANGELOG.md CLAUDE.md tests/active_language.rs
+git commit -m "docs: translate changelog and enforce English"
+```
+
+---
+
+## Task 4: Replace `Qt.darker` with `Util.alpha`
+
+**Files:**
+- Create: `tests/qml/tst_Tokens.qml`
+- Modify: `assets/omarchy/ProviderView.qml:222,232`
+- Modify: `assets/omarchy/SettingsView.qml:83,93,108,162`
+- Modify: `assets/omarchy/MaintenanceView.qml:37,60,70`
+- Modify: `assets/omarchy/components/UsageWindow.qml:41,65,98,126`
+- Modify: `assets/omarchy/components/ProviderHeader.qml:57`
+- Modify: `assets/omarchy/components/StateMessage.qml:71`
+- Modify: `assets/omarchy/components/ConfirmDialog.qml:78`
+
+**Interfaces:**
+- Consumes: `Util.alpha(color, opacity)` from `qs.Commons` — a singleton already imported by every file in the list.
+- Produces: exactly two secondary-text levels used by plans 02 through 05: `Util.alpha(root.foreground, 0.72)` for supporting text and labels, `Util.alpha(root.foreground, 0.55)` for meta and caption text. No third value.
+
+The five existing factors map by role, not by arithmetic:
+
+| Site | Current factor | Role | New |
+| --- | --- | --- | --- |
+| `UsageWindow.qml:41` | 1.35 | window kicker label | `0.72` |
+| `UsageWindow.qml:65` | 1.35 | unit next to the numeral | `0.72` |
+| `UsageWindow.qml:98` | 1.35 | "resets" prefix | `0.72` |
+| `UsageWindow.qml:126` | 1.2 | compact row label | `0.72` |
+| `ProviderHeader.qml:57` | 1.2 | plan badge text | `0.72` |
+| `StateMessage.qml:71` | 1.25 | state body | `0.72` |
+| `ConfirmDialog.qml:78` | 1.15 | dialog body | `0.72` |
+| `SettingsView.qml:83,93` | 1.3 | field labels | `0.72` |
+| `SettingsView.qml:108,162` | 1.35 | section captions | `0.55` |
+| `MaintenanceView.qml:37,60,70` | 1.35, 1.25, 1.2 | meta rows | `0.55` |
+| `ProviderView.qml:222` | 1.4 | footer meta left | `0.55` |
+| `ProviderView.qml:232` | ternary `1.0 : 1.15` | footer connection | `showStale ? 0.72 : 0.55` |
+
+`ProviderView.qml:222` and `:232` sit in the meta footer that plan 03 deletes. Convert them anyway so the gate stays green in between; plan 03 removes the whole `Row`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/qml/tst_Tokens.qml`:
+
+```qml
+import QtQuick
+import QtTest
+import qs.Commons
+
+TestCase {
+  id: testCase
+  name: "AgentBarTokens"
+  when: windowShown
+
+  property string repoRoot: {
+    var path = String(Qt.resolvedUrl(".")).replace("file://", "")
+    if (path.endsWith("/"))
+      path = path.slice(0, -1)
+    var parts = path.split("/")
+    parts.pop(); parts.pop()
+    return parts.join("/")
+  }
+
+  function read(rel) {
+    var xhr = new XMLHttpRequest()
+    xhr.open("GET", "file://" + repoRoot + "/" + rel, false)
+    xhr.send()
+    return String(xhr.responseText || "")
+  }
+
+  function tokenScannedFiles() {
+    return [
+      "assets/omarchy/BarWidget.qml",
+      "assets/omarchy/Popup.qml",
+      "assets/omarchy/ProviderRail.qml",
+      "assets/omarchy/ProviderView.qml",
+      "assets/omarchy/SettingsView.qml",
+      "assets/omarchy/MaintenanceView.qml",
+      "assets/omarchy/components/ProviderChip.qml",
+      "assets/omarchy/components/ProviderHeader.qml",
+      "assets/omarchy/components/UsageWindow.qml",
+      "assets/omarchy/components/StateMessage.qml",
+      "assets/omarchy/components/SettingsProviderRow.qml",
+      "assets/omarchy/components/ConfirmDialog.qml"
+    ]
+  }
+
+  // Qt.darker divides HSV value. On a dark theme that recedes; on a light
+  // theme it advances, so secondary text outranks primary. Util.alpha works
+  // in both directions with one value.
+  function test_no_qt_darker() {
+    var files = tokenScannedFiles()
+    for (var i = 0; i < files.length; i++) {
+      var code = read(files[i]).replace(/\/\/[^\n]*/g, "")
+      verify(code.indexOf("Qt.darker") < 0,
+             files[i] + " still calls Qt.darker; use Util.alpha")
+    }
+  }
+
+  // Composite a translucent foreground over a background, the way the
+  // compositor does, then compare WCAG contrast.
+  function composite(fg, bg, a) {
+    return Qt.rgba(fg.r * a + bg.r * (1 - a),
+                   fg.g * a + bg.g * (1 - a),
+                   fg.b * a + bg.b * (1 - a), 1)
+  }
+
+  function luminance(c) {
+    function ch(v) { return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4) }
+    return 0.2126 * ch(c.r) + 0.7152 * ch(c.g) + 0.0722 * ch(c.b)
+  }
+
+  function contrast(a, b) {
+    var la = luminance(a), lb = luminance(b)
+    var hi = Math.max(la, lb), lo = Math.min(la, lb)
+    return (hi + 0.05) / (lo + 0.05)
+  }
+
+  function test_secondary_recedes_in_both_themes_data() {
+    return [
+      { tag: "dark",  fg: Qt.color("#fff6ff"), bg: Qt.color("#05080a") },
+      { tag: "light", fg: Qt.color("#18181b"), bg: Qt.color("#f4f4f5") },
+      { tag: "white", fg: Qt.color("#000000"), bg: Qt.color("#ffffff") }
+    ]
+  }
+
+  function test_secondary_recedes_in_both_themes(data) {
+    var primary = contrast(data.fg, data.bg)
+    var supporting = contrast(composite(data.fg, data.bg, 0.72), data.bg)
+    var meta = contrast(composite(data.fg, data.bg, 0.55), data.bg)
+    verify(supporting < primary,
+           data.tag + ": supporting " + supporting + " must be under primary " + primary)
+    verify(meta < supporting,
+           data.tag + ": meta " + meta + " must be under supporting " + supporting)
+  }
+}
+```
+
+- [ ] **Step 2: Run the QML suite and verify the source scan fails**
+
+Run:
+```bash
+QT_QPA_PLATFORM=offscreen QML_XHR_ALLOW_FILE_READ=1 QT_LOGGING_TO_CONSOLE=1 \
+  /usr/lib/qt6/bin/qmltestrunner -input tests/qml \
+  -import /usr/share/omarchy/shell -import assets/omarchy -o -,txt
+```
+Expected: `test_no_qt_darker` FAILS naming the first offending file. The three `test_secondary_recedes_in_both_themes` rows PASS already — they describe the target, and they are what proves `Util.alpha` is the right replacement rather than a different magic number.
+
+- [ ] **Step 3: Replace every call site**
+
+Work through the table above. Each edit is the same shape. In `UsageWindow.qml:41`:
+
+```qml
+      color: Util.alpha(root.foreground, 0.72)
+```
+
+Every listed file already imports `qs.Commons`; confirm with `rg -n 'import qs.Commons' <file>` before editing, and add the import if a file lacks it.
+
+`ProviderView.qml:232` keeps its conditional, expressed on the new scale:
+
+```qml
+        color: Util.alpha(root.foreground, root.header.showStale ? 0.72 : 0.55)
+```
+
+- [ ] **Step 4: Run the QML gate and verify it passes**
+
+Run:
+```bash
+find assets/omarchy -type f -name '*.qml' -exec qmllint -I /usr/share/omarchy/shell {} +
+omarchy plugin validate assets/omarchy
+QT_QPA_PLATFORM=offscreen QML_XHR_ALLOW_FILE_READ=1 QT_LOGGING_TO_CONSOLE=1 \
+  /usr/lib/qt6/bin/qmltestrunner -input tests/qml \
+  -import /usr/share/omarchy/shell -import assets/omarchy -o -,txt
+```
+Expected: 0 failed. `AgentBarTokens::test_no_qt_darker` and all three
+`test_secondary_recedes_in_both_themes` rows report `PASS`. `qmllint` clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/qml/tst_Tokens.qml assets/omarchy
+git commit -m "fix: bind secondary text to theme alpha"
+```
+
+---
+
+## Task 5: Bind control chrome to `Style` state tokens
+
+**Files:**
+- Modify: `assets/omarchy/ProviderRail.qml:88,90,146,150,208`
+- Modify: `assets/omarchy/components/StateMessage.qml:31,37,43`
+- Modify: `assets/omarchy/components/ConfirmDialog.qml:31,47,48`
+- Modify: `assets/omarchy/components/ProviderHeader.qml:52`
+- Modify: `tests/qml/tst_Tokens.qml`
+
+**Interfaces:**
+- Consumes: `Style.selectedFill`, `Style.selectedBorderColor`, `Style.hoverFill`, `Style.normalFill`, `Style.normalBorderColor` from `qs.Commons` — all `readonly property color`, already resolved against the active palette.
+- Produces: no new symbols. After this task the only raw alphas left are separators (Task 6) and the usage track (Task 7).
+
+| Site | Current | Role | New |
+| --- | --- | --- | --- |
+| `ProviderRail.qml:88` | `Qt.rgba(fg, 0.05)` | rail frame fill | delete — the frame goes in plan 03; until then, `Style.normalFill` |
+| `ProviderRail.qml:90` | `Qt.rgba(fg, 0.22)` | rail frame border | `Style.normalBorderColor` |
+| `ProviderRail.qml:146` | `Qt.rgba(fg, 0.12)` | selected provider plate | `Style.selectedFill` |
+| `ProviderRail.qml:150` | `Qt.rgba(fg, 0.3)` | selected plate border | `Style.selectedBorderColor` |
+| `ProviderRail.qml:208` | `Qt.rgba(fg, 0.08)` | settings hover plate | `Style.hoverFill` |
+| `StateMessage.qml:31` | `Qt.rgba(fg, 0.12)` | skeleton bar, strong | `Style.selectedFill` |
+| `StateMessage.qml:37,43` | `Qt.rgba(fg, 0.08)` | skeleton bar, weak | `Style.hoverFill` |
+| `ConfirmDialog.qml:31` | `Qt.rgba(fg, 0.45)` | scrim | keep raw; a scrim is not control chrome. Declare once as `readonly property color scrimColor` on the dialog root and reference it. |
+| `ConfirmDialog.qml:47` | `Qt.rgba(fg, 0.55)` | card fill | `Style.selectedFill` |
+| `ConfirmDialog.qml:48` | `Qt.rgba(fg, 0.28)` | card border | `Style.normalBorderColor` |
+| `ProviderHeader.qml:52` | `Qt.rgba(fg, 0.25)` | plan badge border | `Style.normalBorderColor` |
+
+The values differ slightly from the tokens — 0.12 against the theme's 0.18, 0.22 against 0.4. That is the point: the tokens track the installed theme, the literals never did.
+
+- [ ] **Step 1: Add the failing test**
+
+Append to `tests/qml/tst_Tokens.qml`, inside the `TestCase`:
+
+```qml
+  // Raw foreground alphas are allowed only where no host token exists.
+  // Every other surface must read the theme's state vocabulary.
+  function allowedRawAlphaFiles() {
+    return [
+      "assets/omarchy/components/UsageWindow.qml",   // usage track, Task 7
+      "assets/omarchy/components/ConfirmDialog.qml", // modal scrim
+      "assets/omarchy/ProviderView.qml",             // separators, Task 6
+      "assets/omarchy/SettingsView.qml",             // separators, Task 6
+      "assets/omarchy/MaintenanceView.qml"           // separators, Task 6
+    ]
+  }
+
+  function test_control_chrome_uses_style_tokens() {
+    var files = tokenScannedFiles()
+    var allowed = allowedRawAlphaFiles()
+    for (var i = 0; i < files.length; i++) {
+      if (allowed.indexOf(files[i]) >= 0)
+        continue
+      var code = read(files[i]).replace(/\/\/[^\n]*/g, "")
+      verify(code.indexOf("Qt.rgba(") < 0,
+             files[i] + " still hardcodes an alpha; use a Style state token")
+    }
+  }
+```
+
+- [ ] **Step 2: Run the suite and verify it fails**
+
+Run the QML gate command from Task 4 Step 4.
+Expected: `test_control_chrome_uses_style_tokens` FAILS naming `ProviderRail.qml`.
+
+- [ ] **Step 3: Replace the call sites**
+
+Work the table. Two shapes appear. A direct token, `ProviderRail.qml:146`:
+
+```qml
+          color: railItem.selected ? Style.selectedFill : "transparent"
+```
+
+And the one value with no host token, `ConfirmDialog.qml`, declared once on the root and referenced at line 31:
+
+```qml
+  readonly property color scrimColor: Util.alpha(Color.foreground, 0.45)
+```
+
+Verify `import qs.Ui` is present in `ProviderRail.qml` and `StateMessage.qml` — `Style` lives in `qs.Commons`, but these files also use `qs.Ui` components; do not remove either import.
+
+- [ ] **Step 4: Run the QML gate and verify it passes**
+
+Run the QML gate command from Task 4 Step 4.
+Expected: 0 failed, with `AgentBarTokens::test_control_chrome_uses_style_tokens`
+reporting `PASS`.
+
+- [ ] **Step 5: Verify the rail still shows selection**
+
+The selected-provider plate is the one visible behaviour this task touches, and `UX-020B` requires a neutral plate with no accent tick. Confirm the existing coverage still passes:
+
+Run:
+```bash
+QT_QPA_PLATFORM=offscreen QML_XHR_ALLOW_FILE_READ=1 QT_LOGGING_TO_CONSOLE=1 \
+  /usr/lib/qt6/bin/qmltestrunner -input tests/qml \
+  -import /usr/share/omarchy/shell -import assets/omarchy -o -,txt 2>&1 | rg -i 'rail|selected'
+```
+Expected: every matching line reports PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/qml/tst_Tokens.qml assets/omarchy
+git commit -m "fix: bind control chrome to Quattro tokens"
+```
+
+---
+
+## Task 6: Replace separators with `PanelSeparator`
+
+**Files:**
+- Modify: `assets/omarchy/ProviderView.qml:72,164`
+- Modify: `assets/omarchy/SettingsView.qml:150,248,302`
+- Modify: `assets/omarchy/MaintenanceView.qml:129`
+- Modify: `tests/qml/tst_Tokens.qml`
+
+**Interfaces:**
+- Consumes: `PanelSeparator` from `qs.Ui`. It is a `Rectangle` with `property color foreground` and `property real strength` defaulting to `0.12`, `height` fixed at 1, `width` bound to its parent.
+- Produces: no new symbols.
+
+Six hand-rolled 1px rules become the host component. Five already use `0.12`, which is `PanelSeparator`'s default. `ProviderView.qml:164` uses `0.08` — the quiet rule above the secondary window list. Pass `strength: 0.08` there rather than changing the default.
+
+- [ ] **Step 1: Tighten the test so the separator files lose their exemption**
+
+In `tests/qml/tst_Tokens.qml`, reduce `allowedRawAlphaFiles()` to:
+
+```qml
+  function allowedRawAlphaFiles() {
+    return [
+      "assets/omarchy/components/UsageWindow.qml",   // usage track, Task 7
+      "assets/omarchy/components/ConfirmDialog.qml"  // modal scrim
+    ]
+  }
+```
+
+- [ ] **Step 2: Run the suite and verify it fails**
+
+Run the QML gate command from Task 4 Step 4.
+Expected: `test_control_chrome_uses_style_tokens` FAILS naming `ProviderView.qml`.
+
+- [ ] **Step 3: Replace each separator**
+
+`ProviderView.qml:69-73` currently reads:
+
+```qml
+    Rectangle {
+      width: parent.width
+      height: 1
+      color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.12)
+    }
+```
+
+becomes:
+
+```qml
+    PanelSeparator {
+      width: parent.width
+      foreground: root.foreground
+    }
+```
+
+and `ProviderView.qml:161-165`, the quiet rule, becomes:
+
+```qml
+      PanelSeparator {
+        width: parent.width
+        foreground: root.foreground
+        strength: 0.08
+      }
+```
+
+`SettingsView.qml` and `MaintenanceView.qml` follow the first shape. Confirm each file imports `qs.Ui`; `ProviderView.qml` currently does not — add `import qs.Ui` there.
+
+- [ ] **Step 4: Run the QML gate and verify it passes**
+
+Run the QML gate command from Task 4 Step 4.
+Expected: 0 failed. `qmllint` must be clean — a missing `qs.Ui` import surfaces here as an unresolved type, not as a test failure.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/qml/tst_Tokens.qml assets/omarchy
+git commit -m "refactor: use PanelSeparator for panel rules"
+```
+
+---
+
+## Task 7: Give the usage track a single declaration site
+
+**Files:**
+- Modify: `assets/omarchy/components/UsageWindow.qml:73-91`
+- Modify: `tests/qml/tst_Tokens.qml`
+
+**Interfaces:**
+- Consumes: `Util.alpha` from Task 4.
+- Produces: `UsageWindow.trackColor` — a `readonly property color`. Plan 03 reuses it for the compact rows so both track shapes tint from one place.
+
+The track background has no host token: it is not control chrome, it is a data surface. That does not license repeating the literal. It is declared once, named, and referenced.
+
+- [ ] **Step 1: Tighten the test to its final shape**
+
+In `tests/qml/tst_Tokens.qml`, reduce the exemption to the scrim alone and add a declaration-count assertion:
+
+```qml
+  function allowedRawAlphaFiles() {
+    return ["assets/omarchy/components/ConfirmDialog.qml"] // modal scrim
+  }
+
+  // The track tint has no host token, so it gets a name and exactly one
+  // declaration. Two would be a parallel system starting over.
+  function test_usage_track_declared_once() {
+    var code = read("assets/omarchy/components/UsageWindow.qml")
+        .replace(/\/\/[^\n]*/g, "")
+    var declarations = code.split("readonly property color trackColor").length - 1
+    compare(declarations, 1, "trackColor must be declared exactly once")
+    verify(code.indexOf("Qt.rgba(") < 0,
+           "UsageWindow must reference trackColor, not a literal alpha")
+  }
+```
+
+- [ ] **Step 2: Run the suite and verify it fails**
+
+Run the QML gate command from Task 4 Step 4.
+Expected: `test_usage_track_declared_once` FAILS with `trackColor must be declared exactly once`, actual 0.
+
+- [ ] **Step 3: Declare the property and reference it**
+
+Add to the `UsageWindow` root, beside the existing `readonly property bool hasPercent`:
+
+```qml
+  // Data surface, not control chrome — no host token covers it. Declared
+  // once here so plan 03's compact rows tint from the same place.
+  readonly property color trackColor: Util.alpha(root.foreground, 0.12)
+```
+
+Then at line 77 replace the literal:
+
+```qml
+      color: root.trackColor
+```
+
+- [ ] **Step 4: Run the QML gate and verify it passes**
+
+Run the QML gate command from Task 4 Step 4.
+Expected: 0 failed, with `AgentBarTokens::test_usage_track_declared_once`
+reporting `PASS`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/qml/tst_Tokens.qml assets/omarchy/components/UsageWindow.qml
+git commit -m "refactor: name the usage track tint"
+```
+
+---
+
+## Task 8: Make the light-theme evidence real
+
+**Files:**
+- Modify: `tests/qml/TestPalette.js:27-43` (`themePalette`) and `requiredScreenshotNames()`
+- Modify: `tests/qml/tst_Screenshots.qml:85-101` (`applyTheme`, `paintState`)
+
+**Interfaces:**
+- Consumes: `Util.alpha` from Task 4.
+- Produces: a screenshot harness whose muted colour is derived the same way the shipped components derive it, plus a `white` theme case.
+
+**Why this task exists.** The repository already renders a `ready-light.png`
+and has since v10. It never caught the `Qt.darker` inversion, because the
+harness does not use the components: `TestPalette.themePalette` hands back a
+hand-picked `muted` (`#52525b` light, `#a1a1aa` dark) and `applyTheme` assigns
+it straight to `stage.muted`. The light-theme gate was testing a mock of
+itself. Binding the fixture to the real expression is what turns it into
+evidence; the `white` palette is then the worst case, because
+`Qt.darker(#000000, n)` returns `#000000` and the hierarchy collapses to
+identical pixels.
+
+- [ ] **Step 1: Add the white palette and require its screenshot**
+
+In `tests/qml/TestPalette.js`, add `"ready-white.png"` to the array returned by
+`requiredScreenshotNames()`, and add the palette to `themePalette` above the
+existing `light` branch. Note it deliberately carries no `muted` key — Step 3
+removes that key from every palette:
+
+```js
+  if (mode === "white") {
+    return {
+      mode: "white",
+      background: "#ffffff",
+      foreground: "#000000",
+      accent: "#0057d8",
+      urgent: "#c31432"
+    }
+  }
+```
+
+- [ ] **Step 2: Run the suite and verify it fails**
+
+Run the QML gate command from Task 4 Step 4.
+Expected: FAIL on the screenshot inventory test, reporting `ready-white.png`
+missing.
+
+- [ ] **Step 3: Derive `muted` the way the components do**
+
+In `tests/qml/TestPalette.js`, delete the `muted` key from both the `light` and
+`dark` return objects. A fixture that hardcodes the value it is meant to verify
+cannot verify it.
+
+Then in `tests/qml/tst_Screenshots.qml`, add `import qs.Commons` at the top if
+it is absent, and replace `applyTheme` at line 85:
+
+```qml
+  function applyTheme(mode) {
+    var p = Core.themePalette(mode)
+    stage.color = p.background
+    stage.fg = p.foreground
+    // Same expression the shipped components use, so this fixture actually
+    // exercises the token binding instead of a hand-picked stand-in.
+    stage.muted = Util.alpha(p.foreground, 0.72)
+    stage.badgeColor = p.urgent
+  }
+```
+
+- [ ] **Step 4: Render the white case**
+
+In `tests/qml/tst_Screenshots.qml`, `paintState` currently special-cases
+`ready-light` at line 95 and then falls through to `applyTheme("dark")`. Add
+the white branch immediately after the light one, before that fallthrough,
+using the same three strings so the only variable between the three renders is
+the palette:
+
+```qml
+    if (name.indexOf("ready-white") === 0) {
+      applyTheme("white")
+      stage.titleText = "Claude"
+      stage.badgeText = "Connected"
+      stage.bodyText = "Session (5h) 58% left · Max plan"
+      return
+    }
+```
+
+- [ ] **Step 5: Run the QML gate and verify it passes**
+
+Run the QML gate command from Task 4 Step 4.
+Expected: 0 failed, and `ready-white.png` present in the screenshot output
+directory alongside `ready-light.png` and `ready-dark.png`.
+
+- [ ] **Step 6: Look at the three renders**
+
+The contrast test proves the ordering arithmetically; a human confirms it reads
+right.
+
+```bash
+ls tests/qml/screenshots/ready-{dark,light,white}.png
+```
+
+Open all three. In every one, `Session (5h) 58% left · Max plan` must read
+quieter than `Claude`. If the body competes with the title in any theme, the
+role mapping in Task 4 is wrong — fix the mapping, not the token.
+
+- [ ] **Step 7: Run both full gates**
+
+```bash
+cargo fmt --check && cargo test && cargo clippy --all-targets -- -D warnings && git diff --check
+find assets/omarchy -type f -name '*.qml' -exec qmllint -I /usr/share/omarchy/shell {} +
+omarchy plugin validate assets/omarchy
+QT_QPA_PLATFORM=offscreen QML_XHR_ALLOW_FILE_READ=1 QT_LOGGING_TO_CONSOLE=1 \
+  /usr/lib/qt6/bin/qmltestrunner -input tests/qml \
+  -import /usr/share/omarchy/shell -import assets/omarchy -o -,txt
+```
+Expected: cargo 286 passing, clippy clean; qmltestrunner 0 failed.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add tests/qml
+git commit -m "test: bind theme fixture to real token"
+```
+
+---
+
+## Done when
+
+- `cargo test` reports 286 passing; `qmltestrunner` reports 0 failed.
+- `rg -c 'Qt.darker' assets/omarchy` returns nothing.
+- `rg -c 'Qt.rgba' assets/omarchy` matches only `ConfirmDialog.qml`.
+- `tests/qml/TestPalette.js` no longer defines a `muted` colour anywhere.
+- No tracked file outside `docs/superpowers/**` contains an alphabetic non-ASCII character, except the one allowlisted fixture.
+- `A11Y-013` and `TEST-029` still pass, untouched.
+
+## Not in this plan
+
+Layout, copy, assets, severity, notifications, and the CLI. Those are:
+
+| Plan | Covers |
+| --- | --- |
+| 02 — bar chip | `WidgetButton` base, icon canvas and optical scale, fixed-width numeral, Codex mark, Grok tint, state cues, tooltip humaniser |
+| 03 — popup | rail alignment, header tags, footer removal, stale banner, typed-state copy |
+| 04 — severity | thresholds shared with Rust, lead-window election, `UX-017`/`UX-020A`/`UX-028`/`UX-054` amendments |
+| 05 — notifications and CLI | Rust countdown humaniser, notification metric and copy, CLI and `install.sh` copy |

--- a/docs/superpowers/plans/2026-07-30-v11-01-foundation-tokens-language.md
+++ b/docs/superpowers/plans/2026-07-30-v11-01-foundation-tokens-language.md
@@ -107,11 +107,26 @@ fn tracked_files(root: &Path) -> Vec<String> {
         .arg("ls-files")
         .current_dir(root)
         .output()
-        .expect("git ls-files must run inside the repository");
-    String::from_utf8_lossy(&output.stdout)
+        .expect("git ls-files must be spawnable");
+    // `.expect` above only covers a failure to spawn. Outside a checkout git
+    // spawns fine and exits non-zero, which would leave an empty list and let
+    // the gate pass having read nothing — the same defect as a gate that never
+    // fails on purpose, arriving through a different door.
+    assert!(
+        output.status.success(),
+        "git ls-files failed ({}): {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr).trim()
+    );
+    let files: Vec<String> = String::from_utf8_lossy(&output.stdout)
         .lines()
         .map(str::to_owned)
-        .collect()
+        .collect();
+    assert!(
+        !files.is_empty(),
+        "git ls-files returned nothing; the gate would scan an empty set"
+    );
+    files
 }
 
 fn is_scannable(rel: &str) -> bool {

--- a/docs/superpowers/plans/2026-07-30-v11-01-foundation-tokens-language.md
+++ b/docs/superpowers/plans/2026-07-30-v11-01-foundation-tokens-language.md
@@ -983,7 +983,7 @@ The contrast test proves the ordering arithmetically; a human confirms it reads
 right.
 
 ```bash
-ls tests/qml/screenshots/ready-{dark,light,white}.png
+ls target/v10-ui-evidence/ready-{dark,light,white}.png
 ```
 
 Open all three. In every one, `Session (5h) 58% left · Max plan` must read

--- a/docs/superpowers/plans/2026-07-30-v11-01-foundation-tokens-language.md
+++ b/docs/superpowers/plans/2026-07-30-v11-01-foundation-tokens-language.md
@@ -316,12 +316,26 @@ Expected: FAIL on `active_files_contain_no_non_english_letters`, listing the `CH
 
 - [ ] **Step 3: Translate `CHANGELOG.md`**
 
+**Read every line of the file. Do not let the gate decide when you are finished.**
+The gate detects alphabetic non-ASCII characters, so it sees accented
+Portuguese and is blind to unaccented Portuguese. Measured on this file:
+206 lines carry an accent and 16 do not, such as
+
+```
+- Clique esquerdo com settings aberto volta ao usage sem fechar o popup.
+```
+
+which the gate will never report. Translating until the test turns green
+would leave those sixteen in place and call the job done. Green is necessary,
+not sufficient.
+
 Work release by release, oldest first, so a partial run is still coherent. Rules:
 
 - Version headings, dates, links, code spans, file paths, command names and commit-type prefixes stay byte-identical.
 - Translate only the prose describing what changed.
 - Do not merge, reorder, reword-for-brevity, or delete entries. This is a published record; the meaning must survive, and nothing else may.
-- After each release section, re-run the scan to see the remaining count fall:
+- After each release section, re-run the scan to watch the accented count fall,
+  while still reading every line of the section you just finished:
   ```bash
   cargo test --test active_language 2>&1 | rg -c 'CHANGELOG.md:'
   ```
@@ -330,6 +344,17 @@ Work release by release, oldest first, so a partial run is still coherent. Rules
 
 Run: `cargo test --test active_language`
 Expected: PASS, 3 tests.
+
+Then confirm what the gate cannot: search for unaccented Portuguese that
+survived the pass.
+
+```bash
+rg -in '\b(nao|voce|para|que|uma|dos|das|pelo|pela|arquivo|erro|atualizar|instalar|usuario|falhou|verifique|remover|adicionar|corrigir|quando|sobre|agora|ainda)\b' CHANGELOG.md
+```
+
+Expected: only false positives — `com` inside a hostname, `para` inside an
+English word broken across a line, and similar. Every genuine Portuguese hit
+is a line you missed; translate it and run again.
 
 - [ ] **Step 5: Update the contract in `CLAUDE.md`**
 

--- a/docs/superpowers/plans/2026-07-30-v11-01-foundation-tokens-language.md
+++ b/docs/superpowers/plans/2026-07-30-v11-01-foundation-tokens-language.md
@@ -732,12 +732,13 @@ In `tests/qml/tst_Tokens.qml`, reduce `allowedRawAlphaFiles()` to:
 
 ```qml
   function allowedRawAlphaFiles() {
-    return [
-      "assets/omarchy/components/UsageWindow.qml",   // usage track, Task 7
-      "assets/omarchy/components/ConfirmDialog.qml"  // modal scrim
-    ]
+    return ["assets/omarchy/components/UsageWindow.qml"] // usage track, Task 7
   }
 ```
+
+`ConfirmDialog.qml` is already absent from that list. Task 5 bound its scrim to the
+host token `Color.menu.scrim`, which removed the file's last raw alpha, so it left
+the exemption early. Do not add it back.
 
 - [ ] **Step 2: Run the suite and verify it fails**
 
@@ -810,8 +811,11 @@ The track background has no host token: it is not control chrome, it is a data s
 In `tests/qml/tst_Tokens.qml`, reduce the exemption to the scrim alone and add a declaration-count assertion:
 
 ```qml
+  // Empty: after this task no file keeps a raw foreground alpha. ConfirmDialog
+  // left the list in Task 5 when its scrim bound to Color.menu.scrim, and the
+  // usage track is the last holdout.
   function allowedRawAlphaFiles() {
-    return ["assets/omarchy/components/ConfirmDialog.qml"] // modal scrim
+    return []
   }
 
   // The track tint has no host token, so it gets a name and exactly one
@@ -990,7 +994,7 @@ git commit -m "test: bind theme fixture to real token"
 
 - `cargo test` reports 286 passing; `qmltestrunner` reports 0 failed.
 - `rg -c 'Qt.darker' assets/omarchy` returns nothing.
-- `rg -c 'Qt.rgba' assets/omarchy` matches only `ConfirmDialog.qml`.
+- `rg -c 'Qt.rgba' assets/omarchy` returns nothing: no file keeps a raw foreground alpha.
 - `tests/qml/TestPalette.js` no longer defines a `muted` colour anywhere.
 - No tracked file outside `docs/superpowers/**` contains an alphabetic non-ASCII character, except the one allowlisted fixture.
 - `A11Y-013` and `TEST-029` still pass, untouched.

--- a/docs/superpowers/specs/2026-07-30-copy-and-language-design.md
+++ b/docs/superpowers/specs/2026-07-30-copy-and-language-design.md
@@ -51,9 +51,32 @@ tuning.
 This paragraph names those characters by code point rather than by glyph on
 purpose: a document that defines the gate should survive it.
 
-A word-list approach was tried first and rejected: it under-reported by more
-than an order of magnitude because unaccented Portuguese passes straight
-through it.
+### 3.1.1 What the rule does not catch
+
+A Portuguese-word-list approach was tried first. It reported an order of
+magnitude fewer lines, which is why the character rule is the primary signal —
+but the two methods fail in opposite directions, and the character rule has a
+blind spot that must be stated rather than glossed over: **unaccented
+Portuguese passes straight through it.**
+
+Measured on the files this design translates:
+
+| File | Lines the rule catches | Portuguese lines it cannot see |
+| --- | --- | --- |
+| `CHANGELOG.md` | 206 | 16 |
+| `docs/adr/0001..0003` | 14 | 0 |
+
+So the rule finds roughly 93% of the Portuguese in the worst file and all of it
+in the rest. Two consequences follow, and both are requirements, not caveats:
+
+1. **The one-time cleanup is done by reading, not by chasing the gate.** A
+   translator who stops when the test turns green leaves those sixteen lines
+   behind. The implementation plan states this explicitly and pairs the gate
+   with a word-list sweep as a second pass.
+2. **For regression prevention the blind spot is tolerable.** New Portuguese
+   prose entering the repository is a paragraph, not a line, and a Portuguese
+   paragraph carries an accent with near-certainty. The rule is a tripwire
+   against drift, not a translator.
 
 ### 3.2 Configuration
 

--- a/docs/superpowers/specs/2026-07-30-copy-and-language-design.md
+++ b/docs/superpowers/specs/2026-07-30-copy-and-language-design.md
@@ -1,0 +1,282 @@
+# Agent Bar v11 — Copy and Language Design
+
+Status: approved design, not yet planned or implemented.
+Date: 2026-07-30.
+Companion to `2026-07-30-visual-update-design.md`. Where the two overlap, the
+visual design owns layout and this document owns wording.
+
+## 1. Scope
+
+Two requests, one document:
+
+1. Every active surface is English, and a test enforces it. Today no test does.
+2. Every error, warning and notification is rewritten to be direct.
+
+Inventory: a seven-agent sweep found **685 unique user-facing strings** —
+212 in the GUI, 431 in the CLI and `install.sh`, 40 reaching only journald.
+Measured defects in the GUI set: 21 strings leak internal vocabulary, 9 are
+passive, 3 exceed twelve words, 0 apologise or hedge. The copy was never
+sycophantic; it was bureaucratic.
+
+## 2. Decisions
+
+1. **Voice:** the ten rules in section 4, applied to every GUI string.
+2. **Language:** `CHANGELOG.md`, `docs/adr/0001..0003` and the one affected
+   code line are translated to English. The `docs/superpowers/**` tree is left
+   as it is — 73 files, ~47,000 lines of past session plans and specs. It is a
+   build record, not documentation, and translating it buys no reader.
+   New files written there are English; this document and the visual design
+   already are.
+3. **The word "provider" stays** on screen. It is current in developer tools
+   and it keeps the UI aligned with the logs.
+4. **The CLI is in scope**, all 431 strings — but under section 7's narrower
+   rules, not the GUI voice.
+5. **A language gate is added.** Without it the rule is honoured only by
+   discipline, which is exactly how the drift happened.
+
+## 3. Language gate
+
+### 3.1 Detection
+
+A tracked text file must contain no **alphabetic non-ASCII character**.
+
+Alphabetic is the operative word. It flags letters such as `U+00E3`, `U+00E7`,
+`U+00E9` and `U+03B1`; it does not flag the characters this project
+legitimately uses — Nerd Font glyphs (Private Use Area, category `Co`), and the
+punctuation and symbols at `U+2014`, `U+00B7`, `U+2026` and `U+231B`. Measured
+against the current repository the rule produced 80 hits and exactly **two**
+false positives, both legitimately allowlistable. Precision is 97.5% with no
+tuning.
+
+This paragraph names those characters by code point rather than by glyph on
+purpose: a document that defines the gate should survive it.
+
+A word-list approach was tried first and rejected: it under-reported by more
+than an order of magnitude because unaccented Portuguese passes straight
+through it.
+
+### 3.2 Configuration
+
+- **Scanned:** every file reported by `git ls-files`, excluding binary
+  extensions.
+- **Excluded path:** `docs/superpowers/**`, per decision 2.
+- **Allowlist:** `src/support/redact.rs:97`, where an accented test string is a
+  deliberate fixture for the ANSI and control-character stripper. The allowlist
+  is path-scoped and each entry carries a one-line reason.
+- **Failure output:** file, line, the offending characters, and the line
+  content, so the fix is obvious from the test output alone.
+
+### 3.3 Contract change
+
+`CLAUDE.md` currently exempts "historical changelog entries, ADR bodies
+0001–0003, and `docs/superpowers/**`". After the translation only the last
+exemption is true. The sentence is rewritten to name `docs/superpowers/**`
+alone, and to state that the gate enforces the rest.
+
+## 4. Voice rules
+
+The register is a tired senior engineer: say what broke, say what to do, stop
+talking.
+
+1. **Name before category.** The title says *what*, not *what kind*.
+   `Codex returned no limits`, never `Provider error`.
+2. **No internal vocabulary.** `provider` as a *label* is allowed by decision
+   3; `adapter`, `schema`, `payload`, `envelope`, `bundle`, `collect`,
+   `clause`, `snapshot` are not.
+3. **Active voice.** `Codex hit a rate limit`, not `The provider rate-limited
+   this request`.
+4. **No repetition.** If the title said it, the body is silent. If the button
+   said it, the body is silent.
+5. **Word ceiling.** Title 5, body 10, button 2.
+6. **Fixes are imperative.** `Install it.` — never `You may want to…`
+7. **No ceremony.** No apology, no "unfortunately", no "Final confirmation:",
+   no exclamation marks.
+8. **No invented action.** If the user can do nothing, there is no button.
+9. **Fixed punctuation.** Sentences take a period. Titles, labels and buttons
+   do not.
+10. **Never blame the user.** The failure belongs to the system or the
+    provider.
+
+## 5. GUI rewrites
+
+`{Name}` is the real provider name. No current title contains it.
+
+### 5.1 Typed state titles — `CoreView.stateTitle`
+
+| State | Now | New |
+| --- | --- | --- |
+| `loading` | `Loading` | none; the mode is already a skeleton |
+| `ready`, no windows | `No percentage usage` | `{Name} reports no quota` |
+| `stale` | `Stale` | none; moves to the stale banner |
+| `cli_missing` | `CLI not found` | `{Name} CLI is not installed` |
+| `unauthenticated` | `Authentication required` | `Not signed in to {Name}` |
+| `rate_limited` | `Rate limited` | `{Name} hit a rate limit` |
+| `network_error` | `Network error` | `Cannot reach {Name}` |
+| `provider_error` | `Provider error` | `{Name} returned no limits` |
+| `unknown` | `Unknown` | `{Name} state is unknown` |
+
+### 5.2 Typed state bodies — `CoreView.stateBody`
+
+| State | Now | New |
+| --- | --- | --- |
+| `loading` | `Collecting provider status…` | none |
+| `ready`, no windows | `Percentage usage is not available for this account` | `This account is billed another way.` |
+| `stale` | `Showing the last successful result. {error}` | `Last data {age} ago · {error}` |
+| `cli_missing` | `Required CLI was not found.` | `Agent Bar reads the quota through it.` |
+| `unauthenticated` | `Sign in to collect usage.` | `Signing in opens the official {Name} CLI.` |
+| `rate_limited` | `The provider rate-limited this request. Try again shortly.` | `Try again in a few minutes.` |
+| `network_error` | `A temporary network error prevented collection.` | `Check your connection.` |
+| `provider_error` | `The provider returned an unusable response.` | none |
+
+The `ready`-with-no-windows body was the only string in the file missing a
+final period.
+
+### 5.3 Actions
+
+| Now | New | Reason |
+| --- | --- | --- |
+| `Connect` | `Sign in` | `Connect` reads as networking; the action is authentication. Amends `UX-054`, which names `Connect` explicitly. |
+| `View installation` | `Install guide` | Two words, same meaning. |
+| `Retry` | `Retry` | unchanged |
+| `Check again` | `Check again` | unchanged |
+
+### 5.4 Bar tooltip — the enum leak
+
+`CoreView.chipTooltip` executes `parts.push(state)` with the raw enum value.
+The most-seen surface in the product renders a code identifier:
+
+| Situation | Now | New |
+| --- | --- | --- |
+| healthy | `Claude · 96% · ready` | `Claude · 96%` |
+| signed out | `Claude · — · unauthenticated` | `Claude · signed out` |
+| rate limited | `Codex · 98% · rate_limited` | `Codex · 98% · rate limited` |
+| no CLI | `Grok · — · cli_missing` | `Grok · no CLI` |
+| failed | `Amp · — · provider_error` | `Amp · failed` |
+
+`connectionLabel` would have become dead code when the visual design removed
+the meta footer. Instead it is repurposed as this humaniser, in lower case
+because it is a trailing qualifier. Its strings become: `` (ready, omitted),
+`stale`, `loading`, `no CLI`, `signed out`, `rate limited`, `offline`,
+`failed`, `unknown`.
+
+### 5.5 Notifications
+
+| Field | Now | New |
+| --- | --- | --- |
+| title, warning | `{Name} usage warning` | `{Name} {Window} is running low` |
+| title, critical | `{Name} usage critical` | `{Name} {Window} is almost out` |
+| body, with reset | `{Window}: {n}% used. Resets 2026-07-30T16:00:00.818843Z.` | `{n}% left. Resets in 3h 1m.` |
+| body, no reset | `{Window}: {n}% used.` | `{n}% left.` |
+| timestamp fallback | `Resets unknown.` | the clause is omitted |
+
+Two engineering consequences, both in section 6.
+
+The Quattro notification card allows two lines of summary and three of body at
+`Style.font.title`. Space was never the constraint.
+
+### 5.6 Maintenance
+
+| Now | New |
+| --- | --- |
+| `Uninstall agent-bar` | `Uninstall Agent Bar` |
+| `Final confirmation: uninstall will remove the plugin, settings, and backups. Click Uninstall again.` | `Deletes Agent Bar, your settings and every backup.` |
+| `Final confirmation: uninstall will remove the plugin bundle. Settings stay. Click Uninstall again.` | `Deletes Agent Bar. Your settings stay.` |
+| `This removes the Agent Bar plugin bundle. Settings are preserved by default.` | `Removes Agent Bar. Your settings stay.` |
+| `Update Agent Bar from {a}. This replaces the plugin bundle, preserves settings, and can roll back on failure.` | `Updates {a} → {b}. Settings stay. Rolls back if it fails.` |
+| `Installation type: Plugin bundle` | row deleted; only one type exists and it never varied |
+| `Update check returned an unusable response.` | `Update check failed.` — the identical string already exists 34 lines above |
+
+`agent-bar` is the package name. Every other surface says `Agent Bar`.
+
+### 5.7 Settings
+
+| Now | New |
+| --- | --- |
+| `Chip number` | `Bar shows` |
+| `Refresh interval (seconds)` | `Refresh every`, with `seconds` as the field suffix |
+| `Usage threshold alerts for enabled providers` | `Warn me before a quota runs out.` |
+| `Loading settings…` | `Loading…` |
+| `Providers` | unchanged, per decision 3 |
+
+## 6. Cross-cutting engineering
+
+### 6.1 The countdown humaniser must exist in Rust
+
+`CoreView.countdownText` produces `3h 1m` and `2d 18h`. It lives only in QML.
+The notification path is Rust and formats RFC3339 instead. A Rust
+implementation is added, and a test asserts both produce identical output for
+a shared table of inputs — the same treatment the visual design applies to the
+severity thresholds.
+
+QML keeps its copy because the popup re-humanises live on a 30-second timer.
+
+### 6.2 One unit across the product
+
+The bar and popup show the metric the user chose in Settings; the notification
+showed `used` unconditionally. Two opposite units for one number.
+
+The notification body follows the user's display metric, like every other
+surface. If the display metric does not currently reach
+`src/notifications/`, threading it there is part of the work; the
+notification must not carry a second source of truth for this.
+
+Trigger thresholds stay on `usedPercent` regardless, per the visual design —
+what fires the notification and what the notification says are different
+concepts.
+
+## 7. CLI rules
+
+The CLI is deliberately excluded from section 4. It is a private helper at
+`bin/agent-bar`, its stderr is read while debugging, and Unix convention there
+is lower case, no trailing period, no product-name prefix — which the current
+code already follows. Applying the GUI voice would make it worse.
+
+The CLI rewrite targets three things only:
+
+1. **Jargon that is not a real CLI concept.** `clause` is parser vocabulary and
+   becomes the user-visible word: `unknown status clause 'bogus'` →
+   `unknown argument 'bogus' for status`.
+2. **Duplicated messages across parse and validate paths.** `setup plugins-dir
+   path must be absolute` exists in both `grammar.rs` and `mod.rs`; one wins.
+3. **Messages that state a problem without the fix** where the fix is short and
+   certain.
+
+`install.sh` (50 strings) and the interactive `update` flow are the exception:
+those are read by a human installing the product for the first time, and they
+follow section 4.
+
+## 8. Test impact
+
+Locked exact strings: about 16 assertions in `tests/*.rs`, about 42 inline
+tests across `src/`, plus the QML suites — `tst_ProviderStates.qml` and
+`tst_Popup.qml` carry the typed state copy directly.
+
+New tests:
+
+- The language gate of section 3.
+- Rust/QML countdown equivalence, section 6.1.
+- A test asserting no GUI string matches the internal-vocabulary word list of
+  rule 2, so the leak cannot return.
+
+`notify_send_argv_shape` currently asserts `"Claude usage warning"` and a body
+containing `"91% used"`. It is rewritten against the new format, and is the
+canary for section 6.2.
+
+## 9. Suggested phasing
+
+1. **Language gate plus translation** (section 3, decision 2). Independent of
+   everything else and it stops the drift immediately.
+2. **GUI copy** (section 5), landed with the visual design's phase 3 and 4 so
+   the rewritten states ship with the layout that hosts them.
+3. **Cross-cutting engineering** (section 6): the Rust countdown and the
+   notification metric. These are behaviour, not wording, and carry their own
+   tests.
+4. **CLI and `install.sh`** (section 7). Largest string count, smallest user
+   impact; last, and safe to defer.
+
+## 10. Out of scope
+
+- No change to what triggers a notification, only to what it says.
+- No change to provider states, the status schema, or exit codes.
+- No translation of `docs/superpowers/**`, per decision 2.
+- No renaming of `provider` in code, per decision 3.

--- a/docs/superpowers/specs/2026-07-30-visual-update-design.md
+++ b/docs/superpowers/specs/2026-07-30-visual-update-design.md
@@ -12,7 +12,7 @@ model, and the v10 removal contract are preserved.
 
 Agent Bar renders correct data through an accidental parallel design system.
 Sixteen `Qt.darker(foreground, n)` calls and nineteen hardcoded
-`Qt.rgba(foreground…, α)` alphas reimplement, badly, a token vocabulary the
+`Qt.rgba(foreground…, alpha)` calls reimplement, badly, a token vocabulary the
 host already exports. That single root cause produces the visible defects:
 icons off the bar grid, a rail that does not align with its own content,
 severity that never appears, and a text hierarchy that inverts on light
@@ -122,7 +122,7 @@ This is the backbone of the change. Most of the work is deletion.
 
 | Current | Replacement |
 | --- | --- |
-| `Qt.darker(fg, 1.2…1.4)` — 16 sites | `Util.alpha(Color.foreground, α)`. The five existing factors collapse to two roles: supporting text and labels at `0.72`, meta and caption text at `0.55`. The mapping is by role, resolved per call site; no call site keeps a third value. |
+| `Qt.darker(fg, 1.2…1.4)` — 16 sites | `Util.alpha(Color.foreground, a)`. The five existing factors collapse to two roles: supporting text and labels at `0.72`, meta and caption text at `0.55`. The mapping is by role, resolved per call site; no call site keeps a third value. |
 | `Qt.rgba(fg…, 0.05)` + `0.22` — rail frame | deleted with the frame |
 | `Qt.rgba(fg…, 0.12)` — selected rail plate | `Style.selectedFill` |
 | `Qt.rgba(fg…, 0.3)` — selected rail border | `Style.selectedBorderColor` |

--- a/docs/superpowers/specs/2026-07-30-visual-update-design.md
+++ b/docs/superpowers/specs/2026-07-30-visual-update-design.md
@@ -1,0 +1,307 @@
+# Agent Bar v11 — Visual Update Design
+
+Status: approved design, not yet planned or implemented.
+Date: 2026-07-30.
+Surface: bar chips and consolidated popup. Mode: Operate.
+
+This design refines the incumbent Quattro-native visual world. It is not a
+redesign: product truth, copy language, information architecture, keyboard
+model, and the v10 removal contract are preserved.
+
+## 1. Problem
+
+Agent Bar renders correct data through an accidental parallel design system.
+Sixteen `Qt.darker(foreground, n)` calls and nineteen hardcoded
+`Qt.rgba(foreground…, α)` alphas reimplement, badly, a token vocabulary the
+host already exports. That single root cause produces the visible defects:
+icons off the bar grid, a rail that does not align with its own content,
+severity that never appears, and a text hierarchy that inverts on light
+themes.
+
+`PRODUCT.md` design principle 6 ("No custom theme system over Quattro") and
+`UX-056` already forbid this. The code drifted from its own contract.
+
+## 2. Measured evidence
+
+All figures measured against the live installation and the checked-in assets
+on 2026-07-30.
+
+### 2.1 Provider icon optical weight
+
+Ink coverage inside an identical 64x64 box (ImageMagick, alpha channel mean):
+
+| Asset | Format | Coverage | Reads as |
+| --- | --- | --- | --- |
+| `codex.png` | PNG 64x64, gray+alpha | 78.5% | solid white puck |
+| `amp.svg` | SVG, `#F34E3F` | 36.3% | correct |
+| `claude.png` | PNG 48x48, indexed | 35.9% | correct |
+| `grok.svg` | SVG, `fill="white"` | 22.6% | thin ring |
+
+Codex carries 3.5x the ink of Grok in the same box. Cause: `codex.png` is an
+app icon — a filled white disc with the artwork knocked out in black — while
+the other three are marks on transparency. It is the wrong grade of asset,
+not the wrong size.
+
+`grok.svg` hardcodes `fill="white"`. Omarchy ships five light themes
+(`catppuccin-latte`, `flexoki-light`, `lupine`, `rose-pine`, `white`), on
+which the Grok mark is invisible. This violates `UX-057`.
+
+### 2.2 Bar grid
+
+Quattro exports `Style.bar.iconSlot` (27), `Style.bar.iconCanvas` (16),
+`Style.bar.iconFont` (13) and `Style.bar.statusSlot` (21), plus `OpticalGlyph`
+for optical centring. `ProviderChip.qml` uses none of them and hardcodes
+`width: 13; height: 13`. Agent Bar chips do not sit on the same icon grid as
+every neighbouring bar module.
+
+### 2.3 Horizontal jitter
+
+Chip text length varies between one and four characters (`—`, `97%`, `100%`,
+`—…`). The bar is right-aligned, so any provider crossing 100 to 99, or
+entering loading, shifts every module to its left by roughly one character
+cell.
+
+### 2.4 Light-theme hierarchy inversion
+
+`Qt.darker` divides HSV value. On a dark theme this recedes; on a light theme
+it advances. Contrast ratio of primary versus `Qt.darker(foreground, 1.35)`
+secondary, against each theme background:
+
+| Theme | Primary CR | Secondary CR | Result |
+| --- | --- | --- | --- |
+| tokyo-night | 8.10 | 4.58 | correct |
+| catppuccin-latte | 7.06 | 9.80 | inverted — secondary 39% louder |
+| lupine | 15.43 | 16.94 | inverted |
+| flexoki-light | 18.62 | 19.12 | inverted |
+| white | 21.00 | 21.00 | collapsed — identical pixels |
+
+On the `white` theme `Qt.darker(#000000, n)` returns `#000000`: secondary and
+primary text become indistinguishable. Sixteen call sites are affected.
+
+Note: the host's own `PanelSectionHeader.qml` has the same flaw. That is an
+upstream issue and is out of scope here; Agent Bar's sixteen call sites are
+in scope.
+
+### 2.5 Popup geometry
+
+The rail frame starts 18px from the card top (`popupPadding` 14 +
+`ProviderRail.outerMargin` 4). Content starts at 28px (`popupPadding` 14 +
+`Popup.contentMargins` 14). Ten pixels of drift on a baseline that should be
+shared. The rail additionally draws its own fill and border inside a card
+that already has a 2px border.
+
+### 2.6 Emoji in a monospace surface
+
+`CoreView.chipStateCue` returns `⌛` (U+231B), which fontconfig resolves
+through the emoji font — a colour glyph inside a JetBrainsMono bar. The cue
+strings are also inconsistently padded: `" ⌛"` and `" !"` carry a leading
+space, `"…"` does not.
+
+## 3. Decisions
+
+Taken with the user across four visual-companion reviews.
+
+1. **Brand colour is preserved.** Claude and Amp keep their official colours.
+   Codex and Grok are monochrome brands and adopt `Color.foreground`, which
+   is the correct use of a monochrome mark and fixes light themes. Rule:
+   polychrome marks keep their colour, monochrome marks inherit the theme ink.
+2. **Bar chips keep number and unit** (`97%`), with a fixed-width numeral box.
+3. **Motion stays host-owned.** Agent Bar declares no `Behavior`, `Transition`
+   or animation. `A11Y-013` and `TEST-029` are unchanged.
+4. **The popup leads with one window.** The most urgent window renders large;
+   every other window renders as a compact row with its own track.
+5. **The plan badge becomes a tag**, not a pill.
+6. **The meta footer is removed** in all states. The user confirmed this after
+   the `UX-017`/`UX-028` cost was raised. See section 9.
+7. **Reset countdowns show hours below 24h.** Already correct in
+   `CoreView.countdownText`; the compact row must not abbreviate it.
+
+## 4. Token binding
+
+This is the backbone of the change. Most of the work is deletion.
+
+| Current | Replacement |
+| --- | --- |
+| `Qt.darker(fg, 1.2…1.4)` — 16 sites | `Util.alpha(Color.foreground, α)`. The five existing factors collapse to two roles: supporting text and labels at `0.72`, meta and caption text at `0.55`. The mapping is by role, resolved per call site; no call site keeps a third value. |
+| `Qt.rgba(fg…, 0.05)` + `0.22` — rail frame | deleted with the frame |
+| `Qt.rgba(fg…, 0.12)` — selected rail plate | `Style.selectedFill` |
+| `Qt.rgba(fg…, 0.3)` — selected rail border | `Style.selectedBorderColor` |
+| `Qt.rgba(fg…, 0.08)` — hover plate | `Style.hoverFill` |
+| `Qt.rgba(fg…, 0.12)` and `0.08` — separators (8 sites) | `PanelSeparator` (its default `strength` is already `0.12`) |
+| hardcoded `width: 13` / `16` on icons | `Style.bar.iconCanvas` and `Style.bar.iconSlot` |
+| chip `opacity: 0.55` / `0.45` for dimmed | `WidgetButton.dimmed` semantics (`0.45`) |
+| ad-hoc spacings | `Style.spacing.{sm,md,lg,xl,xxl}` and `Style.spacing.popupPadding` |
+
+One value has no host token: the usage track background. It is declared once,
+as a named readonly property on `UsageWindow`, and never repeated.
+
+`Color.urgent` is the single severity colour. No new colour is introduced.
+
+## 5. Bar specification
+
+- `ProviderChip` is rebuilt on Quattro's `WidgetButton`, inheriting slot
+  sizing, `dimmed`/`concealed` semantics, tooltip delivery, pointer cursor,
+  and the host `Behavior on opacity` (140ms OutCubic) and `Behavior on color`
+  (160ms). Implementation must verify that `WidgetButton`'s own bar
+  registration does not double-register the click target required by
+  `UX-010`; if it does, the chip keeps its explicit registration and adopts
+  only the sizing and state vocabulary.
+- Icon canvas is `Style.bar.iconCanvas`. Per-provider optical scale lives in
+  `CoreView.iconOpticalScale(providerId)`, beside the existing
+  `iconFileName`: Claude, Codex and Amp at `1.0`; Grok at `0.875`, because its
+  mark is a thin ring that fills its own box edge to edge.
+- Numeral box is fixed width, right-aligned, measured with `TextMetrics` on
+  the string `100%` at `Style.font.body`. Never a hardcoded pixel value: the
+  font scales with `[font] base-size`.
+- Gap inside a chip is `Style.spacing.sm` (4). Gap between chips is
+  `Style.spacing.xxl` (12). The 3:1 ratio is what makes an icon and its number
+  read as one unit; today's 4:10 does not.
+- State cues carry no leading space; separation is layout spacing. `⌛` is
+  replaced by a Nerd Font glyph from the active bar family. The loading cue is
+  visually distinct from the `—` no-data glyph.
+
+## 6. Popup specification
+
+- **Rail.** Own fill and border deleted. Slot stack top edge equals content
+  top edge: one shared inset of `Style.spacing.popupPadding`. Gutter stays
+  `Style.spacing.lg` (8). Selected plate uses `Style.selectedFill` and
+  `Style.selectedBorderColor`, preserving `UX-020B` (neutral plate, no accent
+  tick).
+- **Header.** `name · plan tag · [severity tag] · spacer · refresh`. The tag
+  is a 1px `Style.normalBorderColor` border at `Style.cornerRadius`,
+  `Style.font.caption`, uppercase. Uppercasing also normalises provider plan
+  labels that arrive lowercase from the API, such as Codex's `plus`.
+- **Lead window.** `Style.font.body * 2.5` numeral, unit at
+  `Style.font.caption`, a `Style.spacing.md` track, and the reset promoted
+  into the label line: `Session (5h) · resets in 3h 1m`.
+- **Other windows.** One compact row each: `label · track · value · time to
+  reset`. Reset time uses `CoreView.countdownText` unmodified, so anything
+  under 24h reads in hours. The compact column is sized for `23h 1m`.
+- **Footer.** Removed.
+- **Stale banner.** Absorbs the last-success age that the footer carried:
+  glyph, `Last data 14m ago · <safe error summary>`, `Retry`. Only rendered
+  when stale, which is the existing behaviour.
+- **Connection state.** No longer rendered as a label. It is already implied
+  structurally: `CoreView.contentMode` only returns `windows` when the
+  provider state is `ready`, so a pane showing windows with no stale banner is
+  by definition connected. The label was redundant. See section 9.
+
+## 7. Severity model
+
+Severity reuses the existing Rust thresholds in
+`NotificationLevel::from_used_percent`. No second threshold is invented.
+
+| `usedPercent` | Level | Treatment |
+| --- | --- | --- |
+| `>= 95` | Critical | severity tag reading `Critical`; lead numeral and track in `Color.urgent`; `!` cue on the bar chip |
+| `>= 90` | Warning | severity tag reading `Low`; numeral and track unchanged |
+| `< 90` | none | no tag |
+
+Severity is always computed from `usedPercent`, independent of the user's
+`remaining`/`used` display metric, so switching the metric never changes what
+counts as critical.
+
+`A11Y-012` is satisfied: every level carries a word, never colour alone.
+
+Thresholds are duplicated in `CoreView.js` because the status schema is
+frozen at v2 and must not gain a field. A Rust test reads both
+`src/notifications/state.rs` and `assets/omarchy/CoreView.js` and asserts the
+constants match, so the duplication cannot drift.
+
+## 8. Lead window election
+
+Deterministic, in order:
+
+1. If any window is Critical, the lead is the Critical window with the lowest
+   `remainingPercent`.
+2. Otherwise the lead is the window with the nearest future `resetsAt`.
+3. Ties break by the provider's window order as delivered, then by window id.
+4. If no window has `resetsAt`, the lead is the first window.
+5. Every other window renders as a compact row, in delivered order.
+
+This replaces the `PRIMARY_WINDOW_IDS` allowlist (`session`, `weekly`,
+`daily`), which is deleted. The allowlist silently demoted any window whose id
+was not in the set; election handles new window ids without a code change.
+
+## 9. Specification amendments required
+
+- **`UX-017`** currently reads: "The header shows name, plan badge, connection
+  state, update age, and provider refresh." Amend to: "The header shows name,
+  plan badge, severity when present, and provider refresh." Rationale in
+  section 6: connection state is structurally implied and update age moves to
+  the stale banner.
+- **`UX-028`** currently requires stale content to show a `Stale` label, last
+  success age, and safe error summary. The requirement is preserved; only its
+  location changes, from the meta footer to the stale banner. Amend the
+  wording to name the banner as the carrier.
+- **`UX-020A`** already requires a track per percentage window. Extend it to
+  the compact rows so secondary windows stay comparable.
+- **`UX-016`** (header does not repeat the provider icon) is unchanged.
+- **`A11Y-013`**, **`TEST-029`**, **`UX-049`**, **`UX-056`** and
+  **`UX-057`** are unchanged and this design moves the code toward compliance
+  with the last three rather than away.
+
+The user was told the footer removal costs two amendments and confirmed the
+removal. This section records that decision, not a proposal.
+
+## 10. Asset actions
+
+- **Codex.** The design requires a mark-grade monochrome asset, not the
+  filled app icon. A knockout derived from the current official asset proves
+  the target and measures at 14.5% coverage. Implementation must obtain the
+  official monochrome mark; if none is published, the derivation is adopted
+  and recorded as the approved asset under `UX-049`.
+- **Grok.** `fill="white"` is removed. The mark is tinted to
+  `Color.foreground` at render time with `MultiEffect { colorization: 1.0 }`
+  from `QtQuick.Effects`, which is present in the runtime and already used by
+  first-party Omarchy plugins (`plugins/background/Background.qml:250`). The
+  same treatment applies to Codex. Claude and Amp are never tinted.
+
+## 11. Copy
+
+All shipped UI copy remains English, per the engineering contract. The
+Portuguese strings in the companion mockups existed for review only and must
+not reach the code.
+
+## 12. Out of scope
+
+- The Settings and Maintenance views are not redesigned. They inherit the
+  section 4 token binding, and nothing else. Eight of the sixteen `Qt.darker`
+  sites live outside the bar and provider pane — four in `SettingsView.qml`,
+  three in `MaintenanceView.qml`, one in `ConfirmDialog.qml` — and are fixed
+  as part of that binding.
+- No new provider, metric, window type, or setting.
+- No spend, currency, history, chart, or dashboard affordance.
+- No change to polling, caching, IPC, keyboard model, or focus order.
+
+## 13. Suggested phasing
+
+The change is coherent but too large for one commit. Natural order, each
+phase independently verifiable and independently shippable:
+
+1. **Token binding** (section 4). Mechanical, repo-wide, highest value per
+   risk: it alone fixes light themes and removes the parallel system.
+2. **Bar chip** (section 5) plus the asset actions (section 10), because chip
+   sizing and asset grade are the same problem.
+3. **Popup structure** (section 6): rail, header, tags, footer removal, stale
+   banner.
+4. **Severity and lead-window election** (sections 7 and 8), the only phase
+   introducing new product rules.
+5. **Specification amendments** (section 9), landed with phase 3 and 4 so the
+   spec never describes shipped behaviour incorrectly.
+
+## 14. Verification
+
+In addition to the standard checkpoint and the QML gate:
+
+- A test asserting no `Qt.darker` remains in `assets/omarchy/**`.
+- A test asserting the severity constants in `CoreView.js` match
+  `NotificationLevel::from_used_percent`.
+- A test asserting `CoreView.iconOpticalScale` returns a value for every
+  catalog provider id.
+- Lead-window election unit tests covering: critical wins over nearest reset,
+  nearest reset among healthy windows, no `resetsAt`, single window, and tie
+  breaking.
+- Screenshot review on one dark theme and one light theme, with `white` as
+  the light case, since it is where the current hierarchy collapses entirely.
+- `TEST-029` must still pass unchanged.

--- a/scripts/verify-v10-ui
+++ b/scripts/verify-v10-ui
@@ -9,6 +9,7 @@ QML_TEST="${ROOT}/tests/qml/tst_Screenshots.qml"
 REQUIRED=(
   ready-light.png
   ready-dark.png
+  ready-white.png
   loading-dark.png
   refreshing-with-data-dark.png
   stale-dark.png

--- a/tests/active_language.rs
+++ b/tests/active_language.rs
@@ -17,8 +17,8 @@ const ALLOWLIST: &[(&str, &str)] = &[(
     "accented fixture for the ANSI and control-character stripper",
 )];
 
-/// Files awaiting translation. Task 3 empties this and locks it shut.
-const PENDING_TRANSLATION: &[&str] = &["CHANGELOG.md"];
+/// Empty, and it stays empty. See `translation_backlog_is_empty`.
+const PENDING_TRANSLATION: &[&str] = &[];
 
 const BINARY_EXTENSIONS: &[&str] = &["png", "jpg", "jpeg", "svg", "ico", "lock"];
 
@@ -111,4 +111,12 @@ fn allowlisted_files_still_need_their_exemption() {
              non-ASCII letters; remove the entry"
         );
     }
+}
+
+#[test]
+fn translation_backlog_is_empty() {
+    assert!(
+        PENDING_TRANSLATION.is_empty(),
+        "translation backlog must stay empty; still pending: {PENDING_TRANSLATION:?}"
+    );
 }

--- a/tests/active_language.rs
+++ b/tests/active_language.rs
@@ -1,0 +1,107 @@
+//! Active-surface language gate.
+//!
+//! Rule: no tracked text file may contain an alphabetic non-ASCII character.
+//! "Alphabetic" is load-bearing — it flags accented letters while ignoring the
+//! Nerd Font glyphs (Private Use Area) and the punctuation this project uses
+//! on purpose.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Past session artefacts. Build record, not documentation.
+const EXCLUDED_PREFIXES: &[&str] = &["docs/superpowers/"];
+
+/// Deliberate non-ASCII, with the reason it stays.
+const ALLOWLIST: &[(&str, &str)] = &[(
+    "src/support/redact.rs",
+    "accented fixture for the ANSI and control-character stripper",
+)];
+
+/// Files awaiting translation. Task 3 empties this and locks it shut.
+const PENDING_TRANSLATION: &[&str] = &[
+    "CHANGELOG.md",
+    "docs/adr/0001-omarchy-right-click-settings.md",
+    "docs/adr/0002-config-cli-dual-write.md",
+    "docs/adr/0003-cli-help-hide-internals.md",
+];
+
+const BINARY_EXTENSIONS: &[&str] = &["png", "jpg", "jpeg", "svg", "ico", "lock"];
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn tracked_files(root: &Path) -> Vec<String> {
+    let output = Command::new("git")
+        .arg("ls-files")
+        .current_dir(root)
+        .output()
+        .expect("git ls-files must run inside the repository");
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(str::to_owned)
+        .collect()
+}
+
+fn is_scannable(rel: &str) -> bool {
+    if EXCLUDED_PREFIXES.iter().any(|p| rel.starts_with(p)) {
+        return false;
+    }
+    if ALLOWLIST.iter().any(|(path, _)| *path == rel) {
+        return false;
+    }
+    if PENDING_TRANSLATION.contains(&rel) {
+        return false;
+    }
+    match Path::new(rel).extension().and_then(|e| e.to_str()) {
+        Some(ext) => !BINARY_EXTENSIONS.contains(&ext),
+        None => true,
+    }
+}
+
+/// file:line:offending characters:trimmed line
+fn offenders(root: &Path, rel: &str) -> Vec<String> {
+    let Ok(text) = std::fs::read_to_string(root.join(rel)) else {
+        return Vec::new();
+    };
+    let mut found = Vec::new();
+    for (index, line) in text.lines().enumerate() {
+        let bad: String = line
+            .chars()
+            .filter(|c| c.is_alphabetic() && !c.is_ascii())
+            .collect();
+        if !bad.is_empty() {
+            found.push(format!("{rel}:{}: [{bad}] {}", index + 1, line.trim()));
+        }
+    }
+    found
+}
+
+#[test]
+fn active_files_contain_no_non_english_letters() {
+    let root = workspace_root();
+    let mut all = Vec::new();
+    for rel in tracked_files(&root) {
+        if !is_scannable(&rel) {
+            continue;
+        }
+        all.extend(offenders(&root, &rel));
+    }
+    assert!(
+        all.is_empty(),
+        "alphabetic non-ASCII characters in active files:\n{}",
+        all.join("\n")
+    );
+}
+
+#[test]
+fn allowlisted_files_still_need_their_exemption() {
+    let root = workspace_root();
+    for (rel, reason) in ALLOWLIST {
+        assert!(
+            !offenders(&root, rel).is_empty(),
+            "{rel} is allowlisted for '{reason}' but no longer contains \
+             non-ASCII letters; remove the entry"
+        );
+    }
+}

--- a/tests/active_language.rs
+++ b/tests/active_language.rs
@@ -18,12 +18,7 @@ const ALLOWLIST: &[(&str, &str)] = &[(
 )];
 
 /// Files awaiting translation. Task 3 empties this and locks it shut.
-const PENDING_TRANSLATION: &[&str] = &[
-    "CHANGELOG.md",
-    "docs/adr/0001-omarchy-right-click-settings.md",
-    "docs/adr/0002-config-cli-dual-write.md",
-    "docs/adr/0003-cli-help-hide-internals.md",
-];
+const PENDING_TRANSLATION: &[&str] = &["CHANGELOG.md"];
 
 const BINARY_EXTENSIONS: &[&str] = &["png", "jpg", "jpeg", "svg", "ico", "lock"];
 

--- a/tests/active_language.rs
+++ b/tests/active_language.rs
@@ -37,10 +37,22 @@ fn tracked_files(root: &Path) -> Vec<String> {
         .current_dir(root)
         .output()
         .expect("git ls-files must run inside the repository");
-    String::from_utf8_lossy(&output.stdout)
+    assert!(
+        output.status.success(),
+        "git ls-files exited with {}, stderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let files: Vec<String> = String::from_utf8_lossy(&output.stdout)
         .lines()
         .map(str::to_owned)
-        .collect()
+        .collect();
+    assert!(
+        !files.is_empty(),
+        "git ls-files returned zero tracked files; the gate would silently \
+         scan nothing"
+    );
+    files
 }
 
 fn is_scannable(rel: &str) -> bool {

--- a/tests/qml/TestPalette.js
+++ b/tests/qml/TestPalette.js
@@ -6,6 +6,7 @@ function requiredScreenshotNames() {
   return [
     "ready-light.png",
     "ready-dark.png",
+    "ready-white.png",
     "loading-dark.png",
     "refreshing-with-data-dark.png",
     "stale-dark.png",
@@ -23,12 +24,20 @@ function requiredScreenshotNames() {
 }
 
 function themePalette(mode) {
+  if (mode === "white") {
+    return {
+      mode: "white",
+      background: "#ffffff",
+      foreground: "#000000",
+      accent: "#0057d8",
+      urgent: "#c31432"
+    }
+  }
   if (mode === "light") {
     return {
       mode: "light",
       background: "#f4f4f5",
       foreground: "#18181b",
-      muted: "#52525b",
       border: "#d4d4d8",
       urgent: "#b91c1c"
     }
@@ -37,7 +46,6 @@ function themePalette(mode) {
     mode: "dark",
     background: "#18181b",
     foreground: "#e4e4e7",
-    muted: "#a1a1aa",
     border: "#3f3f46",
     urgent: "#f87171"
   }

--- a/tests/qml/tst_Popup.qml
+++ b/tests/qml/tst_Popup.qml
@@ -65,8 +65,10 @@ TestCase {
 
   function test_full_width_separator_present() {
     var src = read("assets/omarchy/ProviderView.qml")
+    // Separator is the host's PanelSeparator (fixed 1px height internally);
+    // this file only needs to place it full-width.
+    verify(src.indexOf("PanelSeparator") >= 0)
     verify(src.indexOf("width: parent.width") >= 0)
-    verify(src.indexOf("height: 1") >= 0)
   }
 
   function test_plain_text_only_no_rich_text() {

--- a/tests/qml/tst_Screenshots.qml
+++ b/tests/qml/tst_Screenshots.qml
@@ -86,7 +86,13 @@ TestCase {
     var p = Core.themePalette(mode)
     stage.color = p.background
     stage.fg = p.foreground
-    stage.muted = p.muted
+    // Derived from this palette's own foreground at the supporting-text level,
+    // which is what the shipped components compute through Util.alpha. The
+    // literal 0.72 is pinned by tst_Tokens.qml's test_no_third_alpha_value;
+    // Util itself is unreachable here because qs.Commons will not compile
+    // under the bare Qt6 runner.
+    var fg = Qt.color(p.foreground)
+    stage.muted = Qt.rgba(fg.r, fg.g, fg.b, 0.72)
     stage.badgeColor = p.urgent
   }
 
@@ -94,6 +100,13 @@ TestCase {
     // Map evidence basename → deterministic fixture panel
     if (name.indexOf("ready-light") === 0) {
       applyTheme("light")
+      stage.titleText = "Claude"
+      stage.badgeText = "Connected"
+      stage.bodyText = "Session (5h) 58% left · Max plan"
+      return
+    }
+    if (name.indexOf("ready-white") === 0) {
+      applyTheme("white")
       stage.titleText = "Claude"
       stage.badgeText = "Connected"
       stage.bodyText = "Session (5h) 58% left · Max plan"
@@ -191,8 +204,9 @@ TestCase {
 
   function test_required_names_match_spec() {
     var names = Core.requiredScreenshotNames()
-    compare(names.length, 15)
+    compare(names.length, 16)
     verify(names.indexOf("ready-light.png") >= 0)
+    verify(names.indexOf("ready-white.png") >= 0)
     verify(names.indexOf("uninstall-confirmation-dark.png") >= 0)
   }
 }

--- a/tests/qml/tst_Tokens.qml
+++ b/tests/qml/tst_Tokens.qml
@@ -51,6 +51,68 @@ TestCase {
     }
   }
 
+  // Every numeric literal that appears in the opacity slot of a
+  // Util.alpha(color, opacity) call, read from source. Handles both plain
+  // literals and conditional expressions (the showStale ternary).
+  function alphaArgValues(code) {
+    var values = []
+    var callRe = /Util\.alpha\(([^()]*)\)/g
+    var m
+    while ((m = callRe.exec(code)) !== null) {
+      var args = m[1]
+      var commaIdx = args.indexOf(",")
+      if (commaIdx < 0)
+        continue
+      var opacityArg = args.slice(commaIdx + 1)
+      var numRe = /\d+(?:\.\d+)?/g
+      var nm
+      while ((nm = numRe.exec(opacityArg)) !== null)
+        values.push(nm[0])
+    }
+    return values
+  }
+
+  function convertedFiles() {
+    return [
+      "assets/omarchy/ProviderView.qml",
+      "assets/omarchy/SettingsView.qml",
+      "assets/omarchy/MaintenanceView.qml",
+      "assets/omarchy/components/UsageWindow.qml",
+      "assets/omarchy/components/ProviderHeader.qml",
+      "assets/omarchy/components/StateMessage.qml",
+      "assets/omarchy/components/ConfirmDialog.qml"
+    ]
+  }
+
+  // The "exactly two levels, no third value" contract that Tasks 5-8 build
+  // on. Values are extracted from the call sites themselves, not hardcoded,
+  // so a future task introducing a third alpha value fails here. Does not
+  // assert a call-site count: later plans legitimately add/remove sites.
+  function test_no_third_alpha_value() {
+    var files = tokenScannedFiles()
+    var seen = {}
+    for (var i = 0; i < files.length; i++) {
+      var code = read(files[i]).replace(/\/\/[^\n]*/g, "")
+      var values = alphaArgValues(code)
+      for (var j = 0; j < values.length; j++)
+        seen[values[j]] = true
+    }
+    var distinct = Object.keys(seen).sort()
+    compare(distinct.join(","), "0.55,0.72",
+            "Util.alpha opacity must be exactly 0.55 or 0.72, found: " + distinct.join(","))
+  }
+
+  // Closes the substitution hole: a hardcoded Qt.rgba(...) literal would
+  // satisfy test_no_qt_darker without ever using Util.alpha.
+  function test_util_alpha_used_in_converted_files() {
+    var files = convertedFiles()
+    for (var i = 0; i < files.length; i++) {
+      var code = read(files[i]).replace(/\/\/[^\n]*/g, "")
+      verify(code.indexOf("Util.alpha(") >= 0,
+             files[i] + " has no Util.alpha( call; conversion must use Util.alpha")
+    }
+  }
+
   // Composite a translucent foreground over a background, the way the
   // compositor does, then compare WCAG contrast.
   function composite(fg, bg, a) {

--- a/tests/qml/tst_Tokens.qml
+++ b/tests/qml/tst_Tokens.qml
@@ -1,0 +1,90 @@
+import QtQuick
+import QtTest
+
+TestCase {
+  id: testCase
+  name: "AgentBarTokens"
+  when: windowShown
+
+  property string repoRoot: {
+    var path = String(Qt.resolvedUrl(".")).replace("file://", "")
+    if (path.endsWith("/"))
+      path = path.slice(0, -1)
+    var parts = path.split("/")
+    parts.pop(); parts.pop()
+    return parts.join("/")
+  }
+
+  function read(rel) {
+    var xhr = new XMLHttpRequest()
+    xhr.open("GET", "file://" + repoRoot + "/" + rel, false)
+    xhr.send()
+    return String(xhr.responseText || "")
+  }
+
+  function tokenScannedFiles() {
+    return [
+      "assets/omarchy/BarWidget.qml",
+      "assets/omarchy/Popup.qml",
+      "assets/omarchy/ProviderRail.qml",
+      "assets/omarchy/ProviderView.qml",
+      "assets/omarchy/SettingsView.qml",
+      "assets/omarchy/MaintenanceView.qml",
+      "assets/omarchy/components/ProviderChip.qml",
+      "assets/omarchy/components/ProviderHeader.qml",
+      "assets/omarchy/components/UsageWindow.qml",
+      "assets/omarchy/components/StateMessage.qml",
+      "assets/omarchy/components/SettingsProviderRow.qml",
+      "assets/omarchy/components/ConfirmDialog.qml"
+    ]
+  }
+
+  // Qt.darker divides HSV value. On a dark theme that recedes; on a light
+  // theme it advances, so secondary text outranks primary. Util.alpha works
+  // in both directions with one value.
+  function test_no_qt_darker() {
+    var files = tokenScannedFiles()
+    for (var i = 0; i < files.length; i++) {
+      var code = read(files[i]).replace(/\/\/[^\n]*/g, "")
+      verify(code.indexOf("Qt.darker") < 0,
+             files[i] + " still calls Qt.darker; use Util.alpha")
+    }
+  }
+
+  // Composite a translucent foreground over a background, the way the
+  // compositor does, then compare WCAG contrast.
+  function composite(fg, bg, a) {
+    return Qt.rgba(fg.r * a + bg.r * (1 - a),
+                   fg.g * a + bg.g * (1 - a),
+                   fg.b * a + bg.b * (1 - a), 1)
+  }
+
+  function luminance(c) {
+    function ch(v) { return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4) }
+    return 0.2126 * ch(c.r) + 0.7152 * ch(c.g) + 0.0722 * ch(c.b)
+  }
+
+  function contrast(a, b) {
+    var la = luminance(a), lb = luminance(b)
+    var hi = Math.max(la, lb), lo = Math.min(la, lb)
+    return (hi + 0.05) / (lo + 0.05)
+  }
+
+  function test_secondary_recedes_in_both_themes_data() {
+    return [
+      { tag: "dark",  fg: Qt.color("#fff6ff"), bg: Qt.color("#05080a") },
+      { tag: "light", fg: Qt.color("#18181b"), bg: Qt.color("#f4f4f5") },
+      { tag: "white", fg: Qt.color("#000000"), bg: Qt.color("#ffffff") }
+    ]
+  }
+
+  function test_secondary_recedes_in_both_themes(data) {
+    var primary = contrast(data.fg, data.bg)
+    var supporting = contrast(composite(data.fg, data.bg, 0.72), data.bg)
+    var meta = contrast(composite(data.fg, data.bg, 0.55), data.bg)
+    verify(supporting < primary,
+           data.tag + ": supporting " + supporting + " must be under primary " + primary)
+    verify(meta < supporting,
+           data.tag + ": meta " + meta + " must be under supporting " + supporting)
+  }
+}

--- a/tests/qml/tst_Tokens.qml
+++ b/tests/qml/tst_Tokens.qml
@@ -88,11 +88,12 @@ TestCase {
   // token, declared once with its reason so the strict rule keeps applying
   // everywhere else. An undeclared third value still fails — exceptions only
   // subtract the exact values listed, only for the file listed.
+  //
+  // Empty today: the modal scrim that motivated this mechanism now binds to
+  // the host's Color.menu.scrim token instead of a raw alpha, so it needs no
+  // entry. The mechanism stays — Task 7 adds "0.12" for the usage track.
   function textAlphaExceptions() {
-    return {
-      // Modal scrim: full-screen wash, not text or control chrome (Task 5).
-      "assets/omarchy/components/ConfirmDialog.qml": ["0.45"]
-    }
+    return {}
   }
 
   // The "exactly two levels, no third value" contract that Tasks 5-8 build
@@ -171,7 +172,6 @@ TestCase {
   function allowedRawAlphaFiles() {
     return [
       "assets/omarchy/components/UsageWindow.qml",   // usage track, Task 7
-      "assets/omarchy/components/ConfirmDialog.qml", // modal scrim
       "assets/omarchy/ProviderView.qml",             // separators, Task 6
       "assets/omarchy/SettingsView.qml",             // separators, Task 6
       "assets/omarchy/MaintenanceView.qml"           // separators, Task 6

--- a/tests/qml/tst_Tokens.qml
+++ b/tests/qml/tst_Tokens.qml
@@ -84,18 +84,34 @@ TestCase {
     ]
   }
 
+  // Per-file exceptions to the two-level rule: a raw alpha with no host
+  // token, declared once with its reason so the strict rule keeps applying
+  // everywhere else. An undeclared third value still fails — exceptions only
+  // subtract the exact values listed, only for the file listed.
+  function textAlphaExceptions() {
+    return {
+      // Modal scrim: full-screen wash, not text or control chrome (Task 5).
+      "assets/omarchy/components/ConfirmDialog.qml": ["0.45"]
+    }
+  }
+
   // The "exactly two levels, no third value" contract that Tasks 5-8 build
   // on. Values are extracted from the call sites themselves, not hardcoded,
   // so a future task introducing a third alpha value fails here. Does not
   // assert a call-site count: later plans legitimately add/remove sites.
   function test_no_third_alpha_value() {
     var files = tokenScannedFiles()
+    var exceptions = textAlphaExceptions()
     var seen = {}
     for (var i = 0; i < files.length; i++) {
       var code = read(files[i]).replace(/\/\/[^\n]*/g, "")
       var values = alphaArgValues(code)
-      for (var j = 0; j < values.length; j++)
+      var excepted = exceptions[files[i]] || []
+      for (var j = 0; j < values.length; j++) {
+        if (excepted.indexOf(values[j]) >= 0)
+          continue
         seen[values[j]] = true
+      }
     }
     var distinct = Object.keys(seen).sort()
     compare(distinct.join(","), "0.55,0.72",
@@ -148,5 +164,29 @@ TestCase {
            data.tag + ": supporting " + supporting + " must be under primary " + primary)
     verify(meta < supporting,
            data.tag + ": meta " + meta + " must be under supporting " + supporting)
+  }
+
+  // Raw foreground alphas are allowed only where no host token exists.
+  // Every other surface must read the theme's state vocabulary.
+  function allowedRawAlphaFiles() {
+    return [
+      "assets/omarchy/components/UsageWindow.qml",   // usage track, Task 7
+      "assets/omarchy/components/ConfirmDialog.qml", // modal scrim
+      "assets/omarchy/ProviderView.qml",             // separators, Task 6
+      "assets/omarchy/SettingsView.qml",             // separators, Task 6
+      "assets/omarchy/MaintenanceView.qml"           // separators, Task 6
+    ]
+  }
+
+  function test_control_chrome_uses_style_tokens() {
+    var files = tokenScannedFiles()
+    var allowed = allowedRawAlphaFiles()
+    for (var i = 0; i < files.length; i++) {
+      if (allowed.indexOf(files[i]) >= 0)
+        continue
+      var code = read(files[i]).replace(/\/\/[^\n]*/g, "")
+      verify(code.indexOf("Qt.rgba(") < 0,
+             files[i] + " still hardcodes an alpha; use a Style state token")
+    }
   }
 }

--- a/tests/qml/tst_Tokens.qml
+++ b/tests/qml/tst_Tokens.qml
@@ -89,11 +89,15 @@ TestCase {
   // everywhere else. An undeclared third value still fails — exceptions only
   // subtract the exact values listed, only for the file listed.
   //
-  // Empty today: the modal scrim that motivated this mechanism now binds to
-  // the host's Color.menu.scrim token instead of a raw alpha, so it needs no
-  // entry. The mechanism stays — Task 7 adds "0.12" for the usage track.
+  // The modal scrim that motivated this mechanism ended up binding to the
+  // host's Color.menu.scrim token instead of a raw alpha, so it needs no
+  // entry. The usage track's trackColor is the one real holdout: a data
+  // surface with no host token. Exactly one entry — a second would mean the
+  // mechanism grew into a loophole instead of staying a documented rarity.
   function textAlphaExceptions() {
-    return {}
+    return {
+      "assets/omarchy/components/UsageWindow.qml": ["0.12"]
+    }
   }
 
   // The "exactly two levels, no third value" contract that Tasks 5-8 build
@@ -167,10 +171,22 @@ TestCase {
            data.tag + ": meta " + meta + " must be under supporting " + supporting)
   }
 
-  // Raw foreground alphas are allowed only where no host token exists.
-  // Every other surface must read the theme's state vocabulary.
+  // Empty: after this task no file keeps a raw foreground alpha. ConfirmDialog
+  // left the list in Task 5 when its scrim bound to Color.menu.scrim, and the
+  // usage track is the last holdout.
   function allowedRawAlphaFiles() {
-    return ["assets/omarchy/components/UsageWindow.qml"] // usage track, Task 7
+    return []
+  }
+
+  // The track tint has no host token, so it gets a name and exactly one
+  // declaration. Two would be a parallel system starting over.
+  function test_usage_track_declared_once() {
+    var code = read("assets/omarchy/components/UsageWindow.qml")
+        .replace(/\/\/[^\n]*/g, "")
+    var declarations = code.split("readonly property color trackColor").length - 1
+    compare(declarations, 1, "trackColor must be declared exactly once")
+    verify(code.indexOf("Qt.rgba(") < 0,
+           "UsageWindow must reference trackColor, not a literal alpha")
   }
 
   function test_control_chrome_uses_style_tokens() {

--- a/tests/qml/tst_Tokens.qml
+++ b/tests/qml/tst_Tokens.qml
@@ -170,12 +170,7 @@ TestCase {
   // Raw foreground alphas are allowed only where no host token exists.
   // Every other surface must read the theme's state vocabulary.
   function allowedRawAlphaFiles() {
-    return [
-      "assets/omarchy/components/UsageWindow.qml",   // usage track, Task 7
-      "assets/omarchy/ProviderView.qml",             // separators, Task 6
-      "assets/omarchy/SettingsView.qml",             // separators, Task 6
-      "assets/omarchy/MaintenanceView.qml"           // separators, Task 6
-    ]
+    return ["assets/omarchy/components/UsageWindow.qml"] // usage track, Task 7
   }
 
   function test_control_chrome_uses_style_tokens() {

--- a/tests/screenshot_inventory.rs
+++ b/tests/screenshot_inventory.rs
@@ -1,0 +1,79 @@
+//! `tests/qml/TestPalette.js` and `scripts/verify-v10-ui` each hand-copy the
+//! same required-screenshot inventory. Nothing keeps the two lists in sync:
+//! adding a name to one and forgetting the other either leaves a gap in the
+//! QML fixture's own count check or makes the shell script reject the new
+//! PNG as "unexpected evidence" (exactly what happened when `ready-white.png`
+//! was added to the JS list without updating the script). This test keeps
+//! them in lock-step: a screenshot added to one side and forgotten on the
+//! other fails here instead of at whatever point someone next runs the
+//! script.
+
+use std::collections::BTreeSet;
+
+/// Quoted `"name.png"` basenames from `TestPalette.js`'s
+/// `requiredScreenshotNames()` array.
+fn js_required_names(source: &str) -> BTreeSet<String> {
+    let mut names = BTreeSet::new();
+    for line in source.lines() {
+        let t = line.trim();
+        let Some(rest) = t.strip_prefix('"') else {
+            continue;
+        };
+        let Some(end) = rest.find('"') else {
+            continue;
+        };
+        let name = &rest[..end];
+        if name.ends_with(".png") {
+            names.insert(name.to_owned());
+        }
+    }
+    names
+}
+
+/// Bare `name.png` basenames from `verify-v10-ui`'s `REQUIRED=( ... )` array.
+fn script_required_names(source: &str) -> BTreeSet<String> {
+    let mut names = BTreeSet::new();
+    let mut in_array = false;
+    for line in source.lines() {
+        let t = line.trim();
+        if t.starts_with("REQUIRED=(") {
+            in_array = true;
+            continue;
+        }
+        if !in_array {
+            continue;
+        }
+        if t == ")" {
+            break;
+        }
+        if t.ends_with(".png") && !t.contains('*') && !t.contains('"') {
+            names.insert(t.to_owned());
+        }
+    }
+    names
+}
+
+#[test]
+fn screenshot_inventory_matches_verify_script() {
+    let js = std::fs::read_to_string("tests/qml/TestPalette.js").expect("read TestPalette.js");
+    let script =
+        std::fs::read_to_string("scripts/verify-v10-ui").expect("read scripts/verify-v10-ui");
+
+    let js_names = js_required_names(&js);
+    let script_names = script_required_names(&script);
+
+    assert!(
+        !js_names.is_empty(),
+        "expected at least one required screenshot name in TestPalette.js"
+    );
+
+    let missing_from_script: Vec<&String> = js_names.difference(&script_names).collect();
+    let missing_from_js: Vec<&String> = script_names.difference(&js_names).collect();
+
+    assert!(
+        missing_from_script.is_empty() && missing_from_js.is_empty(),
+        "screenshot inventory drifted between TestPalette.js and \
+         scripts/verify-v10-ui\n  missing from scripts/verify-v10-ui REQUIRED: {missing_from_script:?}\n  \
+         missing from TestPalette.js requiredScreenshotNames(): {missing_from_js:?}"
+    );
+}


### PR DESCRIPTION
Foundation pass for the v11 visual update: bind every hardcoded colour to the
Quattro tokens the host already exports, and add the language gate this
repository never had. No layout, copy or behaviour changes — those are plans 02
through 05.

## Why

Agent Bar had grown an accidental parallel design system: 16
`Qt.darker(foreground, n)` calls and 19 hardcoded `Qt.rgba(foreground…, alpha)`
values reimplementing a token vocabulary Quattro already exports. Principle 6 of
`PRODUCT.md` and `UX-056` already forbid this; the code had drifted from its own
contract.

That root cause produced a real, measurable bug. `Qt.darker` divides HSV value,
so it recedes on a dark theme and **advances** on a light one. Omarchy ships
five light themes. Contrast of primary text versus secondary, against each
theme's background:

| Theme | Primary | Secondary | Result |
| --- | --- | --- | --- |
| tokyo-night | 8.10 | 4.58 | correct |
| catppuccin-latte | 7.06 | 9.80 | inverted — secondary 39% louder |
| flexoki-light | 18.62 | 19.12 | inverted |
| white | 21.00 | 21.00 | collapsed — identical pixels |

On the `white` theme `Qt.darker(#000000, n)` returns `#000000`, so secondary and
primary text were the same pixel value. After this branch the same case measures
21.00 against 9.23.

Separately, `CLAUDE.md` has always required English for active docs, and nothing
enforced it. Portuguese accumulated in `CHANGELOG.md` and ADRs 0001–0003.

## What changed

**Token binding.** All 16 `Qt.darker` calls become `Util.alpha` at one of two
secondary-text levels. Control chrome binds to `Style.selectedFill`,
`Style.selectedBorderColor`, `Style.hoverFill` and `Style.normalBorderColor`.
Six hand-rolled 1px dividers become the host's `PanelSeparator`. The modal scrim
binds to `Color.menu.scrim`. `rg -c 'Qt.darker' assets/omarchy` and
`rg -c 'Qt.rgba' assets/omarchy` now both return nothing.

**Language gate.** `tests/active_language.rs` rejects alphabetic non-ASCII
characters in any tracked file outside `docs/superpowers/**`, with a path-scoped
allowlist carrying reasons. `CHANGELOG.md` and the three ADRs are translated,
and the `CLAUDE.md` carve-out shrinks to the one exemption that is still true.

**Three new gates that did not exist:** language, token binding, and screenshot
list parity.

**One existing gate stopped testing a mock.** `ready-light.png` has rendered
since v10 and never caught the inversion above, because `TestPalette` handed the
fixture a hand-picked `muted` colour with no relationship to the palette's
foreground. It now derives from that foreground, and a `white` case was added —
the theme where the bug was total rather than partial.

## Verification

| | before | after |
| --- | --- | --- |
| `cargo test` | 283 in 12 suites | **287 in 14 suites** |
| `qmltestrunner` | 177 passed | **187 passed, 0 failed** |

`cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`,
`git diff --check`, `qmllint`, `omarchy plugin validate` and
`scripts/verify-v10-ui` all clean.

`A11Y-013` and `TEST-029` pass untouched — no plugin-authored motion was
introduced.

## Notes for review

Six defects surfaced during execution and were fixed. Five originated in the
implementation plan rather than the code, and all six share one shape: source
that reads correctly but behaves differently at runtime, invisible to tests that
read code as text. Two examples worth knowing, because plans 02 through 05 touch
the same surfaces:

- The scrim was `Qt.rgba(0, 0, 0, 0.45)`, pure black. The plan described it as
  foreground-derived, which on a dark theme would have **brightened** the
  content behind a modal instead of dimming it. No source-scanning test can see
  a colour inversion.
- `Style.selectedBorderColor` resolves to alpha 1.0, not the ~0.3 the literal it
  replaced used. The theme sets `selected-border-width = 0`, meaning native
  components draw no selected border at all; the rail was overriding that with a
  hardcoded `1`. It now binds to `Style.selectedBorderWidth`, so a theme that
  wants a ring still gets one.

Thirteen minor findings were triaged and deliberately deferred; they are listed
with rationale at the end of the plan. The one worth watching in later plans:
the text-alpha exception mechanism constrains values, not growth of the
exception list itself.

## Reading order

- `docs/superpowers/specs/2026-07-30-visual-update-design.md` — section 4 is the
  token binding this branch implements
- `docs/superpowers/specs/2026-07-30-copy-and-language-design.md` — section 3 is
  the language gate
- `docs/superpowers/plans/2026-07-30-v11-01-foundation-tokens-language.md` — the
  executed plan, with the execution record appended


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Visual Improvements**
  * Refined popup, provider, settings, maintenance, and usage-window styling for more consistent themes.
  * Improved contrast and transparency for secondary text, status messages, dividers, borders, and dialog overlays.
  * Added support for a dedicated light “white” screenshot theme.

* **Documentation**
  * Updated historical release notes and architecture documentation in English.
  * Clarified CLI help, configuration behavior, and language guidelines.

* **Tests**
  * Added checks for active-language content, theme token consistency, contrast, and screenshot coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->