### PR TITLE
Release 10.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,71 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [10.3.0] - 2026-08-01
+
+The visual and copy pass over the whole product: severity you can see, one
+window that leads the popup, and every message rewritten in plain words.
+Same Omarchy Quattro plugin `agent-bar.usage` with the private Rust helper at
+`bin/agent-bar`; no breaking changes.
+
+### Added
+
+- Severity. A window at or above 95% used is Critical and at or above 90% is
+  Low. The popup header carries the word, the lead window's numeral and track
+  turn urgent, and a ready provider shows `!` on its bar chip. Every level
+  carries a word, never colour alone. The thresholds are the notification
+  ones, shared with the Rust notifier and pinned by a test that reads both
+  sides, so the bar and the alert can never disagree about what counts as
+  critical.
+- Lead-window election. The popup used to render large whichever windows
+  matched a hardcoded list of ids, silently demoting anything else. It now
+  elects: a critical window leads, otherwise the one resetting soonest, with
+  ties keeping the order the provider delivered. A window id nobody
+  anticipated can lead without a code change.
+- A usage track on every window row, not only the large one.
+- The reset countdown now exists in Rust as well as QML, pinned to one shared
+  table of inputs, so a notification and the popup can never render the same
+  duration differently.
+
+### Changed
+
+- Notifications say what is running out, in your unit: `Claude Session (5h)
+  is almost out` with a body of `4% left. Resets in 3h 1m.` The body follows
+  the used/remaining choice from Settings instead of always saying `used`.
+  What triggers the alert is still the used percentage — what fires it and
+  what it says are different questions.
+- The popup leads with one large window and renders every other as a compact
+  row: label, track, value, countdown. Reset times read as a countdown.
+- Provider states speak plainly: `Not signed in to Claude`, `Codex hit a rate
+  limit`, `This account is billed another way.` The two actions are now
+  `Sign in` and `Install guide`, end to end including the helper's payload.
+- Settings reads `Bar shows`, `Refresh every` with `seconds` beside the
+  field, and `Warn me before a quota runs out.`
+- Maintenance drops the ceremony: `Deletes Agent Bar. Your settings stay.`
+  and `Updates 10.2.0 to 10.3.0. Settings stay. Rolls back if it fails.` The
+  second destructive click is still required and is carried by the button.
+- The bar chip is built on the host's `WidgetButton`, so it sits on the same
+  icon grid as neighbouring modules and inherits the host's motion. Codex
+  ships a mark-grade icon; monochrome marks take the theme ink.
+- The plan badge is a tag, and the rail shares one inset with the content
+  instead of drawing its own frame.
+- CLI errors say `argument` where they said `clause`, and four of them now
+  name the fix. `install.sh` is rewritten for someone reading it once.
+
+### Fixed
+
+- Light themes. Sixteen `Qt.darker` calls became alpha over the foreground,
+  so secondary text stops outranking primary. On the `white` theme the two
+  had collapsed to identical pixels.
+- The stale banner carries the last-success age, the safe error summary and
+  Retry, in both stale modes rather than only one.
+
+### Removed
+
+- The popup's meta footer, and the absolute clock beside reset times.
+- `PRIMARY_WINDOW_IDS`, the window-id allowlist the election replaces.
+- The `Installation type` row, which only ever displayed one value.
+
 ## [10.2.0] - 2026-07-29
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-bar"
-version = "10.2.0"
+version = "10.3.0"
 dependencies = [
  "assert_cmd",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-bar"
-version = "10.2.0"
+version = "10.3.0"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT"

--- a/docs/releases/10.3.0.md
+++ b/docs/releases/10.3.0.md
@@ -1,0 +1,61 @@
+# Agent Bar 10.3.0
+
+The visual and copy pass over the whole product: severity you can see, one
+window that leads the popup, and every message rewritten in plain words. Same
+Omarchy Quattro plugin `agent-bar.usage` with the private Rust helper at
+`bin/agent-bar`; no breaking changes.
+
+## Highlights
+
+- Severity is visible and never colour alone. At or above 95% used a window
+  is Critical, at or above 90% it is Low: the popup header carries the word,
+  the leading window's numeral and track turn urgent, and a ready provider
+  shows `!` on its bar chip. The thresholds are the notification ones, shared
+  with the Rust notifier and pinned by a test that reads both sides.
+- The popup leads with one window, elected rather than allowlisted. A
+  critical window leads; otherwise the one resetting soonest; ties keep the
+  order the provider delivered. Every other window is a compact row with its
+  own usage track, so they stay comparable.
+- Notifications say what is running out, in your unit. `Claude Session (5h)
+  is almost out`, with a body of `4% left. Resets in 3h 1m.` The body follows
+  the used/remaining choice from Settings; the used percentage still decides
+  when the alert fires.
+- Reset times read as a countdown, humanised the same way in Rust and QML and
+  pinned to one shared table so the two cannot drift.
+- Plain words everywhere: `Not signed in to Claude`, `Codex hit a rate
+  limit`, `This account is billed another way.`, `Sign in`, `Install guide`,
+  `Bar shows`, `Warn me before a quota runs out.`, `Deletes Agent Bar. Your
+  settings stay.` The CLI says `argument` where it said `clause`, and
+  `install.sh` is written for someone reading it once.
+- Light themes are fixed. Sixteen `Qt.darker` calls became alpha over the
+  foreground, so secondary text stops outranking primary; on the `white`
+  theme the two had collapsed to identical pixels.
+- The bar chip is built on the host's `WidgetButton`, so it sits on the same
+  icon grid as neighbouring modules and inherits the host's motion rather
+  than declaring its own.
+
+## Removed
+
+- The popup's meta footer and the absolute clock beside reset times.
+- `PRIMARY_WINDOW_IDS`, the window-id allowlist the election replaces.
+- The `Installation type` row, which only ever displayed one value.
+
+## Migration
+
+None required. Settings, cache, and plugin layout are unchanged. Update an
+existing install with the plugin's update flow or `omarchy plugin rescan`
+after replacing the bundle.
+
+## Artifact
+
+```text
+agent-bar.usage-10.3.0-x86_64-unknown-linux-gnu.tar.zst
+agent-bar.usage-10.3.0-x86_64-unknown-linux-gnu.tar.zst.sha256
+agent-bar.usage-10.3.0-x86_64-unknown-linux-gnu.metadata.json
+LICENSE
+```
+
+## Notes
+
+This file is the tracked release-notes source for the bundle builder and
+`publish.yml`.

--- a/src/app_identity.rs
+++ b/src/app_identity.rs
@@ -26,7 +26,7 @@ mod tests {
     #[test]
     fn package_version_is_release_identity() {
         assert_eq!(
-            VERSION, "10.2.0",
+            VERSION, "10.3.0",
             "Cargo.toml package version must match the release identity"
         );
     }


### PR DESCRIPTION
## Summary

Cuts **10.3.0** for the v11 visual and copy track. Everything since 10.2.0 — plans 01 through 06, PRs #34 through #40 — shipped without a version bump, so the released artifact has been stale for the whole track.

- `Cargo.toml`, `Cargo.lock`, and the `app_identity` release-identity pin move to 10.3.0.
- `CHANGELOG.md` gains the 10.3.0 entry: severity and lead-window election under Added; the notification, popup, Settings, Maintenance and CLI rewrites under Changed; the light-theme hierarchy fix under Fixed; the meta footer, the absolute clock, `PRIMARY_WINDOW_IDS` and the installation-type row under Removed.
- `docs/releases/10.3.0.md` added, the tracked release-notes source the bundle builder and `publish.yml` read.

Minor, not major: the plugin id, settings schema, cache layout, status schema v2, exit codes, and the CLI grammar are all unchanged. No migration.

## Verification

`scripts/check-version` → `version OK: 10.3.0` · `cargo test` **307 / 19 suites** · `cargo fmt --check` · clippy `-D warnings` · `git diff --check` · Qt 6 `qmltestrunner` **232 / 0** · `omarchy plugin validate` · `agent-bar version` prints `10.3.0`.

## After merge

Tagging `v10.3.0` and publishing the release is the remaining step — `publish.yml` fires on *release published*, not on the tag, and builds the bundle, checksum, and metadata. That step is the owner's.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added severity indicators and clearer provider and quota notifications.
  - Introduced shared reset countdowns and elected popup leading-window behavior.
  - Added host-integrated bar rendering through `WidgetButton`.

- **Improvements**
  - Revised settings, maintenance, CLI, and installation wording.
  - Improved light-theme contrast and stale-banner details.
  - Simplified the popup by removing the meta footer, absolute reset clock, and installation-type row.

- **Release**
  - Published version 10.3.0 release documentation and updated package version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->