### PR TITLE
fix: unpin release identity test

### DIFF
--- a/src/app_identity.rs
+++ b/src/app_identity.rs
@@ -7,6 +7,9 @@ pub const OMARCHY_PLUGIN_ID: &str = "agent-bar.usage";
 /// Omarchy Quickshell root — detection signal only.
 pub const OMARCHY_SHELL_DIR: &str = "/usr/share/omarchy/shell";
 
+// Release identity (version == manifest == helper == tag) is enforced by
+// scripts/check-version inside the auto-release workflow; a literal pin here
+// would fail every automated bump.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[cfg(test)]
@@ -19,15 +22,5 @@ mod tests {
         assert!(!OMARCHY_PLUGIN_ID.starts_with("omarchy."));
         assert!(OMARCHY_PLUGIN_ID.contains('.'));
         assert!(OMARCHY_SHELL_DIR.starts_with('/'));
-    }
-
-    /// Release identity: package version, manifest, helper, and archive
-    /// name must all match (BUNDLE-006 / docs/dev/releasing.md).
-    #[test]
-    fn package_version_is_release_identity() {
-        assert_eq!(
-            VERSION, "10.3.0",
-            "Cargo.toml package version must match the release identity"
-        );
     }
 }


### PR DESCRIPTION
Every auto-release since v10.3.0 (#45, #46, #49 merge runs) failed at the Rust gates: `app_identity::tests::package_version_is_release_identity` pins the literal "10.3.0" while `scripts/agent-bar-cut-release` bumps Cargo.toml before the gates run, so the assertion can never pass on an automated bump.

The property the test wanted (package version == manifest == helper output == tag) is already enforced end to end by `scripts/check-version` inside the same workflow, so the literal pin adds no coverage — it only blocks the pipeline. This removes the test and documents where the identity check lives.

Verification: `cargo fmt --check`, `cargo test` (254 passing, 21 suites), `cargo clippy --all-targets -- -D warnings`, `git diff --check` — all green on top of current master.

Merging this cuts the first converted release (dist repo push + assetless release).