### PR TITLE
fix: fetch deps before offline release cut

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -42,6 +42,13 @@ jobs:
           rustup default stable
           rustup target list --installed
 
+      - name: Fetch dependencies
+        # cut-release runs `cargo update --workspace --offline`; a fresh
+        # runner has an empty registry, so offline resolution fails without
+        # this. The test and build steps need these exact crates later in
+        # the same run, so the download is moved earlier, not added.
+        run: cargo fetch
+
       - name: Cut release (bump + notes)
         id: cut
         run: |


### PR DESCRIPTION
## Problem

Every auto-release run has failed since the workflow shipped — all 3 runs (2026-08-03 14:41Z, 2026-08-04 12:38Z, 2026-08-04 15:37Z after #46) die identically in the "Cut release" step:

```
error: no matching package named `env_logger` found
location searched: crates.io index
note: offline mode (via `--offline`) can sometimes cause surprising resolution failures
```

`scripts/agent-bar-cut-release` runs `cargo update --workspace --offline` to sync the lockfile with the bumped version. Locally that works because the cargo registry is warm; on a fresh runner the registry is empty, so offline resolution cannot see any package. The 10.1.0–10.3.0 releases were cut by the old release-triggered publish.yml, so this path never ran green in CI. Net effect: no 10.3.1 exists and the 17 product commits pending since v10.3.0 are unreleased.

## Fix

One added workflow step: `cargo fetch` after the Rust install, before the cut. The test/build steps later in the same run need these exact crates anyway, so this moves the download earlier rather than adding one. The script keeps `--offline` (correct for its no-network contract).

## After merge

This PR touches only `.github/**`, so merging it cuts nothing by itself (product path filter). To finally cut 10.3.1 with the pending commits, run the workflow via workflow_dispatch — or let the next product merge trigger it.