### PR TITLE
Remove bar chip hover tooltip

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ know when a limit clears. It covers Claude, Codex, Amp, and Grok.
 ## What you see
 
 Each enabled provider gets a compact chip with its icon and percentage,
-shown as used or remaining, your pick. Hover a chip for the active
-window and its reset time. Click it and the popup opens: plan tag (like
-`MAX 20X`), a lead window with both the countdown and the wall-clock
-reset, and every other window as a row with its own usage track.
+shown as used or remaining, your pick. Click it and the popup opens:
+plan tag (like `MAX 20X`), a lead window with both the countdown and
+the wall-clock reset, and every other window as a row with its own
+usage track.
 
 Windows are normalized across providers, so Claude's `Session (5h)`,
 `Weekly (7d)`, and per-model windows render the same way Codex's do.
@@ -27,7 +27,6 @@ keyboard-navigable.
 
 | Action | Result |
 | --- | --- |
-| Hover a chip | Active window and its reset |
 | Left click | Open the popup; click again to close |
 | Middle click | Force a refresh of all providers |
 | Right click | Open Settings |

--- a/assets/omarchy/BarWidget.qml
+++ b/assets/omarchy/BarWidget.qml
@@ -33,17 +33,6 @@ BarWidget {
   readonly property color chipForeground: bar ? bar.foreground : Color.foreground
   readonly property string chipFontFamily: bar ? bar.fontFamily : "monospace"
 
-  // The host copies tooltipText by value inside WidgetButton.onEntered and
-  // renders that copy 400ms later, so there is no live countdown to keep
-  // ticking — the string only has to be right at the instant of hover.
-  // MouseArea emits containsMouseChanged (which drives tooltipHovered) before
-  // it emits entered(), so refreshing from the chip's handler lands before
-  // the host reads the property. tst_BarWidget proves that order rather than
-  // trusting it. The initial value is the wall clock so a chip that is
-  // somehow read before any hover still shows a sane countdown.
-  property double tooltipNowMs: Date.now()
-  readonly property string shortTimeFormat: Qt.locale().timeFormat(Locale.ShortFormat)
-
   // Popup is open on another monitor → this instance hosts dismiss-only overlay.
   readonly property bool foreignDismissActive: Service.foreignPopupOpen(
     agentService ? agentService.popupOwner : null,
@@ -106,13 +95,7 @@ BarWidget {
         stateCue: Core.chipStateCue(modelData)
         cueLabel: Core.chipCueLabel(modelData)
         severityUrgent: Core.chipSeverityUrgent(modelData)
-        tooltipText: Core.chipTooltip(modelData, root.displayMetric,
-                                      root.tooltipNowMs, root.shortTimeFormat)
-
-        onTooltipHoveredChanged: {
-          if (chip.tooltipHovered)
-            root.tooltipNowMs = Date.now()
-        }
+        accessibleLabel: Core.chipAccessibleLabel(modelData, root.displayMetric)
         iconSource: root.iconUrl(providerId)
         tinted: Core.iconTinted(providerId)
         iconScale: Core.iconOpticalScale(providerId)

--- a/assets/omarchy/CoreView.js
+++ b/assets/omarchy/CoreView.js
@@ -245,44 +245,12 @@ function chipDimmed(provider) {
   return state !== "ready"
 }
 
-// The chip's own window, humanised for the tooltip's second line: the label,
-// the reset, or both. Empty when the window has neither, because an
-// unlabelled window with no reset has nothing to say and "Window" filler is
-// not an answer — that emptiness is what keeps signed-out, no-CLI, loading
-// and windowless-ready tooltips at exactly one line.
-//
-// plainText strips control characters but spares U+000A by design, so a label
-// carried in provider payload (Codex derives window identity from its own
-// response) could forge an entire tooltip line. The newline collapse below is
-// the only thing preventing that, and tst_BarWidget proves it.
-function chipWindowLine(provider, nowMs, localeTimeFormat) {
-  var w = primaryWindow(provider)
-  if (!w)
-    return ""
-  var parts = []
-  var label = plainText(w.label || w.id || "").replace(/[\r\n]+/g, " ").trim()
-  if (label.length)
-    parts.push(label)
-  var iso = w.resetsAt ? String(w.resetsAt) : ""
-  var countdown = iso.length ? resetCountdownText(iso, nowMs) : ""
-  if (countdown.length) {
-    // resetPhrase already owns the "resets" / "resets in" distinction, and an
-    // elapsed reset takes no clock — the same rule the popup lead follows.
-    var clock = countdown === "now" ? "" : resetClockText(iso, localeTimeFormat)
-    parts.push(clock.length
-        ? resetPhrase(countdown) + " " + countdown + " " + clock
-        : resetPhrase(countdown) + " " + countdown)
-  }
-  return parts.join(" \u00b7 ")
-}
-
-// UX-011 (amended 2026-08-03): line 1 is the provider, the displayed
-// percentage when one exists, and a plain-language qualifier when not ready —
-// the raw enum value never renders (copy design §5.4). Line 2 describes the
-// window that produced the numeral beside it, so the two can never disagree.
-// The host copies this string by value in WidgetButton.onEntered, so nowMs
-// only has to be fresh at the moment of hover; BarWidget owns that.
-function chipTooltip(provider, metric, nowMs, localeTimeFormat) {
+// UX-011 (superseded 2026-08-06): the chip renders no hover tooltip. The
+// former tooltip's first line survives as the chip's accessible name — the
+// provider, the displayed percentage when one exists, and a plain-language
+// qualifier when not ready. The raw enum value never renders (copy design
+// §5.4). Single-line by construction: no window detail, no live clock.
+function chipAccessibleLabel(provider, metric) {
   if (!provider)
     return ""
   var name = provider.name ? String(provider.name) : providerDisplayName(provider.id)
@@ -294,11 +262,7 @@ function chipTooltip(provider, metric, nowMs, localeTimeFormat) {
   var qualifier = stateQualifier(state)
   if (qualifier.length)
     parts.push(qualifier)
-  var head = parts.join(" \u00b7 ")
-  var windowLine = chipWindowLine(provider,
-                                  nowMs === undefined ? Date.now() : nowMs,
-                                  localeTimeFormat)
-  return windowLine.length ? head + "\n" + windowLine : head
+  return parts.join(" · ")
 }
 
 // Visual design §5/§10: per-provider optical scale on the shared 16px

--- a/assets/omarchy/components/ProviderChip.qml
+++ b/assets/omarchy/components/ProviderChip.qml
@@ -5,9 +5,9 @@ import qs.Ui
 
 // Bar chip on Quattro's WidgetButton (UX-001..012; visual design §5).
 // WidgetButton owns the click-target registration and triggerPress
-// protocol (UX-010), tooltip delivery, pointer cursor, dimmed/concealed
-// semantics, and the host-owned opacity motion (A11Y-013). Wheel events
-// die unconnected inside the host component (UX-009).
+// protocol (UX-010), pointer cursor, dimmed/concealed semantics, and the
+// host-owned opacity motion (A11Y-013). Wheel events die unconnected
+// inside the host component (UX-009).
 WidgetButton {
   id: root
 
@@ -20,6 +20,10 @@ WidgetButton {
   property real iconScale: 1.0
   property bool severityUrgent: false
   property string cueLabel: ""
+
+  // The host tooltip is intentionally never set; this label exists for
+  // assistive tech only and must stay single-line.
+  property string accessibleLabel: ""
 
   // §7: Color.urgent is the single severity colour; no new colour exists.
   readonly property color numeralColor: root.severityUrgent ? Color.urgent : root.foreground
@@ -91,7 +95,7 @@ WidgetButton {
       anchors.verticalCenter: parent.verticalCenter
       renderType: Text.NativeRendering
       textFormat: Text.PlainText
-      Accessible.name: root.tooltipText
+      Accessible.name: root.accessibleLabel
       Accessible.role: Accessible.StaticText
     }
 

--- a/docs/specs/v10/04-quickshell-ux-and-accessibility.md
+++ b/docs/specs/v10/04-quickshell-ux-and-accessibility.md
@@ -21,10 +21,12 @@ verified Quattro-native glyphs or explicit English text labels.
 - `UX-009`: Mouse wheel over a bar chip has no effect.
 - `UX-010`: Each chip registers and unregisters a Quattro bar click target and
   implements the host trigger protocol.
-- `UX-011`: Tooltip copy includes the provider name, the displayed
-  percentage when one exists, and a plain-language state qualifier when the
-  provider is not ready. Raw state identifiers never render. Reset detail is
-  limited to the chip's own window; every other window lives in the popup.
+- `UX-011` (superseded 2026-08-06): The chip renders no hover tooltip. Its
+  former first line — the provider name, the displayed percentage when one
+  exists, and a plain-language state qualifier when the provider is not
+  ready — survives as the chip's accessible name. Raw state identifiers
+  never render. Reset detail lives only in the popup. See
+  `docs/superpowers/specs/2026-08-06-remove-chip-tooltip-design.md`.
 - `UX-012`: Stale and error states use an icon/text cue in addition to color.
 
 ## Popup layout

--- a/docs/superpowers/plans/2026-08-06-remove-chip-tooltip.md
+++ b/docs/superpowers/plans/2026-08-06-remove-chip-tooltip.md
@@ -1,0 +1,306 @@
+# Remove Bar-Chip Hover Tooltip Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop rendering the hover tooltip on bar chips while preserving the chip's accessible name, with zero visual change to the bar.
+
+**Architecture:** The Quattro host renders a tooltip only when a `WidgetButton` sets `tooltipText`, so removal means the chip stops setting it. `Core.chipTooltip` (two lines, live clock) collapses into `Core.chipAccessibleLabel` (former first line, no clock), consumed by a new `accessibleLabel` property on `ProviderChip` that feeds `Accessible.name`. Popup tooltips are untouched.
+
+**Tech Stack:** QML (Quickshell/Quattro plugin), plain-JS view model (`CoreView.js`), qmltestrunner (Qt6). No Rust changes.
+
+**Spec:** `docs/superpowers/specs/2026-08-06-remove-chip-tooltip-design.md`
+
+## Global Constraints
+
+- Rust/Cargo and QML only; no Node or npm tooling.
+- Commit subjects: English Conventional Commits, at most 50 characters, no AI attribution anywhere.
+- QML never parses raw provider output; render external strings as plain text.
+- Bar visuals must not change: icon, numeral, state cues (`󰅐` / `!`), dimming, click routing.
+- Popup tooltips (Refresh, Settings gear, reorder arrows) must keep working.
+- Verification must use the Qt6 binaries by absolute path: `/usr/lib/qt6/bin/qmllint` and `/usr/lib/qt6/bin/qmltestrunner` (the PATH versions fail silently).
+- Shared time helpers `resetCountdownText`, `resetClockText`, `resetPhrase` in `CoreView.js` stay — the popup uses them.
+- The `fakeBar` test double in `tst_BarWidget.qml` replicates the host bar API (`showTooltip`, `lastTooltip`, click targets). Leave it intact: the host still calls `bar.showTooltip` on hover; only our text becomes empty.
+
+---
+
+### Task 1: Remove the tooltip wiring, keep the accessible label
+
+**Files:**
+- Modify: `assets/omarchy/CoreView.js:248-302` (delete `chipWindowLine` + `chipTooltip`, add `chipAccessibleLabel`)
+- Modify: `assets/omarchy/BarWidget.qml:36-45,109-115` (drop tooltip clock and binding)
+- Modify: `assets/omarchy/components/ProviderChip.qml:7-9,14-22,94` (new property, new `Accessible.name`)
+- Test: `tests/qml/tst_BarWidget.qml`
+
+**Interfaces:**
+- Consumes: `chipPercentText(provider, metric)`, `stateQualifier(state)`, `providerDisplayName(id)` — already in `CoreView.js`, unchanged.
+- Produces: `Core.chipAccessibleLabel(provider, metric) -> string` (single line, `"<name> · <pct> · <qualifier>"`, empty for null provider) and `ProviderChip.accessibleLabel: string`. Task 2 has no code dependency on these.
+
+- [ ] **Step 1: Rewrite the tooltip tests as accessible-label tests**
+
+In `tests/qml/tst_BarWidget.qml`:
+
+**Delete** these five functions entirely (they prove behaviour that is being removed):
+- `test_chip_tooltip_carries_window_and_reset` (lines ~335-403, including the comment block above it)
+- `test_chip_tooltip_window_line_is_earned_not_filled` (lines ~405-434)
+- `test_tooltip_snapshot_is_fresh_at_hover` (lines ~561-594)
+- `test_bar_widget_wires_the_tooltip_clock` (lines ~596-606)
+- `test_host_still_snapshots_the_tooltip_text` (lines ~608-617, including its comment)
+
+**Replace** `test_chip_tooltip_humanized` (lines ~310-333) with:
+
+```qml
+  function test_chip_accessible_label_humanized() {
+    var ready = { name: "Claude", state: "ready",
+                  windows: [{ usedPercent: 4, remainingPercent: 96 }] }
+    compare(Core.chipAccessibleLabel(ready, "remaining"), "Claude · 96%")
+
+    var signedOut = { name: "Claude", state: "unauthenticated", windows: [] }
+    compare(Core.chipAccessibleLabel(signedOut, "remaining"),
+            "Claude · signed out")
+
+    var rateLimited = { name: "Codex", state: "rate_limited",
+                        windows: [{ usedPercent: 98, remainingPercent: 2 }] }
+    compare(Core.chipAccessibleLabel(rateLimited, "used"),
+            "Codex · 98% · rate limited")
+
+    var noCli = { name: "Grok", state: "cli_missing", windows: [] }
+    compare(Core.chipAccessibleLabel(noCli, "remaining"), "Grok · no CLI")
+
+    var failed = { name: "Amp", state: "provider_error", windows: [] }
+    compare(Core.chipAccessibleLabel(failed, "remaining"), "Amp · failed")
+
+    var emptyReady = { name: "Claude", state: "ready", windows: [] }
+    compare(Core.chipAccessibleLabel(emptyReady, "remaining"), "Claude · —")
+
+    var loading = { name: "Claude", state: "loading", windows: [] }
+    compare(Core.chipAccessibleLabel(loading, "remaining"), "Claude · loading")
+
+    var stale = { name: "Claude", state: "stale",
+                  windows: [{ usedPercent: 95, remainingPercent: 5 }] }
+    compare(Core.chipAccessibleLabel(stale, "remaining"), "Claude · 5% · stale")
+
+    // Single-line by construction; no provider stays empty.
+    compare(Core.chipAccessibleLabel(null, "remaining"), "")
+  }
+```
+
+**Add** this source guard (in place of the two deleted wiring tests, near the other `sourceAt` guards):
+
+```qml
+  function test_bar_widget_renders_no_tooltip() {
+    var widget = sourceAt(widgetUrl)
+    verify(widget.indexOf("tooltipText") < 0,
+           "the bar chip must never feed the host tooltip")
+    verify(widget.indexOf("tooltipNowMs") < 0,
+           "the tooltip clock died with the tooltip")
+    verify(widget.indexOf("chipAccessibleLabel") >= 0,
+           "the accessible label must still reach the chip")
+    var chip = sourceAt(chipUrl)
+    verify(chip.indexOf("property string accessibleLabel") >= 0)
+    verify(chip.indexOf("Accessible.name: root.accessibleLabel") >= 0)
+    verify(chip.indexOf("tooltipText") < 0,
+           "the chip must not reference the host tooltip property")
+  }
+```
+
+**Edit** `test_provider_chip_registers_and_unregisters` (line ~535): change the
+`createObject` property `tooltipText: "Claude · 90% · ready"` to
+`accessibleLabel: "Claude · 90% · ready"`.
+
+- [ ] **Step 2: Run the suite to verify the intended failures**
+
+Run:
+```bash
+QT_QPA_PLATFORM=offscreen QML_XHR_ALLOW_FILE_READ=1 QT_LOGGING_TO_CONSOLE=1 \
+  /usr/lib/qt6/bin/qmltestrunner \
+  -input tests/qml/tst_BarWidget.qml \
+  -import /usr/share/omarchy/shell \
+  -import assets/omarchy \
+  -o -,txt
+```
+Expected: FAIL — `test_chip_accessible_label_humanized` (chipAccessibleLabel is not a function) and `test_bar_widget_renders_no_tooltip` (BarWidget still contains `tooltipText`/`tooltipNowMs`).
+
+- [ ] **Step 3: Replace `chipTooltip`/`chipWindowLine` in CoreView.js**
+
+In `assets/omarchy/CoreView.js`, delete lines 248-302 — the `chipWindowLine`
+comment block and function, and the `chipTooltip` comment block and function —
+and put this in their place:
+
+```js
+// UX-011 (superseded 2026-08-06): the chip renders no hover tooltip. The
+// former tooltip's first line survives as the chip's accessible name — the
+// provider, the displayed percentage when one exists, and a plain-language
+// qualifier when not ready. The raw enum value never renders (copy design
+// §5.4). Single-line by construction: no window detail, no live clock.
+function chipAccessibleLabel(provider, metric) {
+  if (!provider)
+    return ""
+  var name = provider.name ? String(provider.name) : providerDisplayName(provider.id)
+  var parts = [name]
+  var state = provider.state ? String(provider.state) : "unknown"
+  var pct = chipPercentText(provider, metric)
+  if (pct !== "—" || state === "ready")
+    parts.push(pct)
+  var qualifier = stateQualifier(state)
+  if (qualifier.length)
+    parts.push(qualifier)
+  return parts.join(" \u00b7 ")
+}
+```
+
+(The head-building logic is copied verbatim from the old `chipTooltip`; only
+the window line and its `nowMs`/`localeTimeFormat` parameters are gone.)
+
+- [ ] **Step 4: Give ProviderChip an accessibleLabel and stop reading tooltipText**
+
+In `assets/omarchy/components/ProviderChip.qml`:
+
+1. In the header comment (lines 7-10), delete the words `tooltip delivery,` —
+   the host no longer delivers a tooltip for this widget.
+2. Add to the property block (after `property string cueLabel: ""`):
+
+```qml
+  // The host tooltip is intentionally never set; this label exists for
+  // assistive tech only and must stay single-line.
+  property string accessibleLabel: ""
+```
+
+3. Change line 94 from `Accessible.name: root.tooltipText` to:
+
+```qml
+      Accessible.name: root.accessibleLabel
+```
+
+- [ ] **Step 5: Strip the tooltip machinery from BarWidget.qml**
+
+In `assets/omarchy/BarWidget.qml`:
+
+1. Delete lines 36-45: the entire tooltip-freshness comment block plus both
+   properties `property double tooltipNowMs: Date.now()` and
+   `readonly property string shortTimeFormat: Qt.locale().timeFormat(Locale.ShortFormat)`.
+2. Replace the chip bindings at lines 109-115 —
+
+```qml
+        tooltipText: Core.chipTooltip(modelData, root.displayMetric,
+                                      root.tooltipNowMs, root.shortTimeFormat)
+
+        onTooltipHoveredChanged: {
+          if (chip.tooltipHovered)
+            root.tooltipNowMs = Date.now()
+        }
+```
+
+— with:
+
+```qml
+        accessibleLabel: Core.chipAccessibleLabel(modelData, root.displayMetric)
+```
+
+- [ ] **Step 6: Run the BarWidget suite to verify it passes**
+
+Run the same qmltestrunner command as Step 2.
+Expected: PASS, zero failures.
+
+- [ ] **Step 7: Run the full checkpoint**
+
+```bash
+cargo fmt --check
+cargo test
+cargo clippy --all-targets -- -D warnings
+git diff --check
+find assets/omarchy -type f -name '*.qml' -exec \
+  /usr/lib/qt6/bin/qmllint -I /usr/share/omarchy/shell {} +
+omarchy plugin validate assets/omarchy
+QT_QPA_PLATFORM=offscreen QML_XHR_ALLOW_FILE_READ=1 QT_LOGGING_TO_CONSOLE=1 \
+  /usr/lib/qt6/bin/qmltestrunner \
+  -input tests/qml \
+  -import /usr/share/omarchy/shell \
+  -import assets/omarchy \
+  -o -,txt
+```
+Expected: everything green. Read qmllint output only for warnings this change
+introduced (the `qs.*` unresolved-import noise is pre-existing); its exit code
+is not a verdict.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add assets/omarchy/CoreView.js assets/omarchy/BarWidget.qml \
+  assets/omarchy/components/ProviderChip.qml tests/qml/tst_BarWidget.qml
+git commit -m "feat: remove bar chip hover tooltip"
+```
+
+---
+
+### Task 2: Update user-facing docs and amend UX-011
+
+**Files:**
+- Modify: `README.md:11-15,28-33`
+- Modify: `docs/specs/v10/04-quickshell-ux-and-accessibility.md:24-27`
+
+**Interfaces:**
+- Consumes: nothing from Task 1 (prose only).
+- Produces: nothing consumed by code.
+
+- [ ] **Step 1: Remove hover copy from README.md**
+
+Replace lines 11-15:
+
+```markdown
+Each enabled provider gets a compact chip with its icon and percentage,
+shown as used or remaining, your pick. Hover a chip for the active
+window and its reset time. Click it and the popup opens: plan tag (like
+`MAX 20X`), a lead window with both the countdown and the wall-clock
+reset, and every other window as a row with its own usage track.
+```
+
+with:
+
+```markdown
+Each enabled provider gets a compact chip with its icon and percentage,
+shown as used or remaining, your pick. Click it and the popup opens:
+plan tag (like `MAX 20X`), a lead window with both the countdown and
+the wall-clock reset, and every other window as a row with its own
+usage track.
+```
+
+Then delete the table row `| Hover a chip | Active window and its reset |`
+(line 30), leaving the Left/Middle/Right click rows.
+
+- [ ] **Step 2: Amend UX-011 in the v10 spec**
+
+In `docs/specs/v10/04-quickshell-ux-and-accessibility.md`, replace the
+`UX-011` bullet (lines 24-27):
+
+```markdown
+- `UX-011`: Tooltip copy includes the provider name, the displayed
+  percentage when one exists, and a plain-language state qualifier when the
+  provider is not ready. Raw state identifiers never render. Reset detail is
+  limited to the chip's own window; every other window lives in the popup.
+```
+
+with:
+
+```markdown
+- `UX-011` (superseded 2026-08-06): The chip renders no hover tooltip. Its
+  former first line — the provider name, the displayed percentage when one
+  exists, and a plain-language state qualifier when the provider is not
+  ready — survives as the chip's accessible name. Raw state identifiers
+  never render. Reset detail lives only in the popup. See
+  `docs/superpowers/specs/2026-08-06-remove-chip-tooltip-design.md`.
+```
+
+- [ ] **Step 3: Verify the language gate and diff hygiene**
+
+```bash
+cargo test --test active_language
+git diff --check
+```
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md docs/specs/v10/04-quickshell-ux-and-accessibility.md
+git commit -m "docs: record chip tooltip removal"
+```

--- a/docs/superpowers/plans/2026-08-06-remove-chip-tooltip.md
+++ b/docs/superpowers/plans/2026-08-06-remove-chip-tooltip.md
@@ -35,7 +35,7 @@
 - Consumes: `chipPercentText(provider, metric)`, `stateQualifier(state)`, `providerDisplayName(id)` — already in `CoreView.js`, unchanged.
 - Produces: `Core.chipAccessibleLabel(provider, metric) -> string` (single line, `"<name> · <pct> · <qualifier>"`, empty for null provider) and `ProviderChip.accessibleLabel: string`. Task 2 has no code dependency on these.
 
-- [ ] **Step 1: Rewrite the tooltip tests as accessible-label tests**
+- [x] **Step 1: Rewrite the tooltip tests as accessible-label tests**
 
 In `tests/qml/tst_BarWidget.qml`:
 
@@ -107,7 +107,7 @@ In `tests/qml/tst_BarWidget.qml`:
 `createObject` property `tooltipText: "Claude · 90% · ready"` to
 `accessibleLabel: "Claude · 90% · ready"`.
 
-- [ ] **Step 2: Run the suite to verify the intended failures**
+- [x] **Step 2: Run the suite to verify the intended failures**
 
 Run:
 ```bash
@@ -120,7 +120,7 @@ QT_QPA_PLATFORM=offscreen QML_XHR_ALLOW_FILE_READ=1 QT_LOGGING_TO_CONSOLE=1 \
 ```
 Expected: FAIL — `test_chip_accessible_label_humanized` (chipAccessibleLabel is not a function) and `test_bar_widget_renders_no_tooltip` (BarWidget still contains `tooltipText`/`tooltipNowMs`).
 
-- [ ] **Step 3: Replace `chipTooltip`/`chipWindowLine` in CoreView.js**
+- [x] **Step 3: Replace `chipTooltip`/`chipWindowLine` in CoreView.js**
 
 In `assets/omarchy/CoreView.js`, delete lines 248-302 — the `chipWindowLine`
 comment block and function, and the `chipTooltip` comment block and function —
@@ -144,14 +144,14 @@ function chipAccessibleLabel(provider, metric) {
   var qualifier = stateQualifier(state)
   if (qualifier.length)
     parts.push(qualifier)
-  return parts.join(" \u00b7 ")
+  return parts.join(" · ")
 }
 ```
 
 (The head-building logic is copied verbatim from the old `chipTooltip`; only
 the window line and its `nowMs`/`localeTimeFormat` parameters are gone.)
 
-- [ ] **Step 4: Give ProviderChip an accessibleLabel and stop reading tooltipText**
+- [x] **Step 4: Give ProviderChip an accessibleLabel and stop reading tooltipText**
 
 In `assets/omarchy/components/ProviderChip.qml`:
 
@@ -171,7 +171,7 @@ In `assets/omarchy/components/ProviderChip.qml`:
       Accessible.name: root.accessibleLabel
 ```
 
-- [ ] **Step 5: Strip the tooltip machinery from BarWidget.qml**
+- [x] **Step 5: Strip the tooltip machinery from BarWidget.qml**
 
 In `assets/omarchy/BarWidget.qml`:
 
@@ -196,12 +196,12 @@ In `assets/omarchy/BarWidget.qml`:
         accessibleLabel: Core.chipAccessibleLabel(modelData, root.displayMetric)
 ```
 
-- [ ] **Step 6: Run the BarWidget suite to verify it passes**
+- [x] **Step 6: Run the BarWidget suite to verify it passes**
 
 Run the same qmltestrunner command as Step 2.
 Expected: PASS, zero failures.
 
-- [ ] **Step 7: Run the full checkpoint**
+- [x] **Step 7: Run the full checkpoint**
 
 ```bash
 cargo fmt --check
@@ -222,7 +222,7 @@ Expected: everything green. Read qmllint output only for warnings this change
 introduced (the `qs.*` unresolved-import noise is pre-existing); its exit code
 is not a verdict.
 
-- [ ] **Step 8: Commit**
+- [x] **Step 8: Commit**
 
 ```bash
 git add assets/omarchy/CoreView.js assets/omarchy/BarWidget.qml \
@@ -242,7 +242,7 @@ git commit -m "feat: remove bar chip hover tooltip"
 - Consumes: nothing from Task 1 (prose only).
 - Produces: nothing consumed by code.
 
-- [ ] **Step 1: Remove hover copy from README.md**
+- [x] **Step 1: Remove hover copy from README.md**
 
 Replace lines 11-15:
 
@@ -267,7 +267,7 @@ usage track.
 Then delete the table row `| Hover a chip | Active window and its reset |`
 (line 30), leaving the Left/Middle/Right click rows.
 
-- [ ] **Step 2: Amend UX-011 in the v10 spec**
+- [x] **Step 2: Amend UX-011 in the v10 spec**
 
 In `docs/specs/v10/04-quickshell-ux-and-accessibility.md`, replace the
 `UX-011` bullet (lines 24-27):
@@ -290,7 +290,7 @@ with:
   `docs/superpowers/specs/2026-08-06-remove-chip-tooltip-design.md`.
 ```
 
-- [ ] **Step 3: Verify the language gate and diff hygiene**
+- [x] **Step 3: Verify the language gate and diff hygiene**
 
 ```bash
 cargo test --test active_language
@@ -298,7 +298,7 @@ git diff --check
 ```
 Expected: PASS.
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add README.md docs/specs/v10/04-quickshell-ux-and-accessibility.md

--- a/docs/superpowers/specs/2026-08-06-remove-chip-tooltip-design.md
+++ b/docs/superpowers/specs/2026-08-06-remove-chip-tooltip-design.md
@@ -1,0 +1,62 @@
+# Remove bar-chip hover tooltip
+
+Date: 2026-08-06
+Status: approved
+
+## Context
+
+The bar chip currently sets `tooltipText`, so the Quattro host renders a
+hover tooltip ~400ms after the pointer enters a chip (`Claude · 96%` plus a
+second line describing the window and its reset countdown). The owner judged
+the tooltip unnecessary: the chip already shows the percentage and state cue,
+and the popup carries the full detail one click away.
+
+A stale-status review preceded this decision and found no defect: stale
+retention (temporary failure + prior good data → cached windows with
+`lastSuccessAt`, typed error, and Retry) works as specified, `cargo test
+stale` passes, and stale rendering (dimmed chip, 󰅐 cue, popup banner) is
+untouched by this change.
+
+## Decision
+
+Remove the hover tooltip from the bar chips only. Popup tooltips (provider
+Refresh, Settings gear, reorder arrows) stay: those buttons are icon-only and
+the tooltip is their only visible name.
+
+## Design
+
+- `BarWidget.qml` stops setting `tooltipText` on `ProviderChip`. The host
+  only renders a tooltip when that text is non-empty, so hover shows nothing.
+  The machinery that existed solely for the tooltip is deleted with it:
+  `tooltipNowMs`, `shortTimeFormat`, and the `onTooltipHoveredChanged`
+  refresh handler.
+- Accessibility is preserved, not dropped. The chip numeral's
+  `Accessible.name` currently reuses the tooltip string. `Core.chipTooltip`
+  becomes `Core.chipAccessibleLabel`, returning only the former first line
+  (`<name> · <pct> · <qualifier>`), which needs no live clock or locale time
+  format. `ProviderChip` exposes a dedicated property for that label,
+  decoupled from the host's `tooltipText`.
+- `Core.chipWindowLine` is deleted; its only consumer was the tooltip's
+  second line. Its newline-injection guard (a provider-supplied window label
+  forging an extra tooltip line) becomes moot because the accessible label is
+  single-line by construction; `plainText` sanitisation still applies.
+- Shared time helpers (`resetCountdownText`, `resetClockText`,
+  `resetPhrase`) remain: the popup uses them.
+
+## Not changing
+
+- Bar visuals: icon, numeral, state cues, dimming, click routing, popup.
+- Popup tooltips and every popup surface.
+- Stale semantics in Rust and in the UI.
+
+## Tests
+
+In `tests/qml/tst_BarWidget.qml`: first-line tooltip assertions are
+repointed at `chipAccessibleLabel`; countdown, hover-ordering
+(`tooltipNowMs`), and forged-window-label tests are removed together with
+the behaviour they proved.
+
+## Spec amendment
+
+UX-011 (chip tooltip, amended 2026-08-03) is superseded: the chip renders no
+hover tooltip; its former first line survives as the chip's accessible name.

--- a/tests/qml/tst_BarWidget.qml
+++ b/tests/qml/tst_BarWidget.qml
@@ -22,7 +22,6 @@ TestCase {
   property string widgetUrl: "file://" + repoRoot + "/assets/omarchy/BarWidget.qml"
   property string chipUrl: "file://" + repoRoot + "/assets/omarchy/components/ProviderChip.qml"
   property string coreViewUrl: "file://" + repoRoot + "/assets/omarchy/CoreView.js"
-  property string widgetButtonUrl: "file:///usr/share/omarchy/shell/Ui/WidgetButton.qml"
 
   // Minimal shell stand-in with Quattro serviceFor API.
   Item {
@@ -307,130 +306,38 @@ TestCase {
     verify(widget.indexOf("chipCueLabel") >= 0)
   }
 
-  function test_chip_tooltip_humanized() {
+  function test_chip_accessible_label_humanized() {
     var ready = { name: "Claude", state: "ready",
                   windows: [{ usedPercent: 4, remainingPercent: 96 }] }
-    compare(Core.chipTooltip(ready, "remaining"), "Claude · 96%")
+    compare(Core.chipAccessibleLabel(ready, "remaining"), "Claude · 96%")
 
     var signedOut = { name: "Claude", state: "unauthenticated", windows: [] }
-    compare(Core.chipTooltip(signedOut, "remaining"), "Claude · signed out")
+    compare(Core.chipAccessibleLabel(signedOut, "remaining"),
+            "Claude · signed out")
 
     var rateLimited = { name: "Codex", state: "rate_limited",
                         windows: [{ usedPercent: 98, remainingPercent: 2 }] }
-    compare(Core.chipTooltip(rateLimited, "used"), "Codex · 98% · rate limited")
+    compare(Core.chipAccessibleLabel(rateLimited, "used"),
+            "Codex · 98% · rate limited")
 
     var noCli = { name: "Grok", state: "cli_missing", windows: [] }
-    compare(Core.chipTooltip(noCli, "remaining"), "Grok · no CLI")
+    compare(Core.chipAccessibleLabel(noCli, "remaining"), "Grok · no CLI")
 
     var failed = { name: "Amp", state: "provider_error", windows: [] }
-    compare(Core.chipTooltip(failed, "remaining"), "Amp · failed")
+    compare(Core.chipAccessibleLabel(failed, "remaining"), "Amp · failed")
 
     var emptyReady = { name: "Claude", state: "ready", windows: [] }
-    compare(Core.chipTooltip(emptyReady, "remaining"), "Claude · —")
+    compare(Core.chipAccessibleLabel(emptyReady, "remaining"), "Claude · —")
 
     var loading = { name: "Claude", state: "loading", windows: [] }
-    compare(Core.chipTooltip(loading, "remaining"), "Claude · loading")
-  }
+    compare(Core.chipAccessibleLabel(loading, "remaining"), "Claude · loading")
 
-  // Expected clocks are composed through resetClockText, never written out:
-  // Qt.formatTime renders in the machine's zone, so a literal "(13:31)" would
-  // pass in one timezone only. The formatting itself is covered by tst_Popup.
-  function test_chip_tooltip_carries_window_and_reset() {
-    var nowMs = Date.parse("2026-08-03T10:30:00Z")
-
-    // Reset today: label, countdown and clock all land on line 2.
-    var todayIso = "2026-08-03T13:31:00Z"
-    var todayClock = Core.resetClockText(todayIso, "HH:mm")
-    var today = { name: "Claude", state: "ready",
-                  windows: [{ id: "session", label: "Session (5h)",
-                              usedPercent: 95, remainingPercent: 5,
-                              resetsAt: todayIso }] }
-    compare(Core.chipTooltip(today, "remaining", nowMs, "HH:mm"),
-            "Claude · 5%\nSession (5h) · resets in 3h 1m " + todayClock)
-
-    // Distance never suppresses the clock (design decision 3).
-    var farIso = "2026-08-09T14:34:00Z"
-    var farClock = Core.resetClockText(farIso, "HH:mm")
-    var far = { name: "Codex", state: "ready",
-                windows: [{ id: "weekly", label: "Weekly (7d)",
-                            usedPercent: 98, remainingPercent: 2,
-                            resetsAt: farIso }] }
-    compare(Core.chipTooltip(far, "remaining", nowMs, "HH:mm"),
-            "Codex · 2%\nWeekly (7d) · resets in 6d 4h " + farClock)
-
-    // An elapsed reset speaks the popup's phrase and drops the clock.
-    var elapsed = { name: "Claude", state: "ready",
-                    windows: [{ id: "session", label: "Session (5h)",
-                                usedPercent: 4, remainingPercent: 96,
-                                resetsAt: "2026-08-03T10:00:00Z" }] }
-    compare(Core.chipTooltip(elapsed, "remaining", nowMs, "HH:mm"),
-            "Claude · 96%\nSession (5h) · resets now")
-
-    // The qualifier stays on line 1, and the window keeps its reset — this is
-    // the most valuable hover in the product: when does work resume.
-    var limitedIso = "2026-08-03T11:11:00Z"
-    var limitedClock = Core.resetClockText(limitedIso, "HH:mm")
-    var limited = { name: "Grok", state: "rate_limited",
-                    windows: [{ id: "daily", label: "Daily (1d)",
-                                usedPercent: 100, remainingPercent: 0,
-                                resetsAt: limitedIso }] }
-    compare(Core.chipTooltip(limited, "remaining", nowMs, "HH:mm"),
-            "Grok · 0% · rate limited\nDaily (1d) · resets in 41m "
-            + limitedClock)
-
-    // Stale keeps the cached window: resetsAt is an absolute instant, and
-    // staleness devalues the percentage, never the timestamp.
     var stale = { name: "Claude", state: "stale",
-                  windows: [{ id: "session", label: "Session (5h)",
-                              usedPercent: 95, remainingPercent: 5,
-                              resetsAt: todayIso }] }
-    compare(Core.chipTooltip(stale, "remaining", nowMs, "HH:mm"),
-            "Claude · 5% · stale\nSession (5h) · resets in 3h 1m " + todayClock)
+                  windows: [{ usedPercent: 95, remainingPercent: 5 }] }
+    compare(Core.chipAccessibleLabel(stale, "remaining"), "Claude · 5% · stale")
 
-    // A window with no resetsAt says only what it is.
-    var noReset = { name: "Amp", state: "ready",
-                    windows: [{ id: "context", label: "Context",
-                                usedPercent: 95, remainingPercent: 5 }] }
-    compare(Core.chipTooltip(noReset, "remaining", nowMs, "HH:mm"),
-            "Amp · 5%\nContext")
-
-    // No locale format: the countdown survives, the clock does not.
-    compare(Core.chipTooltip(today, "remaining", nowMs, ""),
-            "Claude · 5%\nSession (5h) · resets in 3h 1m")
-
-    // Omitted nowMs falls back to the wall clock without throwing.
-    verify(Core.chipTooltip(today, "remaining").indexOf("Claude · 5%") === 0)
-  }
-
-  function test_chip_tooltip_window_line_is_earned_not_filled() {
-    var nowMs = Date.parse("2026-08-03T10:30:00Z")
-
-    // Neither label nor reset: nothing to say. No second line, and no
-    // "Window" filler — this is what keeps every one-line state one line.
-    var bare = { name: "Claude", state: "ready",
-                 windows: [{ usedPercent: 4, remainingPercent: 96 }] }
-    compare(Core.chipTooltip(bare, "remaining", nowMs, "HH:mm"), "Claude · 96%")
-
-    // Unlabelled but resettable: the reset stands alone, no leading separator.
-    var unlabelledIso = "2026-08-03T13:31:00Z"
-    var unlabelledClock = Core.resetClockText(unlabelledIso, "HH:mm")
-    var unlabelled = { name: "Claude", state: "ready",
-                       windows: [{ usedPercent: 4, remainingPercent: 96,
-                                   resetsAt: unlabelledIso }] }
-    compare(Core.chipTooltip(unlabelled, "remaining", nowMs, "HH:mm"),
-            "Claude · 96%\nresets in 3h 1m " + unlabelledClock)
-
-    // plainText spares U+000A on purpose, so a label carried in provider
-    // payload could forge a whole tooltip line. Exactly one newline may exist.
-    var forged = { name: "Claude", state: "ready",
-                   windows: [{ id: "session", label: "Session\nresets in 0m",
-                               usedPercent: 4, remainingPercent: 96 }] }
-    var tip = Core.chipTooltip(forged, "remaining", nowMs, "HH:mm")
-    compare(tip.split("\n").length, 2)
-    compare(tip, "Claude · 96%\nSession resets in 0m")
-
-    // No provider at all stays empty, as before.
-    compare(Core.chipTooltip(null, "remaining", nowMs, "HH:mm"), "")
+    // Single-line by construction; no provider stays empty.
+    compare(Core.chipAccessibleLabel(null, "remaining"), "")
   }
 
   function test_state_qualifier_strings() {
@@ -532,7 +439,7 @@ TestCase {
       providerId: "claude",
       displayName: "Claude",
       numeralText: "90%",
-      tooltipText: "Claude · 90% · ready"
+      accessibleLabel: "Claude · 90% · ready"
     })
     verify(chip !== null)
     // Allow Component.onCompleted to run.
@@ -558,62 +465,19 @@ TestCase {
     chip.destroy()
   }
 
-  function test_tooltip_snapshot_is_fresh_at_hover() {
-    // A reset a decade out gives a four-digit countdown; measured from the
-    // epoch the same reset gives five digits. That gap is the probe: it
-    // proves the refresh ran before the host copied the string, without
-    // restating the binding back to itself.
-    var provider = { name: "Claude", state: "ready",
-                     windows: [{ id: "session", label: "Session (5h)",
-                                 usedPercent: 4, remainingPercent: 96,
-                                 resetsAt: "2036-01-01T00:00:00Z" }] }
-    // TestCase itself is invisible and 0x0 in qmltestrunner, and an invisible
-    // parent makes every child invisible, which silently swallows hover. The
-    // chip is parented to the visible root item instead.
-    var chip = providerChipComp.createObject(testCase.parent, { bar: fakeBar })
-    verify(chip !== null)
-    verify(chip.visible, "the chip must be visible or hover never fires")
-    chip.tooltipText = Qt.binding(function () {
-      return Core.chipTooltip(provider, "remaining", chip.tooltipNowMs, "HH:mm")
-    })
-
-    chip.tooltipNowMs = 0
-    verify(/\d{5}d/.test(chip.tooltipText),
-           "epoch baseline must be five-digit days, got: " + chip.tooltipText)
-
-    fakeBar.lastTooltip = ""
-    mouseMove(chip, 5, 5)
-    verify(fakeBar.lastTooltip.length > 0, "hover must push a tooltip")
-    verify(!/\d{5}d/.test(fakeBar.lastTooltip),
-           "host read a stale clock: " + fakeBar.lastTooltip)
-    verify(fakeBar.lastTooltip.indexOf("Session (5h) · resets in") >= 0,
-           "got: " + fakeBar.lastTooltip)
-
-    chip.destroy()
-    wait(0)
-  }
-
-  function test_bar_widget_wires_the_tooltip_clock() {
+  function test_bar_widget_renders_no_tooltip() {
     var widget = sourceAt(widgetUrl)
-    verify(widget.indexOf("property double tooltipNowMs") >= 0)
-    verify(widget.indexOf("Qt.locale().timeFormat(Locale.ShortFormat)") >= 0,
-           "the clock format is the host locale's, never a literal")
-    verify(widget.indexOf("onTooltipHoveredChanged") >= 0,
-           "nowMs must refresh before the host snapshots the text")
-    verify(widget.indexOf("root.tooltipNowMs = Date.now()") >= 0)
-    verify(widget.indexOf("root.shortTimeFormat") >= 0,
-           "the locale format must reach chipTooltip")
-  }
-
-  function test_host_still_snapshots_the_tooltip_text() {
-    // If an Omarchy upgrade changes either of these, the replica above stops
-    // representing the host and the freshness strategy needs rethinking.
-    var host = sourceAt(widgetButtonUrl)
-    verify(host.length > 0, "host WidgetButton.qml must be readable")
-    verify(host.indexOf("root.bar.showTooltip(root, root.tooltipText)") >= 0,
-           "host still copies the text by value inside onEntered")
-    verify(host.indexOf("mouseArea.containsMouse") >= 0,
-           "tooltipHovered still derives from containsMouse")
+    verify(widget.indexOf("tooltipText") < 0,
+           "the bar chip must never feed the host tooltip")
+    verify(widget.indexOf("tooltipNowMs") < 0,
+           "the tooltip clock died with the tooltip")
+    verify(widget.indexOf("chipAccessibleLabel") >= 0,
+           "the accessible label must still reach the chip")
+    var chip = sourceAt(chipUrl)
+    verify(chip.indexOf("property string accessibleLabel") >= 0)
+    verify(chip.indexOf("Accessible.name: root.accessibleLabel") >= 0)
+    verify(chip.indexOf("tooltipText") < 0,
+           "the chip must not reference the host tooltip property")
   }
 
   function test_source_guard_no_process_timer_shell() {
@@ -769,38 +633,11 @@ TestCase {
     property string displayName: ""
     property string numeralText: "\u2014"
     property string stateCue: ""
-    property string tooltipText: ""
+    property string accessibleLabel: ""
     property var registeredBar: null
 
-    // Hover shape copied from qs.Ui's WidgetButton: tooltipHovered derives
-    // from containsMouse, and onEntered hands the host a *copy* of the text.
-    // The real ProviderChip cannot be instantiated here (qs.Ui does not
-    // resolve in this runner), so this replica is what exercises the Qt
-    // signal order; test_host_still_snapshots_the_tooltip_text is what keeps
-    // the replica honest against the installed host.
     width: 40
     height: 20
-    property double tooltipNowMs: 0
-    readonly property bool tooltipHovered: hoverArea.containsMouse
-
-    onTooltipHoveredChanged: {
-      if (chipRoot.tooltipHovered)
-        chipRoot.tooltipNowMs = Date.now()
-    }
-
-    MouseArea {
-      id: hoverArea
-      anchors.fill: parent
-      hoverEnabled: true
-      onEntered: {
-        if (chipRoot.bar && typeof chipRoot.bar.showTooltip === "function")
-          chipRoot.bar.showTooltip(chipRoot, chipRoot.tooltipText)
-      }
-      onExited: {
-        if (chipRoot.bar && typeof chipRoot.bar.hideTooltip === "function")
-          chipRoot.bar.hideTooltip(chipRoot)
-      }
-    }
 
     signal pressed(int button)
 


### PR DESCRIPTION
## Summary

- The bar chip no longer sets `tooltipText`, so the Quattro host renders no hover tooltip. Zero visual change to the bar itself: icon, numeral, state cues, dimming, and click routing are untouched.
- The former tooltip's first line (`Claude · 96% · stale`) survives as the chip's accessible name via the new `Core.chipAccessibleLabel` and a dedicated `accessibleLabel` property on `ProviderChip`.
- `chipWindowLine` and the tooltip-freshness machinery (`tooltipNowMs`, locale time format, hover handler) are deleted; shared reset helpers stay (the popup uses them).
- Popup tooltips (Refresh, Settings gear, reorder arrows) are unchanged — they are the only visible name of icon-only buttons.
- Docs: README hover copy removed; spec `UX-011` amended with a supersession note. Design and plan under `docs/superpowers/`.

## Verification

- `cargo fmt --check`, `cargo test` (254), `cargo clippy -D warnings`, `git diff --check`
- Qt6 `qmllint`, `omarchy plugin validate`, Qt6 `qmltestrunner` full suite (243 passed, 0 failed)
- Not yet verified on a live bar: hover removal only lands visually after the installed plugin updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chips now show a direct popup on click, with clearer accessible labels for provider name, status, and percentage where applicable.
* **Bug Fixes**
  * Removed hover-based chip tooltips and related countdown behavior.
  * Improved accessibility by exposing chip information in a screen-reader-friendly format.
* **Documentation**
  * Updated user-facing docs to reflect the new click-first interaction and the removal of hover tooltips.
* **Tests**
  * Updated automated checks to validate accessible labels instead of tooltip behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->