### PR TITLE
v11 copy plan 06: CLI and installer

### DIFF
--- a/assets/omarchy/CoreMaintenance.js
+++ b/assets/omarchy/CoreMaintenance.js
@@ -216,7 +216,6 @@ function maintenanceUiArmOrConfirmUninstall(ui) {
     return { ui: next, confirmed: false }
   if (!next.uninstallArmed) {
     next.uninstallArmed = true
-    next.message = "Click Uninstall again to confirm."
     return { ui: next, confirmed: false }
   }
   return { ui: next, confirmed: true }

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -21,7 +21,7 @@ agent-bar status cache use|bypass
 agent-bar status notifications evaluate|skip
 ```
 
-Status clauses may appear in any order and at most once. Defaults:
+Status arguments may appear in any order and at most once. Defaults:
 
 ```text
 format human

--- a/docs/superpowers/plans/2026-08-01-v11-06-cli-and-installer-copy.md
+++ b/docs/superpowers/plans/2026-08-01-v11-06-cli-and-installer-copy.md
@@ -630,3 +630,133 @@ This is the last plan in the v11 copy and visual track. Deliberately untouched:
 - `INTERACTIVE_UPDATE_REQUIRES_TTY`, which already names its fix and is read by script authors.
 - The GUI vocabulary guard's word list, which stays GUI-only because `bundle`, `collect`, and `schema` are legitimate CLI and installer vocabulary.
 - `ProviderHeader.showStale`, dead since plan 03 and still carried in `headerModel`.
+
+## Execution record
+
+Executed 2026-07-31–08-01 on branch `feat/v11-foundation`, task order
+1 → 2 → 3 → 4 → 5 → 6. Nine implementation/fix commits across Tasks 1–5 plus
+this record: `a01da0b` + `b25e203` + `8e8daa5` (Task 1: `clause` to
+`argument`, then the live help-text leak measured fact 1 missed, then the
+raw-string-aware scanner — two fix rounds), `ae0ae0e` (Task 2: one definition
+per message, clean on the first commit), `9c04d6a` + `ec53882` (Task 3: name
+the fix in four CLI errors, then retract the two that were not certain — one
+fix round), `d8d0534` (Task 4: the installer rewritten in plain words, clean
+on the first commit), `deefd70` (Task 5: the interactive update prompt).
+Tasks 1, 3, and 5 needed fix rounds; Task 1 needed two. This commit closes
+Task 6: it deletes the dead arming-message assignment at
+`CoreMaintenance.js:219`, adds `tst_Maintenance.qml`'s
+`test_arming_sets_no_unseen_message` guard (confirmed failing first — 231
+passed, 1 failed — before the deletion), runs the four Step 2 hygiene greps,
+the full checkpoint, and writes this record.
+
+Final state: `cargo test` **306 passed across 19 suites** — one more than
+Step 3's own "305 across 19 suites" arithmetic (301 baseline + 3 in
+`cli_vocabulary`, one per Task 1–3, + Task 5's inline prompt test). The extra
+test is not lost work, it is uncounted work: Task 3's fix round (`ec53882`)
+split its own fix-naming test into two — narrowed
+`cli_messages_that_can_name_a_fix_do` to the three needles that still name a
+remedy, and added a companion, `cli_writability_message_does_not_claim_a_fix`,
+pinning the fourth message's now-bare form — so `cli_vocabulary` carries four
+tests, not the three the plan's arithmetic assumed when it was written against
+Task 3's first commit. Verified suite-by-suite (`cargo test` piped to a file
+sidesteps this environment's condensed one-line summary and prints the real
+per-suite listing): lib 243, `src/main.rs` 0, `agent-bar-bundle` 0,
+`active_docs` 5, `active_language` 3, `active_legacy_scan` 4,
+`agent_bar_bundle_cli` 4, `cli` 19, `cli_vocabulary` 4, `countdown_parity` 2,
+`gui_vocabulary` 1, `icon_assets` 1, `login` 6, `schema_contract` 5,
+`screenshot_inventory` 1, `servicecore_contract` 1, `severity_parity` 2,
+`terminal_helper` 5, doc-tests 0 — 19 suites, 306 passed, 0 failed.
+`qmltestrunner` **232 passed / 0 failed** (231 baseline + this task's
+`test_arming_sets_no_unseen_message`). `cargo fmt --check`, `cargo clippy
+--all-targets -- -D warnings`, and `git diff --check` all clean. `shellcheck
+install.sh` clean. `qmllint -I /usr/share/omarchy/shell` over every
+`assets/omarchy/**/*.qml` file: 0 errors, 365 warnings — the same
+pre-existing `qs.*`/unqualified-access/missing-import noise the earlier
+plans recorded across the whole plugin tree, none of it in the files this
+task touches (`CoreMaintenance.js` is JS, outside qmllint's `*.qml` scope;
+`tst_Maintenance.qml` is under `tests/qml`, outside `find assets/omarchy`).
+`omarchy plugin validate assets/omarchy`: exit 0, no output. `scripts/
+verify-v10-ui`: `verify-v10-ui: 17 PNGs ok → …/SHA256SUMS`, exit 0 —
+unchanged at 17, since this task adds and removes no capture.
+
+Every Step 2 hygiene grep returned nothing: `clause '` under `src/cli`,
+`Staged bundle|Staged helper|Staged inventory` in `install.sh`, `Click
+Uninstall again` under `assets`, and `agent-bar plugin installer|Checksum OK`
+in `install.sh`.
+
+### What the plan got wrong
+
+Five defects surfaced during execution, all confirmed live rather than
+assumed:
+
+1. Measured fact 1 counted `clause` only in `src/cli/grammar.rs`. It missed
+   a live user-facing leak: `agent-bar help status` printed `Clauses (any
+   order, each at most once):` (`src/cli/mod.rs:53`), and
+   `docs/commands.md:24` said "Status clauses". Found by review, reproduced
+   by running the real binary before the fix was dispatched.
+2. The guard Task 1 specified could not have caught that leak even with the
+   word in scope: `string_literals` split each physical line on quote
+   characters, and the help text is one literal continued across nine lines
+   with trailing backslashes — line 53 itself contains no quote character at
+   all, so it was never scanned. The plural, `Clauses`, would not have
+   matched a singular-only pattern either. The fix round taught the scanner
+   to track an open string across line continuations and to match the
+   plural, alongside fixing both live texts.
+3. A reviewer stated that `src/cli/**` contains no raw strings; the
+   controller propagated that claim verbatim into the fix instruction for
+   Task 1's second round; the implementer wrote it into the new scanner's
+   doc comment as fact. A second reviewer found three `br#"..."#` fixtures in
+   `src/cli/mod.rs`'s own test module (`:1116`, `:1127`, `:1139`) that the
+   claim was false against. The lesson recorded plainly for next time: a
+   reviewer's negative claim ("none exist") deserves the same verification as
+   an implementer's positive one — neither is free just because it is easy
+   to state.
+4. Two of the four remedies Task 3's brief specified for §7.3 failed the
+   rule's own qualifier, "short **and certain**", once reproduced against the
+   real filesystem. `pass a directory you own` fired on a directory the user
+   fully owns whenever a stale `.agent-bar-write-probe` file was left behind:
+   the probe's own `create_new` also fails with `AlreadyExists`, and its
+   cleanup swallows its own error, so the message blamed ownership for a
+   condition ownership does not explain. `create it or pass an existing
+   parent` fired on `EACCES` on an ancestor directory, where creating
+   anything is not the fix. Both were reproduced live before the fix round.
+   The controller ruled per §7.3 as written: the writability message reverted
+   to bare (`setup plugins-dir path is not writable: {}`), and the
+   existence message was reworded to name both realistic causes
+   (`setup plugins-dir path cannot be read: {}; create it, or check the
+   permissions on its parents`).
+5. The controller ran two agents editing `tests/cli_vocabulary.rs` at the
+   same time — Task 1's second fix round (the raw-string-aware scanner) and
+   Task 3's fix round — a direct violation of this project's own rule against
+   parallel implementers sharing a tree. Nothing broke: the Task 3 implementer
+   noticed the foreign uncommitted diff already in the worktree, isolated its
+   own hunks with `git apply --cached`, committed only those, and left the
+   other agent's insertions untouched for its own commit. The cost was risk
+   that happened not to land, not actual breakage — the rule holds regardless.
+
+### Deferred minors carried forward
+
+None blocking; triaged here for whoever next touches these files.
+
+1. `cli_messages_are_defined_once`'s duplication guard counts raw source
+   substrings read non-recursively from `src/cli/`. A duplicate message
+   reintroduced with a different line-continuation shape would have
+   identical runtime text but different source text, so the guard's count
+   would not move and it would miss the duplicate.
+2. `opens_raw_string` finds each raw-string prefix (`r"`, `r#"`, `br"`,
+   `br#"`) with a leftmost match. A line holding a false prefix substring
+   before a genuine opener of the same prefix would report the false one and
+   miss the real opener. No such line exists in `src/cli` today.
+3. `install.sh`'s `Could not reach the release list` names a network cause,
+   but the same `die` fires on zero published releases or GitHub API
+   rate-limiting too — the same defect class as item 4 above, materially
+   weaker because the remedy it suggests (set `AGENT_BAR_VERSION`) is correct
+   whichever cause fired. Cause-agnostic fix on file: `reach` → `find`.
+4. Task 4's own report claims two `install.sh` lines gained a backslash
+   continuation; only one did. The report is inaccurate; the shipped code is
+   not.
+5. `shellcheck` was not installed on the machine that ran Task 4, and the
+   implementer installed it via `mise`, writing to the global
+   `~/.config/mise/config.toml` — outside this repository. Benign (the
+   project contract requires ShellCheck for shell changes), but a host side
+   effect the owner should know about.

--- a/docs/superpowers/plans/2026-08-01-v11-06-cli-and-installer-copy.md
+++ b/docs/superpowers/plans/2026-08-01-v11-06-cli-and-installer-copy.md
@@ -687,8 +687,8 @@ in `install.sh`.
 
 ### What the plan got wrong
 
-Five defects surfaced during execution, all confirmed live rather than
-assumed:
+Six defects surfaced — five during execution, the sixth during the final
+whole-branch review — all confirmed live rather than assumed:
 
 1. Measured fact 1 counted `clause` only in `src/cli/grammar.rs`. It missed
    a live user-facing leak: `agent-bar help status` printed `Clauses (any

--- a/docs/superpowers/plans/2026-08-01-v11-06-cli-and-installer-copy.md
+++ b/docs/superpowers/plans/2026-08-01-v11-06-cli-and-installer-copy.md
@@ -641,9 +641,10 @@ raw-string-aware scanner — two fix rounds), `ae0ae0e` (Task 2: one definition
 per message, clean on the first commit), `9c04d6a` + `ec53882` (Task 3: name
 the fix in four CLI errors, then retract the two that were not certain — one
 fix round), `d8d0534` (Task 4: the installer rewritten in plain words, clean
-on the first commit), `deefd70` (Task 5: the interactive update prompt).
-Tasks 1, 3, and 5 needed fix rounds; Task 1 needed two. This commit closes
-Task 6: it deletes the dead arming-message assignment at
+on the first commit), `deefd70` (Task 5: the interactive update prompt,
+clean on the first commit). Tasks 1 and 3 needed fix rounds; Task 1 needed
+two. This commit closes Task 6: it deletes the dead arming-message
+assignment at
 `CoreMaintenance.js:219`, adds `tst_Maintenance.qml`'s
 `test_arming_sets_no_unseen_message` guard (confirmed failing first — 231
 passed, 1 failed — before the deletion), runs the four Step 2 hygiene greps,
@@ -733,6 +734,19 @@ assumed:
    own hunks with `git apply --cached`, committed only those, and left the
    other agent's insertions untouched for its own commit. The cost was risk
    that happened not to land, not actual breakage — the rule holds regardless.
+6. Task 5's own instruction (this file, "The GUI says `Updates 10.0.0 →
+   10.2.0. Settings stay. Rolls back if it fails.`; the CLI drops the arrow
+   for ASCII safety and drops the rollback clause, which the CLI's own
+   `update apply` path does not promise.") justified dropping the rollback
+   clause with a claim that is false. `dispatch_update_interactive` calls
+   `dispatch_update_apply`, which hands off through
+   `MaintenanceWorker::handoff_update` to the same worker the GUI spawns, and
+   `src/plugin/maintenance.rs` calls `rollback_update` on failure at five
+   call sites. The CLI's `update apply` promises exactly the rollback the
+   plan said it did not. Found in the final whole-branch review, not during
+   Task 5 itself. Fix: `confirm_interactive_update`'s stdout line now reads
+   `Updates {current} to {target}. Settings stay. Rolls back if it fails.`,
+   matching the Maintenance screen's wording for the identical operation.
 
 ### Deferred minors carried forward
 
@@ -760,3 +774,52 @@ None blocking; triaged here for whoever next touches these files.
    `~/.config/mise/config.toml` — outside this repository. Benign (the
    project contract requires ShellCheck for shell changes), but a host side
    effect the owner should know about.
+
+### Final fix wave (post-Task 6)
+
+The final whole-branch review found three things Task 6's checkpoint could
+not have caught, because none of them are new code — they are a stale claim
+in a prompt string, a stale word in an error message, and a coverage gap in
+a guard that had nothing to walk yet. One commit closes all three plus the
+Task 5 record correction above:
+
+1. `confirm_interactive_update`'s stdout line (`src/cli/mod.rs`) now reads
+   `Updates {current} to {target}. Settings stay. Rolls back if it fails.`
+   — see "What the plan got wrong" item 6. `interactive_update_prompt_speaks_plainly`
+   was updated to match; the typed phrase `update agent-bar`, the confirmation
+   logic, and the stderr prompt are untouched.
+2. `install.sh`'s `resolve_version` die message changed `reach` to `find`
+   (`Could not find the release list. Set AGENT_BAR_VERSION and run this
+   again.`), resolving deferred minor item 3 above: the old wording named a
+   network cause the failure cannot actually distinguish from zero
+   published releases or an API rate limit.
+3. `tests/cli_vocabulary.rs`'s four guards now walk `src/cli/` with an
+   explicit-stack recursive traversal (`cli_files`, shaped after
+   `tests/gui_vocabulary.rs::gui_files`) instead of a single non-recursive
+   `fs::read_dir`, so a future module split keeps every guard's coverage.
+   This resolves the recursion half of deferred minor item 1 above; the
+   line-continuation-shape gap it also describes is unrelated to recursion
+   and still stands. `src/cli/` holds exactly four files today
+   (`command.rs`, `exit.rs`, `grammar.rs`, `mod.rs`) with no subdirectories,
+   so the recursive walk finds the same four files the old scan did and the
+   `files.len() >= 4` floor needed no change. A fifth test,
+   `docs_commands_do_not_say_clause`, was added to the same file: it reads
+   `docs/commands.md` directly and asserts no whole-word `clause`/`clauses`,
+   guarding the one live leak this plan actually found (measured fact 1 —
+   "Status clauses") on the one prose surface none of the Rust-literal
+   guards can see. Verified with a live probe before committing: reintroducing
+   "clauses" into `docs/commands.md` failed the new test with `docs/commands.md
+   still says clause (1 occurrences)`; reverting made it pass again. A second
+   probe, `src/cli/tmp_probe/mod.rs` holding the string `"unknown clause here"`,
+   failed `cli_messages_do_not_say_clause` with `mod.rs: "unknown clause
+   here"` before the directory was deleted, confirming the recursive walk
+   reaches a nested file a non-recursive scan would have missed.
+
+Final state at the end of this wave: `cargo test` **307 passed across 19
+suites, 0 failed** (the 306 Task 6 left, plus the new docs guard) —
+`cli_vocabulary` alone carries 5 tests, up from 4. `qmltestrunner`
+**232 passed, 0 failed** — unchanged from Task 6, confirming nothing QML-side
+moved. `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`,
+`git diff --check`, and `shellcheck install.sh` are all clean. This is
+`feat/v11-foundation`'s real final state before it is proposed for merge;
+nothing further is planned after this commit.

--- a/docs/superpowers/plans/2026-08-01-v11-06-cli-and-installer-copy.md
+++ b/docs/superpowers/plans/2026-08-01-v11-06-cli-and-installer-copy.md
@@ -1,0 +1,632 @@
+# v11 CLI and Installer Copy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Take parser vocabulary out of the CLI's error messages, collapse the messages that exist twice, and rewrite the installer and the interactive update prompt in the voice a person reads once, at the moment they are installing the product for the first time.
+
+**Architecture:** Two different rulebooks, deliberately. `src/cli/` keeps Unix convention — lower case, no trailing period, no product-name prefix — and only three things change there: the word `clause`, messages duplicated across the parse and validate paths, and a short enumerated set that names a problem without its fix. `install.sh` and the interactive `update` prompt are the exception the copy design carves out: they are read by a human installing the product, so they follow the full GUI voice. A narrow guard bans `clause` from CLI string literals; the GUI vocabulary guard is deliberately **not** extended here.
+
+**Tech Stack:** Rust (`src/cli/`), Bash (`install.sh`), no QML behaviour change.
+
+## Global Constraints
+
+- Contract: `CLAUDE.md` at repo root; product contract: `docs/specs/v10/` plus the approved design `docs/superpowers/specs/2026-07-30-copy-and-language-design.md` (§4 voice, §7 CLI rules, §8 test impact). This plan is §9's phase 4, the last one.
+- **`install.sh` stays Bash and stays argv-safe.** Never introduce `eval`, `sh -c`, `bash -lc`, or `cmd="$*"`. `scripts/agent-bar-open-terminal` is not touched at all.
+- Rust: no production `unwrap()`/`expect()`. Test code may use them.
+- All copy is English. The language gate flags alphabetic non-ASCII only. Keep `install.sh` output ASCII — it runs before any font or locale is known, so prefer `...` over `…` there. The Rust CLI may keep whatever it already uses.
+- `cargo test` accepts ONE filter per invocation. Baseline at plan-06 start: **301 Rust tests / 18 suites, 231 QML / 0 failed**. Known flake: `binary_interactive_update_rejects_non_tty` (`ExecutableFileBusy`) — retry once, pre-existing.
+- `qmltestrunner` from `PATH` is Qt 5 and fails SILENTLY; the Qt 6 binary and both env vars are mandatory. `qmllint` from `PATH` is a stub reporting version `1.0`; use `/usr/lib/qt6/bin/qmllint` and judge it by output, never exit code.
+- Checkpoint gates: `cargo fmt --check` · `cargo test` · `cargo clippy --all-targets -- -D warnings` · `git diff --check` · ShellCheck on `install.sh` · the Qt 6 QML gates · `omarchy plugin validate` · `scripts/verify-v10-ui`.
+- Commits: English Conventional Commit subject ≤ 50 chars. Never any AI-attribution text anywhere.
+- The plan-01…05 defect pattern applies: *source that reads correctly and behaves differently at runtime.* Resolve every claim against the real file before trusting it.
+
+## Measured facts (2026-08-01, this machine)
+
+1. **`clause` is both a message word and an identifier, and only the message word is in scope.** `src/cli/grammar.rs` contains nine occurrences: six inside format strings (`:99` `unknown status clause`, `:106` `duplicate status clause`, `:243` `unknown setup clause`, `:268` `unknown update clause`, `:278` `unknown uninstall clause`, `:289` `unknown doctor clause`) and three as code (`:92` `let clause = match word`, `:103` `let idx = clause as usize`, `:120` `match clause`), plus the `StatusClause` enum. The enum and the binding are code vocabulary and stay. A guard that bans the token file-wide would fail on them, so the guard must scan string literals only.
+2. **No test asserts a `clause` message.** `tests/cli.rs` has four hits and all four are a test-local `clauses` array (`:45-46,69-70`), not an assertion on the text. The rename breaks no test.
+3. **Four messages exist twice, and two of those cross a module boundary.** `setup plugins-dir path must be absolute` is at `grammar.rs:229` **and** `mod.rs:104`; `setup plugins-dir path must be the parent directory, not the plugin root` is at `grammar.rs:234` **and** `mod.rs:113`. Two more repeat inside `grammar.rs` alone: `config apply requires stdin, file <path>, or json <value>` (`:189`, `:208`) and `setup plugins-dir requires a path` (`:221`, `:240`). A fifth repeats three times inside `mod.rs`: the long `setup requires a complete plugin tree at <plugin-root>/bin/agent-bar; use install.sh for first bootstrap from a release archive` (`:250`, `:259`, `:264`).
+4. **`missing value for status {word}` is written twice** (`grammar.rs:114` and `:116-118`) for two different conditions — a missing token and a token that looks like a flag. Same text, same meaning to the reader; one definition serves both.
+5. **`install.sh` has four output helpers and 49 call-site strings.** `log`/`ok`/`warn`/`die` at `:43-46` prefix with `==> `, `OK  `, `!   `, `ERR `. Those prefixes are structure, not copy, and stay. `--help` does not use them: it prints the file's own header comment through `sed -n '2,/^$/p' "$0" | sed 's/^# \?//'` (`:33`), so the header block at `:2-15` is a second output surface that must be edited as copy.
+6. **`bundle` is not internal vocabulary in the installer.** The GUI vocabulary guard bans it because a popup user never sees an archive. The installer user downloads, verifies, and extracts one, and the v10 contract itself names the artifact a plugin bundle throughout `08-plugin-bundle-and-release.md`. `bundle` therefore stays in `install.sh` wherever it names the real artifact or the `bundle.json` receipt. Do not sweep it.
+7. **The two confirmation phrases are load-bearing and frozen.** `update agent-bar` (`mod.rs:193,201`) and `uninstall agent-bar` are what the user must type to proceed, pinned by `mod.rs:1050-1052` and `:1101` and by `tests/cli.rs:678-680`. They are a safety mechanism, not copy. The sentence around them may change; the phrase may not.
+8. **Test-pinned CLI strings are few.** `tests/cli.rs` pins `Quickshell plugin` and `diagnostics` (`:359-360`), `complete plugin tree` (`:404`), `doctor scan`/`read-only` (`:626-627`), `doctor clean`/`removed:` (`:649-650`), `update check`/`update apply` (`:678-680`), and the exact `version` stdout (`:293-311`). Inline `mod.rs` tests pin `Agent Bar is up to date.` exactly (`:1026-1029`) and the two typed phrases. Nothing pins an `install.sh` string: no test executes the installer, and `tests/active_legacy_scan.rs:518-538` only asserts negatives about it.
+9. **`tests/active_docs.rs` structurally pins every `agent-bar …` argv appearing in fenced code blocks** of `README.md`, `docs/commands.md`, and the other active docs — they must still parse. Help *text* is not pinned, but the grammar the help text advertises is.
+10. **One item is carried from plan 05.** `assets/omarchy/CoreMaintenance.js:219` sets `next.message = "Click Uninstall again to confirm."`, which nothing renders: the dialog binds its own message from `ui.uninstallArmed`/`ui.purgeSettings`, and the only reader of `ui.message` sits behind the dialog's `z: 100` scrim. Two reviewers confirmed it is dead. It is one line and the v10 contract forbids dormant code.
+
+## File Structure
+
+- Modify: `src/cli/grammar.rs` — six `clause` messages become `argument`; four repeated messages become module constants.
+- Modify: `src/cli/mod.rs` — consume `grammar`'s two shared constants; collapse the three-times-repeated setup message; the enumerated problem-without-fix rewrites; the interactive update prompt.
+- Create: `tests/cli_vocabulary.rs` — bans `clause` from `src/cli/**` string literals.
+- Modify: `install.sh` — the header banner and all 49 call-site strings.
+- Modify: `assets/omarchy/CoreMaintenance.js` — delete the dead arming message (plan-05 carry-over).
+- Modify: `tests/cli.rs` only if an assertion genuinely breaks; the measured expectation is that none does.
+- Modify: `docs/superpowers/plans/2026-08-01-v11-06-cli-and-installer-copy.md` (this file — execution record).
+
+## Seams (do not cross)
+
+- **No grammar changes.** Every command, clause keyword, flag, and provider id stays exactly as it parses today. This plan edits messages, not the language. `tests/active_docs.rs` would catch a grammar change through the doc examples, but the rule is stronger than the test: do not touch parsing.
+- **No behaviour changes.** Exit codes, TTY gating, confirmation phrases, and dispatch order are untouched.
+- **The GUI vocabulary guard is not extended.** `tests/gui_vocabulary.rs` keeps scanning `assets/omarchy/**` only. `bundle`, `collect`, and `schema` are legitimate CLI and installer vocabulary; only `clause` gets a CLI guard, because §7.1 names it specifically.
+- `src/bin/agent-bar-bundle.rs` is an internal build tool, not the shipped helper. Its strings are out of scope.
+
+---
+
+### Task 1: Take parser vocabulary out of the CLI
+
+**Files:**
+- Modify: `src/cli/grammar.rs` (messages at :99, :106, :243, :268, :278, :289)
+- Create: `tests/cli_vocabulary.rs`
+
+**Interfaces:** produces no API. The six messages change text only.
+
+- [ ] **Step 1: Write the failing guard**
+
+Create `tests/cli_vocabulary.rs`:
+
+```rust
+//! `clause` is parser vocabulary. It names a concept in the grammar's own
+//! implementation, not anything the person typing the command can see, and it
+//! leaked into six error messages. The word stays in the code — `StatusClause`
+//! and its bindings are exactly the kind of internal name that belongs there —
+//! so this guard scans string literals only.
+//!
+//! Scope is `src/cli/**`. The GUI has its own, wider guard in
+//! `tests/gui_vocabulary.rs`; the two lists differ on purpose, because
+//! `bundle` and `schema` name real things a CLI user deals with.
+
+use std::fs;
+use std::path::PathBuf;
+
+/// Double-quoted spans, skipping whole-line `//` comments. Crude on purpose:
+/// the CLI's messages are plain literals, never built by a macro.
+fn string_literals(source: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    for line in source.lines() {
+        if line.trim_start().starts_with("//") {
+            continue;
+        }
+        for piece in line.split('"').skip(1).step_by(2) {
+            out.push(piece.to_owned());
+        }
+    }
+    out
+}
+
+#[test]
+fn cli_messages_do_not_say_clause() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/cli");
+    let mut violations = Vec::new();
+    let entries = fs::read_dir(&root).expect("read src/cli");
+    let mut files: Vec<PathBuf> = entries
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("rs"))
+        .collect();
+    files.sort();
+    assert!(
+        files.len() >= 4,
+        "expected the cli module tree, found {} files",
+        files.len()
+    );
+    for path in files {
+        let Ok(source) = fs::read_to_string(&path) else {
+            continue;
+        };
+        let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("?").to_owned();
+        for literal in string_literals(&source) {
+            if literal
+                .to_lowercase()
+                .split(|c: char| !c.is_ascii_alphabetic())
+                .any(|token| token == "clause")
+            {
+                violations.push(format!("{name}: {literal:?}"));
+            }
+        }
+    }
+    assert!(
+        violations.is_empty(),
+        "CLI messages still say clause ({}):\n  - {}",
+        violations.len(),
+        violations.join("\n  - ")
+    );
+}
+```
+
+- [ ] **Step 2: Run it and confirm the intended failure**
+
+Run: `cargo test --test cli_vocabulary`
+Expected: FAIL, listing the six `grammar.rs` messages. Paste the list into the report — it is the evidence the guard has teeth.
+
+- [ ] **Step 3: Implement**
+
+In `src/cli/grammar.rs`, change only these six format strings. Leave `StatusClause`, `let clause`, `let idx = clause as usize`, and `match clause` exactly as they are.
+
+| Line | Now | New |
+| --- | --- | --- |
+| :99 | `unknown status clause '{other}'` | `unknown argument '{other}' for status` |
+| :106 | `duplicate status clause '{word}'` | `repeated argument '{word}' for status` |
+| :243 | `unknown setup clause '{other}'` | `unknown argument '{other}' for setup` |
+| :268 | `unknown update clause '{other}'` | `unknown argument '{other}' for update` |
+| :278 | `unknown uninstall clause '{other}'` | `unknown argument '{other}' for uninstall` |
+| :289 | `unknown doctor clause '{other}'` | `unknown argument '{other}' for doctor` |
+
+The `unknown argument '{x}' for <command>` shape is the copy design's own example for the first of these; the other five follow it so the CLI speaks one pattern rather than six.
+
+- [ ] **Step 4: Run the guard and the CLI suites**
+
+`cargo test --test cli_vocabulary` (expect 1 passed), then `cargo test --test cli` and `cargo test --lib cli`. Measured expectation: no assertion breaks, because no test pins a `clause` message. If one does break, report it before changing it.
+
+- [ ] **Step 5: Full Rust gates** — `cargo fmt --check`, `cargo test`, `cargo clippy --all-targets -- -D warnings`, `git diff --check`. Expect **302 across 19 suites** (301 plus the new suite); report the real number.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/cli/grammar.rs tests/cli_vocabulary.rs
+git commit -m "feat: say argument, not clause, in cli errors"
+```
+
+---
+
+### Task 2: One message, one definition
+
+**Files:**
+- Modify: `src/cli/grammar.rs` (:189, :208, :221, :229, :234, :240, and the two `missing value for status` sites at :114 and :116-118)
+- Modify: `src/cli/mod.rs` (:104, :113, :250, :259, :264)
+
+**Interfaces:**
+- Produces `pub(crate)` constants in `src/cli/grammar.rs`, consumed by `src/cli/mod.rs`:
+  - `SETUP_PLUGINS_DIR_ABSOLUTE: &str`
+  - `SETUP_PLUGINS_DIR_NOT_PLUGIN_ROOT: &str`
+- Produces two module-private constants used only inside `grammar.rs`, and one inside `mod.rs`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/cli_vocabulary.rs` (it already walks `src/cli/**`, so this is where a duplication guard belongs):
+
+```rust
+/// A message that exists twice drifts: one copy gets fixed, the other does
+/// not, and the user sees two wordings for one condition depending on which
+/// code path noticed. These four were duplicated across the parse and
+/// validate paths before this guard existed.
+#[test]
+fn cli_messages_are_defined_once() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/cli");
+    let watched = [
+        "setup plugins-dir path must be absolute",
+        "setup plugins-dir path must be the parent directory, not the plugin root",
+        "config apply requires stdin, file <path>, or json <value>",
+        "setup plugins-dir requires a path",
+        "setup requires a complete plugin tree",
+    ];
+    let mut violations = Vec::new();
+    let entries = fs::read_dir(&root).expect("read src/cli");
+    let mut totals = vec![0usize; watched.len()];
+    let mut files: Vec<PathBuf> = entries
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("rs"))
+        .collect();
+    files.sort();
+    for path in &files {
+        let Ok(source) = fs::read_to_string(path) else {
+            continue;
+        };
+        // Count only literal occurrences, so the single `const` definition
+        // counts once and every use site counts zero.
+        for (idx, needle) in watched.iter().enumerate() {
+            totals[idx] += source.matches(needle).count();
+        }
+    }
+    for (idx, needle) in watched.iter().enumerate() {
+        if totals[idx] > 1 {
+            violations.push(format!("{needle:?} appears {} times", totals[idx]));
+        }
+    }
+    assert!(
+        violations.is_empty(),
+        "CLI messages defined more than once ({}):\n  - {}",
+        violations.len(),
+        violations.join("\n  - ")
+    );
+}
+```
+
+- [ ] **Step 2: Run it and confirm the intended failure**
+
+Run: `cargo test --test cli_vocabulary`
+Expected: this test FAILS listing all five, with counts 2, 2, 2, 2, 3. Record the counts.
+
+- [ ] **Step 3: Implement in `grammar.rs`**
+
+Add near the top of `src/cli/grammar.rs`, after the imports:
+
+```rust
+/// Shared with `super::validate_plugins_dir`, which re-checks the same two
+/// conditions after the filesystem is consulted. One definition means the
+/// parse path and the validate path can never disagree about the wording.
+pub(crate) const SETUP_PLUGINS_DIR_ABSOLUTE: &str = "setup plugins-dir path must be absolute";
+pub(crate) const SETUP_PLUGINS_DIR_NOT_PLUGIN_ROOT: &str =
+    "setup plugins-dir path must be the parent directory, not the plugin root";
+
+const CONFIG_APPLY_USAGE: &str = "config apply requires stdin, file <path>, or json <value>";
+const SETUP_PLUGINS_DIR_REQUIRES_PATH: &str = "setup plugins-dir requires a path";
+```
+
+Replace the literals at `:189`, `:208` with `CONFIG_APPLY_USAGE`; at `:221`, `:240` with `SETUP_PLUGINS_DIR_REQUIRES_PATH`; at `:229` with `SETUP_PLUGINS_DIR_ABSOLUTE`; at `:234` with `SETUP_PLUGINS_DIR_NOT_PLUGIN_ROOT`.
+
+For the two `missing value for status {word}` sites (`:114` and `:116-118`), both take the same `word`, so give them one definition:
+
+```rust
+fn missing_status_value(word: &str) -> CliFailure {
+    CliFailure::grammar(format!("missing value for status {word}"))
+}
+```
+
+and call it from both.
+
+- [ ] **Step 4: Implement in `mod.rs`**
+
+Replace the literal at `:104` with `grammar::SETUP_PLUGINS_DIR_ABSOLUTE` and at `:113` with `grammar::SETUP_PLUGINS_DIR_NOT_PLUGIN_ROOT`, adjusting the `use` at the top of the file if `grammar` is not already in scope by that path.
+
+Collapse the three copies of the long setup message (`:250`, `:259`, `:264`) into one module constant:
+
+```rust
+/// Three call sites reach this condition — a missing plugin root, a missing
+/// helper, and a non-executable helper — and all three want the same sentence.
+const SETUP_REQUIRES_PLUGIN_TREE: &str =
+    "setup requires a complete plugin tree at <plugin-root>/bin/agent-bar; \
+     use install.sh for first bootstrap from a release archive";
+```
+
+Take care with the line continuation: `tests/cli.rs:404` pins the substring `complete plugin tree`, so the concatenated result must still contain it with single spaces. Verify by running that test, not by reading.
+
+- [ ] **Step 5: Run the guard and the CLI suites** — `cargo test --test cli_vocabulary` (2 passed), `cargo test --test cli`, `cargo test --lib cli`.
+
+- [ ] **Step 6: Full Rust gates.** Expect **303 across 19 suites** — Task 1's 302 plus this task's second `cli_vocabulary` test. Report the real number.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/cli/grammar.rs src/cli/mod.rs tests/cli_vocabulary.rs
+git commit -m "refactor: define each cli message once"
+```
+
+---
+
+### Task 3: Name the fix where the fix is certain
+
+**Files:**
+- Modify: `src/cli/mod.rs` (`:117-120`, `:123-126`, `:139-142`, `:902-905`)
+
+**Interfaces:** none; message text only.
+
+- [ ] **Step 1: Write the failing test**
+
+Copy design §7.3 covers messages that state a problem without its fix "where the fix is short and certain". That qualifier is the whole rule — a guessed fix is worse than none. Exactly four messages qualify. Add to `tests/cli_vocabulary.rs`:
+
+```rust
+/// §7.3: a message names the fix only where the fix is short and certain.
+/// These four are the whole set — every other CLI error either states a
+/// grammar mistake the user can see from their own command line, or a
+/// condition whose remedy depends on facts the helper does not have.
+#[test]
+fn cli_messages_that_can_name_a_fix_do() {
+    let source = fs::read_to_string(
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/cli/mod.rs"),
+    )
+    .expect("read mod.rs");
+    for needle in [
+        "setup plugins-dir path does not exist: {}; create it or pass an existing parent",
+        "setup plugins-dir path is not a directory: {}; pass the parent directory",
+        "setup plugins-dir path is not writable: {}; pass a directory you own",
+        "{} login executable was not found; install the provider CLI first",
+    ] {
+        assert!(
+            source.contains(needle),
+            "missing fix-naming message: {needle}"
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Run it and confirm the intended failure** — `cargo test --test cli_vocabulary`, expect this test to fail on the first needle.
+
+- [ ] **Step 3: Implement**
+
+Extend the four messages, keeping Unix convention: lower case, no trailing period, semicolon before the remedy.
+
+| Site | Now | New |
+| --- | --- | --- |
+| `:117-120` | `setup plugins-dir path does not exist: {}` | `setup plugins-dir path does not exist: {}; create it or pass an existing parent` |
+| `:123-126` | `setup plugins-dir path is not a directory: {}` | `setup plugins-dir path is not a directory: {}; pass the parent directory` |
+| `:139-142` | `setup plugins-dir path is not writable: {}` | `setup plugins-dir path is not writable: {}; pass a directory you own` |
+| `:902-905` | `{} login executable was not found` | `{} login executable was not found; install the provider CLI first` |
+
+Leave every other CLI message alone. In particular do **not** add a remedy to the grammar errors: the user's own command line already shows the mistake, and `agent-bar help <command>` exists for the rest.
+
+- [ ] **Step 4: Run the suites** — `cargo test --test cli_vocabulary` (3 passed), `cargo test --test cli`, `cargo test --lib cli`, `cargo test --test login`.
+
+- [ ] **Step 5: Full Rust gates.** Expect **304 across 19 suites**. Report the real number.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/cli/mod.rs tests/cli_vocabulary.rs
+git commit -m "feat: name the fix in four cli errors"
+```
+
+---
+
+### Task 4: The installer speaks to a person
+
+**Files:**
+- Modify: `install.sh` (header `:2-15`, unknown-flag `:37`, and every `log`/`ok`/`warn`/`die` call site)
+
+**Interfaces:** none. The four output helpers at `:43-46` and their prefixes are unchanged; only the messages passed to them change.
+
+`install.sh` is one of the two surfaces the copy design exempts from Unix convention and holds to the full GUI voice: name before category, active voice, no ceremony, imperative fixes, sentences take a period, never blame the user. Keep every message ASCII.
+
+- [ ] **Step 1: Rewrite the header banner**
+
+`install.sh:2-15` is printed verbatim by `--help` (measured fact 5). Replace lines 3–15 with:
+
+```bash
+# Installs the Agent Bar plugin for Omarchy Quattro. Nothing else.
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/othavi0/agent-bar/master/install.sh | bash
+#
+# Flags:
+#   --force      Reinstall even if this version is already installed.
+#   --yes, -y    Answer yes to every prompt.
+#
+# Env:
+#   AGENT_BAR_VERSION  Version to install. Defaults to the latest release.
+#
+# Installs to: $HOME/.config/omarchy/plugins/agent-bar.usage
+# No global executable is installed.
+```
+
+Keep line 2 (`#`) and line 16 (blank) exactly — the `sed -n '2,/^$/p'` range depends on both.
+
+- [ ] **Step 2: Rewrite every message**
+
+Apply this table exactly. The left column is the current argument passed to the helper; the right column replaces it. Prefixes (`==> `, `OK  `, `!   `, `ERR `) are added by the helpers and are not part of these strings.
+
+| Line | Now | New |
+| --- | --- | --- |
+| 37 | `agent-bar install: unknown flag: $arg` | `Unknown flag: $arg` |
+| 51 | `agent-bar requires Linux. Detected: $uname_s` | `Agent Bar needs Linux. This is $uname_s.` |
+| 53 | `Only x86_64 plugin bundles are published. Detected: $arch` | `Agent Bar ships for x86_64 only. This is $arch.` |
+| 57 | `curl not found` | `curl is missing. Install it and run this again.` |
+| 58 | `sha256sum not found` | `sha256sum is missing. Install coreutils and run this again.` |
+| 59 | `tar not found` | `tar is missing. Install it and run this again.` |
+| 60 | `zstd not found (required for .tar.zst)` | `zstd is missing. Install it and run this again.` |
+| 70 | `Resolving latest release...` | `Finding the latest release...` |
+| 76 | `Could not resolve latest release. Set AGENT_BAR_VERSION.` | `Could not reach the release list. Set AGENT_BAR_VERSION and run this again.` |
+| 95 | `Staged bundle missing bundle.json receipt` | `The download is incomplete: bundle.json is missing.` |
+| 96 | `Staged bundle missing manifest.json` | `The download is incomplete: manifest.json is missing.` |
+| 97 | `Staged bundle missing Service.qml` | `The download is incomplete: Service.qml is missing.` |
+| 98 | `Staged bundle missing BarWidget.qml` | `The download is incomplete: BarWidget.qml is missing.` |
+| 99 | `Staged helper bin/agent-bar missing or not executable` | `The download is incomplete: bin/agent-bar is missing or not executable.` |
+| 101 | `Staged terminal helper missing or not executable` | `The download is incomplete: the terminal helper is missing or not executable.` |
+| 105 | `bundle.json pluginId is not ${PLUGIN_ID}` | `This download is for another plugin, not ${PLUGIN_ID}.` |
+| 110 | `bundle.json missing version` | `The download is incomplete: bundle.json has no version.` |
+| 112 | `bundle.json version ${receipt_version} != expected ${expected_version}` | `The download is version ${receipt_version}, not ${expected_version}.` |
+| 119 | `manifest version ${man_version} != expected ${expected_version}` | `The manifest is version ${man_version}, not ${expected_version}.` |
+| 127 | `Receipt path missing on disk: ${path}` | `The download is missing a file it lists: ${path}` |
+| 132 | `Staged inventory does not match bundle.json` | `The download does not match its own receipt.` |
+| 137 | `Staged helper did not print a version` | `The helper in this download does not run here.` |
+| 139 | `Helper version ${helper_version} != expected ${expected_version}` | `The helper is version ${helper_version}, not ${expected_version}.` |
+| 141 | `Staged bundle inventory/receipt validated (${expected_version})` | `Download verified (${expected_version})` |
+| 153 | `Downloading ${asset}...` | `Downloading ${asset}...` (unchanged) |
+| 157 | `Verifying checksum...` | `Verifying the download...` |
+| 159 | `Checksum mismatch — download may be corrupted.` | `The download is corrupted. Run this again.` |
+| 160 | `Checksum OK` | `Checksum matches` |
+| 162 | `Extracting plugin bundle...` | `Extracting...` |
+| 167 | `Archive missing top-level ${PLUGIN_ID}/` | `The archive has no ${PLUGIN_ID} directory.` |
+| 171 | `Archive contains links or traversal components` | `The archive contains unsafe paths. Nothing was installed.` |
+| 189 | `Failed to install plugin root` | `Could not write to ${PLUGINS_DIR}.` |
+| 196 | `Plugin installed at ${PLUGIN_ROOT}` | `Installed at ${PLUGIN_ROOT}` |
+| 204 | `omarchy CLI not found. Enable manually: omarchy plugin enable ${PLUGIN_ID}` | `omarchy was not found. Enable it yourself: omarchy plugin enable ${PLUGIN_ID}` |
+| 210 | `Existing shell entry — running omarchy plugin rescan` | `Already in your shell. Rescanning...` |
+| 211 | `rescan failed; run: omarchy plugin rescan` | `Rescan failed. Run it yourself: omarchy plugin rescan` |
+| 218 | `Enable ${PLUGIN_ID} via omarchy plugin enable? [Y/n] ` | `Enable ${PLUGIN_ID} now? [Y/n] ` |
+| 224 | `Non-interactive install. Run: omarchy plugin enable ${PLUGIN_ID}` | `Nothing to answer here. Run: omarchy plugin enable ${PLUGIN_ID}` |
+| 228 | `Running omarchy plugin enable ${PLUGIN_ID}` | `Enabling ${PLUGIN_ID}...` |
+| 230 | `enable failed; run: omarchy plugin enable ${PLUGIN_ID}` | `Enable failed. Run it yourself: omarchy plugin enable ${PLUGIN_ID}` |
+| 237 | `agent-bar plugin installer` | `Agent Bar installer` |
+| 248 | `agent-bar.usage is already at ${version}` | `Already at ${version}. Use --force to reinstall.` |
+| 253 | `Updating agent-bar.usage (${existing} -> ${version})...` | `Updating ${existing} to ${version}...` |
+| 255 | `Installing agent-bar.usage ${version}...` | `Installing ${version}...` |
+| 260 | `agent-bar.usage ${version} ready` | `Agent Bar ${version} is ready` |
+| 261 | `Private helper: ${PLUGIN_ROOT}/bin/agent-bar` | `Helper: ${PLUGIN_ROOT}/bin/agent-bar` |
+| 262 | `No global executable was installed.` | `No global executable was installed.` (unchanged) |
+
+Two things the table encodes deliberately, so do not "fix" them: `bundle`/`bundle.json` survive wherever they name the real artifact or receipt (measured fact 6), and `ok` lines are labels rather than sentences, so they take no trailing period (voice rule 9).
+
+- [ ] **Step 3: ShellCheck and a real run**
+
+```bash
+shellcheck install.sh
+bash -n install.sh
+bash install.sh --help
+```
+
+`--help` must print the new banner with no leading `#`, and `shellcheck` must be clean. Paste the `--help` output into the report — it is the only way this surface gets looked at.
+
+- [ ] **Step 4: Confirm nothing else broke**
+
+```bash
+cargo test --test active_legacy_scan
+cargo test --test active_docs
+cargo test --test active_language
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add install.sh
+git commit -m "feat: rewrite the installer in plain words"
+```
+
+---
+
+### Task 5: The interactive update prompt
+
+**Files:**
+- Modify: `src/cli/mod.rs` (`INTERACTIVE_UPDATE_REQUIRES_TTY` :156-157, `confirm_interactive_update` :182-210)
+
+**Interfaces:** none. `confirm_interactive_update`'s signature and return values are unchanged.
+
+This is the second surface the copy design holds to the GUI voice. **The typed phrase `update agent-bar` is frozen** (measured fact 7) — it is what the user must type, pinned by two tests, and it is a safety mechanism.
+
+- [ ] **Step 1: Write the failing test**
+
+The inline tests in `src/cli/mod.rs` already cover this flow. Extend them rather than adding a file — find `confirm_interactive_update`'s existing tests near `:1020-1060` and add:
+
+```rust
+    #[test]
+    fn interactive_update_prompt_speaks_plainly() {
+        let mut stdin = std::io::Cursor::new(b"update agent-bar\n".to_vec());
+        let mut stdout: Vec<u8> = Vec::new();
+        let mut stderr: Vec<u8> = Vec::new();
+        confirm_interactive_update(
+            true,
+            InteractiveUpdateOffer::Available {
+                current: "10.0.0".into(),
+                target: "10.2.0".into(),
+            },
+            &mut stdin,
+            &mut stdout,
+            &mut stderr,
+        )
+        .expect("confirmed");
+        let out = String::from_utf8(stdout).expect("utf8");
+        let err = String::from_utf8(stderr).expect("utf8");
+        assert_eq!(out, "Updates 10.0.0 to 10.2.0. Settings stay.\n");
+        // The typed phrase is a safety mechanism, not copy: it must survive
+        // every rewording of the sentence around it.
+        assert!(err.contains("update agent-bar"));
+        assert_eq!(err, "Type update agent-bar to continue: ");
+    }
+```
+
+- [ ] **Step 2: Run it and confirm the intended failure** — `cargo test --lib cli`, expect this test to fail on the stdout comparison.
+
+- [ ] **Step 3: Implement**
+
+Replace the two `writeln!` calls to stdout (`:189-192`) with one line that matches the Maintenance screen's wording for the same decision, so the two surfaces agree:
+
+```rust
+            writeln!(stdout, "Updates {current} to {target}. Settings stay.")
+                .map_err(|err| CliFailure::internal(err.to_string()))?;
+```
+
+and give the prompt a trailing space so the caret does not touch the colon (`:193`):
+
+```rust
+            write!(stderr, "Type update agent-bar to continue: ")
+```
+
+The GUI says `Updates 10.0.0 → 10.2.0. Settings stay. Rolls back if it fails.`; the CLI drops the arrow for ASCII safety and drops the rollback clause, which the CLI's own `update apply` path does not promise.
+
+Leave `INTERACTIVE_UPDATE_REQUIRES_TTY` unchanged: it already names its fix, `tests/cli.rs:678-680` and `mod.rs:1009-1010` pin its substrings, and it is read by a script author, not an installer.
+
+- [ ] **Step 4: Run the suites** — `cargo test --lib cli`, `cargo test --test cli`.
+
+- [ ] **Step 5: Full Rust gates.**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/cli/mod.rs
+git commit -m "feat: plain words at the update prompt"
+```
+
+---
+
+### Task 6: The carried dead line, the sweep, the checkpoint, the record
+
+**Files:**
+- Modify: `assets/omarchy/CoreMaintenance.js` (`:219`)
+- Modify: `tests/qml/tst_Maintenance.qml` (add the guard)
+- Modify: `docs/superpowers/plans/2026-08-01-v11-06-cli-and-installer-copy.md` (this file)
+
+- [ ] **Step 1: Delete the dead arming message**
+
+Plan 05 carried this forward and two reviewers confirmed it (measured fact 10). In `assets/omarchy/CoreMaintenance.js:219`, remove the `next.message = "Click Uninstall again to confirm."` assignment from `maintenanceUiArmOrConfirmUninstall`, leaving the rest of the function — the `uninstallArmed` flip and both return shapes — exactly as it is.
+
+Pin it in `tests/qml/tst_Maintenance.qml`, beside the existing uninstall tests:
+
+```qml
+  // The dialog binds its own message from uninstallArmed/purgeSettings, and
+  // the only reader of ui.message sits behind the dialog's scrim, so this
+  // string was set and never seen. The second click is communicated by the
+  // confirm button flipping to "Uninstall now".
+  function test_arming_sets_no_unseen_message() {
+    var src = read("assets/omarchy/CoreMaintenance.js")
+    verify(src.indexOf("Click Uninstall again") < 0)
+    var view = read("assets/omarchy/MaintenanceView.qml")
+    verify(view.indexOf('"Uninstall now"') >= 0)
+  }
+```
+
+- [ ] **Step 2: Hygiene greps (each must return nothing)**
+
+```bash
+rg -n "clause '" src/cli
+rg -n 'Staged bundle|Staged helper|Staged inventory' install.sh
+rg -n 'Click Uninstall again' assets
+rg -n 'agent-bar plugin installer|Checksum OK' install.sh
+```
+
+- [ ] **Step 3: Full checkpoint**
+
+```bash
+cargo fmt --check
+cargo test
+cargo clippy --all-targets -- -D warnings
+git diff --check
+shellcheck install.sh
+find assets/omarchy -type f -name '*.qml' -exec \
+  /usr/lib/qt6/bin/qmllint -I /usr/share/omarchy/shell {} +
+omarchy plugin validate assets/omarchy
+QT_QPA_PLATFORM=offscreen QML_XHR_ALLOW_FILE_READ=1 QT_LOGGING_TO_CONSOLE=1 \
+  /usr/lib/qt6/bin/qmltestrunner -input tests/qml \
+  -import /usr/share/omarchy/shell -import assets/omarchy -o -,txt
+scripts/verify-v10-ui
+```
+
+Expect Rust **305 across 19 suites**: 301 baseline, plus 3 in the new `cli_vocabulary` suite (one per Task 1–3), plus Task 5's inline prompt test. QML **232 / 0 failed** — 231 plus this task's guard. Verify rather than trust this arithmetic and report the real numbers; a mismatch means a test was lost, which is worth finding.
+
+- [ ] **Step 4: Execution record** — append to this file in the shape plans 02–05 use: commits mapped to tasks, final counts, "What the plan got wrong", "Deferred minors carried forward". Then:
+
+```bash
+git add assets/omarchy/CoreMaintenance.js tests/qml/tst_Maintenance.qml \
+  docs/superpowers/plans/2026-08-01-v11-06-cli-and-installer-copy.md
+git commit -m "docs: record execution outcome in plan"
+```
+
+---
+
+## Done when
+
+- `cargo test --test cli_vocabulary` passes with all three tests, and each was seen failing first.
+- No string literal under `src/cli/` contains `clause`; `StatusClause` and its bindings are untouched.
+- Each of the five watched messages is defined exactly once.
+- `shellcheck install.sh` is clean, `bash install.sh --help` prints the new banner, and no `Staged` wording survives.
+- The interactive update prompt reads `Updates 10.0.0 to 10.2.0. Settings stay.` and still requires the exact phrase `update agent-bar`.
+- `Click Uninstall again` appears nowhere under `assets/`.
+- Every checkpoint gate green; the real test counts reported rather than assumed.
+- Nothing installed into `~/.config/omarchy/plugins/` — live QA remains the owner's gate.
+
+## Not in this plan
+
+This is the last plan in the v11 copy and visual track. Deliberately untouched:
+
+- `src/bin/agent-bar-bundle.rs`, an internal build tool that is never installed.
+- The CLI grammar itself: every command, keyword, flag, and provider id parses exactly as before.
+- `INTERACTIVE_UPDATE_REQUIRES_TTY`, which already names its fix and is read by script authors.
+- The GUI vocabulary guard's word list, which stays GUI-only because `bundle`, `collect`, and `schema` are legitimate CLI and installer vocabulary.
+- `ProviderHeader.showStale`, dead since plan 03 and still carried in `headerModel`.

--- a/install.sh
+++ b/install.sh
@@ -1,17 +1,17 @@
 #!/usr/bin/env bash
 #
-# agent-bar plugin bootstrap — installs the Omarchy Quattro plugin bundle only.
+# Installs the Agent Bar plugin for Omarchy Quattro. Nothing else.
 # Usage:
 #   curl -fsSL https://raw.githubusercontent.com/othavi0/agent-bar/master/install.sh | bash
 #
 # Flags:
-#   --force      Reinstall even if already at the target version.
-#   --yes, -y    Assume yes for prompts (non-interactive enable).
+#   --force      Reinstall even if this version is already installed.
+#   --yes, -y    Answer yes to every prompt.
 #
 # Env:
-#   AGENT_BAR_VERSION  Version to install (default: latest release tag, without v).
+#   AGENT_BAR_VERSION  Version to install. Defaults to the latest release.
 #
-# Product: $HOME/.config/omarchy/plugins/agent-bar.usage
+# Installs to: $HOME/.config/omarchy/plugins/agent-bar.usage
 # No global executable is installed.
 
 set -euo pipefail
@@ -34,7 +34,7 @@ for arg in "$@"; do
       exit 0
       ;;
     *)
-      echo "agent-bar install: unknown flag: $arg" >&2
+      echo "Unknown flag: $arg" >&2
       exit 2
       ;;
   esac
@@ -48,16 +48,16 @@ die()  { echo "ERR $*" >&2; exit 1; }
 check_platform() {
   local uname_s arch
   uname_s=$(uname -s 2>/dev/null || echo unknown)
-  [[ "$uname_s" == "Linux" ]] || die "agent-bar requires Linux. Detected: $uname_s"
+  [[ "$uname_s" == "Linux" ]] || die "Agent Bar needs Linux. This is $uname_s."
   arch=$(uname -m 2>/dev/null || echo unknown)
-  [[ "$arch" == "x86_64" ]] || die "Only x86_64 plugin bundles are published. Detected: $arch"
+  [[ "$arch" == "x86_64" ]] || die "Agent Bar ships for x86_64 only. This is $arch."
 }
 
 check_deps() {
-  command -v curl >/dev/null 2>&1 || die "curl not found"
-  command -v sha256sum >/dev/null 2>&1 || die "sha256sum not found"
-  command -v tar >/dev/null 2>&1 || die "tar not found"
-  command -v zstd >/dev/null 2>&1 || die "zstd not found (required for .tar.zst)"
+  command -v curl >/dev/null 2>&1 || die "curl is missing. Install it and run this again."
+  command -v sha256sum >/dev/null 2>&1 || die "sha256sum is missing. Install coreutils and run this again."
+  command -v tar >/dev/null 2>&1 || die "tar is missing. Install it and run this again."
+  command -v zstd >/dev/null 2>&1 || die "zstd is missing. Install it and run this again."
 }
 
 resolve_version() {
@@ -67,13 +67,13 @@ resolve_version() {
     echo "$v"
     return
   fi
-  log "Resolving latest release..."
+  log "Finding the latest release..."
   local tag
   tag=$(curl -fsSL "https://api.github.com/repos/${GITHUB_REPO}/releases/latest" \
     | grep '"tag_name"' \
     | head -1 \
     | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')
-  [[ -n "$tag" ]] || die "Could not resolve latest release. Set AGENT_BAR_VERSION."
+  [[ -n "$tag" ]] || die "Could not reach the release list. Set AGENT_BAR_VERSION and run this again."
   echo "${tag#v}"
 }
 
@@ -92,31 +92,32 @@ validate_staged_bundle() {
   local receipt="${stage}/bundle.json"
   local manifest="${stage}/manifest.json"
 
-  [[ -f "$receipt" ]] || die "Staged bundle missing bundle.json receipt"
-  [[ -f "$manifest" ]] || die "Staged bundle missing manifest.json"
-  [[ -f "${stage}/Service.qml" ]] || die "Staged bundle missing Service.qml"
-  [[ -f "${stage}/BarWidget.qml" ]] || die "Staged bundle missing BarWidget.qml"
-  [[ -x "${stage}/bin/agent-bar" ]] || die "Staged helper bin/agent-bar missing or not executable"
+  [[ -f "$receipt" ]] || die "The download is incomplete: bundle.json is missing."
+  [[ -f "$manifest" ]] || die "The download is incomplete: manifest.json is missing."
+  [[ -f "${stage}/Service.qml" ]] || die "The download is incomplete: Service.qml is missing."
+  [[ -f "${stage}/BarWidget.qml" ]] || die "The download is incomplete: BarWidget.qml is missing."
+  [[ -x "${stage}/bin/agent-bar" ]] \
+    || die "The download is incomplete: bin/agent-bar is missing or not executable."
   [[ -x "${stage}/scripts/agent-bar-open-terminal" ]] \
-    || die "Staged terminal helper missing or not executable"
+    || die "The download is incomplete: the terminal helper is missing or not executable."
 
   # Receipt pluginId + version must match expected install target.
   grep -q '"pluginId"[[:space:]]*:[[:space:]]*"'"${PLUGIN_ID}"'"' "$receipt" \
-    || die "bundle.json pluginId is not ${PLUGIN_ID}"
+    || die "This download is for another plugin, not ${PLUGIN_ID}."
   local receipt_version
   receipt_version=$(grep -o '"version"[[:space:]]*:[[:space:]]*"[^"]*"' "$receipt" \
     | head -1 \
     | sed 's/.*"\([^"]*\)"$/\1/')
-  [[ -n "$receipt_version" ]] || die "bundle.json missing version"
+  [[ -n "$receipt_version" ]] || die "The download is incomplete: bundle.json has no version."
   [[ "$receipt_version" == "$expected_version" ]] \
-    || die "bundle.json version ${receipt_version} != expected ${expected_version}"
+    || die "The download is version ${receipt_version}, not ${expected_version}."
 
   local man_version
   man_version=$(grep -o '"version"[[:space:]]*:[[:space:]]*"[^"]*"' "$manifest" \
     | head -1 \
     | sed 's/.*"\([^"]*\)"$/\1/')
   [[ "$man_version" == "$expected_version" ]] \
-    || die "manifest version ${man_version} != expected ${expected_version}"
+    || die "The manifest is version ${man_version}, not ${expected_version}."
 
   # Inventory paths listed in the receipt must exist on disk.
   # bundle.json is not listed in its own files array.
@@ -124,21 +125,21 @@ validate_staged_bundle() {
   while IFS= read -r path; do
     [[ -n "$path" ]] || continue
     if [[ ! -e "${stage}/${path}" ]]; then
-      warn "Receipt path missing on disk: ${path}"
+      warn "The download is missing a file it lists: ${path}"
       missing=1
     fi
   done < <(grep -o '"path"[[:space:]]*:[[:space:]]*"[^"]*"' "$receipt" \
     | sed 's/.*"\([^"]*\)"$/\1/')
-  [[ "$missing" -eq 0 ]] || die "Staged inventory does not match bundle.json"
+  [[ "$missing" -eq 0 ]] || die "The download does not match its own receipt."
 
   # Helper version must match receipt (BUNDLE-006).
   local helper_version
   helper_version=$("${stage}/bin/agent-bar" version 2>/dev/null | head -1 | tr -d '[:space:]' || true)
-  [[ -n "$helper_version" ]] || die "Staged helper did not print a version"
+  [[ -n "$helper_version" ]] || die "The helper in this download does not run here."
   [[ "$helper_version" == "$expected_version" ]] \
-    || die "Helper version ${helper_version} != expected ${expected_version}"
+    || die "The helper is version ${helper_version}, not ${expected_version}."
 
-  ok "Staged bundle inventory/receipt validated (${expected_version})"
+  ok "Download verified (${expected_version})"
 }
 
 install_plugin() {
@@ -154,21 +155,21 @@ install_plugin() {
   curl -fL --progress-bar "${base_url}/${asset}" -o "${tmpdir}/${asset}"
   curl -fsSL "${base_url}/${asset}.sha256" -o "${tmpdir}/${asset}.sha256"
 
-  log "Verifying checksum..."
+  log "Verifying the download..."
   (cd "$tmpdir" && sha256sum -c "${asset}.sha256") >&2 \
-    || die "Checksum mismatch — download may be corrupted."
-  ok "Checksum OK"
+    || die "The download is corrupted. Run this again."
+  ok "Checksum matches"
 
-  log "Extracting plugin bundle..."
+  log "Extracting..."
   mkdir -p "${tmpdir}/extract"
   tar --use-compress-program=zstd -xf "${tmpdir}/${asset}" -C "${tmpdir}/extract"
 
   [[ -d "${tmpdir}/extract/${PLUGIN_ID}" ]] \
-    || die "Archive missing top-level ${PLUGIN_ID}/"
+    || die "The archive has no ${PLUGIN_ID} directory."
 
   # Refuse archive paths that escape the extract root (defense in depth).
   if find "${tmpdir}/extract" -name '..' -o -type l | grep -q .; then
-    die "Archive contains links or traversal components"
+    die "The archive contains unsafe paths. Nothing was installed."
   fi
 
   mkdir -p "${PLUGINS_DIR}"
@@ -186,14 +187,14 @@ install_plugin() {
     mv "${PLUGIN_ROOT}" "${bak}"
     if ! mv "${stage}" "${PLUGIN_ROOT}"; then
       mv "${bak}" "${PLUGIN_ROOT}" || true
-      die "Failed to install plugin root"
+      die "Could not write to ${PLUGINS_DIR}."
     fi
     rm -rf "${bak}"
   else
     mv "${stage}" "${PLUGIN_ROOT}"
   fi
 
-  ok "Plugin installed at ${PLUGIN_ROOT}"
+  ok "Installed at ${PLUGIN_ROOT}"
 
   rm -rf "$tmpdir"
   trap - EXIT
@@ -201,40 +202,40 @@ install_plugin() {
 
 activate_plugin() {
   if ! command -v omarchy >/dev/null 2>&1; then
-    warn "omarchy CLI not found. Enable manually: omarchy plugin enable ${PLUGIN_ID}"
+    warn "omarchy was not found. Enable it yourself: omarchy plugin enable ${PLUGIN_ID}"
     return
   fi
 
   if [[ -f "${HOME}/.config/omarchy/shell.json" ]] \
     && grep -q "${PLUGIN_ID}" "${HOME}/.config/omarchy/shell.json" 2>/dev/null; then
-    log "Existing shell entry — running omarchy plugin rescan"
-    omarchy plugin rescan || warn "rescan failed; run: omarchy plugin rescan"
+    log "Already in your shell. Rescanning..."
+    omarchy plugin rescan || warn "Rescan failed. Run it yourself: omarchy plugin rescan"
   else
     local proceed=0
     if [[ "$YES" -eq 1 ]]; then
       proceed=1
     elif [[ -t 0 ]]; then
       echo "" >&2
-      read -r -p "Enable ${PLUGIN_ID} via omarchy plugin enable? [Y/n] " ans
+      read -r -p "Enable ${PLUGIN_ID} now? [Y/n] " ans
       case "${ans:-Y}" in
         [yY]|[yY][eE][sS]|"") proceed=1 ;;
         *) proceed=0 ;;
       esac
     else
-      warn "Non-interactive install. Run: omarchy plugin enable ${PLUGIN_ID}"
+      warn "Nothing to answer here. Run: omarchy plugin enable ${PLUGIN_ID}"
       return
     fi
     if [[ "$proceed" -eq 1 ]]; then
-      log "Running omarchy plugin enable ${PLUGIN_ID}"
+      log "Enabling ${PLUGIN_ID}..."
       omarchy plugin enable "${PLUGIN_ID}" \
-        || warn "enable failed; run: omarchy plugin enable ${PLUGIN_ID}"
+        || warn "Enable failed. Run it yourself: omarchy plugin enable ${PLUGIN_ID}"
     fi
   fi
 }
 
 main() {
   echo "" >&2
-  log "agent-bar plugin installer"
+  log "Agent Bar installer"
   check_platform
   check_deps
 
@@ -245,20 +246,20 @@ main() {
   local existing
   existing=$(existing_version || true)
   if [[ -n "$existing" && "$existing" == "$version" && "$FORCE" -eq 0 ]]; then
-    ok "agent-bar.usage is already at ${version}"
+    ok "Already at ${version}. Use --force to reinstall."
     exit 0
   fi
 
   if [[ -n "$existing" ]]; then
-    log "Updating agent-bar.usage (${existing} -> ${version})..."
+    log "Updating ${existing} to ${version}..."
   else
-    log "Installing agent-bar.usage ${version}..."
+    log "Installing ${version}..."
   fi
 
   install_plugin "$version"
   activate_plugin
-  ok "agent-bar.usage ${version} ready"
-  log "Private helper: ${PLUGIN_ROOT}/bin/agent-bar"
+  ok "Agent Bar ${version} is ready"
+  log "Helper: ${PLUGIN_ROOT}/bin/agent-bar"
   log "No global executable was installed."
 }
 

--- a/install.sh
+++ b/install.sh
@@ -73,7 +73,7 @@ resolve_version() {
     | grep '"tag_name"' \
     | head -1 \
     | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')
-  [[ -n "$tag" ]] || die "Could not reach the release list. Set AGENT_BAR_VERSION and run this again."
+  [[ -n "$tag" ]] || die "Could not find the release list. Set AGENT_BAR_VERSION and run this again."
   echo "${tag#v}"
 }
 

--- a/src/cli/grammar.rs
+++ b/src/cli/grammar.rs
@@ -8,6 +8,16 @@ use super::command::{
 };
 use super::exit::CliFailure;
 
+/// Shared with `super::validate_plugins_dir`, which re-checks the same two
+/// conditions after the filesystem is consulted. One definition means the
+/// parse path and the validate path can never disagree about the wording.
+pub(crate) const SETUP_PLUGINS_DIR_ABSOLUTE: &str = "setup plugins-dir path must be absolute";
+pub(crate) const SETUP_PLUGINS_DIR_NOT_PLUGIN_ROOT: &str =
+    "setup plugins-dir path must be the parent directory, not the plugin root";
+
+const CONFIG_APPLY_USAGE: &str = "config apply requires stdin, file <path>, or json <value>";
+const SETUP_PLUGINS_DIR_REQUIRES_PATH: &str = "setup plugins-dir requires a path";
+
 /// Parse argv words after the program name into a closed [`Command`].
 ///
 /// Grammar failures map to exit code 2. Parsing never touches the filesystem,
@@ -111,11 +121,9 @@ fn parse_status(tokens: &[String]) -> Result<Command, CliFailure> {
         let value = tokens
             .get(i)
             .map(String::as_str)
-            .ok_or_else(|| CliFailure::grammar(format!("missing value for status {word}")))?;
+            .ok_or_else(|| missing_status_value(word))?;
         if value.starts_with('-') {
-            return Err(CliFailure::grammar(format!(
-                "missing value for status {word}"
-            )));
+            return Err(missing_status_value(word));
         }
         match clause {
             StatusClause::Format => {
@@ -162,6 +170,12 @@ fn parse_status(tokens: &[String]) -> Result<Command, CliFailure> {
     Ok(Command::Status(opts))
 }
 
+/// Both status clause errors — no value present, and a value that looks like
+/// a flag — take the same `word` and want the same sentence.
+fn missing_status_value(word: &str) -> CliFailure {
+    CliFailure::grammar(format!("missing value for status {word}"))
+}
+
 fn parse_login(tokens: &[String]) -> Result<Command, CliFailure> {
     match tokens {
         [] => Err(CliFailure::grammar("login requires a provider id")),
@@ -185,9 +199,7 @@ fn parse_config(tokens: &[String]) -> Result<Command, CliFailure> {
     match tokens {
         [] => Err(CliFailure::grammar("config requires show or apply")),
         [cmd] if cmd == "show" => Ok(Command::Config(ConfigCommand::Show)),
-        [cmd] if cmd == "apply" => Err(CliFailure::grammar(
-            "config apply requires stdin, file <path>, or json <value>",
-        )),
+        [cmd] if cmd == "apply" => Err(CliFailure::grammar(CONFIG_APPLY_USAGE)),
         [cmd, mode] if cmd == "apply" && mode == "stdin" => {
             Ok(Command::Config(ConfigCommand::Apply(ConfigInput::Stdin)))
         }
@@ -204,9 +216,7 @@ fn parse_config(tokens: &[String]) -> Result<Command, CliFailure> {
         [cmd, mode, value] if cmd == "apply" && mode == "json" => Ok(Command::Config(
             ConfigCommand::Apply(ConfigInput::Json(value.clone())),
         )),
-        [cmd, ..] if cmd == "apply" => Err(CliFailure::grammar(
-            "config apply requires stdin, file <path>, or json <value>",
-        )),
+        [cmd, ..] if cmd == "apply" => Err(CliFailure::grammar(CONFIG_APPLY_USAGE)),
         [other, ..] => Err(CliFailure::grammar(format!(
             "unknown config command '{other}'"
         ))),
@@ -218,26 +228,22 @@ fn parse_setup(tokens: &[String]) -> Result<Command, CliFailure> {
         [] => Ok(Command::Setup(SetupOptions::Production)),
         [word, path] if word == "plugins-dir" => {
             if path.is_empty() {
-                return Err(CliFailure::grammar("setup plugins-dir requires a path"));
+                return Err(CliFailure::grammar(SETUP_PLUGINS_DIR_REQUIRES_PATH));
             }
             // Path shape checks that need no filesystem: relative and direct
             // plugin-root forms are rejected here; existence/writability are
             // validated after parse.
             let pb = PathBuf::from(path);
             if !pb.is_absolute() {
-                return Err(CliFailure::grammar(
-                    "setup plugins-dir path must be absolute",
-                ));
+                return Err(CliFailure::grammar(SETUP_PLUGINS_DIR_ABSOLUTE));
             }
             if path_ends_with_plugin_id(&pb) {
-                return Err(CliFailure::grammar(
-                    "setup plugins-dir path must be the parent directory, not the plugin root",
-                ));
+                return Err(CliFailure::grammar(SETUP_PLUGINS_DIR_NOT_PLUGIN_ROOT));
             }
             Ok(Command::Setup(SetupOptions::PluginsDir(pb)))
         }
         [word] if word == "plugins-dir" => {
-            Err(CliFailure::grammar("setup plugins-dir requires a path"))
+            Err(CliFailure::grammar(SETUP_PLUGINS_DIR_REQUIRES_PATH))
         }
         [other, ..] => Err(CliFailure::grammar(format!(
             "unknown argument '{other}' for setup"

--- a/src/cli/grammar.rs
+++ b/src/cli/grammar.rs
@@ -96,14 +96,14 @@ fn parse_status(tokens: &[String]) -> Result<Command, CliFailure> {
             "notifications" => StatusClause::Notifications,
             other => {
                 return Err(CliFailure::grammar(format!(
-                    "unknown status clause '{other}'"
+                    "unknown argument '{other}' for status"
                 )));
             }
         };
         let idx = clause as usize;
         if seen[idx] {
             return Err(CliFailure::grammar(format!(
-                "duplicate status clause '{word}'"
+                "repeated argument '{word}' for status"
             )));
         }
         seen[idx] = true;
@@ -240,7 +240,7 @@ fn parse_setup(tokens: &[String]) -> Result<Command, CliFailure> {
             Err(CliFailure::grammar("setup plugins-dir requires a path"))
         }
         [other, ..] => Err(CliFailure::grammar(format!(
-            "unknown setup clause '{other}'"
+            "unknown argument '{other}' for setup"
         ))),
     }
 }
@@ -265,7 +265,7 @@ fn parse_update(tokens: &[String]) -> Result<Command, CliFailure> {
             Ok(Command::Update(UpdateCommand::Apply(release)))
         }
         [other, ..] => Err(CliFailure::grammar(format!(
-            "unknown update clause '{other}'"
+            "unknown argument '{other}' for update"
         ))),
     }
 }
@@ -275,7 +275,7 @@ fn parse_uninstall(tokens: &[String]) -> Result<Command, CliFailure> {
         [] => Ok(Command::Uninstall { purge: false }),
         [word] if word == "purge" => Ok(Command::Uninstall { purge: true }),
         [other, ..] => Err(CliFailure::grammar(format!(
-            "unknown uninstall clause '{other}'"
+            "unknown argument '{other}' for uninstall"
         ))),
     }
 }
@@ -286,7 +286,7 @@ fn parse_doctor(tokens: &[String]) -> Result<Command, CliFailure> {
         [word] if word == "clean" => Ok(Command::Doctor(DoctorCommand::Clean)),
         [] => Err(CliFailure::grammar("doctor requires scan or clean")),
         [other, ..] => Err(CliFailure::grammar(format!(
-            "unknown doctor clause '{other}'"
+            "unknown argument '{other}' for doctor"
         ))),
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -113,7 +113,7 @@ pub fn validate_plugins_dir(path: &Path) -> Result<PathBuf, CliFailure> {
     }
     let meta = std::fs::metadata(path).map_err(|_| {
         CliFailure::validation(format!(
-            "setup plugins-dir path does not exist: {}; create it or pass an existing parent",
+            "setup plugins-dir path cannot be read: {}; create it, or check the permissions on its parents",
             path.display()
         ))
     })?;
@@ -135,7 +135,7 @@ pub fn validate_plugins_dir(path: &Path) -> Result<PathBuf, CliFailure> {
         }
         Err(_) => {
             return Err(CliFailure::validation(format!(
-                "setup plugins-dir path is not writable: {}; pass a directory you own",
+                "setup plugins-dir path is not writable: {}",
                 path.display()
             )));
         }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -190,11 +190,9 @@ where
             Ok(())
         }
         InteractiveUpdateOffer::Available { current, target } => {
-            writeln!(stdout, "Current version: {current}")
+            writeln!(stdout, "Updates {current} to {target}. Settings stay.")
                 .map_err(|err| CliFailure::internal(err.to_string()))?;
-            writeln!(stdout, "Target version: {target}")
-                .map_err(|err| CliFailure::internal(err.to_string()))?;
-            write!(stderr, "Type update agent-bar to continue:")
+            write!(stderr, "Type update agent-bar to continue: ")
                 .map_err(|err| CliFailure::internal(err.to_string()))?;
             let _ = stderr.flush();
             let mut line = String::new();
@@ -1081,6 +1079,31 @@ mod tests {
         )
         .unwrap_err();
         assert_eq!(err.exit_code, VALIDATION);
+    }
+
+    #[test]
+    fn interactive_update_prompt_speaks_plainly() {
+        let mut stdin = std::io::Cursor::new(b"update agent-bar\n".to_vec());
+        let mut stdout: Vec<u8> = Vec::new();
+        let mut stderr: Vec<u8> = Vec::new();
+        confirm_interactive_update(
+            true,
+            InteractiveUpdateOffer::Available {
+                current: "10.0.0".into(),
+                target: "10.2.0".into(),
+            },
+            &mut stdin,
+            &mut stdout,
+            &mut stderr,
+        )
+        .expect("confirmed");
+        let out = String::from_utf8(stdout).expect("utf8");
+        let err = String::from_utf8(stderr).expect("utf8");
+        assert_eq!(out, "Updates 10.0.0 to 10.2.0. Settings stay.\n");
+        // The typed phrase is a safety mechanism, not copy: it must survive
+        // every rewording of the sentence around it.
+        assert!(err.contains("update agent-bar"));
+        assert_eq!(err, "Type update agent-bar to continue: ");
     }
 
     #[test]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -113,13 +113,13 @@ pub fn validate_plugins_dir(path: &Path) -> Result<PathBuf, CliFailure> {
     }
     let meta = std::fs::metadata(path).map_err(|_| {
         CliFailure::validation(format!(
-            "setup plugins-dir path does not exist: {}",
+            "setup plugins-dir path does not exist: {}; create it or pass an existing parent",
             path.display()
         ))
     })?;
     if !meta.is_dir() {
         return Err(CliFailure::validation(format!(
-            "setup plugins-dir path is not a directory: {}",
+            "setup plugins-dir path is not a directory: {}; pass the parent directory",
             path.display()
         )));
     }
@@ -135,7 +135,7 @@ pub fn validate_plugins_dir(path: &Path) -> Result<PathBuf, CliFailure> {
         }
         Err(_) => {
             return Err(CliFailure::validation(format!(
-                "setup plugins-dir path is not writable: {}",
+                "setup plugins-dir path is not writable: {}; pass a directory you own",
                 path.display()
             )));
         }
@@ -898,7 +898,7 @@ fn dispatch_login(provider: ProviderId) -> Result<(), CliFailure> {
     if discovery.login_executable().is_none() {
         return Err(CliFailure {
             message: format!(
-                "{} login executable was not found",
+                "{} login executable was not found; install the provider CLI first",
                 adapter.descriptor().display_name
             ),
             exit_code: GENERIC_FAILURE,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -50,7 +50,7 @@ pub fn help_text(topic: Option<HelpTopic>) -> String {
         }
         Some(HelpTopic::Status) => "status — collect provider quota windows\n\
              \n\
-             Clauses (any order, each at most once):\n\
+             Arguments (any order, each at most once):\n\
                format human|json          default: human\n\
                provider <id>              single provider (even if disabled)\n\
                cache use|bypass           default: use\n\

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -100,9 +100,7 @@ pub fn help_text(topic: Option<HelpTopic>) -> String {
 /// path are rejected by the grammar before this runs.
 pub fn validate_plugins_dir(path: &Path) -> Result<PathBuf, CliFailure> {
     if !path.is_absolute() {
-        return Err(CliFailure::grammar(
-            "setup plugins-dir path must be absolute",
-        ));
+        return Err(CliFailure::grammar(grammar::SETUP_PLUGINS_DIR_ABSOLUTE));
     }
     if path
         .file_name()
@@ -110,7 +108,7 @@ pub fn validate_plugins_dir(path: &Path) -> Result<PathBuf, CliFailure> {
         .is_some_and(|n| n == "agent-bar.usage")
     {
         return Err(CliFailure::grammar(
-            "setup plugins-dir path must be the parent directory, not the plugin root",
+            grammar::SETUP_PLUGINS_DIR_NOT_PLUGIN_ROOT,
         ));
     }
     let meta = std::fs::metadata(path).map_err(|_| {
@@ -155,6 +153,12 @@ pub enum InteractiveUpdateOffer {
 /// Shared non-TTY rejection message for interactive `update` (CLI contract).
 const INTERACTIVE_UPDATE_REQUIRES_TTY: &str =
     "interactive update requires a TTY; use 'update check' and 'update apply <version>'";
+
+/// Three call sites reach this condition — a missing plugin root, a missing
+/// helper, and a non-executable helper — and all three want the same sentence.
+const SETUP_REQUIRES_PLUGIN_TREE: &str =
+    "setup requires a complete plugin tree at <plugin-root>/bin/agent-bar; \
+     use install.sh for first bootstrap from a release archive";
 
 /// Pure interactive `update` confirmation gate (CLI contract).
 ///
@@ -246,23 +250,17 @@ fn resolve_plugin_source_root() -> Result<PathBuf, CliFailure> {
         std::env::current_exe().map_err(|e| CliFailure::plugin(format!("current_exe: {e}")))?;
     let exe = fs_canonicalize(&exe);
     let Some(bin_dir) = exe.parent() else {
-        return Err(CliFailure::plugin(
-            "setup requires a complete plugin tree at <plugin-root>/bin/agent-bar; use install.sh for first bootstrap from a release archive",
-        ));
+        return Err(CliFailure::plugin(SETUP_REQUIRES_PLUGIN_TREE));
     };
     if bin_dir
         .file_name()
         .and_then(|s| s.to_str())
         .is_none_or(|n| n != "bin")
     {
-        return Err(CliFailure::plugin(
-            "setup requires a complete plugin tree at <plugin-root>/bin/agent-bar; use install.sh for first bootstrap from a release archive",
-        ));
+        return Err(CliFailure::plugin(SETUP_REQUIRES_PLUGIN_TREE));
     }
     let Some(root) = bin_dir.parent() else {
-        return Err(CliFailure::plugin(
-            "setup requires a complete plugin tree at <plugin-root>/bin/agent-bar; use install.sh for first bootstrap from a release archive",
-        ));
+        return Err(CliFailure::plugin(SETUP_REQUIRES_PLUGIN_TREE));
     };
     if !root.join("manifest.json").is_file() {
         return Err(CliFailure::plugin(

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -190,8 +190,11 @@ where
             Ok(())
         }
         InteractiveUpdateOffer::Available { current, target } => {
-            writeln!(stdout, "Updates {current} to {target}. Settings stay.")
-                .map_err(|err| CliFailure::internal(err.to_string()))?;
+            writeln!(
+                stdout,
+                "Updates {current} to {target}. Settings stay. Rolls back if it fails."
+            )
+            .map_err(|err| CliFailure::internal(err.to_string()))?;
             write!(stderr, "Type update agent-bar to continue: ")
                 .map_err(|err| CliFailure::internal(err.to_string()))?;
             let _ = stderr.flush();
@@ -1099,7 +1102,10 @@ mod tests {
         .expect("confirmed");
         let out = String::from_utf8(stdout).expect("utf8");
         let err = String::from_utf8(stderr).expect("utf8");
-        assert_eq!(out, "Updates 10.0.0 to 10.2.0. Settings stay.\n");
+        assert_eq!(
+            out,
+            "Updates 10.0.0 to 10.2.0. Settings stay. Rolls back if it fails.\n"
+        );
         // The typed phrase is a safety mechanism, not copy: it must survive
         // every rewording of the sentence around it.
         assert!(err.contains("update agent-bar"));

--- a/tests/cli_vocabulary.rs
+++ b/tests/cli_vocabulary.rs
@@ -68,3 +68,49 @@ fn cli_messages_do_not_say_clause() {
         violations.join("\n  - ")
     );
 }
+
+/// A message that exists twice drifts: one copy gets fixed, the other does
+/// not, and the user sees two wordings for one condition depending on which
+/// code path noticed. These four were duplicated across the parse and
+/// validate paths before this guard existed.
+#[test]
+fn cli_messages_are_defined_once() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/cli");
+    let watched = [
+        "setup plugins-dir path must be absolute",
+        "setup plugins-dir path must be the parent directory, not the plugin root",
+        "config apply requires stdin, file <path>, or json <value>",
+        "setup plugins-dir requires a path",
+        "setup requires a complete plugin tree",
+    ];
+    let mut violations = Vec::new();
+    let entries = fs::read_dir(&root).expect("read src/cli");
+    let mut totals = vec![0usize; watched.len()];
+    let mut files: Vec<PathBuf> = entries
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("rs"))
+        .collect();
+    files.sort();
+    for path in &files {
+        let Ok(source) = fs::read_to_string(path) else {
+            continue;
+        };
+        // Count only literal occurrences, so the single `const` definition
+        // counts once and every use site counts zero.
+        for (idx, needle) in watched.iter().enumerate() {
+            totals[idx] += source.matches(needle).count();
+        }
+    }
+    for (idx, needle) in watched.iter().enumerate() {
+        if totals[idx] > 1 {
+            violations.push(format!("{needle:?} appears {} times", totals[idx]));
+        }
+    }
+    assert!(
+        violations.is_empty(),
+        "CLI messages defined more than once ({}):\n  - {}",
+        violations.len(),
+        violations.join("\n  - ")
+    );
+}

--- a/tests/cli_vocabulary.rs
+++ b/tests/cli_vocabulary.rs
@@ -130,3 +130,25 @@ fn cli_messages_are_defined_once() {
         violations.join("\n  - ")
     );
 }
+
+/// §7.3: a message names the fix only where the fix is short and certain.
+/// These four are the whole set — every other CLI error either states a
+/// grammar mistake the user can see from their own command line, or a
+/// condition whose remedy depends on facts the helper does not have.
+#[test]
+fn cli_messages_that_can_name_a_fix_do() {
+    let source =
+        fs::read_to_string(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/cli/mod.rs"))
+            .expect("read mod.rs");
+    for needle in [
+        "setup plugins-dir path does not exist: {}; create it or pass an existing parent",
+        "setup plugins-dir path is not a directory: {}; pass the parent directory",
+        "setup plugins-dir path is not writable: {}; pass a directory you own",
+        "{} login executable was not found; install the provider CLI first",
+    ] {
+        assert!(
+            source.contains(needle),
+            "missing fix-naming message: {needle}"
+        );
+    }
+}

--- a/tests/cli_vocabulary.rs
+++ b/tests/cli_vocabulary.rs
@@ -11,16 +11,32 @@
 use std::fs;
 use std::path::PathBuf;
 
-/// Double-quoted spans, skipping whole-line `//` comments. Crude on purpose:
-/// the CLI's messages are plain literals, never built by a macro.
+/// Double-quoted spans, tracked across lines so a literal continued with a
+/// trailing `\` (the multi-line `HelpTopic` help text) is not lost. `//`
+/// comments are skipped, but only outside a literal — a continuation line
+/// never starts with `//` in this codebase. Counting quote characters per
+/// line to track in/out-of-string state is sound here because `src/cli/**`
+/// has no raw strings and no escaped quotes (checked by hand; there is
+/// nothing else crude enough to fool a bare quote count).
 fn string_literals(source: &str) -> Vec<String> {
     let mut out = Vec::new();
+    let mut in_string = false;
     for line in source.lines() {
-        if line.trim_start().starts_with("//") {
+        if !in_string && line.trim_start().starts_with("//") {
             continue;
         }
-        for piece in line.split('"').skip(1).step_by(2) {
-            out.push(piece.to_owned());
+        for (idx, piece) in line.split('"').enumerate() {
+            let is_inside = if in_string {
+                idx % 2 == 0
+            } else {
+                idx % 2 == 1
+            };
+            if is_inside {
+                out.push(piece.to_owned());
+            }
+        }
+        if line.matches('"').count() % 2 == 1 {
+            in_string = !in_string;
         }
     }
     out
@@ -55,7 +71,7 @@ fn cli_messages_do_not_say_clause() {
             if literal
                 .to_lowercase()
                 .split(|c: char| !c.is_ascii_alphabetic())
-                .any(|token| token == "clause")
+                .any(|token| token == "clause" || token == "clauses")
             {
                 violations.push(format!("{name}: {literal:?}"));
             }

--- a/tests/cli_vocabulary.rs
+++ b/tests/cli_vocabulary.rs
@@ -132,18 +132,25 @@ fn cli_messages_are_defined_once() {
 }
 
 /// §7.3: a message names the fix only where the fix is short and certain.
-/// These four are the whole set — every other CLI error either states a
-/// grammar mistake the user can see from their own command line, or a
-/// condition whose remedy depends on facts the helper does not have.
+/// These three are the whole set of messages that name a remedy — every
+/// other CLI error either states a grammar mistake the user can see from
+/// their own command line, or a condition whose remedy depends on facts the
+/// helper does not have.
+///
+/// The writability probe is that last case: `create_new(true)` fails both on
+/// a real permission problem and on a stale `.agent-bar-write-probe` left by
+/// an earlier run (its own cleanup swallows failure), so a directory the
+/// user fully owns can still report this error. There is no short, certain
+/// fix to name, so [`cli_writability_message_does_not_claim_a_fix`] pins
+/// that message bare.
 #[test]
 fn cli_messages_that_can_name_a_fix_do() {
     let source =
         fs::read_to_string(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/cli/mod.rs"))
             .expect("read mod.rs");
     for needle in [
-        "setup plugins-dir path does not exist: {}; create it or pass an existing parent",
+        "setup plugins-dir path cannot be read: {}; create it, or check the permissions on its parents",
         "setup plugins-dir path is not a directory: {}; pass the parent directory",
-        "setup plugins-dir path is not writable: {}; pass a directory you own",
         "{} login executable was not found; install the provider CLI first",
     ] {
         assert!(
@@ -151,4 +158,21 @@ fn cli_messages_that_can_name_a_fix_do() {
             "missing fix-naming message: {needle}"
         );
     }
+}
+
+/// Companion to [`cli_messages_that_can_name_a_fix_do`]: the writability
+/// probe cannot tell a permission problem from a stale probe file, so its
+/// message must not claim a fix. Checks for the literal closing quote and
+/// trailing comma right after `{}` so a future well-meaning edit cannot
+/// quietly bolt a remedy back onto this message.
+#[test]
+fn cli_writability_message_does_not_claim_a_fix() {
+    let source =
+        fs::read_to_string(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/cli/mod.rs"))
+            .expect("read mod.rs");
+    assert!(
+        source.contains("\"setup plugins-dir path is not writable: {}\","),
+        "the writability probe cannot tell a permission problem from a stale probe file, \
+         so its message must not claim a fix"
+    );
 }

--- a/tests/cli_vocabulary.rs
+++ b/tests/cli_vocabulary.rs
@@ -1,0 +1,70 @@
+//! `clause` is parser vocabulary. It names a concept in the grammar's own
+//! implementation, not anything the person typing the command can see, and it
+//! leaked into six error messages. The word stays in the code — `StatusClause`
+//! and its bindings are exactly the kind of internal name that belongs there —
+//! so this guard scans string literals only.
+//!
+//! Scope is `src/cli/**`. The GUI has its own, wider guard in
+//! `tests/gui_vocabulary.rs`; the two lists differ on purpose, because
+//! `bundle` and `schema` name real things a CLI user deals with.
+
+use std::fs;
+use std::path::PathBuf;
+
+/// Double-quoted spans, skipping whole-line `//` comments. Crude on purpose:
+/// the CLI's messages are plain literals, never built by a macro.
+fn string_literals(source: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    for line in source.lines() {
+        if line.trim_start().starts_with("//") {
+            continue;
+        }
+        for piece in line.split('"').skip(1).step_by(2) {
+            out.push(piece.to_owned());
+        }
+    }
+    out
+}
+
+#[test]
+fn cli_messages_do_not_say_clause() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/cli");
+    let mut violations = Vec::new();
+    let entries = fs::read_dir(&root).expect("read src/cli");
+    let mut files: Vec<PathBuf> = entries
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("rs"))
+        .collect();
+    files.sort();
+    assert!(
+        files.len() >= 4,
+        "expected the cli module tree, found {} files",
+        files.len()
+    );
+    for path in files {
+        let Ok(source) = fs::read_to_string(&path) else {
+            continue;
+        };
+        let name = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("?")
+            .to_owned();
+        for literal in string_literals(&source) {
+            if literal
+                .to_lowercase()
+                .split(|c: char| !c.is_ascii_alphabetic())
+                .any(|token| token == "clause")
+            {
+                violations.push(format!("{name}: {literal:?}"));
+            }
+        }
+    }
+    assert!(
+        violations.is_empty(),
+        "CLI messages still say clause ({}):\n  - {}",
+        violations.len(),
+        violations.join("\n  - ")
+    );
+}

--- a/tests/cli_vocabulary.rs
+++ b/tests/cli_vocabulary.rs
@@ -9,7 +9,7 @@
 //! `bundle` and `schema` name real things a CLI user deals with.
 
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// True when `prefix` opens a raw string as a real token on `line` at byte
 /// offset `pos`, not merely as the tail of an ordinary word ending in `r`
@@ -77,17 +77,57 @@ fn string_literals(source: &str) -> Vec<String> {
     out
 }
 
+/// Every `.rs` file under `src/cli/`, found by walking the tree with an
+/// explicit stack rather than reading one directory. `src/cli/mod.rs` is
+/// past a thousand lines; the day it splits into submodules
+/// (`src/cli/help/mod.rs` or similar), a non-recursive `fs::read_dir` would
+/// silently stop covering the new file while every guard below kept
+/// passing. Shape matches `tests/gui_vocabulary.rs::gui_files` on purpose,
+/// so the two guards read as siblings.
+fn cli_files(root: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let mut stack = vec![root.join("src/cli")];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+                continue;
+            }
+            let is_source = path.extension().and_then(|e| e.to_str()) == Some("rs");
+            if is_source {
+                out.push(path);
+            }
+        }
+    }
+    out.sort();
+    out
+}
+
+/// Concatenation of every `.rs` file under `src/cli/`, for guards that check
+/// whether a message exists anywhere in the tree rather than walking file by
+/// file themselves. A `\n` separator sits between files; none of the needles
+/// these guards check span a file boundary, so the separator only prevents
+/// two files' text from fusing into an accidental match.
+fn all_cli_source(root: &Path) -> String {
+    let mut combined = String::new();
+    for path in cli_files(root) {
+        if let Ok(source) = fs::read_to_string(&path) {
+            combined.push_str(&source);
+            combined.push('\n');
+        }
+    }
+    combined
+}
+
 #[test]
 fn cli_messages_do_not_say_clause() {
-    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/cli");
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let mut violations = Vec::new();
-    let entries = fs::read_dir(&root).expect("read src/cli");
-    let mut files: Vec<PathBuf> = entries
-        .flatten()
-        .map(|e| e.path())
-        .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("rs"))
-        .collect();
-    files.sort();
+    let files = cli_files(&root);
     assert!(
         files.len() >= 4,
         "expected the cli module tree, found {} files",
@@ -126,7 +166,7 @@ fn cli_messages_do_not_say_clause() {
 /// validate paths before this guard existed.
 #[test]
 fn cli_messages_are_defined_once() {
-    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/cli");
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let watched = [
         "setup plugins-dir path must be absolute",
         "setup plugins-dir path must be the parent directory, not the plugin root",
@@ -135,14 +175,8 @@ fn cli_messages_are_defined_once() {
         "setup requires a complete plugin tree",
     ];
     let mut violations = Vec::new();
-    let entries = fs::read_dir(&root).expect("read src/cli");
+    let files = cli_files(&root);
     let mut totals = vec![0usize; watched.len()];
-    let mut files: Vec<PathBuf> = entries
-        .flatten()
-        .map(|e| e.path())
-        .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("rs"))
-        .collect();
-    files.sort();
     for path in &files {
         let Ok(source) = fs::read_to_string(path) else {
             continue;
@@ -180,9 +214,8 @@ fn cli_messages_are_defined_once() {
 /// that message bare.
 #[test]
 fn cli_messages_that_can_name_a_fix_do() {
-    let source =
-        fs::read_to_string(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/cli/mod.rs"))
-            .expect("read mod.rs");
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let source = all_cli_source(&root);
     for needle in [
         "setup plugins-dir path cannot be read: {}; create it, or check the permissions on its parents",
         "setup plugins-dir path is not a directory: {}; pass the parent directory",
@@ -202,12 +235,34 @@ fn cli_messages_that_can_name_a_fix_do() {
 /// quietly bolt a remedy back onto this message.
 #[test]
 fn cli_writability_message_does_not_claim_a_fix() {
-    let source =
-        fs::read_to_string(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/cli/mod.rs"))
-            .expect("read mod.rs");
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let source = all_cli_source(&root);
     assert!(
         source.contains("\"setup plugins-dir path is not writable: {}\","),
         "the writability probe cannot tell a permission problem from a stale probe file, \
          so its message must not claim a fix"
+    );
+}
+
+/// `docs/commands.md` documents the same command grammar the CLI's own help
+/// text implements, and it drifted once: the v11-06 plan's own measurement
+/// found "Status clauses" live in this file after `clause` was renamed to
+/// `argument` in the help text it describes. None of the guards above can
+/// see prose in a Markdown file, so this one reads `docs/commands.md`
+/// directly rather than relying on the `src/cli/**` walk to catch prose that
+/// never lives under `src/cli/` in the first place.
+#[test]
+fn docs_commands_do_not_say_clause() {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("docs/commands.md");
+    let source = fs::read_to_string(&path).expect("read docs/commands.md");
+    let lowered = source.to_lowercase();
+    let violations: Vec<&str> = lowered
+        .split(|c: char| !c.is_ascii_alphabetic())
+        .filter(|token| *token == "clause" || *token == "clauses")
+        .collect();
+    assert!(
+        violations.is_empty(),
+        "docs/commands.md still says clause ({} occurrences)",
+        violations.len()
     );
 }

--- a/tests/cli_vocabulary.rs
+++ b/tests/cli_vocabulary.rs
@@ -11,18 +11,53 @@
 use std::fs;
 use std::path::PathBuf;
 
+/// True when `prefix` opens a raw string as a real token on `line` at byte
+/// offset `pos`, not merely as the tail of an ordinary word ending in `r`
+/// right before a closing quote (`"doctor"`, `"provider"` both contain the
+/// literal bytes `r"` but do not open anything).
+fn is_token_boundary(line: &str, pos: usize) -> bool {
+    pos == 0 || {
+        let prev = line.as_bytes()[pos - 1];
+        !(prev.is_ascii_alphanumeric() || prev == b'_')
+    }
+}
+
+/// True when `line` opens one of this codebase's raw string prefixes (`r"`,
+/// `r#"`, `br"`, `br#"`) — used by the CLI test module for raw JSON
+/// payloads. See [`is_token_boundary`] for why a plain substring search is
+/// not enough.
+fn opens_raw_string(line: &str) -> bool {
+    ["br#\"", "br\"", "r#\"", "r\""]
+        .iter()
+        .any(|prefix| matches!(line.find(prefix), Some(pos) if is_token_boundary(line, pos)))
+}
+
 /// Double-quoted spans, tracked across lines so a literal continued with a
 /// trailing `\` (the multi-line `HelpTopic` help text) is not lost. `//`
 /// comments are skipped, but only outside a literal — a continuation line
-/// never starts with `//` in this codebase. Counting quote characters per
-/// line to track in/out-of-string state is sound here because `src/cli/**`
-/// has no raw strings and no escaped quotes (checked by hand; there is
-/// nothing else crude enough to fool a bare quote count).
+/// never starts with `//` in this codebase.
+///
+/// `src/cli/mod.rs`'s test module has three raw byte-string literals
+/// (`br#"..."#`, JSON confirmation payloads). Counting quote characters
+/// would misread their embedded `"` as ordinary literal boundaries, so those
+/// lines are detected by [`opens_raw_string`] and skipped rather than
+/// parsed — never scanned for content, and never allowed to flip the
+/// carried in/out-of-string state on a hunch. That skip is safe only when
+/// the line is self-contained (an even number of quote characters); it is
+/// verified per line rather than assumed, because an odd count would mean
+/// the raw string continues past this line and silently skipping it would
+/// desynchronize the parity count for every line after it. Outside of those
+/// three lines, counting quote characters is sound because no other line in
+/// this scope has an escaped quote.
 fn string_literals(source: &str) -> Vec<String> {
     let mut out = Vec::new();
     let mut in_string = false;
     for line in source.lines() {
         if !in_string && line.trim_start().starts_with("//") {
+            continue;
+        }
+        let quote_count = line.matches('"').count();
+        if !in_string && opens_raw_string(line) && quote_count % 2 == 0 {
             continue;
         }
         for (idx, piece) in line.split('"').enumerate() {
@@ -35,7 +70,7 @@ fn string_literals(source: &str) -> Vec<String> {
                 out.push(piece.to_owned());
             }
         }
-        if line.matches('"').count() % 2 == 1 {
+        if quote_count % 2 == 1 {
             in_string = !in_string;
         }
     }

--- a/tests/qml/tst_Maintenance.qml
+++ b/tests/qml/tst_Maintenance.qml
@@ -138,6 +138,17 @@ TestCase {
     compare(ui.uninstallArmed, false)
   }
 
+  // The dialog binds its own message from uninstallArmed/purgeSettings, and
+  // the only reader of ui.message sits behind the dialog's scrim, so this
+  // string was set and never seen. The second click is communicated by the
+  // confirm button flipping to "Uninstall now".
+  function test_arming_sets_no_unseen_message() {
+    var src = read("assets/omarchy/CoreMaintenance.js")
+    verify(src.indexOf("Click Uninstall again") < 0)
+    var view = read("assets/omarchy/MaintenanceView.qml")
+    verify(view.indexOf('"Uninstall now"') >= 0)
+  }
+
   function test_maintenance_intention_shapes() {
     var ui = Core.maintenanceUiIdle("10.0.0")
     ui.targetVersion = "10.1.0"


### PR DESCRIPTION
## Summary

Plan 06 of the v11 copy update, and the last plan in the track (spec: `2026-07-30-copy-and-language-design.md` §7, §4 for the two surfaces it exempts). Plan with full execution record: `docs/superpowers/plans/2026-08-01-v11-06-cli-and-installer-copy.md`.

Two rulebooks, deliberately. `src/cli/` keeps Unix convention — lower case, no trailing period, no product-name prefix — and only three things change there. `install.sh` and the interactive `update` prompt are the exception the copy design carves out, because they are read by a person installing the product for the first time.

- **Parser vocabulary is gone from the messages.** Six errors said `clause`, a word from the grammar's own implementation. They now say `argument`, in one shape: `unknown argument 'bogus' for status`. The `StatusClause` enum and its bindings stay — that vocabulary belongs in code, which is why the guard scans string literals only.
- **Each message has one definition.** Five were written two or three times each, two of them across a module boundary where the parse path and the validate path hardcoded the same sentence independently. They are now constants, and a test counts occurrences so a copy cannot drift from its twin.
- **Four errors that named a problem now name the fix — and two that were going to, no longer do.** The rule is "short *and certain*", and the qualifier did real work: review reproduced `pass a directory you own` firing on a directory the user fully owns (a stale `.agent-bar-write-probe` makes `create_new` fail with `AlreadyExists`), and `create it or pass an existing parent` firing on `EACCES` on an ancestor. The first reverted to bare; the second now names both realistic causes.
- **`install.sh` speaks to a person.** 47 messages and the `--help` banner rewritten: `Staged bundle missing bundle.json receipt` becomes `The download is incomplete: bundle.json is missing.`, `curl not found` becomes `curl is missing. Install it and run this again.` The four output helpers and their prefixes are structure and stay. `bundle` survives where it names the real downloaded artifact — the GUI bans that word because a popup user never sees an archive; the installer's user downloads and verifies one.
- **The update prompt matches the GUI.** Both surfaces now say `Updates 10.0.0 to 10.2.0. Settings stay. Rolls back if it fails.` The typed phrase `update agent-bar` is untouched: it is a safety mechanism, not copy.
- **One line of dead code deleted**, carried from plan 05: `CoreMaintenance.js` set an arming message that nothing rendered, because the dialog binds its own and the only reader sits behind the dialog's scrim.

## Measured facts worth knowing

- **The plan missed a live leak, and its own guard could not have caught it.** `agent-bar help status` printed `Clauses (any order, each at most once):` — the exact word the plan set out to remove, one command away from the errors it fixed, plus a matching line in `docs/commands.md`. The guard scanned each physical line for quote characters, but the help text is one literal continued across nine lines, so the offending line — which contains no quote at all — was never read. The scanner now tracks string state across lines, matches the plural, and skips raw strings; it walks `src/cli/` recursively so a future file split cannot silently void it; and a second guard covers `docs/commands.md`, the prose surface that actually drifted.
- **A false claim travelled three layers before anyone measured it.** A reviewer stated `src/cli/**` has no raw strings; I passed that into a fix instruction without checking; the implementer wrote it into a doc comment; a second reviewer found three `br#"..."#` fixtures in that module's own test code. A reviewer's negative claim deserves the same verification as an implementer's positive one.
- **The plan justified omitting the rollback clause from the CLI with a claim that was false.** The CLI's `update apply` hands off to the same worker the GUI spawns, and that worker calls `rollback_update` on failure at five sites. Both surfaces now say the same true thing.
- Six plan-born defects are recorded in the execution record, along with the deferred minors and one honest note: a task agent refused to accept an unverifiable claim in its own dispatch and said so rather than writing it down as fact.

## Verification

`cargo fmt --check` · `cargo test` **307 / 19 suites** (was 301/18; +1 suite, the CLI vocabulary guards) · clippy `-D warnings` · `git diff --check` · `shellcheck install.sh` · Qt 6 `qmllint` · `omarchy plugin validate` · Qt 6 `qmltestrunner` **232 passed / 0 failed** · `scripts/verify-v10-ui` exit 0 with 17 captures — all re-run independently on the final head.

Six task-scoped reviews, four fix rounds, a final whole-branch review with no critical findings, one fix wave, and a scoped re-review of that wave. Every guard added here was watched failing before it was accepted, including by reintroducing the removed word and by planting a probe file in a nested directory to prove the recursive walk works.

One known gap left deliberately outside this plan's seam, for a fast follow: `install.sh`'s two `curl` calls have no error handling of their own, so a failed transfer prints raw curl stderr and never reaches any of the new messages. Fixing it is a behaviour change; this plan was text only.

Live QA remains the owner's gate — nothing was installed into `~/.config/omarchy/plugins/`. This completes the v11 visual and copy track.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified the uninstall confirmation flow while preserving its two-step safety behavior.
  * Improved CLI error messages for invalid arguments, setup paths, plugin directories, and missing login tools.
  * Clarified interactive update prompts and status output.

* **Documentation**
  * Updated command documentation to use consistent argument terminology.
  * Refined installer guidance, diagnostics, verification messages, and Agent Bar references.

* **Tests**
  * Added coverage to help ensure consistent CLI wording and uninstall behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->