### PR TITLE
Mark qmllint as a syntax-only gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,8 +93,10 @@ git diff --check
 QML/plugin changes also run:
 
 ```bash
+# PATH qmllint is a stub reporting version 1.0 that stays SILENT even on an
+# undefined type — the Qt6 binary path is mandatory here too
 find assets/omarchy -type f -name '*.qml' -exec \
-  qmllint -I /usr/share/omarchy/shell {} +
+  /usr/lib/qt6/bin/qmllint -I /usr/share/omarchy/shell {} +
 omarchy plugin validate assets/omarchy
 # PATH qmltestrunner is Qt5 and fails SILENTLY (errors only in journald) —
 # the Qt6 binary path and both env vars below are mandatory
@@ -105,6 +107,14 @@ QT_QPA_PLATFORM=offscreen QML_XHR_ALLOW_FILE_READ=1 QT_LOGGING_TO_CONSOLE=1 \
   -import assets/omarchy \
   -o -,txt
 ```
+
+`qmllint` catches syntax and structure only. It cannot resolve the `qs.*`
+module namespace, so every plugin QML file — including files a change never
+touched — emits unresolved-import and unqualified-access warnings. Read its
+output for what a change introduced, never as a type check, and never treat
+its exit code as a verdict: it exits 0 while printing warnings. Type errors,
+dangling references, and readonly-property assignments in plugin QML reach
+only `qmltestrunner`, `omarchy plugin validate`, and live QA.
 
 Shell changes run ShellCheck. Bundle changes run the complete archive,
 inventory, mode, architecture, version, traversal, and rollback matrix in the


### PR DESCRIPTION
## Summary

The `qmllint` line in the engineering contract's Verification section has never verified what it appears to verify. Measured on this machine during plan 04 execution:

- `/usr/bin/qmllint` — the one the gate resolves to — reports version `1.0` and stays **completely silent** on a file containing an undefined type. Exit 0, zero output. Reproduced against a two-line QML file whose only content was an undefined type.
- `/usr/lib/qt6/bin/qmllint` 6.11.1 reports that same undefined type correctly, but **cannot resolve the `qs.*` module namespace at all**. Every plugin QML file emits unresolved-import and unqualified-access warnings, including files a change never touched: `ProviderRail.qml` produces 36 and `StateMessage.qml` produces 28, on a tree where neither was modified.
- Both binaries exit 0 while printing warnings, so the exit code is not a verdict either.

The practical consequence is that type errors, dangling references, and readonly-property assignments in plugin QML reach only `qmltestrunner`, `omarchy plugin validate`, and live QA — which is exactly the blind spot plan 03 documented from the other direction when a dangling id survived all three QML gates.

## Change

Same shape the `qmltestrunner` line already uses: pin the Qt 6 binary path, keep the command (it still catches syntax and structure, and it is cheap), and state plainly what it does not do so the next reader does not trust it for more than it delivers.

Not a behaviour change. `cargo test --test active_language` 3/3, `cargo test --test active_docs` 5/5, `git diff --check` clean.

Kept off `feat/v11-foundation` deliberately: that branch's PR is already reviewed, and a contract amendment does not belong in it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified QML verification guidance, including the role of `qmllint` warnings and exit status.
  * Documented additional validation through QML tests, plugin checks, and live quality assurance.

* **Bug Fixes**
  * Improved reliability by invoking the required Qt6 QML verification tool directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->