### PR TITLE
v11 visual update plan 03: popup rail, tags, copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ collection, cache, settings, and safe maintenance.
 
 - One bar chip per enabled provider.
 - Used or remaining percentage.
-- Plan and connection state.
+- Plan tag and typed provider states.
 - Normalized quota windows and reset times.
 - Loading, stale, missing CLI, unauthenticated, rate-limit, network, and
   provider-error states.

--- a/assets/omarchy/CoreView.js
+++ b/assets/omarchy/CoreView.js
@@ -106,6 +106,16 @@ function chipPercentText(provider, metric) {
   return Math.round(v) + "%"
 }
 
+// Typed error/collection-failure states shared by the chip cue and the
+// tooltip/copy qualifiers (plan 03 §5.1-5.3).
+var ERROR_STATES = {
+  "cli_missing": true,
+  "unauthenticated": true,
+  "rate_limited": true,
+  "network_error": true,
+  "provider_error": true
+}
+
 // UX-012: text cue beyond color for stale/error. No leading space — the
 // chip separates cue from numeral with layout spacing (visual design §5).
 // 󰅐 is U+F0150 from the bar's Nerd Font family, replacing the old
@@ -116,10 +126,19 @@ function chipStateCue(provider) {
   var state = String(provider.state || "")
   if (state === "stale")
     return "󰅐"
-  if (state === "cli_missing" || state === "unauthenticated" || state === "rate_limited"
-      || state === "network_error" || state === "provider_error")
+  if (ERROR_STATES[state])
     return "!"
   return ""
+}
+
+var STATE_QUALIFIERS = {
+  "stale": "stale",
+  "loading": "loading",
+  "cli_missing": "no CLI",
+  "unauthenticated": "signed out",
+  "rate_limited": "rate limited",
+  "network_error": "offline",
+  "provider_error": "failed"
 }
 
 // Copy design §5.4: lowercase trailing qualifier for the chip tooltip.
@@ -129,20 +148,8 @@ function stateQualifier(state) {
   var s = String(state || "")
   if (s === "ready")
     return ""
-  if (s === "stale")
-    return "stale"
-  if (s === "loading")
-    return "loading"
-  if (s === "cli_missing")
-    return "no CLI"
-  if (s === "unauthenticated")
-    return "signed out"
-  if (s === "rate_limited")
-    return "rate limited"
-  if (s === "network_error")
-    return "offline"
-  if (s === "provider_error")
-    return "failed"
+  if (STATE_QUALIFIERS[s] !== undefined)
+    return STATE_QUALIFIERS[s]
   return "unknown"
 }
 
@@ -262,27 +269,6 @@ function resolveSelectedProvider(snapshot, selectedProviderId, settings) {
   return chips[0]
 }
 
-function connectionLabel(state) {
-  var s = String(state || "")
-  if (s === "ready")
-    return "Connected"
-  if (s === "stale")
-    return "Stale"
-  if (s === "loading")
-    return "Loading"
-  if (s === "cli_missing")
-    return "CLI missing"
-  if (s === "unauthenticated")
-    return "Not connected"
-  if (s === "rate_limited")
-    return "Rate limited"
-  if (s === "network_error")
-    return "Network error"
-  if (s === "provider_error")
-    return "Provider error"
-  return "Unknown"
-}
-
 function planBadge(provider) {
   if (!provider || !provider.plan)
     return ""
@@ -316,67 +302,51 @@ function containsMoneyCopy(text) {
 }
 
 function emptyWindowsMessage() {
-  return "Percentage usage is not available for this account"
+  return "This account is billed another way."
 }
 
 function stateTitle(provider) {
   if (!provider)
-    return "Loading"
+    return ""
+  var name = plainText(provider.name || providerDisplayName(provider.id))
   var s = String(provider.state || "")
-  if (s === "loading")
-    return "Loading"
+  if (s === "loading" || s === "stale")
+    return ""
   if (s === "ready" && (!provider.windows || provider.windows.length === 0))
-    return "No percentage usage"
-  if (s === "stale")
-    return "Stale"
+    return name + " reports no quota"
+  if (s === "ready")
+    return ""
   if (s === "cli_missing")
-    return "CLI not found"
+    return name + " CLI is not installed"
   if (s === "unauthenticated")
-    return "Authentication required"
+    return "Not signed in to " + name
   if (s === "rate_limited")
-    return "Rate limited"
+    return name + " hit a rate limit"
   if (s === "network_error")
-    return "Network error"
+    return "Cannot reach " + name
   if (s === "provider_error")
-    return "Provider error"
-  return connectionLabel(s)
+    return name + " returned no limits"
+  return name + " state is unknown"
 }
 
 function stateBody(provider) {
   if (!provider)
-    return "Collecting provider status\u2026"
+    return ""
+  var name = plainText(provider.name || providerDisplayName(provider.id))
   var s = String(provider.state || "")
-  if (s === "loading")
-    return "Collecting provider status\u2026"
   if (s === "ready" && (!provider.windows || provider.windows.length === 0))
     return emptyWindowsMessage()
-  if (s === "stale") {
-    var base = "Showing the last successful result."
-    var err = errorMessage(provider)
-    if (err.length)
-      return base + " " + err
-    return base
-  }
-  if (s === "cli_missing") {
-    var cli = errorMessage(provider)
-    return cli.length ? cli : "Required CLI was not found."
-  }
-  if (s === "unauthenticated") {
-    var auth = errorMessage(provider)
-    return auth.length ? auth : "Sign in to collect usage."
-  }
-  if (s === "rate_limited") {
-    var rl = errorMessage(provider)
-    return rl.length ? rl : "The provider rate-limited this request. Try again shortly."
-  }
-  if (s === "network_error") {
-    var net = errorMessage(provider)
-    return net.length ? net : "A temporary network error prevented collection."
-  }
-  if (s === "provider_error") {
-    var pe = errorMessage(provider)
-    return pe.length ? pe : "The provider returned an unusable response."
-  }
+  var err = errorMessage(provider)
+  if (err.length)
+    return err
+  if (s === "cli_missing")
+    return "Agent Bar reads the quota through it."
+  if (s === "unauthenticated")
+    return "Signing in opens the official " + name + " CLI."
+  if (s === "rate_limited")
+    return "Try again in a few minutes."
+  if (s === "network_error")
+    return "Check your connection."
   return ""
 }
 
@@ -384,9 +354,9 @@ function defaultActionLabel(kind) {
   if (kind === "retry")
     return "Retry"
   if (kind === "login")
-    return "Connect"
+    return "Sign in"
   if (kind === "view_installation")
-    return "View installation"
+    return "Install guide"
   return String(kind || "")
 }
 
@@ -418,7 +388,7 @@ function stateActions(provider) {
   if (state === "stale" || state === "rate_limited" || state === "network_error" || state === "provider_error")
     pushAction("retry", "Retry", null)
   if (state === "unauthenticated" && !seen.login && !seen.view_installation)
-    pushAction("login", "Connect", null)
+    pushAction("login", "Sign in", null)
 
   // JSON-025 addendum: a typed non-retryable error must never offer Retry,
   // regardless of which branch above produced it.
@@ -545,7 +515,6 @@ function headerModel(provider, refreshing) {
     return {
       name: "",
       plan: "",
-      connection: "Loading",
       lastSuccessAt: null,
       refreshing: !!refreshing,
       showStale: false
@@ -554,7 +523,6 @@ function headerModel(provider, refreshing) {
   return {
     name: plainText(provider.name || providerDisplayName(provider.id)),
     plan: plainText(planBadge(provider)),
-    connection: connectionLabel(provider.state),
     lastSuccessAt: provider.lastSuccessAt ? String(provider.lastSuccessAt) : null,
     refreshing: !!refreshing,
     showStale: String(provider.state) === "stale"

--- a/assets/omarchy/CoreView.js
+++ b/assets/omarchy/CoreView.js
@@ -334,6 +334,8 @@ function stateBody(provider) {
     return ""
   var name = plainText(provider.name || providerDisplayName(provider.id))
   var s = String(provider.state || "")
+  if (s === "loading" || s === "stale")
+    return ""
   if (s === "ready" && (!provider.windows || provider.windows.length === 0))
     return emptyWindowsMessage()
   var err = errorMessage(provider)

--- a/assets/omarchy/Popup.qml
+++ b/assets/omarchy/Popup.qml
@@ -24,7 +24,7 @@ KeyboardPanel {
   // Compact floor: header + one window row + rail stack — not a 280px void.
   property int minContentHeight: Style.space(160)
   property int contentLineHeight: Style.font.body + Style.space(8)
-  property int contentMargins: Style.space(14)
+  property int contentMargins: Style.spacing.popupPadding
 
   // A11Y-008: Settings/NumberField can raise this while editing.
   property bool editorActive: contentLoader.item && contentLoader.item.editorOwnsFocus

--- a/assets/omarchy/ProviderRail.qml
+++ b/assets/omarchy/ProviderRail.qml
@@ -5,7 +5,8 @@ import qs.Ui
 import "CoreView.js" as Core
 
 // Left rail — stack: providers → spacer → Settings.
-// Horizontal padding is symmetric (slot fits exactly in the frame).
+// No own frame (§6): the card border already bounds the popup, so the slot
+// stack shares the popup's inset token and fits the rail width exactly.
 // Selected = brainstorming “A” plate (soft fill + thin border), only on the
 // active provider id — never a sticky focus ring on Claude.
 Item {
@@ -20,22 +21,19 @@ Item {
   signal providerSelected(string providerId)
   signal settingsClicked()
 
-  readonly property int outerMargin: Style.space(4)
-  readonly property int framePad: Style.space(8)
   readonly property int slotSize: Style.space(32)
   readonly property int iconSize: 16
   readonly property int stackGap: Style.space(8)
   readonly property int spacerMin: Style.space(4)
 
-  // outer + pad + slot + pad + outer — equal L/R inset around each icon.
-  readonly property int railWidth: outerMargin * 2 + framePad * 2 + slotSize
+  // No own frame (§6) — the slot fits exactly, horizontal inset is 0.
+  readonly property int railWidth: slotSize
 
   readonly property int minStackHeight: {
     var n = providers && providers.length ? providers.length : 0
     var slots = n + 1
     var gaps = n + 1 // n providers + spacer + settings → n+2 items → n+1 gaps
-    return outerMargin * 2
-        + framePad * 2
+    return Style.spacing.popupPadding * 2
         + slots * slotSize
         + gaps * stackGap
         + spacerMin
@@ -81,24 +79,11 @@ Item {
     _railFocusItems = next
   }
 
-  Rectangle {
-    id: frame
-    anchors.fill: parent
-    anchors.margins: root.outerMargin
-    color: Style.normalFill
-    border.width: 1
-    border.color: Style.normalBorderColor
-    radius: Style.cornerRadius
-    clip: true
-  }
-
   ColumnLayout {
     id: stack
-    anchors.fill: frame
-    anchors.topMargin: root.framePad
-    anchors.bottomMargin: root.framePad
-    anchors.leftMargin: root.framePad
-    anchors.rightMargin: root.framePad
+    anchors.fill: parent
+    anchors.topMargin: Style.spacing.popupPadding
+    anchors.bottomMargin: Style.spacing.popupPadding
     spacing: root.stackGap
 
     Repeater {

--- a/assets/omarchy/ProviderView.qml
+++ b/assets/omarchy/ProviderView.qml
@@ -84,7 +84,7 @@ Item {
     // Never color-only (A11Y-012): glyph and words, urgent-tinted per the
     // approved mockup.
     Row {
-      visible: root.provider && String(root.provider.state || "") === "stale"
+      visible: root.isStale
       width: parent.width
       spacing: Style.space(8)
 

--- a/assets/omarchy/ProviderView.qml
+++ b/assets/omarchy/ProviderView.qml
@@ -6,7 +6,9 @@ import "components"
 
 // Single selected-provider content pane, "Camadas" (Fase 2):
 // header -> [stale banner] -> primary windows (large) -> model list (quiet)
-// -> state message (non-window modes) -> meta footer.
+// -> state message (non-window, non-stale modes). Plan 03 removed the meta
+// footer; last-success age now lives in the stale banner and is otherwise
+// implied structurally (windows render only when ready).
 Item {
   id: root
 
@@ -40,7 +42,13 @@ Item {
   readonly property string mode: Core.contentMode(provider)
   readonly property var groups: Core.windowGroups(provider, displayMetric, nowMs)
   readonly property var actions: Core.stateActions(provider)
-  readonly property bool isStale: root.mode === "stale_windows"
+  // Adjusted (plan 03): was mode === "stale_windows" only, which fed the
+  // banner's Retry Repeater and left the no-windows stale mode ("state")
+  // without a Retry control. Both stale modes share one provider.state
+  // check; dimmed: root.isStale on the windows Column is unaffected since
+  // that Column is only visible in the "windows"/"stale_windows" modes,
+  // where state === "stale" iff mode === "stale_windows" anyway.
+  readonly property bool isStale: String(root.provider && root.provider.state || "") === "stale"
   readonly property string unitText: root.displayMetric === "used" ? "used" : "left"
   readonly property color accentColor: Color.accent
 
@@ -72,15 +80,17 @@ Item {
       foreground: root.foreground
     }
 
-    // Stale banner: glyph + typed message + Retry (never color-only).
+    // Stale banner (UX-028): carries last-success age + safe error + Retry.
+    // Never color-only (A11Y-012): glyph and words, urgent-tinted per the
+    // approved mockup.
     Row {
-      visible: root.isStale
+      visible: root.provider && String(root.provider.state || "") === "stale"
       width: parent.width
       spacing: Style.space(8)
 
       Text {
-        text: "⌛"
-        color: root.foreground
+        text: "󰅐"
+        color: Color.urgent
         font.family: root.fontFamily
         font.pixelSize: Style.font.body
         textFormat: Text.PlainText
@@ -88,8 +98,16 @@ Item {
       }
       Text {
         width: Math.max(0, parent.width - Style.space(120))
-        text: "Stale — " + Core.errorMessage(root.provider)
-        color: root.foreground
+        text: {
+          var age = Core.formatAgoText(
+            root.header.lastSuccessAt ? root.header.lastSuccessAt : "", root.nowMs)
+          var line = "Last data " + (age.length ? age : "unknown")
+          var err = Core.errorMessage(root.provider)
+          if (err.length)
+            line += " · " + err
+          return line
+        }
+        color: Color.urgent
         font.family: root.fontFamily
         font.pixelSize: Style.font.caption
         wrapMode: Text.WordWrap
@@ -185,7 +203,8 @@ Item {
 
     StateMessage {
       width: parent.width
-      visible: root.mode === "skeleton" || root.mode === "empty_windows" || root.mode === "state"
+      visible: (root.mode === "skeleton" || root.mode === "empty_windows" || root.mode === "state")
+          && String(root.provider && root.provider.state || "") !== "stale"
       skeleton: root.mode === "skeleton"
       title: root.mode === "skeleton" ? "" : Core.stateTitle(root.provider)
       body: root.mode === "skeleton" ? "" : Core.stateBody(root.provider)
@@ -196,47 +215,6 @@ Item {
         if (!root.provider)
           return
         root.actionRequested(String(root.provider.id), kind, target)
-      }
-    }
-
-    // Meta footer: age + source left, connection right (was header noise).
-    Row {
-      width: parent.width
-      visible: root.mode === "windows" || root.mode === "stale_windows"
-
-      Text {
-        id: footerLeft
-        width: Math.max(0, parent.width * 0.6)
-        text: {
-          var parts = []
-          var age = Core.formatAgoText(
-            root.header.lastSuccessAt ? root.header.lastSuccessAt : "", root.nowMs)
-          if (age.length)
-            parts.push("Updated " + age)
-          if (root.provider && root.provider.source)
-            parts.push(String(root.provider.source) === "cache" ? "Cache" : "Live")
-          if (root.header.refreshing)
-            parts.push("refreshing…")
-          return parts.join(" · ")
-        }
-        color: Util.alpha(root.foreground, 0.55)
-        font.family: root.fontFamily
-        font.pixelSize: Style.font.caption
-        elide: Text.ElideRight
-        textFormat: Text.PlainText
-        Accessible.name: text
-      }
-      Text {
-        width: Math.max(0, parent.width - footerLeft.width)
-        text: root.header.connection
-        color: Util.alpha(root.foreground, root.header.showStale ? 0.72 : 0.55)
-        font.family: root.fontFamily
-        font.pixelSize: Style.font.caption
-        font.bold: root.header.showStale
-        horizontalAlignment: Text.AlignRight
-        elide: Text.ElideRight
-        textFormat: Text.PlainText
-        Accessible.name: text
       }
     }
   }

--- a/assets/omarchy/components/ProviderHeader.qml
+++ b/assets/omarchy/components/ProviderHeader.qml
@@ -46,7 +46,7 @@ Item {
       anchors.verticalCenter: parent.verticalCenter
       width: planText.implicitWidth + Style.space(10)
       height: planText.implicitHeight + Style.space(4)
-      radius: height / 2
+      radius: Style.cornerRadius
       color: "transparent"
       border.width: 1
       border.color: Style.normalBorderColor
@@ -57,6 +57,8 @@ Item {
         color: Util.alpha(root.foreground, 0.72)
         font.family: root.fontFamily
         font.pixelSize: Style.font.caption
+        font.capitalization: Font.AllUppercase
+        font.letterSpacing: 0.5
         textFormat: Text.PlainText
         Accessible.name: "plan " + root.plan
       }

--- a/assets/omarchy/components/ProviderHeader.qml
+++ b/assets/omarchy/components/ProviderHeader.qml
@@ -3,7 +3,8 @@ import qs.Commons
 import qs.Ui
 
 // Provider content header — name, plan pill, refresh only (Fase 2 slim-down).
-// Connection and "Updated" age moved to ProviderView's meta footer.
+// Connection state is implied structurally (UX-017); last-success age
+// appears in the stale banner, not here.
 // UX-016: deliberately no provider icon here (icon lives only on the rail).
 Item {
   id: root

--- a/docs/specs/v10/01-product-contract.md
+++ b/docs/specs/v10/01-product-contract.md
@@ -68,8 +68,9 @@ Notifications: enabled
 
 1. The bar shows one compact chip per enabled provider.
 2. Left-clicking a chip opens that provider in the consolidated popup.
-3. The popup shows plan, connection state, usage windows, reset times, update
-   age, and typed error/action state.
+3. The popup shows plan, usage windows, reset times, and typed error/action
+   state; connection state is implied structurally and the last-success age
+   appears in the stale banner.
 4. Clicking the same chip closes the popup; clicking another chip switches
    provider without closing it.
 

--- a/docs/specs/v10/01-product-contract.md
+++ b/docs/specs/v10/01-product-contract.md
@@ -120,4 +120,4 @@ Notifications: enabled
 - `PROD-030`: The plugin must never display an empty or silently malformed
   status result.
 - `PROD-031`: A connected provider with no percentage window shows `—` in its
-  chip and `Percentage usage is not available for this account` in its popup.
+  chip and `This account is billed another way.` in its popup.

--- a/docs/specs/v10/01-product-contract.md
+++ b/docs/specs/v10/01-product-contract.md
@@ -80,10 +80,10 @@ Notifications: enabled
 3. Middle-clicking any bar chip bypasses cache for all enabled providers once.
 4. Concurrent forced requests are coalesced without being discarded.
 
-### Connect
+### Sign in
 
-1. A detected but unauthenticated provider shows `Connect` when login
-   discovery succeeds; otherwise it shows `View installation`.
+1. A detected but unauthenticated provider shows `Sign in` when login
+   discovery succeeds; otherwise it shows `Install guide`.
 2. The action opens the configured terminal through the bundled Bash helper.
 3. The private Rust helper delegates to the provider's official login command.
 4. Success preserves the provider command's meaningful status and forces a

--- a/docs/specs/v10/03-cli-and-json-contract.md
+++ b/docs/specs/v10/03-cli-and-json-contract.md
@@ -253,7 +253,7 @@ to `cli_missing`.
   },
   "action": {
     "kind": "view_installation",
-    "label": "View installation",
+    "label": "Install guide",
     "target": "https://ampcode.com/manual"
   }
 }

--- a/docs/specs/v10/04-quickshell-ux-and-accessibility.md
+++ b/docs/specs/v10/04-quickshell-ux-and-accessibility.md
@@ -49,8 +49,9 @@ not literal UI.
 
 - `UX-013`: The left rail is visually separate and uses provider icons only.
 - `UX-014`: Provider names are available through tooltips and accessibility.
-- `UX-015`: Settings is the last control in the rail stack (equal frame
-  padding top and bottom; not overlaid with `anchors.bottom` on short cards).
+- `UX-015`: Settings is the last control in the rail stack (the stack shares
+  the popup content inset top and bottom; not overlaid with
+  `anchors.bottom` on short cards).
 - `UX-016`: The provider header does not repeat the provider icon.
 - `UX-017`: The header shows the provider name, the plan tag, severity when
   present, and the provider refresh control. Connection state is implied
@@ -79,8 +80,9 @@ not literal UI.
 - `UX-026`: Initial collection with no prior data uses skeleton placeholders.
 - `UX-027`: Refresh with prior data keeps content and shows a subtle progress
   indicator.
-- `UX-028`: Stale content stays visible with a visible `Stale` label, last
-  success age, and safe error summary.
+- `UX-028`: Stale content stays visible. The stale banner carries the
+  `󰅐` cue, the last success age, the safe error summary, and Retry; it
+  renders whenever the provider state is stale.
 - `UX-029`: Missing CLI keeps the enabled provider icon dimmed and shows
   `Install guide` and `Check again`.
 - `UX-030`: Unauthenticated shows `Sign in` when login discovery succeeds;
@@ -89,8 +91,7 @@ not literal UI.
   not imply authentication failure.
 - `UX-032`: Provider errors never render raw stderr or rich text.
 - `UX-032A`: A ready provider with no normalized percentage window shows `—`
-  in its chip and `Percentage usage is not available for this account` in the
-  popup.
+  in its chip and `This account is billed another way.` in the popup.
 
 ## Settings
 

--- a/docs/specs/v10/04-quickshell-ux-and-accessibility.md
+++ b/docs/specs/v10/04-quickshell-ux-and-accessibility.md
@@ -80,9 +80,9 @@ not literal UI.
 - `UX-028`: Stale content stays visible with a visible `Stale` label, last
   success age, and safe error summary.
 - `UX-029`: Missing CLI keeps the enabled provider icon dimmed and shows
-  `View installation` and `Check again`.
-- `UX-030`: Unauthenticated shows `Connect` when login discovery succeeds;
-  otherwise it shows `View installation`.
+  `Install guide` and `Check again`.
+- `UX-030`: Unauthenticated shows `Sign in` when login discovery succeeds;
+  otherwise it shows `Install guide`.
 - `UX-031`: Network and rate-limit screens distinguish retryable state and do
   not imply authentication failure.
 - `UX-032`: Provider errors never render raw stderr or rich text.
@@ -147,7 +147,7 @@ Requirements:
 - `UX-051`: Refresh uses `󰑐`.
 - `UX-052`: Settings uses `󰒓`.
 - `UX-053`: Navigation uses Quattro's verified native chevrons.
-- `UX-054`: `Connect`, `Save changes`, and `Restore defaults` use text labels.
+- `UX-054`: `Sign in`, `Save changes`, and `Restore defaults` use text labels.
 - `UX-055`: Delete the v9 custom `IconButton` and its mixed Unicode/Font
   Awesome codepoint table.
 - `UX-056`: Color, typography, spacing, radius, and focus use the values and

--- a/docs/specs/v10/04-quickshell-ux-and-accessibility.md
+++ b/docs/specs/v10/04-quickshell-ux-and-accessibility.md
@@ -52,8 +52,10 @@ not literal UI.
 - `UX-015`: Settings is the last control in the rail stack (equal frame
   padding top and bottom; not overlaid with `anchors.bottom` on short cards).
 - `UX-016`: The provider header does not repeat the provider icon.
-- `UX-017`: The header shows name, plan badge, connection state, update age,
-  and provider refresh.
+- `UX-017`: The header shows the provider name, the plan tag, severity when
+  present, and the provider refresh control. Connection state is implied
+  structurally (windows render only when ready) and update age lives in the
+  stale banner.
 - `UX-018`: Only one provider's content is visible at a time.
 - `UX-019`: Section backgrounds and separators extend through the full content
   width.

--- a/docs/superpowers/plans/2026-07-30-v11-03-popup.md
+++ b/docs/superpowers/plans/2026-07-30-v11-03-popup.md
@@ -1,0 +1,553 @@
+# v11 Popup — Rail, Header Tag, Footer Removal, Stale Banner, Typed-State Copy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Align the popup rail with the content on one shared inset (deleting the rail's own frame), turn the plan pill into an uppercase tag, remove the meta footer in all states, move last-success age into the stale banner, and rewrite the typed-state copy to the approved voice.
+
+**Architecture:** All copy lives in `CoreView.js` pure functions (`stateTitle`, `stateBody`, `defaultActionLabel`) locked by direct-JS tests; `connectionLabel` and `headerModel.connection` are deleted with the footer, completing the plan-02 seam — `stateQualifier` becomes the only state humaniser. Layout changes are confined to `ProviderRail.qml` (frame deletion, shared inset), `ProviderHeader.qml` (tag), `ProviderView.qml` (footer removal, banner), `Popup.qml` (inset token). The screenshot mirror's hardcoded strings are synced by hand — they do not follow `CoreView.js`.
+
+**Tech Stack:** QML (Qt 6, Quickshell/Quattro host at `/usr/share/omarchy/shell`), qmltestrunner (Qt 6 binary path only), no Rust behavior changes.
+
+## Global Constraints
+
+- Contract: `CLAUDE.md` at repo root; product contract: `docs/specs/v10/` plus the approved designs `docs/superpowers/specs/2026-07-30-visual-update-design.md` (§2.5, §6, §9) and `docs/superpowers/specs/2026-07-30-copy-and-language-design.md` (§4 voice, §5.1–5.3).
+- All shipped UI copy is English. The language gate flags alphabetic non-ASCII only; `󰅐` (U+F0150), `·`, `—`, `…` pass by design.
+- A11Y-012: no provider state is color-only (the stale banner keeps glyph + words). A11Y-013 / TEST-029: no plugin-authored `Behavior`/`Transition`/animation.
+- Test files must never `import qs.Commons` or `qs.Ui` — the pure Qt 6 runner cannot resolve the module and the whole file stops compiling with a misleading error. No test in this repo instantiates the real popup components; everything is XHR text-scan or direct JS calls (`tst_ProviderStates.qml:220-227` documents this).
+- `qmltestrunner` from `PATH` is Qt 5 and fails silently. Always:
+  ```bash
+  QT_QPA_PLATFORM=offscreen QML_XHR_ALLOW_FILE_READ=1 QT_LOGGING_TO_CONSOLE=1 \
+    /usr/lib/qt6/bin/qmltestrunner -input tests/qml \
+    -import /usr/share/omarchy/shell -import assets/omarchy -o -,txt
+  ```
+  The bar is **0 failed** plus named tests printing `PASS`; never chase an exact total.
+- `cargo test` accepts ONE filter per invocation. Baseline after plan 02: **288 Rust tests / 15 suites, 192 QML**.
+- Checkpoint gates: `cargo fmt --check` · `cargo test` · `cargo clippy --all-targets -- -D warnings` · `git diff --check` · `qmllint -I /usr/share/omarchy/shell` over `assets/omarchy/**/*.qml` · `omarchy plugin validate assets/omarchy` · the qmltestrunner line above · `scripts/verify-v10-ui`.
+- Commits: English Conventional Commit subject ≤ 50 chars. Never any AI-attribution text.
+- The plan-01/02 defect pattern applies: *source that reads correctly and behaves differently at runtime.* Resolve every token to its runtime value. `Style.cornerRadius` defaults to **0** (square); themes override it — the tag's rounding is host-owned, never compensate.
+- `tst_Tokens.qml` locks the popup files to the closed `Util.alpha` set {0.55, 0.72} (plus the named `UsageWindow` 0.12 exception). Banner and tag must use one of the two approved roles — no third value, no new exception.
+- Closed decisions (do not reopen): footer removed in ALL states; plan badge becomes a tag, not a pill; "Providers" stays; lead-window layout + election are plan 04; severity tag is plan 04; motion host-owned.
+
+## Measured facts (2026-07-31, this machine)
+
+1. Host `KeyboardPanel` (`/usr/share/omarchy/shell/Ui/KeyboardPanel.qml`): `padding` defaults to `Style.spacing.popupPadding` (14); `verticalContentInset = padding * 2 + borders` (`:138`); the card is a `BorderSurface` with `radius: Style.cornerRadius`. `Popup.qml:90-94` already sizes with `verticalContentInset` (PR #32 lesson — keep it).
+2. Host `PanelSeparator`: `strength` default **0.12**, `width: parent.width`, 1px tall, color `Qt.rgba(foreground…, strength)` internally (host-owned; our files stay free of raw `Qt.rgba`).
+3. The host exports **no Tag/Badge/Pill component** (30 files in `qs.Ui`, none match; the pill-ish components in host plugins are file-local). The tag is `Rectangle` + `Text`, like today's pill at `ProviderHeader.qml:44-63` — only radius, casing, and padding change.
+4. `tst_Screenshots.qml` renders a self-contained mirror with hardcoded `titleText`/`badgeText`/`bodyText` per capture (`paintState`, `:99-177`). Rewriting `CoreView.js` moves NOTHING there; the mirror must be synced in the same task as the copy or every future perceptual review sees dead copy.
+5. `UX-017`'s current text ("header shows name, plan badge, connection state, update age, and provider refresh") is ALREADY false for shipped code — Fase 2 moved connection/age to the meta footer (`ProviderHeader.qml:5-7`), and `tst_Popup.qml:58` asserts the header does NOT contain `connection`. Its amendment is overdue and lands here with the final header shape. The handoff table parked all four §9 amendments in plan 04; the visual design §13.5 principle (amendments land with the phase that changes the behavior) governs instead: UX-017 + UX-028 here, UX-020A extension in plan 04. The copy design §5.3 rename (`Connect` → `Sign in`, `View installation` → `Install guide`) is typed-state copy and ships here, so UX-029/UX-030/UX-054 are amended here too.
+6. Current geometry (visual design §2.5): rail frame starts 18px from card top (KeyboardPanel `padding` 14 + `ProviderRail.outerMargin` 4); content starts 28px (14 + `contentMargins` 14). Target: one shared inset — rail slot stack top edge == content top edge, both `contentMargins` inside the padded card; gutter stays `Style.spacing.lg` (8).
+
+## File Structure
+
+- Modify: `assets/omarchy/CoreView.js` — shared `ERROR_STATES` table; rewrite `stateTitle`, `stateBody`, `defaultActionLabel`, `stateActions` literals; delete `connectionLabel`; drop `headerModel.connection`.
+- Modify: `assets/omarchy/ProviderRail.qml` — frame Rectangle deleted; inset math on shared tokens; selected plate and Settings slot preserved.
+- Modify: `assets/omarchy/ProviderHeader.qml` — pill → uppercase tag.
+- Modify: `assets/omarchy/ProviderView.qml` — footer deleted; stale banner absorbs age + error + Retry with `󰅐`; stale-without-windows renders banner only.
+- Modify: `assets/omarchy/Popup.qml` — `contentMargins` bound to `Style.spacing.popupPadding`.
+- Test: `tests/qml/tst_ProviderStates.qml`, `tests/qml/tst_Popup.qml`, `tests/qml/tst_Accessibility.qml`, `tests/qml/tst_Screenshots.qml`, `tests/qml/tst_BarWidget.qml` (two deferred plan-02 items only).
+- Modify: `docs/specs/v10/04-quickshell-ux-and-accessibility.md` — UX-017, UX-028, UX-029, UX-030, UX-054 amendments.
+
+## Seams with plans 04–05 (do not cross)
+
+- **Lead-window layout and election are plan 04.** `UsageWindow.qml`, `windowGroups`, `PRIMARY_WINDOW_IDS`, the 2.5× numeral, and the compact-row track (UX-020A extension) stay untouched.
+- **Severity is plan 04**: no severity tag, no `Color.urgent` numeral/track, no thresholds. (The stale banner's urgent color is not severity — it is the approved banner treatment from the mockup.)
+- **Notifications and CLI copy are plan 05.**
+- Plan-02 seam closes here: `connectionLabel` deleted; `stateQualifier` is the one humaniser. The chip path is otherwise untouched.
+
+---
+
+### Task 1: CoreView typed-state copy, shared error table, action labels, copy amendments
+
+**Files:**
+- Modify: `assets/omarchy/CoreView.js` (functions `chipStateCue` :109-122, `stateQualifier`, `connectionLabel` :212-231, `stateTitle` :269-290, `stateBody` :292-328, `defaultActionLabel` :330-338, `stateActions` :341-379, `headerModel` :490-509, `emptyWindowsMessage` :265-267 — line numbers as of plan-02 head)
+- Modify: `tests/qml/tst_ProviderStates.qml` (typed-state expectations throughout; `connectionLabel` asserts at :42, :60, :75, :87, :100-101; `headerModel` at :130-138)
+- Modify: `tests/qml/tst_Accessibility.qml:87` (`connectionLabel("stale") === "Stale"`)
+- Modify: `tests/qml/tst_BarWidget.qml` (two deferred plan-02 items — see Step 5)
+- Modify: `tests/qml/tst_ProviderStates.qml:191-194` (rename `test_chip_state_cue_stale_is_hourglass` → `test_chip_state_cue_stale_is_clock_glyph`, deferred item 1)
+- Modify: `docs/specs/v10/04-quickshell-ux-and-accessibility.md` (UX-029 :82-83, UX-030 :84-85, UX-054 :139)
+
+**Interfaces:**
+- Consumes: `providerDisplayName(id)`, `errorMessage(provider)`, `plainText(value)` — unchanged.
+- Produces (Tasks 2–3 and existing consumers rely on these):
+  - `ERROR_STATES` — `{ cli_missing, unauthenticated, rate_limited, network_error, provider_error }`, consumed by `chipStateCue`, `stateQualifier`, and available to plan 04.
+  - `stateTitle(provider) -> string` — new copy (see table below).
+  - `stateBody(provider) -> string` — new copy; provider-supplied `error.message` still wins over the default body (current precedence preserved).
+  - `defaultActionLabel(kind)` — `"Sign in"` for login, `"Install guide"` for view_installation, `"Retry"` unchanged.
+  - `headerModel(provider, refreshing)` — same object WITHOUT the `connection` field.
+  - `connectionLabel` — DELETED. Any caller is a bug.
+
+New copy (copy design §5.1–5.3; `{Name}` = `provider.name || providerDisplayName(id)`):
+
+| state | `stateTitle` | `stateBody` default |
+| --- | --- | --- |
+| loading | `""` (mode is a skeleton; StateMessage hidden) | `""` |
+| ready, no windows | `{Name} reports no quota` | `This account is billed another way.` |
+| stale | `""` (banner carries stale; Task 3) | `""` |
+| cli_missing | `{Name} CLI is not installed` | `Agent Bar reads the quota through it.` |
+| unauthenticated | `Not signed in to {Name}` | `Signing in opens the official {Name} CLI.` |
+| rate_limited | `{Name} hit a rate limit` | `Try again in a few minutes.` |
+| network_error | `Cannot reach {Name}` | `Check your connection.` |
+| provider_error | `{Name} returned no limits` | `""` |
+| anything else | `{Name} state is unknown` | `""` |
+
+`emptyWindowsMessage()` returns the new ready-no-windows body (`This account is billed another way.`) — keep the function, one declaration site.
+
+- [ ] **Step 1: Rewrite the locked expectations (failing tests first)**
+
+In `tests/qml/tst_ProviderStates.qml`: delete every `Core.connectionLabel(...)` assertion (:42, :60, :75, :87, :100-101) — where a test loses its only assertion, replace with the new `stateTitle`/`stateBody` expectations for that state using the fixture's provider name. Update `test_empty_windows_ready_message` (:50-55) to the new strings; `test_stale_retains_windows_and_label` keeps the `retry`-action assert but swaps the title assert for `compare(Core.stateTitle(p), "")`; `test_header_model_fields` (:130-138) drops the `connection` compare and asserts `h.connection === undefined`. Add exact-string tests, one per state, e.g.:
+
+```js
+function test_state_copy_cli_missing() {
+  var p = { id: "grok", name: "Grok", state: "cli_missing", windows: [], error: null }
+  compare(Core.stateTitle(p), "Grok CLI is not installed")
+  compare(Core.stateBody(p), "Agent Bar reads the quota through it.")
+}
+
+function test_state_copy_unauthenticated() {
+  var p = { id: "claude", name: "Claude", state: "unauthenticated", windows: [], error: null }
+  compare(Core.stateTitle(p), "Not signed in to Claude")
+  compare(Core.stateBody(p), "Signing in opens the official Claude CLI.")
+}
+
+function test_state_copy_rate_limited() {
+  var p = { id: "codex", name: "Codex", state: "rate_limited", windows: [], error: null }
+  compare(Core.stateTitle(p), "Codex hit a rate limit")
+  compare(Core.stateBody(p), "Try again in a few minutes.")
+}
+
+function test_state_copy_network_error() {
+  var p = { id: "amp", name: "Amp", state: "network_error", windows: [], error: null }
+  compare(Core.stateTitle(p), "Cannot reach Amp")
+  compare(Core.stateBody(p), "Check your connection.")
+}
+
+function test_state_copy_provider_error_and_unknown() {
+  var pe = { id: "amp", name: "Amp", state: "provider_error", windows: [], error: null }
+  compare(Core.stateTitle(pe), "Amp returned no limits")
+  compare(Core.stateBody(pe), "")
+  var unk = { id: "claude", name: "Claude", state: "weird", windows: [], error: null }
+  compare(Core.stateTitle(unk), "Claude state is unknown")
+}
+
+function test_state_copy_ready_no_quota() {
+  var p = { id: "claude", name: "Claude", state: "ready", windows: [], error: null }
+  compare(Core.stateTitle(p), "Claude reports no quota")
+  compare(Core.stateBody(p), "This account is billed another way.")
+}
+
+function test_state_body_error_message_precedence() {
+  var p = { id: "grok", name: "Grok", state: "network_error", windows: [],
+            error: { message: "DNS lookup failed.", retryable: true } }
+  compare(Core.stateBody(p), "DNS lookup failed.")
+}
+
+function test_action_labels_renamed() {
+  var auth = { id: "claude", name: "Claude", state: "unauthenticated", windows: [], error: null, action: null }
+  var labels = Core.stateActions(auth).map(function (a) { return a.label })
+  verify(labels.indexOf("Sign in") >= 0)
+  verify(labels.indexOf("Connect") < 0)
+  var cli = { id: "grok", name: "Grok", state: "cli_missing", windows: [], error: { message: "", retryable: false },
+              action: { kind: "view_installation", label: "", target: "https://example.com" } }
+  var cliLabels = Core.stateActions(cli).map(function (a) { return a.label })
+  verify(cliLabels.indexOf("Install guide") >= 0)
+  verify(cliLabels.indexOf("Check again") >= 0)
+}
+```
+
+In `tests/qml/tst_Accessibility.qml:87`, replace the `connectionLabel` compare with `compare(Core.stateQualifier("stale"), "stale")` (same A11Y intent: stale carries words, not color alone; the banner test in Task 3 covers the rendered surface).
+
+- [ ] **Step 2: Plan-02 deferred items in `tests/qml/tst_BarWidget.qml`** (test-only, same commit)
+
+Add to the existing guard test (`test_source_chip_is_widgetbutton_no_wheel`), in the BarWidget.qml section:
+
+```js
+  // WidgetButton's vertical/barSize are readonly; qmllint is verifiably
+  // silent on assigning them (plan-02 finding) — failure would be runtime-only.
+  verify(widget.indexOf("vertical: root.vertical") < 0)
+  verify(widget.indexOf("barSize: root.barSize") < 0)
+  verify(widget.indexOf("fontPixelSize:") < 0)
+```
+
+And rename `test_chip_state_cue_stale_is_hourglass` (tst_ProviderStates.qml:191) to `test_chip_state_cue_stale_is_clock_glyph`.
+
+- [ ] **Step 3: Run the QML suite — confirm intended failures**
+
+Run the Global Constraints qmltestrunner line. Expected: the rewritten/new copy tests FAIL (old strings still live); the two BarWidget guard additions PASS already (no such bindings exist — they are regression tripwires, note this in the report).
+
+- [ ] **Step 4: Implement in `assets/omarchy/CoreView.js`**
+
+Add the shared table and rewrite (keep `plainText`/`errorMessage` untouched):
+
+```js
+var ERROR_STATES = {
+  "cli_missing": true,
+  "unauthenticated": true,
+  "rate_limited": true,
+  "network_error": true,
+  "provider_error": true
+}
+```
+
+`chipStateCue`: replace the five-way `||` chain with `if (ERROR_STATES[state]) return "!"`. `stateQualifier`: replace the five parallel ifs for those states with a lookup:
+
+```js
+var STATE_QUALIFIERS = {
+  "stale": "stale",
+  "loading": "loading",
+  "cli_missing": "no CLI",
+  "unauthenticated": "signed out",
+  "rate_limited": "rate limited",
+  "network_error": "offline",
+  "provider_error": "failed"
+}
+
+function stateQualifier(state) {
+  var s = String(state || "")
+  if (s === "ready")
+    return ""
+  if (STATE_QUALIFIERS[s] !== undefined)
+    return STATE_QUALIFIERS[s]
+  return "unknown"
+}
+```
+
+Delete `connectionLabel` (:212-231). Rewrite `stateTitle`/`stateBody` per the table (title falls back to `providerName + " state is unknown"`; the old `connectionLabel(s)` fallback is gone). `emptyWindowsMessage()` returns `"This account is billed another way."`. `defaultActionLabel`: `login` → `"Sign in"`, `view_installation` → `"Install guide"`. In `stateActions`, the explicit `pushAction("login", "Connect", null)` literal (:368) becomes `pushAction("login", "Sign in", null)`; `"Check again"` and `"Retry"` literals stay. `headerModel`: remove the `connection:` field from both return objects.
+
+```js
+function stateTitle(provider) {
+  if (!provider)
+    return ""
+  var name = plainText(provider.name || providerDisplayName(provider.id))
+  var s = String(provider.state || "")
+  if (s === "loading" || s === "stale")
+    return ""
+  if (s === "ready" && (!provider.windows || provider.windows.length === 0))
+    return name + " reports no quota"
+  if (s === "ready")
+    return ""
+  if (s === "cli_missing")
+    return name + " CLI is not installed"
+  if (s === "unauthenticated")
+    return "Not signed in to " + name
+  if (s === "rate_limited")
+    return name + " hit a rate limit"
+  if (s === "network_error")
+    return "Cannot reach " + name
+  if (s === "provider_error")
+    return name + " returned no limits"
+  return name + " state is unknown"
+}
+
+function stateBody(provider) {
+  if (!provider)
+    return ""
+  var name = plainText(provider.name || providerDisplayName(provider.id))
+  var s = String(provider.state || "")
+  if (s === "ready" && (!provider.windows || provider.windows.length === 0))
+    return emptyWindowsMessage()
+  var err = errorMessage(provider)
+  if (err.length)
+    return err
+  if (s === "cli_missing")
+    return "Agent Bar reads the quota through it."
+  if (s === "unauthenticated")
+    return "Signing in opens the official " + name + " CLI."
+  if (s === "rate_limited")
+    return "Try again in a few minutes."
+  if (s === "network_error")
+    return "Check your connection."
+  return ""
+}
+```
+
+Note the precedence change is only structural: error message wins for every error state, as before; `loading`/`stale` return `""` because the skeleton and the banner own those surfaces.
+
+- [ ] **Step 5: Run the QML suite — 0 failed**
+
+- [ ] **Step 6: Amend the action rules**
+
+In `docs/specs/v10/04-quickshell-ux-and-accessibility.md`:
+- UX-029 (:82-83): replace `View installation` with `Install guide` (both occurrences in the rule text), keep `Check again`.
+- UX-030 (:84-85): replace `Connect` with `Sign in` and `View installation` with `Install guide`.
+- UX-054 (:139): replace `Connect` with `Sign in` in the label list.
+Each amendment is a wording swap only — do not restructure the rules.
+
+- [ ] **Step 7: Rust gates**
+
+```bash
+cargo fmt --check && cargo test && cargo clippy --all-targets -- -D warnings && git diff --check
+```
+Expected: 288/15 unchanged (spec file is scanned by the language gate; all new text is ASCII English).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add assets/omarchy/CoreView.js tests/qml/tst_ProviderStates.qml \
+  tests/qml/tst_Accessibility.qml tests/qml/tst_BarWidget.qml \
+  docs/specs/v10/04-quickshell-ux-and-accessibility.md
+git commit -m "feat: rewrite typed-state copy to direct voice"
+```
+
+---
+
+### Task 2: Header tag + rail frame deletion + shared inset + UX-017
+
+**Files:**
+- Modify: `assets/omarchy/ProviderHeader.qml` (pill at :44-63)
+- Modify: `assets/omarchy/ProviderRail.qml` (frame :84-93, inset properties :23-46, stack anchors :95-102)
+- Modify: `assets/omarchy/Popup.qml` (`contentMargins` :27)
+- Modify: `tests/qml/tst_Popup.qml` (rail test :37-47 area; add geometry-invariant asserts)
+- Modify: `docs/specs/v10/04-quickshell-ux-and-accessibility.md` (UX-017 :55-56)
+
+**Interfaces:**
+- Consumes: Task 1's `headerModel` without `connection` (already true — header never used it).
+- Produces: `ProviderHeader` unchanged API (`name`, `plan`, `refreshing`, `showStale`, `foreground`, `fontFamily`, `refreshClicked`); `ProviderRail` unchanged API (`providers`, `selectedProviderId`, `railWidth`, `minStackHeight`, `collectFocusTargets`); `Popup.contentMargins` now `Style.spacing.popupPadding`.
+
+- [ ] **Step 1: Update the locked tests (failing first)**
+
+In `tests/qml/tst_Popup.qml`, extend the rail test region with the frame ban and the shared-inset invariant (adapt to the file's existing `read()` helper):
+
+```js
+function test_rail_has_no_own_frame() {
+  var rail = read("../../assets/omarchy/ProviderRail.qml")
+  // §6: the rail draws no fill or border of its own inside an already
+  // bordered card; the selected plate is the only chrome.
+  verify(rail.indexOf("normalFill") < 0)
+  verify(rail.indexOf("normalBorderColor") < 0)
+  verify(rail.indexOf("selectedFill") >= 0)
+  verify(rail.indexOf("Style.spacing.popupPadding") >= 0)
+}
+
+function test_content_and_rail_share_inset_token() {
+  var popup = read("../../assets/omarchy/Popup.qml")
+  verify(popup.indexOf("contentMargins: Style.spacing.popupPadding") >= 0)
+  verify(popup.indexOf("Style.space(14)") < 0)
+}
+```
+
+And in `test_header_has_no_provider_icon` (:49-59) add `verify(hdr.indexOf("AllUppercase") >= 0)` and `verify(hdr.indexOf("radius: height / 2") < 0)`.
+
+- [ ] **Step 2: Run the QML suite — confirm the new asserts fail**
+
+- [ ] **Step 3: Implement**
+
+`ProviderHeader.qml` — replace the pill Rectangle (:44-63) with the tag (§6: 1px `Style.normalBorderColor` border at `Style.cornerRadius`, `Style.font.caption`, uppercase; uppercasing at render normalises lowercase plan ids like Codex's `plus`):
+
+```qml
+    Rectangle {
+      visible: root.plan.length > 0
+      anchors.verticalCenter: parent.verticalCenter
+      width: planText.implicitWidth + Style.space(10)
+      height: planText.implicitHeight + Style.space(4)
+      radius: Style.cornerRadius
+      color: "transparent"
+      border.width: 1
+      border.color: Style.normalBorderColor
+      Text {
+        id: planText
+        anchors.centerIn: parent
+        text: root.plan
+        color: Util.alpha(root.foreground, 0.72)
+        font.family: root.fontFamily
+        font.pixelSize: Style.font.caption
+        font.capitalization: Font.AllUppercase
+        font.letterSpacing: 0.5
+        textFormat: Text.PlainText
+        Accessible.name: "plan " + root.plan
+      }
+    }
+```
+
+`ProviderRail.qml` — delete the `frame` Rectangle (:84-93). Replace the inset properties: `outerMargin`/`framePad` go away; the stack anchors to the rail Item with `topMargin: Style.spacing.popupPadding` and `bottomMargin: Style.spacing.popupPadding`, horizontal margins 0 (`railWidth = slotSize`); `minStackHeight` becomes `Style.spacing.popupPadding * 2 + slots * slotSize + gaps * stackGap + spacerMin` with the same slot/gap counts. The stack now anchors to the rail root (`anchors.fill: parent` + those margins) instead of `anchors.fill: frame`. Keep the selected plate (:142-152), Settings slot, focus wiring, and `collectFocusTargets` untouched.
+
+`Popup.qml:27` — `property int contentMargins: Style.spacing.popupPadding`.
+
+Geometry check to reason through (write the result in the report): inside `panelBody` both the rail stack (topMargin `popupPadding`) and `contentFlick` (`anchors.topMargin: contentMargins` = `popupPadding`) now start at the same distance from the card's padded edge — the §6 "slot stack top edge equals content top edge" invariant. `railGutter` stays `Style.space(8)` (= `Style.spacing.lg`).
+
+- [ ] **Step 4: Run the full QML gate** (qmllint + validate + qmltestrunner). Expected 0 failed.
+
+- [ ] **Step 5: Amend UX-017**
+
+Replace :55-56 with:
+
+```markdown
+- `UX-017`: The header shows the provider name, the plan tag, severity when
+  present, and the provider refresh control. Connection state is implied
+  structurally (windows render only when ready) and update age lives in the
+  stale banner.
+```
+
+- [ ] **Step 6: Rust gates** (same command). Expected green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add assets/omarchy/ProviderHeader.qml assets/omarchy/ProviderRail.qml \
+  assets/omarchy/Popup.qml tests/qml/tst_Popup.qml \
+  docs/specs/v10/04-quickshell-ux-and-accessibility.md
+git commit -m "feat: align rail inset and turn plan pill into tag"
+```
+
+---
+
+### Task 3: Footer removal + stale banner + screenshot mirror sync + UX-028
+
+**Files:**
+- Modify: `assets/omarchy/ProviderView.qml` (banner :75-126, footer :202-241, StateMessage gating :186-200)
+- Modify: `tests/qml/tst_Popup.qml` (`test_footer_shows_connection` :61-64 replaced; banner test added)
+- Modify: `tests/qml/tst_BarWidget.qml` (extend `test_chip_path_has_no_emoji_hourglass` to a repo-wide assets ban)
+- Modify: `tests/qml/tst_Screenshots.qml` (`paintState` :99-177 strings)
+- Modify: `tests/qml/tst_Tokens.qml` (`convertedFiles()` :75-85 — see Step 1)
+- Modify: `docs/specs/v10/04-quickshell-ux-and-accessibility.md` (UX-028 :80-81)
+
+**Interfaces:**
+- Consumes: Task 1's empty `stateTitle`/`stateBody` for stale; existing `formatAgoText(iso, nowMs)` and `errorMessage(provider)`; existing `nowMs` 30s tick in ProviderView.
+- Produces: ProviderView with no footer and a banner rendered for BOTH stale modes (`stale_windows` and stale-with-no-windows); `StateMessage` never renders for stale.
+
+- [ ] **Step 1: Update the locked tests (failing first)**
+
+Replace `test_footer_shows_connection` (tst_Popup.qml:61-64) with:
+
+```js
+function test_no_meta_footer() {
+  var view = read("../../assets/omarchy/ProviderView.qml")
+  // §6/§9: the meta footer is removed in all states; its age moved to the
+  // stale banner and connection state is structural.
+  verify(view.indexOf("connection") < 0)
+  verify(view.indexOf('"Updated "') < 0)
+  verify(view.indexOf('"Cache"') < 0)
+  verify(view.indexOf('"Live"') < 0)
+}
+
+function test_stale_banner_carries_age_and_retry() {
+  var view = read("../../assets/omarchy/ProviderView.qml")
+  verify(view.indexOf("󰅐") >= 0)
+  verify(view.indexOf('"Last data "') >= 0)
+  verify(view.indexOf("formatAgoText") >= 0)
+  verify(view.indexOf("⌛") < 0)
+}
+```
+
+In `tests/qml/tst_BarWidget.qml`, generalize the hourglass ban (rename to `test_no_emoji_hourglass_in_assets`) to XHR-read every file in a fixed list — `CoreView.js`, `ProviderChip.qml`, `ProviderView.qml`, `ProviderHeader.qml`, `ProviderRail.qml`, `StateMessage.qml`, `UsageWindow.qml`, `Popup.qml`, `BarWidget.qml` — asserting `indexOf("⌛") < 0` for each.
+
+In `tests/qml/tst_Tokens.qml`, remove `ProviderView.qml` from `convertedFiles()` (:75-85): `test_util_alpha_used_in_converted_files` REQUIRES `Util.alpha(` in every listed file, and ProviderView's only two alpha call sites (:222, :232) live in the footer this task deletes. The file legitimately needs no alpha role afterwards (banner is `Color.urgent`, separators are `PanelSeparator`). Leave `ProviderView.qml` in `tokenScannedFiles()` — the no-raw-`Qt.rgba` and closed-alpha-set scans still apply to it. Comment the removal with this reason.
+
+- [ ] **Step 2: Run the QML suite — confirm intended failures** (footer strings still present, banner still `"Stale — "` + `⌛`).
+
+- [ ] **Step 3: Implement in `ProviderView.qml`**
+
+Delete the footer Row (:202-241) entirely. Rewrite the banner (:75-126) — visibility becomes `String(provider.state) === "stale"` under any content mode; glyph `󰅐`; text composed as `Last data {age} ago` + optional ` · {error}`; keep the Retry link Repeater as-is (its labels come from `stateActions`):
+
+```qml
+    // Stale banner (UX-028): carries last-success age + safe error + Retry.
+    // Never color-only (A11Y-012): glyph and words, urgent-tinted per the
+    // approved mockup.
+    Row {
+      visible: root.provider && String(root.provider.state || "") === "stale"
+      width: parent.width
+      spacing: Style.space(8)
+
+      Text {
+        text: "󰅐"
+        color: Color.urgent
+        font.family: root.fontFamily
+        font.pixelSize: Style.font.body
+        textFormat: Text.PlainText
+        Accessible.ignored: true
+      }
+      Text {
+        width: Math.max(0, parent.width - Style.space(120))
+        text: {
+          var age = Core.formatAgoText(
+            root.header.lastSuccessAt ? root.header.lastSuccessAt : "", root.nowMs)
+          var line = "Last data " + (age.length ? age : "unknown")
+          var err = Core.errorMessage(root.provider)
+          if (err.length)
+            line += " · " + err
+          return line
+        }
+        color: Color.urgent
+        font.family: root.fontFamily
+        font.pixelSize: Style.font.caption
+        wrapMode: Text.WordWrap
+        textFormat: Text.PlainText
+        Accessible.name: text
+      }
+      /* keep the existing Retry Repeater block unchanged */
+    }
+```
+
+Note `formatAgoText` returns `"just now"`/`"5m ago"`/… — the composed line reads `Last data 5m ago ago`? NO: `formatAgoText` already appends `ago` (`"5m ago"`), so the prefix must be `"Last data "` + the raw result (`Last data 5m ago`), and the `"just now"` case reads `Last data just now`. Compose exactly that way — do NOT append a literal `" ago"`. (The test in Step 1 asserts the `"Last data "` literal only, for this reason.)
+
+Adjust the `isStale` gating: the banner shows for both stale modes; `StateMessage` visibility (:188) must EXCLUDE stale — change to `visible: (root.mode === "skeleton" || root.mode === "empty_windows" || root.mode === "state") && String(root.provider && root.provider.state || "") !== "stale"`, so a stale provider without retained windows shows the banner alone (age + error + Retry is the complete information; Task 1 made its title/body empty).
+
+- [ ] **Step 4: Sync the screenshot mirror**
+
+In `tests/qml/tst_Screenshots.qml` `paintState` (:99-177), update the hardcoded strings to the shipped copy so future perceptual reviews see live copy: stale captures get `Last data 14m ago · Temporary network failure.` (badge `STALE` uppercase if the mirror shows a badge), `cli-missing-dark` gets `Amp CLI is not installed` / `Agent Bar reads the quota through it. Install guide`, `unauthenticated-dark` gets `Not signed in to Claude` / `Signing in opens the official Claude CLI. Sign in`, `rate-limited-dark` gets `Codex hit a rate limit` / `Try again in a few minutes. Retry`, `network-error-dark` gets `Cannot reach Amp` / `Check your connection. Retry`, `provider-error-dark` gets `Grok returned no limits` / `Retry`. Keep names and count (16) identical — `test_required_names_match_spec` and `tests/screenshot_inventory.rs` lock the inventory, not the content.
+
+- [ ] **Step 5: Run the full QML gate + `scripts/verify-v10-ui`** (screenshots regenerate). Expected 0 failed, exit 0.
+
+- [ ] **Step 6: Amend UX-028**
+
+Replace :80-81 with:
+
+```markdown
+- `UX-028`: Stale content stays visible. The stale banner carries the
+  `󰅐` cue, the last success age, the safe error summary, and Retry; it
+  renders whenever the provider state is stale.
+```
+
+- [ ] **Step 7: Rust gates.** Expected green (288/15).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add assets/omarchy/ProviderView.qml tests/qml/tst_Popup.qml \
+  tests/qml/tst_BarWidget.qml tests/qml/tst_Screenshots.qml \
+  tests/qml/tst_Tokens.qml \
+  docs/specs/v10/04-quickshell-ux-and-accessibility.md
+git commit -m "feat: replace meta footer with stale banner"
+```
+
+---
+
+### Task 4: Full checkpoint + execution record
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-07-30-v11-03-popup.md` (this file — Execution record appended)
+
+- [ ] **Step 1: Full checkpoint** (all gates from Global Constraints, including `scripts/verify-v10-ui`). Expected: Rust 288/15, QML 0 failed, everything clean. No GPU probe needed — this plan touches no shader/tint path; the perceptual gate for the popup is the owner's live QA, as recorded in plans 01–02.
+
+- [ ] **Step 2: Hygiene greps (all must return nothing)**
+
+```bash
+rg -n 'Qt\.darker|Qt\.rgba' assets/omarchy
+rg -n 'connectionLabel' assets/omarchy tests
+rg -n $'⌛' assets/omarchy
+rg -n '"Connect"|View installation' assets/omarchy
+```
+
+- [ ] **Step 3: Execution record** — append to this file (commit counts, final test counts, deviations, deferred minors carried forward), mirroring plans 01–02. Commit:
+
+```bash
+git add docs/superpowers/plans/2026-07-30-v11-03-popup.md
+git commit -m "docs: record execution outcome in plan"
+```
+
+---
+
+## Done when
+
+- `qmltestrunner` 0 failed; new tests (`test_state_copy_*`, `test_action_labels_renamed`, `test_state_body_error_message_precedence`, `test_rail_has_no_own_frame`, `test_content_and_rail_share_inset_token`, `test_no_meta_footer`, `test_stale_banner_carries_age_and_retry`, `test_no_emoji_hourglass_in_assets`) print `PASS`.
+- `cargo test` green (288/15); clippy/fmt/diff-check clean; `scripts/verify-v10-ui` exit 0 with the 16 required captures showing the NEW copy.
+- `rg 'connectionLabel' assets/omarchy tests` returns nothing; no `⌛` anywhere under `assets/omarchy`; no `"Connect"` or `View installation` literals in shipped QML/JS.
+- `ProviderRail.qml` draws no fill/border of its own; `Popup.qml` and the rail share the `Style.spacing.popupPadding` inset token.
+- UX-017, UX-028, UX-029, UX-030, UX-054 amended; spec text matches shipped behavior on the same branch.
+- Nothing installed into `~/.config/omarchy/plugins/` — live QA remains the owner's gate.
+
+## Not in this plan
+
+| Plan | Covers |
+| --- | --- |
+| 04 — severity | thresholds shared with Rust (`NotificationLevel::from_used_percent` ↔ `CoreView.js` constants test), severity tag, `Color.urgent` numeral/track, lead-window election replacing `PRIMARY_WINDOW_IDS`, compact rows with tracks (UX-020A extension), chip `!` urgent coloring, cue `Accessible.name` via `stateQualifier` (deferred from plan 02) |
+| 05 — notifications and CLI | Rust countdown humaniser + QML equivalence test, notification metric threading, notification copy, CLI and `install.sh` copy |

--- a/docs/superpowers/plans/2026-07-30-v11-03-popup.md
+++ b/docs/superpowers/plans/2026-07-30-v11-03-popup.md
@@ -290,6 +290,32 @@ git commit -m "feat: rewrite typed-state copy to direct voice"
 
 ---
 
+### Task 5: Rust action-label parity (inserted during execution; runs after Task 1, before Task 2)
+
+**Why this task exists (execution discovery):** the Rust helper hardcodes action labels into the status JSON (`"Log in"` in `collect.rs`/`schema.rs`/`coordinator.rs`, `"View installation"` in `collect.rs`/`schema.rs`), and QML's `stateActions` prefers the provider-supplied label over `defaultActionLabel`. Without this task, Task 1's `Sign in`/`Install guide` rename is unreachable for real collected data — users would keep seeing `Log in`/`View installation`. Controller ruling: update the Rust literals to match (`"Log in"` → `"Sign in"`, `"View installation"` → `"Install guide"`), preserving the architecture (helper-supplied label wins; QML default is the fallback). These are GUI-surface strings delivered through the payload — copy design §5.3 territory, not plan-05 CLI copy.
+
+**Files:**
+- Modify: every `src/**` site the sweep finds — start from `rg -n '"Log in"|"View installation"' src tests` and treat THAT sweep as the authoritative file list (the three files named above are the known ones; the sweep may find more).
+- Modify: `tests/fixtures/status-v2/valid-unauthenticated.json`, `tests/fixtures/status-v2/valid-cli-missing.json`, and any other fixture the sweep finds carrying the old labels.
+- Modify: any Rust test asserting the old literals; any QML test reading those fixtures and asserting the old labels.
+
+**Interfaces:**
+- Consumes: Task 1's `defaultActionLabel` (already `Sign in`/`Install guide`).
+- Produces: status JSON whose `action.label` values are `Sign in` / `Install guide`. Schema v2 SHAPE unchanged — this is a value-only change; do not add, remove, or rename any field.
+
+- [ ] **Step 1: Sweep and update the locked expectations first (failing tests)** — run the `rg` sweep, update every Rust test assertion and fixture to the new labels, run `cargo test` and the QML suite to confirm the intended failures (Rust literals still old).
+- [ ] **Step 2: Swap the Rust literals** at every site the sweep found. No other Rust changes; no new strings; no `unwrap()`/`expect()`.
+- [ ] **Step 3: Re-run** `cargo test` (expect 288/15 green) and the full QML gate (fixtures feed QML tests; expect 0 failed).
+- [ ] **Step 4: Final sweep** — `rg -n '"Log in"|"View installation"' src tests assets` returns nothing.
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A src tests
+git commit -m "fix: ship renamed action labels from helper"
+```
+
+---
+
 ### Task 2: Header tag + rail frame deletion + shared inset + UX-017
 
 **Files:**
@@ -540,7 +566,7 @@ git commit -m "docs: record execution outcome in plan"
 
 - `qmltestrunner` 0 failed; new tests (`test_state_copy_*`, `test_action_labels_renamed`, `test_state_body_error_message_precedence`, `test_rail_has_no_own_frame`, `test_content_and_rail_share_inset_token`, `test_no_meta_footer`, `test_stale_banner_carries_age_and_retry`, `test_no_emoji_hourglass_in_assets`) print `PASS`.
 - `cargo test` green (288/15); clippy/fmt/diff-check clean; `scripts/verify-v10-ui` exit 0 with the 16 required captures showing the NEW copy.
-- `rg 'connectionLabel' assets/omarchy tests` returns nothing; no `⌛` anywhere under `assets/omarchy`; no `"Connect"` or `View installation` literals in shipped QML/JS.
+- `rg 'connectionLabel' assets/omarchy tests` returns nothing; no `⌛` anywhere under `assets/omarchy`; no `"Connect"` or `View installation` literals in shipped QML/JS; `rg '"Log in"|"View installation"' src tests assets` returns nothing (Task 5).
 - `ProviderRail.qml` draws no fill/border of its own; `Popup.qml` and the rail share the `Style.spacing.popupPadding` inset token.
 - UX-017, UX-028, UX-029, UX-030, UX-054 amended; spec text matches shipped behavior on the same branch.
 - Nothing installed into `~/.config/omarchy/plugins/` — live QA remains the owner's gate.

--- a/docs/superpowers/plans/2026-07-30-v11-03-popup.md
+++ b/docs/superpowers/plans/2026-07-30-v11-03-popup.md
@@ -577,3 +577,104 @@ git commit -m "docs: record execution outcome in plan"
 | --- | --- |
 | 04 — severity | thresholds shared with Rust (`NotificationLevel::from_used_percent` ↔ `CoreView.js` constants test), severity tag, `Color.urgent` numeral/track, lead-window election replacing `PRIMARY_WINDOW_IDS`, compact rows with tracks (UX-020A extension), chip `!` urgent coloring, cue `Accessible.name` via `stateQualifier` (deferred from plan 02) |
 | 05 — notifications and CLI | Rust countdown humaniser + QML equivalence test, notification metric threading, notification copy, CLI and `install.sh` copy |
+
+## Execution record
+
+Executed 2026-07-30/31 on branch `feat/v11-foundation`, task order 1 → 5
+(inserted) → 2 → 3 → 4, 8 implementation/plan-amendment commits plus this
+record: `23f7e95` (Task 1 implement), `bd1baec` (Task 1 fix round 1),
+`9cf5c0a` (plan amended in-flight with Task 5), `ccaba36` (Task 5 implement),
+`7aeb0b8` (Task 2 implement), `062b31a` (Task 2 fix round 1), `8659422`
+(Task 3 implement), `d584f67` (Task 3 fix round 1). Every task was reviewed;
+Tasks 1, 2, and 3 each needed exactly one fix round before going clean, Task 5
+went clean on first review. Task 4 produced no product commit — full
+checkpoint and this record only.
+
+Final state: `cargo test` 290 passed across 15 suites (up from 288, via
+Task 5's two label-pinning tests), `qmltestrunner` 203 passed / 0 failed (up
+from 200, via Tasks 1–3's new copy/rail/banner/hygiene tests), `cargo fmt
+--check` clean, `cargo clippy --all-targets -- -D warnings` clean, `git diff
+--check` clean, `qmllint -I /usr/share/omarchy/shell` over every
+`assets/omarchy/**/*.qml` clean, `omarchy plugin validate assets/omarchy`
+clean, `scripts/verify-v10-ui` exit 0 (16 PNGs captured, `SHA256SUMS`
+written). No GPU probe was run — this plan touches no shader/tint path. All
+hygiene greps from Step 2 (`Qt.darker`/`Qt.rgba`, `⌛`, `"Connect"`/`View
+installation`, `"Log in"`/`"View installation"` in `src`/`tests`/`assets`,
+`headerModel.connection`/`footerLeft`) returned nothing, with one expected
+exception: `rg 'connectionLabel' assets/omarchy tests` still matches a single
+comment line (`CoreView.js:144-145`) — the deferred-minor prose describing
+the now-completed deletion, not a live reference to the deleted function; see
+below.
+
+### Deferred minors carried forward
+
+None blocking; triaged here for whoever next touches these files.
+
+1. `docs/troubleshooting.md:29-30` is doubly stale: it still says "Connect"
+   for the login action, which never matched shipped copy even before this
+   plan (the shipped label was "Log in"), and now the shipped label is "Sign
+   in"; the doc's "View installation" is stale the same way against the
+   shipped "Install guide". A one-line doc fix, out of this plan's file list.
+2. The screenshot mirror (`tst_Screenshots.qml`) renders the stale badge as
+   `STALE`, all caps, while the shipped `ProviderChip`/banner treatment does
+   not force that casing anywhere else — a plan-mandated taste outlier in the
+   mirror's hardcoded strings, not a shipped-UI defect.
+3. `CoreView.js:144-146`'s comment above `stateQualifier` still reads "Plan
+   03 deletes `connectionLabel` with the meta footer" in future tense; the
+   deletion is done (Task 1). Cosmetic only — the function itself is gone
+   and no code references it.
+
+### What the plan got wrong
+
+Six defects surfaced during execution, all resolved by the controller and
+recorded in the session ledger:
+
+1. The brief's `test_action_labels_renamed` fixture for the `cli_missing`
+   case set `error: { message: "", retryable: false }`, which contradicts the
+   JSON-025 addendum this same suite enforces elsewhere (that addendum strips
+   retry actions when `retryable` is false) — the fixture as written could
+   never assert `"Check again"` present. Ruling: the fixture's `error`
+   becomes `null`; the label test owns labels only, JSON-025 gating stays
+   with its own sibling test.
+2. The brief's sample implementation code for `stateBody` omitted the
+   stale/loading early return that the brief's own prose required (`""` for
+   both). Caught in Task 1 review, not by the QML suite — the gap was
+   live-visible only via the stale-no-windows `StateMessage` path, which
+   the brief's own test coverage didn't reach directly.
+3. The plan never accounted for the Rust helper hardcoding action labels
+   (`"Log in"` / `"View installation"` in `collect.rs`/`schema.rs`/
+   `coordinator.rs`) while QML's `stateActions` prefers the provider-supplied
+   label over `defaultActionLabel`. This made the §5.3 rename
+   (`Sign in`/`Install guide`) unreachable for real collected data until
+   Task 5 was inserted specifically to close the gap.
+4. The brief's file list for Task 2 gave `ProviderHeader.qml`'s path without
+   its `components/` prefix (actual path
+   `assets/omarchy/components/ProviderHeader.qml`); the implementer resolved
+   the correct location without incident.
+5. The brief's verbatim Task 3 banner-test sample code used a `../../` XHR
+   path that didn't match this repo's file-read convention, which would have
+   made one assertion vacuous (silently reading nothing) and the sibling
+   assertion unable to ever pass. Fixed to the file's established convention
+   during implementation.
+6. Two plan-mandated guard tests, as originally specified, didn't actually
+   guard the risk they were named for: `test_rail_has_no_own_frame` never
+   banned the dangling `frame` id it existed to forbid, and the Task 3
+   banner test's four substring checks all passed even under the exact
+   double-`ago` composition regression (`"Last data 5m ago ago"`) it was
+   meant to catch. Both were caught in review, hardened in their task's fix
+   round 1, and re-verified for falsifiability before being accepted.
+
+### Verification gap (measured)
+
+`qmllint`, `qmltestrunner`, and `omarchy plugin validate` are all empirically
+blind to dangling ids and references inside plugin QML: the pure Qt 6 runner
+cannot resolve `qs.Commons`/`qs.Ui` imports, so any file that imports them
+never compiles under the runner at all, and a dangling reference inside such
+a file produces no static signal from any of the three gates — the failure
+surfaces only as a runtime QML error, reachable solely through live QA. This
+was confirmed empirically during Tasks 2 and 3 of this plan (the frame-id
+deletion in `ProviderRail.qml` and the footer deletion in `ProviderView.qml`)
+by tracing every reference to the deleted identifiers by hand rather than
+trusting any automated gate. This durable gap — first surfaced in plan 02 —
+persists here with the same mitigation: manual reference traces on every
+deletion, performed for both Task 2's rail frame and Task 3's meta footer.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -26,8 +26,8 @@ Interpret the typed state:
 
 | State | Action |
 | --- | --- |
-| `cli_missing` | Use `View installation`; Agent Bar does not install it |
-| `unauthenticated` | Use `Connect` when login is available; otherwise use `View installation` |
+| `cli_missing` | Use `Install guide`; Agent Bar does not install it |
+| `unauthenticated` | Use `Sign in` when login is available; otherwise use `Install guide` |
 | `rate_limited` | Wait for the provider or reset; do not relogin blindly |
 | `network_error` | Check network, then `Check again` |
 | `provider_error` | Inspect safe stderr diagnostics with `RUST_LOG` |

--- a/src/status/collect.rs
+++ b/src/status/collect.rs
@@ -43,7 +43,7 @@ pub fn provider_status_from_result(result: ProviderResult) -> Result<ProviderSta
             id,
             name,
             ProviderError::new(ErrorCode::CliNotFound, message, false),
-            ProviderAction::view_installation("View installation", installation_url)?,
+            ProviderAction::view_installation("Install guide", installation_url)?,
         ),
         ProviderResult::Unauthenticated {
             id,
@@ -54,9 +54,9 @@ pub fn provider_status_from_result(result: ProviderResult) -> Result<ProviderSta
             retryable,
         } => {
             let action = if login_available {
-                ProviderAction::login("Log in")
+                ProviderAction::login("Sign in")
             } else {
-                ProviderAction::view_installation("View installation", installation_url)?
+                ProviderAction::view_installation("Install guide", installation_url)?
             };
             ProviderStatus::unauthenticated(
                 id,
@@ -121,5 +121,40 @@ mod tests {
         .unwrap();
         assert_eq!(missing.state(), ProviderState::CliMissing);
         assert!(missing.windows().is_empty());
+        assert_eq!(
+            missing.action().map(|a| a.label.as_str()),
+            Some("Install guide")
+        );
+    }
+
+    #[test]
+    fn unauthenticated_action_label_prefers_sign_in_when_login_available() {
+        let status = provider_status_from_result(ProviderResult::Unauthenticated {
+            id: ProviderId::Claude,
+            name: "Claude".into(),
+            message: "not authenticated".into(),
+            login_available: true,
+            installation_url: "https://claude.ai/download".into(),
+            retryable: false,
+        })
+        .unwrap();
+        assert_eq!(status.action().map(|a| a.label.as_str()), Some("Sign in"));
+    }
+
+    #[test]
+    fn unauthenticated_action_label_falls_back_to_install_guide_without_login() {
+        let status = provider_status_from_result(ProviderResult::Unauthenticated {
+            id: ProviderId::Codex,
+            name: "Codex".into(),
+            message: "not authenticated".into(),
+            login_available: false,
+            installation_url: "https://developers.openai.com/codex".into(),
+            retryable: false,
+        })
+        .unwrap();
+        assert_eq!(
+            status.action().map(|a| a.label.as_str()),
+            Some("Install guide")
+        );
     }
 }

--- a/src/status/coordinator.rs
+++ b/src/status/coordinator.rs
@@ -546,7 +546,7 @@ mod tests {
             ProviderId::Claude,
             "Claude",
             ProviderError::new(ErrorCode::AuthenticationRequired, "expired", true),
-            ProviderAction::login("Log in"),
+            ProviderAction::login("Sign in"),
         )
         .unwrap();
         let out = apply_stale_retention(live, Some(&prior)).unwrap();
@@ -563,7 +563,7 @@ mod tests {
             ProviderId::Claude,
             "Claude",
             ProviderError::new(ErrorCode::AuthenticationRequired, "auth", false),
-            ProviderAction::login("Log in"),
+            ProviderAction::login("Sign in"),
         )
         .unwrap();
         let out = apply_stale_retention(live.clone(), Some(&prior)).unwrap();

--- a/src/status/schema.rs
+++ b/src/status/schema.rs
@@ -1119,11 +1119,8 @@ mod tests {
                 ProviderId::Amp,
                 "Amp",
                 ProviderError::new(ErrorCode::CliNotFound, "Amp CLI was not found.", false),
-                ProviderAction::view_installation(
-                    "View installation",
-                    "https://ampcode.com/manual",
-                )
-                .unwrap(),
+                ProviderAction::view_installation("Install guide", "https://ampcode.com/manual")
+                    .unwrap(),
             )
             .unwrap(),
             ProviderStatus::unauthenticated(
@@ -1134,7 +1131,7 @@ mod tests {
                     "Claude is not authenticated.",
                     false,
                 ),
-                ProviderAction::login("Log in"),
+                ProviderAction::login("Sign in"),
             )
             .unwrap(),
             ProviderStatus::rate_limited(
@@ -1187,7 +1184,7 @@ mod tests {
             ProviderId::Codex,
             "Codex",
             ProviderError::new(ErrorCode::CliNotFound, "missing", false),
-            ProviderAction::view_installation("View installation", "https://example.com/codex")
+            ProviderAction::view_installation("Install guide", "https://example.com/codex")
                 .unwrap(),
         )
         .unwrap();

--- a/tests/fixtures/status-v2/valid-cli-missing.json
+++ b/tests/fixtures/status-v2/valid-cli-missing.json
@@ -23,7 +23,7 @@
       },
       "action": {
         "kind": "view_installation",
-        "label": "View installation",
+        "label": "Install guide",
         "target": "https://ampcode.com/manual"
       }
     }

--- a/tests/fixtures/status-v2/valid-multi-provider.json
+++ b/tests/fixtures/status-v2/valid-multi-provider.json
@@ -55,7 +55,7 @@
       },
       "action": {
         "kind": "view_installation",
-        "label": "View installation",
+        "label": "Install guide",
         "target": "https://developers.openai.com/codex"
       }
     }

--- a/tests/fixtures/status-v2/valid-unauthenticated.json
+++ b/tests/fixtures/status-v2/valid-unauthenticated.json
@@ -23,7 +23,7 @@
       },
       "action": {
         "kind": "login",
-        "label": "Log in",
+        "label": "Sign in",
         "target": null
       }
     }

--- a/tests/qml/tst_Accessibility.qml
+++ b/tests/qml/tst_Accessibility.qml
@@ -84,7 +84,7 @@ TestCase {
     verify(Core.chipStateCue({ state: "stale" }).length > 0)
     verify(Core.chipStateCue({ state: "cli_missing" }).length > 0)
     verify(Core.stateTitle({ state: "network_error", windows: [] }).length > 0)
-    verify(Core.connectionLabel("stale") === "Stale")
+    compare(Core.stateQualifier("stale"), "stale")
   }
 
   function test_glyphs_and_text_labels() {

--- a/tests/qml/tst_BarWidget.qml
+++ b/tests/qml/tst_BarWidget.qml
@@ -473,6 +473,11 @@ TestCase {
     verify(widget.indexOf("chipNumeralText") >= 0)
     verify(widget.indexOf("iconTinted") >= 0)
     verify(widget.indexOf("iconOpticalScale") >= 0)
+    // WidgetButton's vertical/barSize are readonly; qmllint is verifiably
+    // silent on assigning them (plan-02 finding) — failure would be runtime-only.
+    verify(widget.indexOf("vertical: root.vertical") < 0)
+    verify(widget.indexOf("barSize: root.barSize") < 0)
+    verify(widget.indexOf("fontPixelSize:") < 0)
   }
 
   // Plan 03 extends this repo-wide when the popup banner drops its ⌛.

--- a/tests/qml/tst_BarWidget.qml
+++ b/tests/qml/tst_BarWidget.qml
@@ -480,13 +480,28 @@ TestCase {
     verify(widget.indexOf("fontPixelSize:") < 0)
   }
 
-  // Plan 03 extends this repo-wide when the popup banner drops its ⌛.
-  function test_chip_path_has_no_emoji_hourglass() {
-    var xhr = new XMLHttpRequest()
-    xhr.open("GET", coreViewUrl, false)
-    xhr.send()
-    var core = String(xhr.responseText)
-    verify(core.indexOf("⌛") < 0)
+  // Plan 03: the popup banner drops its ⌛ for 󰅐 (glyph parity with the chip
+  // stale cue) — ban the emoji repo-wide across every file that could render
+  // provider-facing copy, not just CoreView.js.
+  function test_no_emoji_hourglass_in_assets() {
+    var files = [
+      "assets/omarchy/CoreView.js",
+      "assets/omarchy/components/ProviderChip.qml",
+      "assets/omarchy/ProviderView.qml",
+      "assets/omarchy/components/ProviderHeader.qml",
+      "assets/omarchy/ProviderRail.qml",
+      "assets/omarchy/components/StateMessage.qml",
+      "assets/omarchy/components/UsageWindow.qml",
+      "assets/omarchy/Popup.qml",
+      "assets/omarchy/BarWidget.qml"
+    ]
+    for (var i = 0; i < files.length; i++) {
+      var xhr = new XMLHttpRequest()
+      xhr.open("GET", "file://" + repoRoot + "/" + files[i], false)
+      xhr.send()
+      var src = String(xhr.responseText)
+      verify(src.indexOf("⌛") < 0, files[i] + " must not use the emoji hourglass")
+    }
   }
 
   function test_icon_files_exist_with_approved_names() {

--- a/tests/qml/tst_Popup.qml
+++ b/tests/qml/tst_Popup.qml
@@ -56,6 +56,25 @@ TestCase {
     // Connection moved out of the header into ProviderView's meta footer
     // (Fase 2 slim-down) — the header no longer owns that prop/text at all.
     verify(src.indexOf("connection") < 0)
+    // §6: the plan pill becomes an uppercase tag — no more pill radius.
+    verify(src.indexOf("AllUppercase") >= 0)
+    verify(src.indexOf("radius: height / 2") < 0)
+  }
+
+  function test_rail_has_no_own_frame() {
+    var rail = read("assets/omarchy/ProviderRail.qml")
+    // §6: the rail draws no fill or border of its own inside an already
+    // bordered card; the selected plate is the only chrome.
+    verify(rail.indexOf("normalFill") < 0)
+    verify(rail.indexOf("normalBorderColor") < 0)
+    verify(rail.indexOf("selectedFill") >= 0)
+    verify(rail.indexOf("Style.spacing.popupPadding") >= 0)
+  }
+
+  function test_content_and_rail_share_inset_token() {
+    var popup = read("assets/omarchy/Popup.qml")
+    verify(popup.indexOf("contentMargins: Style.spacing.popupPadding") >= 0)
+    verify(popup.indexOf("Style.space(14)") < 0)
   }
 
   function test_footer_shows_connection() {

--- a/tests/qml/tst_Popup.qml
+++ b/tests/qml/tst_Popup.qml
@@ -53,8 +53,9 @@ TestCase {
     verify(src.indexOf("name") >= 0)
     verify(src.indexOf("plan") >= 0)
     verify(src.indexOf("󰑐") >= 0)
-    // Connection moved out of the header into ProviderView's meta footer
-    // (Fase 2 slim-down) — the header no longer owns that prop/text at all.
+    // Connection state is implied structurally (windows render only when
+    // ready) and update age lives in ProviderView's stale banner (plan 03
+    // deleted the meta footer) — the header no longer owns that prop/text.
     verify(src.indexOf("connection") < 0)
     // §6: the plan pill becomes an uppercase tag — no more pill radius.
     verify(src.indexOf("AllUppercase") >= 0)
@@ -104,6 +105,10 @@ TestCase {
     verify(view.indexOf('"Last data "') >= 0)
     verify(view.indexOf("formatAgoText") >= 0)
     verify(view.indexOf("⌛") < 0)
+    // formatAgoText already returns "5m ago"/"just now" — an appended " ago"
+    // literal is the regression shape this test exists to catch.
+    verify(view.indexOf('+ " ago"') < 0)
+    verify(view.indexOf('"Last data " + (age.length ? age : "unknown")') >= 0)
   }
 
   function test_full_width_separator_present() {

--- a/tests/qml/tst_Popup.qml
+++ b/tests/qml/tst_Popup.qml
@@ -68,7 +68,12 @@ TestCase {
     verify(rail.indexOf("normalFill") < 0)
     verify(rail.indexOf("normalBorderColor") < 0)
     verify(rail.indexOf("selectedFill") >= 0)
-    verify(rail.indexOf("Style.spacing.popupPadding") >= 0)
+    verify(rail.indexOf("anchors.topMargin: Style.spacing.popupPadding") >= 0)
+    // The frame deletion's failure shape is a dangling id — runtime-only,
+    // invisible to qmllint/qmltestrunner/plugin-validate (all three verified
+    // blind to it). Ban the id and any anchor to it outright.
+    verify(rail.indexOf("id: frame") < 0)
+    verify(rail.indexOf("anchors.fill: frame") < 0)
   }
 
   function test_content_and_rail_share_inset_token() {

--- a/tests/qml/tst_Popup.qml
+++ b/tests/qml/tst_Popup.qml
@@ -140,7 +140,7 @@ TestCase {
       windows: [],
       action: {
         kind: "view_installation",
-        label: "View installation",
+        label: "Install guide",
         target: "https://example.com/install"
       }
     }

--- a/tests/qml/tst_Popup.qml
+++ b/tests/qml/tst_Popup.qml
@@ -82,9 +82,28 @@ TestCase {
     verify(popup.indexOf("Style.space(14)") < 0)
   }
 
-  function test_footer_shows_connection() {
-    var src = read("assets/omarchy/ProviderView.qml")
-    verify(src.indexOf("connection") >= 0)
+  function test_no_meta_footer() {
+    // NOTE: repoRoot (above) already pops to the repo root, matching every
+    // sibling read() call in this file ("assets/omarchy/..."); the brief's
+    // literal "../../assets/omarchy/ProviderView.qml" resolves outside the
+    // repo, so XHR returns "" and both new tests would pass/fail vacuously
+    // forever regardless of ProviderView.qml's contents. Fixed to match the
+    // established convention.
+    var view = read("assets/omarchy/ProviderView.qml")
+    // §6/§9: the meta footer is removed in all states; its age moved to the
+    // stale banner and connection state is structural.
+    verify(view.indexOf("connection") < 0)
+    verify(view.indexOf('"Updated "') < 0)
+    verify(view.indexOf('"Cache"') < 0)
+    verify(view.indexOf('"Live"') < 0)
+  }
+
+  function test_stale_banner_carries_age_and_retry() {
+    var view = read("assets/omarchy/ProviderView.qml")
+    verify(view.indexOf("󰅐") >= 0)
+    verify(view.indexOf('"Last data "') >= 0)
+    verify(view.indexOf("formatAgoText") >= 0)
+    verify(view.indexOf("⌛") < 0)
   }
 
   function test_full_width_separator_present() {

--- a/tests/qml/tst_ProviderStates.qml
+++ b/tests/qml/tst_ProviderStates.qml
@@ -57,6 +57,7 @@ TestCase {
     var p = firstProvider("valid-stale.json")
     compare(Core.contentMode(p), "stale_windows")
     compare(Core.stateTitle(p), "")
+    compare(Core.stateBody(p), "")
     verify(Core.errorMessage(p).length > 0)
     var acts = Core.stateActions(p)
     var kinds = acts.map(function (a) { return a.kind })

--- a/tests/qml/tst_ProviderStates.qml
+++ b/tests/qml/tst_ProviderStates.qml
@@ -39,7 +39,6 @@ TestCase {
   function test_ready_windows_mode() {
     var p = firstProvider("ready.json")
     compare(Core.contentMode(p), "windows")
-    compare(Core.connectionLabel(p.state), "Connected")
     verify(Core.planBadge(p).length > 0)
     var lines = Core.windowDisplayLines(p, "remaining")
     verify(lines.length > 0)
@@ -51,14 +50,13 @@ TestCase {
     var p = firstProvider("valid-empty-windows.json")
     compare(Core.contentMode(p), "empty_windows")
     compare(Core.stateBody(p), Core.emptyWindowsMessage())
-    verify(Core.stateBody(p).indexOf("Percentage usage is not available") >= 0)
+    verify(Core.stateBody(p).indexOf("billed another way") >= 0)
   }
 
   function test_stale_retains_windows_and_label() {
     var p = firstProvider("valid-stale.json")
     compare(Core.contentMode(p), "stale_windows")
-    compare(Core.connectionLabel(p.state), "Stale")
-    compare(Core.stateTitle(p), "Stale")
+    compare(Core.stateTitle(p), "")
     verify(Core.errorMessage(p).length > 0)
     var acts = Core.stateActions(p)
     var kinds = acts.map(function (a) { return a.kind })
@@ -72,7 +70,6 @@ TestCase {
   function test_cli_missing_view_installation_and_check_again() {
     var p = firstProvider("valid-cli-missing.json")
     compare(Core.contentMode(p), "state")
-    compare(Core.connectionLabel(p.state), "CLI missing")
     var acts = Core.stateActions(p)
     var kinds = acts.map(function (a) { return a.kind })
     verify(kinds.indexOf("view_installation") >= 0)
@@ -84,12 +81,11 @@ TestCase {
   function test_unauthenticated_connect_or_install() {
     var p = firstProvider("valid-unauthenticated.json")
     compare(Core.contentMode(p), "state")
-    compare(Core.connectionLabel(p.state), "Not connected")
     var acts = Core.stateActions(p)
     verify(acts.length >= 1)
     var kind = acts[0].kind
     verify(kind === "login" || kind === "view_installation")
-    // Label should be user-facing Connect when login
+    // Label should be user-facing Sign in when login
     if (kind === "login")
       verify(acts[0].label.length > 0)
   }
@@ -97,8 +93,6 @@ TestCase {
   function test_network_and_rate_limit_are_retryable_not_auth() {
     var net = firstProvider("valid-network-error.json")
     var rate = firstProvider("valid-rate-limited.json")
-    compare(Core.connectionLabel(net.state), "Network error")
-    compare(Core.connectionLabel(rate.state), "Rate limited")
     verify(Core.stateBody(net).toLowerCase().indexOf("auth") < 0)
     verify(Core.stateBody(rate).toLowerCase().indexOf("auth") < 0)
     verify(Core.stateBody(net).toLowerCase().indexOf("sign in") < 0)
@@ -132,7 +126,7 @@ TestCase {
     var h = Core.headerModel(p, true)
     verify(h.name.length > 0)
     verify(h.plan.length > 0)
-    compare(h.connection, "Connected")
+    verify(h.connection === undefined)
     compare(h.refreshing, true)
     compare(h.showStale, false)
   }
@@ -189,7 +183,7 @@ TestCase {
     compare(groups.secondary[0].label, "Opus")
   }
 
-  function test_chip_state_cue_stale_is_hourglass() {
+  function test_chip_state_cue_stale_is_clock_glyph() {
     compare(Core.chipStateCue({ state: "stale" }), "󰅐")
   }
 
@@ -215,6 +209,62 @@ TestCase {
     for (i = 0; i < acts.length; i++)
       if (acts[i].kind === "retry") hasRetry = true
     verify(hasRetry, "retryable error must offer Retry")
+  }
+
+  function test_state_copy_cli_missing() {
+    var p = { id: "grok", name: "Grok", state: "cli_missing", windows: [], error: null }
+    compare(Core.stateTitle(p), "Grok CLI is not installed")
+    compare(Core.stateBody(p), "Agent Bar reads the quota through it.")
+  }
+
+  function test_state_copy_unauthenticated() {
+    var p = { id: "claude", name: "Claude", state: "unauthenticated", windows: [], error: null }
+    compare(Core.stateTitle(p), "Not signed in to Claude")
+    compare(Core.stateBody(p), "Signing in opens the official Claude CLI.")
+  }
+
+  function test_state_copy_rate_limited() {
+    var p = { id: "codex", name: "Codex", state: "rate_limited", windows: [], error: null }
+    compare(Core.stateTitle(p), "Codex hit a rate limit")
+    compare(Core.stateBody(p), "Try again in a few minutes.")
+  }
+
+  function test_state_copy_network_error() {
+    var p = { id: "amp", name: "Amp", state: "network_error", windows: [], error: null }
+    compare(Core.stateTitle(p), "Cannot reach Amp")
+    compare(Core.stateBody(p), "Check your connection.")
+  }
+
+  function test_state_copy_provider_error_and_unknown() {
+    var pe = { id: "amp", name: "Amp", state: "provider_error", windows: [], error: null }
+    compare(Core.stateTitle(pe), "Amp returned no limits")
+    compare(Core.stateBody(pe), "")
+    var unk = { id: "claude", name: "Claude", state: "weird", windows: [], error: null }
+    compare(Core.stateTitle(unk), "Claude state is unknown")
+  }
+
+  function test_state_copy_ready_no_quota() {
+    var p = { id: "claude", name: "Claude", state: "ready", windows: [], error: null }
+    compare(Core.stateTitle(p), "Claude reports no quota")
+    compare(Core.stateBody(p), "This account is billed another way.")
+  }
+
+  function test_state_body_error_message_precedence() {
+    var p = { id: "grok", name: "Grok", state: "network_error", windows: [],
+              error: { message: "DNS lookup failed.", retryable: true } }
+    compare(Core.stateBody(p), "DNS lookup failed.")
+  }
+
+  function test_action_labels_renamed() {
+    var auth = { id: "claude", name: "Claude", state: "unauthenticated", windows: [], error: null, action: null }
+    var labels = Core.stateActions(auth).map(function (a) { return a.label })
+    verify(labels.indexOf("Sign in") >= 0)
+    verify(labels.indexOf("Connect") < 0)
+    var cli = { id: "grok", name: "Grok", state: "cli_missing", windows: [], error: null,
+                action: { kind: "view_installation", label: "", target: "https://example.com" } }
+    var cliLabels = Core.stateActions(cli).map(function (a) { return a.label })
+    verify(cliLabels.indexOf("Install guide") >= 0)
+    verify(cliLabels.indexOf("Check again") >= 0)
   }
 
   // ProviderView.qml transitively imports qs.Commons/qs.Ui, which only

--- a/tests/qml/tst_Screenshots.qml
+++ b/tests/qml/tst_Screenshots.qml
@@ -127,28 +127,31 @@ TestCase {
       stage.bodyText = "Weekly (7d) 74% left (prior data kept)"
     } else if (name.indexOf("stale-dark") === 0) {
       stage.titleText = "Grok"
-      stage.badgeText = "Stale"
-      stage.bodyText = "Showing the last successful result. Temporary network failure."
+      stage.badgeText = "STALE"
+      stage.bodyText = "Last data 14m ago · Temporary network failure."
     } else if (name.indexOf("cli-missing-dark") === 0) {
       stage.titleText = "Amp"
       stage.badgeText = "CLI missing"
-      stage.bodyText = "Amp CLI was not found. View installation"
+      stage.bodyText = "Amp CLI is not installed. Agent Bar reads the quota through it. Install guide"
     } else if (name.indexOf("unauthenticated-dark") === 0) {
       stage.titleText = "Claude"
       stage.badgeText = "Not connected"
-      stage.bodyText = "Claude is not authenticated. Connect"
+      stage.bodyText = "Not signed in to Claude. Signing in opens the official Claude CLI. Sign in"
     } else if (name.indexOf("rate-limited-dark") === 0) {
       stage.titleText = "Codex"
       stage.badgeText = "Rate limited"
-      stage.bodyText = "The provider rate-limited this request. Retry"
+      stage.bodyText = "Codex hit a rate limit. Try again in a few minutes. Retry"
     } else if (name.indexOf("network-error-dark") === 0) {
-      stage.titleText = "Grok"
-      stage.badgeText = "Network error"
-      stage.bodyText = "A temporary network error prevented collection. Retry"
-    } else if (name.indexOf("provider-error-dark") === 0) {
+      // Provider swapped Grok -> Amp to keep the fixture internally
+      // consistent with the shipped copy (task brief names Amp here).
       stage.titleText = "Amp"
+      stage.badgeText = "Network error"
+      stage.bodyText = "Cannot reach Amp. Check your connection. Retry"
+    } else if (name.indexOf("provider-error-dark") === 0) {
+      // Provider swapped Amp -> Grok to match, same reason as above.
+      stage.titleText = "Grok"
       stage.badgeText = "Provider error"
-      stage.bodyText = "The provider returned an unusable response. Retry"
+      stage.bodyText = "Grok returned no limits. Retry"
     } else if (name.indexOf("settings-clean-dark") === 0) {
       stage.titleText = "Settings"
       stage.badgeText = "clean"

--- a/tests/qml/tst_Tokens.qml
+++ b/tests/qml/tst_Tokens.qml
@@ -72,9 +72,14 @@ TestCase {
     return values
   }
 
+  // Plan 03 removed ProviderView.qml's only two Util.alpha( call sites
+  // (the meta footer, :222/:232) along with the footer itself. The file
+  // legitimately needs no alpha role afterwards: the stale banner uses
+  // Color.urgent directly and the separators are PanelSeparator. It stays
+  // in tokenScannedFiles() above — the no-raw-Qt.rgba and closed-alpha-set
+  // scans still apply — but drops out of this REQUIRES-Util.alpha list.
   function convertedFiles() {
     return [
-      "assets/omarchy/ProviderView.qml",
       "assets/omarchy/SettingsView.qml",
       "assets/omarchy/MaintenanceView.qml",
       "assets/omarchy/components/UsageWindow.qml",


### PR DESCRIPTION
## Summary

Plan 03 of the v11 visual update (specs: `2026-07-30-visual-update-design.md` §2.5/§6/§9, `2026-07-30-copy-and-language-design.md` §4–5.3). Plan with full execution record: `docs/superpowers/plans/2026-07-30-v11-03-popup.md`.

- **Typed-state copy rewritten to the direct voice**: `Grok CLI is not installed`, `Not signed in to Claude`, `Codex hit a rate limit`, `This account is billed another way.` — every title names the provider, no internal vocabulary, error messages still win over defaults. `connectionLabel` is deleted (the plan-02 seam closes; `stateQualifier` is the only humaniser left).
- **Action labels renamed end-to-end**: `Sign in` / `Install guide` — including the Rust helper's payload literals (Task 5, inserted mid-execution when the sweep showed QML prefers helper-supplied labels, making a QML-only rename unreachable for real data). Two new Rust tests pin the labels at the production call sites.
- **Rail loses its own frame**: slot stack and content now share one `Style.spacing.popupPadding` inset (closes a real pre-existing 2px misalignment); selected plate and focus wiring untouched.
- **Plan pill → uppercase tag** at host `cornerRadius` (theme-owned; square on the default theme is correct).
- **Meta footer removed in all states**; the stale banner absorbs last-success age + safe error + Retry (`󰅐 Last data 14m ago · <error>`), rendered for both stale modes, in `Color.urgent`, never color-only.
- **Spec amendments landed with the behavior**: UX-015/017/028/029/030/032A/054, PROD-031, plus prose sync in the product contract journey, CLI/JSON example, troubleshooting table, and README.
- Screenshot mirror synced by hand to the shipped copy (measured: it follows nothing automatically).

## Measured facts worth knowing

- All three QML gates (qmllint, qmltestrunner, `omarchy plugin validate`) are **empirically blind to dangling ids/refs in plugin QML** — the Qt6 runner cannot compile files importing `qs.*`, so runtime QML errors reach only live QA. Mitigation on this branch: manual reference traces after every deletion (recorded in the plan), plus text-guard bans on the exact failure shapes (`id: frame`, `+ " ago"`).
- Six plan-born defects were caught during execution (fixture contradicting JSON-025, sample code contradicting its own prose, the unreachable-rename discovery, two guard tests that didn't guard their named risk, a broken test path) — all documented in the execution record.

## Verification

`cargo fmt --check` · `cargo test` **290/15 suites** (was 288; +2 label pins) · clippy `-D warnings` · `git diff --check` · `qmllint` · `omarchy plugin validate` · Qt6 `qmltestrunner` **203 passed / 0 failed** (was 192) · `scripts/verify-v10-ui` exit 0 (16 captures showing the new copy) — all reproduced independently by the final whole-branch review on the exact head. Five task-scoped reviews + final review + one doc-coherence fix wave, re-reviewed clean.

Live QA on the installed plugin remains the owner's gate. Severity, lead-window election, and notifications are untouched (plans 04–05).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Provider statuses now use clearer, provider-specific messages and actionable guidance.
  - Stale providers display an urgent banner with last-success timing, error details, and Retry.
  - Usage views better explain accounts without percentage-based billing.

- **Improvements**
  - Renamed actions to “Sign in” and “Install guide.”
  - Simplified provider layout and removed redundant connection/update details.
  - Improved plan tags, spacing, and accessibility cues.

- **Documentation**
  - Updated product specifications and troubleshooting guidance to reflect the revised provider states and actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->