### PR TITLE
feat: tighten chip numeral to text width

### DIFF
--- a/assets/omarchy/components/ProviderChip.qml
+++ b/assets/omarchy/components/ProviderChip.qml
@@ -84,8 +84,6 @@ WidgetButton {
 
     Text {
       visible: !root.vertical
-      width: numeralMetrics.advanceWidth
-      horizontalAlignment: Text.AlignLeft
       text: root.numeralText
       color: root.numeralColor
       font.family: root.fontFamily
@@ -111,15 +109,10 @@ WidgetButton {
     }
   }
 
-  // §5: numeral box is fixed width, measured on "100%" at the body size —
-  // never a hardcoded pixel; the font scales with [font] base-size. The
-  // numeral is left-aligned so it hugs the icon at a constant gap; the
-  // box's slack trails into the inter-chip spacing instead of splitting
-  // icon and number (amended 2026-08-01).
-  TextMetrics {
-    id: numeralMetrics
-    font.family: root.fontFamily
-    font.pixelSize: Style.font.body
-    text: "100%"
-  }
+  // §5: the numeral box is tight — width follows the text (amended
+  // 2026-08-04). The reserved box sized on the widest numeral parked ~2
+  // digits of slack in the inter-chip gap when every numeral was short,
+  // reading as disproportionate spacing with an inflated right edge. Chips
+  // may shift when a value crosses a digit boundary; the state cues (! / ln)
+  // already resized them, so width stability was never absolute.
 }

--- a/docs/superpowers/specs/2026-07-30-visual-update-design.md
+++ b/docs/superpowers/specs/2026-07-30-visual-update-design.md
@@ -150,19 +150,20 @@ as a named readonly property on `UsageWindow`, and never repeated.
   `CoreView.iconOpticalScale(providerId)`, beside the existing
   `iconFileName`: Claude, Codex and Amp at `1.0`; Grok at `0.875`, because its
   mark is a thin ring that fills its own box edge to edge.
-- Numeral box is fixed width, left-aligned, measured with `TextMetrics` on
-  the string `100%` at `Style.font.body`. Never a hardcoded pixel value: the
-  font scales with `[font] base-size`. (Amended 2026-08-01, owner decision on
-  live mockups: right alignment parked the box's slack between icon and
-  number — ~2 digits of air for `7%` — so the numeral now hugs the icon and
-  the slack trails into the inter-chip gap. The box stays fixed; chip widths
-  still never move.)
+- Numeral box is tight: the `Text` width follows its content, with no
+  reserved box and no `TextMetrics`. (Amended 2026-08-04, owner decision on
+  live mockups, superseding the 2026-08-01 fixed box measured on `100%`:
+  with every numeral short — `0%`, `2%` — the fixed box parked ~2 digits of
+  slack in each inter-chip gap, reading as disproportionate spacing and an
+  inflated right edge on the widget. The accepted cost is that chips shift
+  when a value crosses a digit boundary; the state cues `!`/`ln` already
+  resized chips, so width stability was never absolute.)
 - Gap inside a chip is `Style.spacing.sm` (4). Gap between chips is
   `Style.spacing.md` (6). (Amended 2026-08-01, owner decision on live
   mockups: with the numeral hugging the icon, the old `xxl` (12) plus the
-  numeral box's trailing slack read as scattered chips. The 1.5:1 ratio is
-  acceptable because that slack — up to two digits on short values — still
-  pads the boundary between chips; pairs stay distinct even at `100%`.)
+  numeral box's trailing slack read as scattered chips. With the 2026-08-04
+  tight box these tokens are the exact perceived gaps in every state, and
+  the widget's `Style.space(12)` outer margin splits symmetrically.)
 - State cues carry no leading space; separation is layout spacing. `⌛` is
   replaced by a Nerd Font glyph from the active bar family. The loading cue is
   visually distinct from the `—` no-data glyph.

--- a/tests/qml/tst_BarWidget.qml
+++ b/tests/qml/tst_BarWidget.qml
@@ -650,14 +650,15 @@ TestCase {
     verify(chip.indexOf("wheelMoved") < 0)
     // A11Y-013: no plugin-authored motion (tst_Accessibility also guards).
     verify(chip.indexOf("Behavior") < 0)
-    // §5: fixed-width numeral measured on "100%", host icon canvas, tint.
-    verify(chip.indexOf("TextMetrics") >= 0)
-    verify(chip.indexOf('"100%"') >= 0)
-    // §5 amended 2026-08-01 (owner picked it on live mockups): the numeral
-    // hugs the icon — left-aligned inside the still-fixed box. Right-aligned
-    // put the box's slack exactly between icon and number (~2 digits for
-    // "7%"), which read as a broken chip.
-    verify(chip.indexOf("Text.AlignLeft") >= 0)
+    // §5 amended 2026-08-04 (owner picked it on live mockups): the numeral
+    // box is tight — width follows the text, no reserved "100%" box. The
+    // fixed box parked ~2 digits of slack in the inter-chip gap whenever
+    // every numeral was short, which read as disproportionate spacing and
+    // an inflated right edge. Chips may shift on digit-count changes; the
+    // state cues (! / ln) already moved them, so nothing new is lost.
+    verify(chip.indexOf("TextMetrics") < 0)
+    verify(chip.indexOf('"100%"') < 0)
+    verify(chip.indexOf("advanceWidth") < 0)
     verify(chip.indexOf("Text.AlignRight") < 0)
     verify(chip.indexOf("Style.bar.iconCanvas") >= 0)
     verify(chip.indexOf("MultiEffect") >= 0)


### PR DESCRIPTION
## What

The bar chip numeral no longer reserves a fixed box measured on `"100%"` — the `Text` sizes to its content.

## Why

With every numeral short (`0%`, `2%`), the fixed box parked ~2 digits of slack in each inter-chip gap: ~20px between providers against 4px inside a chip, plus an inflated right edge on the widget. With the tight box, `Style.spacing.sm` (4) and `Style.spacing.md` (6) are the exact perceived gaps in every state and the outer `Style.space(12)` margin splits symmetrically.

Accepted cost, decided by the owner on live mockups (2026-08-04): chips shift when a value crosses a digit boundary. The state cues `!`/`ln` already resized chips, so width stability was never absolute. Spec §5 of `docs/superpowers/specs/2026-07-30-visual-update-design.md` amended accordingly, superseding the 2026-08-01 fixed-box amendment.

## Verification

- `tests/qml/tst_BarWidget.qml` source-scan now forbids the fixed box (red before the fix, green after): 246 QML tests pass under Qt6 `qmltestrunner`.
- `cargo fmt --check`, `cargo test` (312), `cargo clippy -D warnings`, `git diff --check`, `omarchy plugin validate` all clean.
- Live smoke on the real bar after `omarchy-restart-shell`: before/after screenshots confirm uniform 6px gaps and symmetric edges with real data (3% · 2% · 0%).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Provider chips now size numeral displays to their content, creating a tighter layout.
  * Chip spacing remains consistent, with minor movement allowed when digit counts change.

* **Tests**
  * Updated visual and behavior checks to reflect the dynamic numeral sizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->