### PR TITLE
fix: fable limit, lead wall clock, auto-release

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,18 +1,40 @@
-name: Release plugin bundle
+name: Auto release
+
+# Every product merge to main cuts an official release, so the Settings
+# update button always has the latest merge to offer. The release is created
+# with its assets in one call — a public release never exists without them
+# (an asset-less claiming release is a command error for every installed
+# update check).
 
 on:
-  release:
-    types: [published]
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'assets/**'
+      - 'scripts/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+  workflow_dispatch:
 
 permissions:
-  contents: write # gh release upload
+  contents: write
+
+concurrency:
+  group: auto-release
+  cancel-in-progress: false
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      !startsWith(github.event.head_commit.message, 'chore: release')
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - name: Install Rust (gnu host target)
         run: |
@@ -20,14 +42,13 @@ jobs:
           rustup default stable
           rustup target list --installed
 
-      - name: Verify version matches release tag
-        env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+      - name: Cut release (bump + notes)
+        id: cut
         run: |
-          scripts/check-version "$RELEASE_TAG"
-
-      - name: Build release helper (x86_64-unknown-linux-gnu)
-        run: cargo build --release --target x86_64-unknown-linux-gnu
+          set -euo pipefail
+          scripts/agent-bar-cut-release
+          VERSION="$(grep -m1 '^version' Cargo.toml | sed -E 's/.*"(.*)".*/\1/')"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Rust gates
         run: |
@@ -35,16 +56,30 @@ jobs:
           cargo test
           cargo clippy --all-targets -- -D warnings
 
+      - name: Commit and tag the bump
+        env:
+          VERSION: ${{ steps.cut.outputs.version }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Cargo.toml Cargo.lock CHANGELOG.md "docs/releases/${VERSION}.md"
+          git commit -m "chore: release ${VERSION}"
+          git tag "v${VERSION}"
+
+      - name: Build release helper (x86_64-unknown-linux-gnu)
+        run: cargo build --release --target x86_64-unknown-linux-gnu
+
       - name: Assemble plugin bundle
         run: |
+          set -euo pipefail
           SOURCE_COMMIT="$(git rev-parse HEAD)"
-          # Prefer the target-triple build as the helper.
           mkdir -p target/release
           cp -f target/x86_64-unknown-linux-gnu/release/agent-bar target/release/agent-bar
           cargo run --bin agent-bar-bundle -- \
             assemble output target/release/agent-bar.usage \
             source-commit "$SOURCE_COMMIT"
-          scripts/check-version "v$(grep -m1 '^version' Cargo.toml | sed -E 's/.*"(.*)".*/\1/')" \
+          scripts/check-version "v${{ steps.cut.outputs.version }}" \
             target/release/agent-bar.usage
 
       - name: Bundle inventory / modes / architecture
@@ -55,66 +90,45 @@ jobs:
           test -f "$ROOT/manifest.json"
           test -x "$ROOT/bin/agent-bar"
           test -x "$ROOT/scripts/agent-bar-open-terminal"
-          # No global executable name at plugin root.
           test ! -e "$ROOT/agent-bar"
-          # Architecture: ELF x86-64
           file "$ROOT/bin/agent-bar" | grep -E 'ELF 64-bit|x86-64|x86_64'
           "$ROOT/bin/agent-bar" version
-          # QML/Quattro gates consume accepted checkpoint evidence on Omarchy hosts;
-          # Ubuntu runners do not provide the Omarchy runtime (see v10 acceptance).
+          # QML/Quattro gates consume accepted checkpoint evidence on Omarchy
+          # hosts; Ubuntu runners do not provide the Omarchy runtime.
 
       - name: Build release artifacts
-        id: pkg
         run: |
           set -euo pipefail
           SOURCE_COMMIT="$(git rev-parse HEAD)"
-          VERSION="$(grep -m1 '^version' Cargo.toml | sed -E 's/.*"(.*)".*/\1/')"
+          VERSION="${{ steps.cut.outputs.version }}"
           NOTES="docs/releases/${VERSION}.md"
-          if [ ! -f "$NOTES" ]; then
-            # Prefer authored notes under docs/releases/; otherwise materialize from
-            # the published GitHub release body so the release-builder path is
-            # always satisfiable on tag publish.
-            mkdir -p docs/releases
-            BODY="${{ github.event.release.body }}"
-            if [ -n "$BODY" ]; then
-              printf '%s\n' "$BODY" > "$NOTES"
-            else
-              {
-                echo "# agent-bar ${VERSION}"
-                echo
-                echo "Release ${VERSION} (auto-generated notes; add docs/releases/${VERSION}.md for authored copy)."
-              } > "$NOTES"
-            fi
-            echo "Materialized release notes at $NOTES"
-          fi
+          test -f "$NOTES"
           OUT="target/release-files"
           rm -rf "$OUT"
           mkdir -p "$OUT"
-          # release requires clean worktree; CI checkout is clean after build artifacts
-          # under target/ which git ignores.
           cargo run --bin agent-bar-bundle -- \
             release bundle target/release/agent-bar.usage \
             output "$OUT" \
             source-commit "$SOURCE_COMMIT" \
             release-notes "$NOTES"
-          # Equality: metadata / checksum / archive
           META="$OUT/agent-bar.usage-${VERSION}-x86_64-unknown-linux-gnu.metadata.json"
           ARCHIVE="$OUT/agent-bar.usage-${VERSION}-x86_64-unknown-linux-gnu.tar.zst"
           SUM="$OUT/agent-bar.usage-${VERSION}-x86_64-unknown-linux-gnu.tar.zst.sha256"
           test -f "$META" && test -f "$ARCHIVE" && test -f "$SUM" && test -f "$OUT/LICENSE"
-          # Sidecar paths are basename-relative; verify from the output directory.
           (cd "$OUT" && sha256sum -c "$(basename "$SUM")")
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
-      - name: Attach to release (no clobber)
+      - name: Push and publish release with assets
         env:
           GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.cut.outputs.version }}
         run: |
           set -euo pipefail
-          VERSION="$(grep -m1 '^version' Cargo.toml | sed -E 's/.*"(.*)".*/\1/')"
+          git push origin HEAD:main "refs/tags/v${VERSION}"
           OUT="target/release-files"
-          gh release upload "v${VERSION}" \
+          gh release create "v${VERSION}" \
             "$OUT/agent-bar.usage-${VERSION}-x86_64-unknown-linux-gnu.tar.zst" \
             "$OUT/agent-bar.usage-${VERSION}-x86_64-unknown-linux-gnu.tar.zst.sha256" \
             "$OUT/agent-bar.usage-${VERSION}-x86_64-unknown-linux-gnu.metadata.json" \
-            "$OUT/LICENSE"
+            "$OUT/LICENSE" \
+            --title "Agent Bar ${VERSION}" \
+            --notes-file "docs/releases/${VERSION}.md"

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,6 +1,6 @@
 name: Auto release
 
-# Every product merge to main cuts an official release, so the Settings
+# Every product merge to master cuts an official release, so the Settings
 # update button always has the latest merge to offer. The release is created
 # with its assets in one call — a public release never exists without them
 # (an asset-less claiming release is a command error for every installed
@@ -8,7 +8,7 @@ name: Auto release
 
 on:
   push:
-    branches: [main]
+    branches: [master]
     paths:
       - 'src/**'
       - 'assets/**'
@@ -123,7 +123,7 @@ jobs:
           VERSION: ${{ steps.cut.outputs.version }}
         run: |
           set -euo pipefail
-          git push origin HEAD:main "refs/tags/v${VERSION}"
+          git push origin HEAD:master "refs/tags/v${VERSION}"
           OUT="target/release-files"
           gh release create "v${VERSION}" \
             "$OUT/agent-bar.usage-${VERSION}-x86_64-unknown-linux-gnu.tar.zst" \

--- a/assets/omarchy/CoreView.js
+++ b/assets/omarchy/CoreView.js
@@ -526,6 +526,21 @@ function resetCountdownText(iso, nowMs) {
   return countdownText(diff)
 }
 
+// §6 amended 2026-08-03 (owner decision on live mockups): the lead window
+// appends the reset's wall-clock time after the countdown — "(13:31)" here,
+// "(1:31 PM)" on an en-US machine. The format string is the caller's locale
+// short-time format, never hardcoded; weekday names stay deleted, so compact
+// rows (days away) remain countdown-only.
+function resetClockText(iso, localeTimeFormat) {
+  var ms = parseIsoMs(iso)
+  if (!isFinite(ms))
+    return ""
+  var fmt = String(localeTimeFormat || "")
+  if (!fmt.length)
+    return ""
+  return "(" + Qt.formatTime(new Date(ms), fmt) + ")"
+}
+
 // The muted lead-in the lead window prints before the countdown:
 // "Session (5h) · resets in 3h 1m" / "Session (5h) · resets now".
 function resetPhrase(countdown) {

--- a/assets/omarchy/ProviderView.qml
+++ b/assets/omarchy/ProviderView.qml
@@ -164,6 +164,11 @@ Item {
           percent: modelData.percent !== undefined && modelData.percent !== null
               ? Number(modelData.percent) : -1
           resetCountdown: modelData.resetCountdown ? modelData.resetCountdown : ""
+          resetClock: modelData.resetsAt && modelData.resetCountdown
+              && modelData.resetCountdown !== "now"
+              ? Core.resetClockText(String(modelData.resetsAt),
+                                    Qt.locale().timeFormat(Locale.ShortFormat))
+              : ""
           resetPhrase: modelData.resetPhrase ? modelData.resetPhrase : ""
           severity: modelData.severity ? modelData.severity : ""
           unitText: root.unitText

--- a/assets/omarchy/components/UsageWindow.qml
+++ b/assets/omarchy/components/UsageWindow.qml
@@ -15,6 +15,9 @@ Item {
   property real percent: -1
   // Countdown only: the popup shows no absolute clock (§6).
   property string resetCountdown: ""
+  // Lead-only wall-clock suffix, already parenthesised ("(13:31)"); compact
+  // rows leave it empty (§6 amendment 2026-08-03).
+  property string resetClock: ""
   property string resetPhrase: ""
   property string unitText: "left"
   // "critical" | "warning" | "" — computed from usedPercent by CoreView.
@@ -100,7 +103,9 @@ Item {
 
       Text {
         id: leadReset
-        text: root.resetCountdown
+        text: root.resetClock.length > 0
+            ? root.resetCountdown + " " + root.resetClock
+            : root.resetCountdown
         color: root.foreground
         font.family: root.fontFamily
         font.pixelSize: Style.font.bodySmall
@@ -236,7 +241,9 @@ Item {
     else if (root.severity === "warning")
       parts.push("low")
     if (root.resetCountdown.length > 0)
-      parts.push(root.resetPhrase + " " + root.resetCountdown)
+      parts.push(root.resetClock.length > 0
+          ? root.resetPhrase + " " + root.resetCountdown + " " + root.resetClock
+          : root.resetPhrase + " " + root.resetCountdown)
     return parts.join(", ")
   }
   Accessible.role: Accessible.StaticText

--- a/docs/superpowers/specs/2026-07-30-visual-update-design.md
+++ b/docs/superpowers/specs/2026-07-30-visual-update-design.md
@@ -180,7 +180,13 @@ as a named readonly property on `UsageWindow`, and never repeated.
   labels that arrive lowercase from the API, such as Codex's `plus`.
 - **Lead window.** `Style.font.body * 2.5` numeral, unit at
   `Style.font.caption`, a `Style.spacing.md` track, and the reset promoted
-  into the label line: `Session (5h) · resets in 3h 1m`.
+  into the label line: `Session (5h) · resets in 3h 1m (13:31)`. (Amended
+  2026-08-03, owner decision on live mockups: the countdown gains the reset's
+  wall-clock time in the viewer's locale short format — `(13:31)` on a 24h
+  locale, `(1:31 PM)` on en-US — via `CoreView.resetClockText` fed
+  `Qt.locale().timeFormat(Locale.ShortFormat)`. Lead window only; compact
+  rows stay countdown-only because a bare clock names no day, and the plan-04
+  weekday deletion stands. No clock while the countdown reads `now`.)
 - **Other windows.** One compact row each: `label · track · value · time to
   reset`. Reset time uses `CoreView.countdownText` unmodified, so anything
   under 24h reads in hours. The compact column is sized for `23h 1m`.

--- a/docs/superpowers/specs/2026-08-03-auto-release-design.md
+++ b/docs/superpowers/specs/2026-08-03-auto-release-design.md
@@ -1,0 +1,51 @@
+# Auto-release on main — design
+
+Owner decision (2026-08-03): the Settings update button must offer an update
+after every product merge to `main`, not only after a hand-cut release. The
+button's contract does not change: it keeps consuming official GitHub
+releases with archive + sha256 + metadata, semver strictly-newer gating, and
+rollback. What changes is that releases stop being manual.
+
+## Shape
+
+One new workflow, `.github/workflows/auto-release.yml`, replaces
+`publish.yml` (its bundle/release-file steps move in; the `release:
+published` trigger dies so the two paths cannot double-upload).
+
+Trigger: `push` to `main` filtered to product paths (`src/**`, `assets/**`,
+`scripts/**`, `Cargo.toml`, `Cargo.lock`), plus `workflow_dispatch` for a
+manual cut. A guard skips the run when the head commit is the workflow's own
+`chore: release` bump, and a concurrency group serializes rapid merges.
+
+Steps, in an order chosen so failure never half-publishes:
+
+1. `scripts/agent-bar-cut-release` bumps the patch version in `Cargo.toml`
+   (+ lockfile), writes `docs/releases/{v}.md` from the Conventional Commit
+   subjects since the last tag, and prepends a matching CHANGELOG section.
+   The script is Bash, argv-safe, ShellCheck-clean, and has `--dry-run`.
+2. Rust gates run against the bumped tree (`fmt`, `test`, `clippy`). A red
+   gate stops everything; `main` is untouched because nothing was pushed.
+3. The bump is committed (`chore: release {v}`) and tagged `v{v}` locally,
+   so the bundle's `sourceCommit` names the exact tagged commit.
+4. The plugin bundle and release files are built and verified exactly as
+   `publish.yml` did (assemble, inventory, `check-version`, sha256 check).
+5. Only then: push `main` with the tag, and `gh release create v{v}` with
+   the archive, sha256, metadata, and LICENSE attached in the same call.
+   A public release therefore never exists without its assets — the update
+   check treats an asset-less claiming release as a command error, so this
+   ordering is what protects every installed copy.
+
+## Non-goals
+
+- No dev channel, no rolling tag, no update-from-commit in the product:
+  BUNDLE-024/025 stand unchanged.
+- No minor/major automation: an auto-cut is always a patch bump. Human
+  releases for minor/major remain possible via the same script + dispatch.
+- Docs-only merges cut nothing (path filter).
+
+## Failure modes
+
+- Gates red → run fails before any push; next merge tries again.
+- Release creation fails after the push → `main` carries a bumped version
+  with no release; re-running via `workflow_dispatch` cuts the next patch.
+  Gap versions are harmless under strictly-newer semver.

--- a/docs/superpowers/specs/2026-08-03-auto-release-design.md
+++ b/docs/superpowers/specs/2026-08-03-auto-release-design.md
@@ -1,7 +1,7 @@
-# Auto-release on main — design
+# Auto-release on master — design
 
 Owner decision (2026-08-03): the Settings update button must offer an update
-after every product merge to `main`, not only after a hand-cut release. The
+after every product merge to `master`, not only after a hand-cut release. The
 button's contract does not change: it keeps consuming official GitHub
 releases with archive + sha256 + metadata, semver strictly-newer gating, and
 rollback. What changes is that releases stop being manual.
@@ -12,7 +12,7 @@ One new workflow, `.github/workflows/auto-release.yml`, replaces
 `publish.yml` (its bundle/release-file steps move in; the `release:
 published` trigger dies so the two paths cannot double-upload).
 
-Trigger: `push` to `main` filtered to product paths (`src/**`, `assets/**`,
+Trigger: `push` to `master` filtered to product paths (`src/**`, `assets/**`,
 `scripts/**`, `Cargo.toml`, `Cargo.lock`), plus `workflow_dispatch` for a
 manual cut. A guard skips the run when the head commit is the workflow's own
 `chore: release` bump, and a concurrency group serializes rapid merges.
@@ -24,12 +24,12 @@ Steps, in an order chosen so failure never half-publishes:
    subjects since the last tag, and prepends a matching CHANGELOG section.
    The script is Bash, argv-safe, ShellCheck-clean, and has `--dry-run`.
 2. Rust gates run against the bumped tree (`fmt`, `test`, `clippy`). A red
-   gate stops everything; `main` is untouched because nothing was pushed.
+   gate stops everything; `master` is untouched because nothing was pushed.
 3. The bump is committed (`chore: release {v}`) and tagged `v{v}` locally,
    so the bundle's `sourceCommit` names the exact tagged commit.
 4. The plugin bundle and release files are built and verified exactly as
    `publish.yml` did (assemble, inventory, `check-version`, sha256 check).
-5. Only then: push `main` with the tag, and `gh release create v{v}` with
+5. Only then: push `master` with the tag, and `gh release create v{v}` with
    the archive, sha256, metadata, and LICENSE attached in the same call.
    A public release therefore never exists without its assets — the update
    check treats an asset-less claiming release as a command error, so this
@@ -46,6 +46,6 @@ Steps, in an order chosen so failure never half-publishes:
 ## Failure modes
 
 - Gates red → run fails before any push; next merge tries again.
-- Release creation fails after the push → `main` carries a bumped version
+- Release creation fails after the push → `master` carries a bumped version
   with no release; re-running via `workflow_dispatch` cuts the next patch.
   Gap versions are harmless under strictly-newer semver.

--- a/scripts/agent-bar-cut-release
+++ b/scripts/agent-bar-cut-release
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Bump the patch version and materialize release notes for an auto-release.
+# Mutates: Cargo.toml, Cargo.lock, docs/releases/{next}.md, CHANGELOG.md.
+# Git commit/tag/push stay in the workflow, so this stays testable locally.
+# Usage: scripts/agent-bar-cut-release [--dry-run]
+set -euo pipefail
+
+DRY_RUN=0
+if [ "${1:-}" = "--dry-run" ]; then
+  DRY_RUN=1
+elif [ "${1:-}" != "" ]; then
+  echo "usage: $0 [--dry-run]" >&2
+  exit 2
+fi
+
+CUR="$(grep -m1 '^version' Cargo.toml | sed -E 's/.*"(.*)".*/\1/')"
+case "$CUR" in
+  *.*.*) ;;
+  *)
+    echo "unparseable Cargo.toml version: $CUR" >&2
+    exit 1
+    ;;
+esac
+MAJOR="${CUR%%.*}"
+REST="${CUR#*.}"
+MINOR="${REST%%.*}"
+PATCH="${REST#*.}"
+case "$MAJOR$MINOR$PATCH" in
+  *[!0-9]*)
+    echo "non-numeric version component in: $CUR" >&2
+    exit 1
+    ;;
+esac
+NEXT="${MAJOR}.${MINOR}.$((PATCH + 1))"
+
+RANGE=""
+if git rev-parse -q --verify "refs/tags/v${CUR}" >/dev/null; then
+  RANGE="v${CUR}..HEAD"
+fi
+if [ -n "$RANGE" ]; then
+  SUBJECTS="$(git log --no-merges --pretty='- %s' "$RANGE")"
+else
+  SUBJECTS="$(git log --no-merges --pretty='- %s' -n 20)"
+fi
+if [ -z "$SUBJECTS" ]; then
+  SUBJECTS="- Maintenance release."
+fi
+
+TODAY="$(date -u +%F)"
+NOTES_PATH="docs/releases/${NEXT}.md"
+NOTES="$(printf '# Agent Bar %s\n\nAutomated release cut from main. Changes since %s:\n\n%s\n' \
+  "$NEXT" "$CUR" "$SUBJECTS")"
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  echo "next-version: $NEXT"
+  echo "notes-path: $NOTES_PATH"
+  printf '%s\n' "$NOTES"
+  exit 0
+fi
+
+if [ -n "$(git status --porcelain)" ]; then
+  echo "worktree not clean; refusing to bump" >&2
+  exit 1
+fi
+if [ -f "$NOTES_PATH" ]; then
+  echo "release notes already exist: $NOTES_PATH" >&2
+  exit 1
+fi
+
+# Bump only the first (package) version line.
+sed -i "0,/^version = \"${CUR}\"/s//version = \"${NEXT}\"/" Cargo.toml
+cargo update --workspace --offline --quiet
+
+printf '%s\n' "$NOTES" > "$NOTES_PATH"
+
+# Prepend the matching CHANGELOG section right after the intro block.
+CHANGELOG_ENTRY="$(printf '## [%s] - %s\n\n### Changed\n\n%s\n' \
+  "$NEXT" "$TODAY" "$SUBJECTS")"
+awk -v entry="$CHANGELOG_ENTRY" '
+  BEGIN { inserted = 0 }
+  /^## / && !inserted { print entry; print ""; inserted = 1 }
+  { print }
+  END { if (!inserted) { print ""; print entry } }
+' CHANGELOG.md > CHANGELOG.md.tmp
+mv CHANGELOG.md.tmp CHANGELOG.md
+
+echo "version: $NEXT"

--- a/src/providers/v2_map.rs
+++ b/src/providers/v2_map.rs
@@ -427,6 +427,10 @@ struct ClaudeLimitRaw {
     kind: Option<String>,
     #[serde(default)]
     utilization: Option<f64>,
+    /// Current limits[] vocabulary (captured 2026-08-01) reports the value
+    /// as `percent`; older payloads used `utilization`. Both are 0..=100.
+    #[serde(default)]
+    percent: Option<f64>,
     #[serde(default)]
     resets_at: Option<String>,
     #[serde(default)]
@@ -505,31 +509,46 @@ pub fn claude_from_usage_json(
             push_window_unique(&mut windows, window);
         }
     }
-    // Dynamic model windows from limits[] or legacy seven_day_* fields.
-    for (idx, limit) in doc.limits.iter().enumerate() {
-        let Some(util) = limit.utilization else {
+    // Dynamic windows from limits[] (or legacy seven_day_* fields below).
+    // Grouped entries (session/weekly_all) mirror the dedicated fields and
+    // dedup against them by id — and become the source if the API retires
+    // the top-level fields, as it already did with seven_day_oauth_apps.
+    let mut scoped_count = 0usize;
+    for limit in doc.limits.iter() {
+        let Some(util) = limit.utilization.or(limit.percent) else {
             continue;
         };
         let kind = limit.kind.as_deref().unwrap_or("");
         if kind == "five_hour" || kind == "seven_day" || kind == "seven_day_oauth_apps" {
-            continue; // handled via dedicated fields when present
+            continue; // legacy vocabulary: dedicated fields own these
         }
-        let model_id = limit
-            .scope
-            .as_ref()
-            .and_then(|s| s.model.as_ref())
-            .and_then(|m| m.id.as_deref().or(m.display_name.as_deref()))
-            .unwrap_or("model");
-        let id = weekly_model_id(model_id, idx);
-        let label = limit
-            .scope
-            .as_ref()
-            .and_then(|s| s.model.as_ref())
-            .and_then(|m| m.display_name.clone())
-            .unwrap_or_else(|| "Model".into());
         let raw = ClaudeWindowRaw {
             utilization: util,
             resets_at: limit.resets_at.clone(),
+        };
+        let (id, label) = match kind {
+            "session" => ("session".to_owned(), LABEL_SESSION.to_owned()),
+            "weekly_all" => ("weekly".to_owned(), LABEL_WEEKLY.to_owned()),
+            _ => {
+                let model_id = limit
+                    .scope
+                    .as_ref()
+                    .and_then(|s| s.model.as_ref())
+                    .and_then(|m| m.id.as_deref().or(m.display_name.as_deref()))
+                    .unwrap_or("model");
+                // Ordinal counts emitted model windows, not the array
+                // position: ids must not shift when the API reorders or
+                // prepends grouped entries.
+                let id = weekly_model_id(model_id, scoped_count);
+                scoped_count += 1;
+                let label = limit
+                    .scope
+                    .as_ref()
+                    .and_then(|s| s.model.as_ref())
+                    .and_then(|m| m.display_name.clone())
+                    .unwrap_or_else(|| "Model".into());
+                (id, label)
+            }
         };
         if let Some(window) = claude_window(&id, &label, &raw) {
             push_window_unique(&mut windows, window);
@@ -948,6 +967,72 @@ mod tests {
                 assert_eq!(opus.len(), 1, "duplicate weekly-model:opus windows");
                 // limits[] (dynamic) wins over the legacy field.
                 assert!((opus[0].used_percent() - 20.0).abs() < 0.01);
+            }
+            other => panic!("expected ready, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn claude_reads_current_limits_shape_with_fable() {
+        // Captured live 2026-08-01: limits[] entries carry `percent` (not
+        // `utilization`), kinds are session/weekly_all/weekly_scoped, the
+        // scoped entry names the model only via display_name, and
+        // seven_day_oauth_apps is null. The Fable window must come through
+        // and the grouped entries must not duplicate session/weekly.
+        let body = br#"{
+            "five_hour": {"utilization": 10.0, "resets_at": "2026-08-02T02:00:00+00:00"},
+            "seven_day": {"utilization": 12.0, "resets_at": "2026-08-07T12:00:00+00:00"},
+            "seven_day_oauth_apps": null,
+            "seven_day_cowork": null,
+            "limits": [
+                {"kind": "session", "group": "session", "percent": 10,
+                 "resets_at": "2026-08-02T02:00:00+00:00", "scope": null, "is_active": false},
+                {"kind": "weekly_all", "group": "weekly", "percent": 12,
+                 "resets_at": "2026-08-07T12:00:00+00:00", "scope": null, "is_active": true},
+                {"kind": "weekly_scoped", "group": "weekly", "percent": 10,
+                 "resets_at": "2026-08-07T12:00:00+00:00",
+                 "scope": {"model": {"id": null, "display_name": "Fable"}, "surface": null},
+                 "is_active": false}
+            ]
+        }"#;
+        let result =
+            claude_from_usage_json(body, datetime!(2026-08-01 21:00:00 UTC), None, None, true);
+        match result {
+            ProviderResult::Ready { windows, .. } => {
+                let ids: Vec<_> = windows.iter().map(|w| w.id().to_owned()).collect();
+                assert_eq!(
+                    ids,
+                    vec!["session", "weekly", "weekly-model:fable"],
+                    "got {ids:?}"
+                );
+                let fable = &windows[2];
+                assert_eq!(fable.label(), "Fable");
+                assert!((fable.used_percent() - 10.0).abs() < 0.01);
+                assert!(fable.resets_at().is_some(), "Fable resets_at was dropped");
+            }
+            other => panic!("expected ready, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn claude_limits_only_payload_still_yields_windows() {
+        // The API already retired seven_day_oauth_apps once; if the legacy
+        // top-level fields go next, limits[] must be able to carry the
+        // canonical windows alone.
+        let body = br#"{
+            "limits": [
+                {"kind": "session", "percent": 7.0, "resets_at": "2026-08-02T02:00:00+00:00"},
+                {"kind": "weekly_all", "percent": 12.0, "resets_at": "2026-08-07T12:00:00+00:00"}
+            ]
+        }"#;
+        let result =
+            claude_from_usage_json(body, datetime!(2026-08-01 21:00:00 UTC), None, None, true);
+        match result {
+            ProviderResult::Ready { windows, .. } => {
+                let ids: Vec<_> = windows.iter().map(|w| w.id().to_owned()).collect();
+                assert_eq!(ids, vec!["session", "weekly"], "got {ids:?}");
+                assert_eq!(windows[0].label(), LABEL_SESSION);
+                assert!((windows[0].used_percent() - 7.0).abs() < 0.01);
             }
             other => panic!("expected ready, got {other:?}"),
         }

--- a/tests/qml/tst_Popup.qml
+++ b/tests/qml/tst_Popup.qml
@@ -308,13 +308,43 @@ TestCase {
     verify(view.indexOf("groups.secondary") < 0)
   }
 
-  // §6/§3.7: the popup shows the countdown only. The absolute-clock humaniser
-  // is deleted with its weekday table and its only Qt.formatDateTime call.
+  // §6/§3.7 amended 2026-08-03 (owner decision on live mockups): the LEAD
+  // window appends the reset's wall-clock time after the countdown, in the
+  // viewer's locale format. The plan-04 deletions stay deleted: no weekday
+  // table, no fixed-format humaniser, compact rows countdown-only.
   function test_absolute_clock_humaniser_is_gone() {
     var core = read("assets/omarchy/CoreView.js")
     verify(core.indexOf("formatResetText") < 0)
     verify(core.indexOf("WEEKDAYS") < 0)
     verify(core.indexOf("Qt.formatDateTime") < 0)
     verify(core.indexOf("function resetCountdownText") >= 0)
+  }
+
+  function test_lead_reset_clock_is_locale_formatted() {
+    var core = read("assets/omarchy/CoreView.js")
+    verify(core.indexOf("function resetClockText(") >= 0)
+    // The format is the caller's locale format, never hardcoded.
+    verify(core.indexOf('"hh:mm"') < 0)
+    verify(core.indexOf('"HH:mm"') < 0)
+    // 24h locale shape and 12h locale shape both come from the same seam.
+    var h24 = Core.resetClockText("2026-08-02T02:00:00Z", "HH:mm")
+    verify(/^\(\d{2}:\d{2}\)$/.test(h24), "got: " + h24)
+    var h12 = Core.resetClockText("2026-08-02T02:00:00Z", "h:mm AP")
+    verify(/^\(\d{1,2}:\d{2} (AM|PM)\)$/.test(h12), "got: " + h12)
+    compare(Core.resetClockText("not-a-date", "HH:mm"), "")
+    compare(Core.resetClockText("2026-08-02T02:00:00Z", ""), "")
+  }
+
+  function test_only_the_lead_window_gets_the_clock() {
+    var view = read("assets/omarchy/ProviderView.qml")
+    // Exactly one binding site — the lead Repeater; compact rows stay bare.
+    var first = view.indexOf("resetClock:")
+    verify(first >= 0, "lead window must bind resetClock")
+    verify(view.indexOf("resetClock:", first + 1) < 0,
+           "compact rows must not gain the clock")
+    verify(view.indexOf("Locale.ShortFormat") >= 0,
+           "the format must come from the viewer's locale")
+    var win = read("assets/omarchy/components/UsageWindow.qml")
+    verify(win.indexOf("property string resetClock") >= 0)
   }
 }


### PR DESCRIPTION
## Summary

The three commits pushed to #42's branch after it merged (its `mergedAt` beat the push), plus a branch-name correction caught before first run.

- **Fable limit was invisible** (`114861c`): the /usage `limits[]` vocabulary moved to `percent` + `session`/`weekly_all`/`weekly_scoped` kinds, killing the dynamic model-window path — every entry was skipped for lacking `utilization`. The mapper now accepts both vocabularies, maps grouped kinds to the canonical windows with dedup (and as fallback if the legacy top-level fields retire, as `seven_day_oauth_apps` already did), and keeps model ids stable (`weekly-model:fable`). Tests pin the live-captured shape.
- **Lead reset shows wall-clock time** (`f294561`): `Session (5h) · resets in 4h 39m (13:31)` — the viewer's locale short format (`(1:31 PM)` on en-US), owner-picked on live mockups. Lead window only; compact rows stay countdown-only and the plan-04 weekday deletion stands.
- **Auto-release on merge** (`4a49012` + `master` fix): every product merge to master cuts an official release with assets attached atomically; `auto-release.yml` absorbs `publish.yml`. Design in `docs/superpowers/specs/2026-08-03-auto-release-design.md`. The original commit targeted `main`; the default branch here is `master` — corrected before the workflow ever ran.

## Verification

- `cargo fmt --check` / `cargo test` (312) / `cargo clippy -D warnings` / `git diff --check` / ShellCheck
- Qt6 `qmltestrunner` (241), `omarchy plugin validate` — behavior changes proven red first
- Live QA: Fable window and the wall clock verified in the running popup
- `agent-bar-cut-release --dry-run` output inspected

## Note for merge

Merging this PR triggers the first automated release — watch the Actions run once; it should publish the next patch with these subjects as notes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Lead usage windows now show the reset time in your local short-time format alongside the countdown.
  * Compact usage rows remain countdown-only, and no clock appears when a reset is happening now.
  * Reset times are included in accessible labels when available.
  * Usage limits now support current provider payloads and display session and weekly windows more consistently.

* **Bug Fixes**
  * Improved handling of invalid or missing reset timestamps and time formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->