### PR TITLE
Rename plugin ID to othavi0.agent-bar

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -84,15 +84,15 @@ jobs:
           mkdir -p target/release
           cp -f target/x86_64-unknown-linux-gnu/release/agent-bar target/release/agent-bar
           cargo run --bin agent-bar-bundle -- \
-            assemble output target/release/agent-bar.usage \
+            assemble output target/release/othavi0.agent-bar \
             source-commit "$SOURCE_COMMIT"
           scripts/check-version "v${{ steps.cut.outputs.version }}" \
-            target/release/agent-bar.usage
+            target/release/othavi0.agent-bar
 
       - name: Bundle inventory / modes / architecture
         run: |
           set -euo pipefail
-          ROOT=target/release/agent-bar.usage
+          ROOT=target/release/othavi0.agent-bar
           test -f "$ROOT/bundle.json"
           test -f "$ROOT/manifest.json"
           test -x "$ROOT/bin/agent-bar"
@@ -119,7 +119,7 @@ jobs:
           SOURCE_COMMIT="$(git rev-parse HEAD)"
           git clone --depth 1 git@github.com:othavi0/omarchy-agent-bar.git dist
           find dist -mindepth 1 -maxdepth 1 -not -name .git -exec rm -rf {} +
-          cp -a target/release/agent-bar.usage/. dist/
+          cp -a target/release/othavi0.agent-bar/. dist/
           git -C dist config user.name "github-actions[bot]"
           git -C dist config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git -C dist add -A

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ The approved v10 design and implementation plan are in
 ## Hard bootstrap
 
 - Rust/Cargo and QML only; no Node runtime or test tooling.
-- Product is only the Quickshell plugin `agent-bar.usage`.
+- Product is only the Quickshell plugin `othavi0.agent-bar`.
 - The Rust helper is private inside the plugin bundle.
 - Keep the terminal helper as argv-safe Bash.
 - Do not run live setup, update, uninstall, rescan, shell restart, or config

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ contract when documentation and behavior disagree.
 ## Hard rules
 
 - Rust/Cargo and QML only. No Node, npm, Bun, pnpm, Yarn, ts-node, or Deno.
-- Product artifact is only the Omarchy Quattro plugin `agent-bar.usage`.
+- Product artifact is only the Omarchy Quattro plugin `othavi0.agent-bar`.
 - The Rust helper is private at plugin path `bin/agent-bar`.
 - Do not create a global executable, standalone application, AUR package, or
   cargo-binstall product.
@@ -56,7 +56,7 @@ dependencies.
 ## Quattro contract
 
 - Plugin root is literal
-  `$HOME/.config/omarchy/plugins/agent-bar.usage`.
+  `$HOME/.config/omarchy/plugins/othavi0.agent-bar`.
 - Agent Bar settings/cache/state follow XDG.
 - Manifest schema remains 1 with kinds `service` and `bar-widget`.
 - `Service.qml` is the sole polling/process owner.
@@ -64,7 +64,7 @@ dependencies.
   `bar.shell.serviceFor(moduleName)`.
 - Fresh installs use `omarchy plugin add <dist-repo-url>`, which clones,
   validates, and moves the tree; enabling it is a separate confirmation.
-- Existing installs update with `omarchy plugin update agent-bar.usage`.
+- Existing installs update with `omarchy plugin update othavi0.agent-bar`.
 - Never run an unconditional `omarchy bar plugin add`.
 - Update never edits `shell.json`.
 

--- a/README.md
+++ b/README.md
@@ -50,17 +50,17 @@ that choice, the widget defaults to the right section of the bar. This
 clones one verified directory and nothing else:
 
 ```text
-~/.config/omarchy/plugins/agent-bar.usage/
+~/.config/omarchy/plugins/othavi0.agent-bar/
 ```
 
-Update and remove with `omarchy plugin update agent-bar.usage` and
-`omarchy plugin remove agent-bar.usage`, or use the buttons in Settings.
+Update and remove with `omarchy plugin update othavi0.agent-bar` and
+`omarchy plugin remove othavi0.agent-bar`, or use the buttons in Settings.
 
 If you installed Agent Bar before this release (a plain directory, not a
 git checkout), the update button shows a one-time migration notice. Run:
 
 ```bash
-omarchy plugin remove agent-bar.usage
+omarchy plugin remove othavi0.agent-bar
 omarchy plugin add https://github.com/othavi0/omarchy-agent-bar.git
 ```
 

--- a/assets/dist/README.md
+++ b/assets/dist/README.md
@@ -17,13 +17,13 @@ skip that choice, the widget defaults to the right section of the bar.
 ## Update
 
 ```bash
-omarchy plugin update agent-bar.usage
+omarchy plugin update othavi0.agent-bar
 ```
 
 ## Remove
 
 ```bash
-omarchy plugin remove agent-bar.usage
+omarchy plugin remove othavi0.agent-bar
 ```
 
 ## Source and issues

--- a/assets/omarchy/BarWidget.qml
+++ b/assets/omarchy/BarWidget.qml
@@ -11,7 +11,7 @@ import "components"
 // Presentation only — Service owns I/O and polling (ARCH-023).
 BarWidget {
   id: root
-  moduleName: "agent-bar.usage"
+  moduleName: "othavi0.agent-bar"
 
   readonly property var agentService: bar && bar.shell
       ? bar.shell.serviceFor(moduleName)

--- a/assets/omarchy/CoreMaintenance.js
+++ b/assets/omarchy/CoreMaintenance.js
@@ -137,7 +137,7 @@ function maintenanceUiFromCheck(ui, stdout, exitCode, fallbackVersion) {
           next.phase = "reinstall_required"
           next.targetVersion = ""
           next.releaseNotesUrl = ""
-          next.message = "Installed without git. Run: omarchy plugin remove agent-bar.usage, "
+          next.message = "Installed without git. Run: omarchy plugin remove othavi0.agent-bar, "
               + "then omarchy plugin add https://github.com/othavi0/omarchy-agent-bar.git"
           return next
         }

--- a/assets/omarchy/Service.qml
+++ b/assets/omarchy/Service.qml
@@ -888,7 +888,7 @@ Item {
   }
 
   IpcHandler {
-    target: "agent-bar.usage"
+    target: "othavi0.agent-bar"
     function health(expectedVersion): string { return root.health(expectedVersion) }
     function refresh(providerId): string { return root.refresh(providerId) }
   }

--- a/assets/omarchy/manifest.json
+++ b/assets/omarchy/manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "id": "agent-bar.usage",
+  "id": "othavi0.agent-bar",
   "name": "Agent Bar",
   "version": "__AGENT_BAR_VERSION__",
   "author": "othavi0",

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -131,8 +131,8 @@ themselves:
    (fails closed before anything destructive if either is missing);
 2. `uninstall purge` removes Agent Bar's own XDG state here, before the
    handoff;
-3. run `omarchy plugin update agent-bar.usage --yes` or
-   `omarchy plugin remove agent-bar.usage --yes` as a detached transient
+3. run `omarchy plugin update othavi0.agent-bar --yes` or
+   `omarchy plugin remove othavi0.agent-bar --yes` as a detached transient
    `systemd-run --user` unit;
 4. return once systemd has accepted and started the unit.
 

--- a/docs/dev/json-output.md
+++ b/docs/dev/json-output.md
@@ -6,7 +6,7 @@ Consumed by the shared Quickshell service. The checked-in structural schema is
 Request:
 
 ```bash
-PLUGIN="$HOME/.config/omarchy/plugins/agent-bar.usage/bin/agent-bar"
+PLUGIN="$HOME/.config/omarchy/plugins/othavi0.agent-bar/bin/agent-bar"
 "$PLUGIN" status format json
 ```
 

--- a/docs/dev/omarchy-shell.md
+++ b/docs/dev/omarchy-shell.md
@@ -5,7 +5,7 @@
 Quattro discovers user plugins at the literal path:
 
 ```text
-$HOME/.config/omarchy/plugins/agent-bar.usage/
+$HOME/.config/omarchy/plugins/othavi0.agent-bar/
 ```
 
 It does not apply `XDG_CONFIG_HOME` to plugin discovery or `shell.json`.
@@ -15,7 +15,7 @@ It does not apply `XDG_CONFIG_HOME` to plugin discovery or `shell.json`.
 ```json
 {
   "schemaVersion": 1,
-  "id": "agent-bar.usage",
+  "id": "othavi0.agent-bar",
   "name": "Agent Bar",
   "version": "__AGENT_BAR_VERSION__",
   "author": "othavi0",
@@ -70,7 +70,7 @@ readonly property var agentService:
     bar && bar.shell ? bar.shell.serviceFor(moduleName) : null
 ```
 
-`Service.qml` owns one `IpcHandler` target `agent-bar.usage`. Its closed
+`Service.qml` owns one `IpcHandler` target `othavi0.agent-bar`. Its closed
 surface is `health(expectedVersion)` for maintenance and `refresh(providerId)`
 for successful interactive login. The target architecture fixes the exact
 return values and validation.
@@ -104,22 +104,22 @@ Update (git fetch, fast-forward, re-validate; rolls back on a failed
 validation):
 
 ```bash
-omarchy plugin update agent-bar.usage
+omarchy plugin update othavi0.agent-bar
 ```
 
 Remove (disables the bar entry, deletes or backs up the tree, rescans):
 
 ```bash
-omarchy plugin remove agent-bar.usage
+omarchy plugin remove othavi0.agent-bar
 ```
 
 An already-installed but disabled plugin can be enabled directly:
 
 ```bash
-omarchy plugin enable agent-bar.usage
+omarchy plugin enable othavi0.agent-bar
 ```
 
-Do not run `omarchy bar plugin add agent-bar.usage` over an existing entry;
+Do not run `omarchy bar plugin add othavi0.agent-bar` over an existing entry;
 it can reset placement.
 
 ## Interactive login
@@ -133,9 +133,9 @@ own terminal-emulator fallback list.
 ## Validation
 
 ```bash
-omarchy plugin validate /path/to/agent-bar.usage
+omarchy plugin validate /path/to/othavi0.agent-bar
 # PATH qmllint is a stub; the Qt6 binary path is mandatory
-find /path/to/agent-bar.usage -type f -name '*.qml' -exec \
+find /path/to/othavi0.agent-bar -type f -name '*.qml' -exec \
   /usr/lib/qt6/bin/qmllint -I /usr/share/omarchy/shell {} +
 ```
 

--- a/docs/dev/releasing.md
+++ b/docs/dev/releasing.md
@@ -32,7 +32,7 @@ or global installation.
    exact tagged commit.
 4. The plugin tree is built and verified: the helper builds for
    `x86_64-unknown-linux-gnu`, the assemble step writes
-   `target/release/agent-bar.usage` and runs `scripts/check-version`, and
+   `target/release/othavi0.agent-bar` and runs `scripts/check-version`, and
    an inventory step checks required files, executable modes, and the
    target architecture.
 5. The assembled tree is pushed to the distribution repository first. A
@@ -87,13 +87,13 @@ After merging:
 
    ```bash
    # The Settings button's first stage: must report the new version.
-   ~/.config/omarchy/plugins/agent-bar.usage/bin/agent-bar update check
+   ~/.config/omarchy/plugins/othavi0.agent-bar/bin/agent-bar update check
 
    # The apply path (the Settings button delegates to this same command).
-   omarchy plugin update agent-bar.usage
+   omarchy plugin update othavi0.agent-bar
 
    # Must now report available: false with current == the new version.
-   ~/.config/omarchy/plugins/agent-bar.usage/bin/agent-bar update check
+   ~/.config/omarchy/plugins/othavi0.agent-bar/bin/agent-bar update check
    ```
 
    Then glance at the bar: chips must render with live data after the
@@ -183,6 +183,6 @@ Local bundle reproduction for debugging:
 ```bash
 SOURCE_COMMIT="$(git rev-parse HEAD)"
 cargo run --bin agent-bar-bundle -- assemble \
-  output target/release-candidate/agent-bar.usage \
+  output target/release-candidate/othavi0.agent-bar \
   source-commit "$SOURCE_COMMIT"
 ```

--- a/docs/guide/commands.md
+++ b/docs/guide/commands.md
@@ -7,7 +7,7 @@ recovery, and the shared service.
 Resolve it with:
 
 ```bash
-PLUGIN="$HOME/.config/omarchy/plugins/agent-bar.usage/bin/agent-bar"
+PLUGIN="$HOME/.config/omarchy/plugins/othavi0.agent-bar/bin/agent-bar"
 ```
 
 ## Status
@@ -73,7 +73,7 @@ returns the canonical stored document.
 ```
 
 `setup` takes no arguments; it migrates settings to the current schema.
-Install and update go through `omarchy plugin add|update agent-bar.usage`.
+Install and update go through `omarchy plugin add|update othavi0.agent-bar`.
 `doctor scan` never writes. `doctor clean` backs up and removes only
 confirmed owned legacy artifacts.
 
@@ -90,7 +90,7 @@ confirmed owned legacy artifacts.
 - `update check` returns machine-readable compatibility metadata read from the
   dist repo's git receipt.
 - `update apply` takes no argument. It delegates unconditionally to
-  `omarchy plugin update agent-bar.usage --yes` as a detached transient unit
+  `omarchy plugin update othavi0.agent-bar --yes` as a detached transient unit
   and returns as soon as the handoff is accepted; that command owns the
   fast-forward, re-validation, and automatic rollback on a failed
   validation.
@@ -123,7 +123,7 @@ Both forms require confirmation before any mutation:
   the JSON object are rejected.
 
 After confirmation, `uninstall` purges only Agent Bar's own XDG state, then
-delegates unconditionally to `omarchy plugin remove agent-bar.usage --yes`
+delegates unconditionally to `omarchy plugin remove othavi0.agent-bar --yes`
 as a detached transient unit — that command owns the plugin tree and the
 `shell.json` entry now. Standard uninstall preserves settings, cache, and
 migration backups. Purge additionally removes `$XDG_CONFIG_HOME/agent-bar`,

--- a/docs/guide/integration.md
+++ b/docs/guide/integration.md
@@ -11,7 +11,7 @@ omarchy plugin add https://github.com/othavi0/omarchy-agent-bar.git
 
 This clones the distribution repository, validates the clone with
 `omarchy-plugin-validate`, and moves it to
-`$HOME/.config/omarchy/plugins/agent-bar.usage`. Omarchy then asks whether
+`$HOME/.config/omarchy/plugins/othavi0.agent-bar`. Omarchy then asks whether
 to enable the plugin now; enabling it prompts for a bar section, defaulting
 to `right` from the manifest's `barWidget.defaultSection` when the prompt is
 skipped.
@@ -20,8 +20,8 @@ Update and remove use the matching Omarchy commands, or the Settings
 Maintenance buttons, which delegate to them:
 
 ```bash
-omarchy plugin update agent-bar.usage
-omarchy plugin remove agent-bar.usage
+omarchy plugin update othavi0.agent-bar
+omarchy plugin remove othavi0.agent-bar
 ```
 
 `omarchy plugin update` fetches, fast-forwards, and re-validates the
@@ -42,7 +42,7 @@ the missing `.git` and reports `reinstallRequired: true`; the Settings UI
 shows a one-time migration instruction instead of a false "up to date":
 
 ```bash
-omarchy plugin remove agent-bar.usage
+omarchy plugin remove othavi0.agent-bar
 omarchy plugin add https://github.com/othavi0/omarchy-agent-bar.git
 ```
 
@@ -55,9 +55,9 @@ plugin directory under XDG paths and are untouched by either command.
 
 `shell.json` owns plugin presence and placement. Agent Bar:
 
-- creates one `{ "id": "agent-bar.usage" }` entry only when enabled, either
+- creates one `{ "id": "othavi0.agent-bar" }` entry only when enabled, either
   through the `omarchy plugin add` placement prompt or a later
-  `omarchy plugin enable agent-bar.usage`;
+  `omarchy plugin enable othavi0.agent-bar`;
 - does not edit `shell.json` during update;
 - removes only its own entry during uninstall, which `omarchy plugin
   remove` performs.
@@ -83,10 +83,10 @@ as a detached transient unit:
 
 ```text
 systemd-run --user --collect --unit=agent-bar-update-<txid>.service \
-  -- <omarchy> plugin update agent-bar.usage --yes
+  -- <omarchy> plugin update othavi0.agent-bar --yes
 
 systemd-run --user --collect --unit=agent-bar-remove-<txid>.service \
-  -- <omarchy> plugin remove agent-bar.usage --yes
+  -- <omarchy> plugin remove othavi0.agent-bar --yes
 ```
 
 Detachment lets the helper return as soon as systemd accepts the unit,
@@ -124,7 +124,7 @@ legacy. Modified and ambiguous paths remain untouched.
 
 After confirmation, `uninstall` purges only Agent Bar's own XDG state (when
 invoked with `purge`) under the exclusive maintenance lock, then delegates
-unconditionally to `omarchy plugin remove agent-bar.usage --yes` as above.
+unconditionally to `omarchy plugin remove othavi0.agent-bar --yes` as above.
 Standard uninstall preserves settings, cache, and migration backups; purge
 additionally removes `$XDG_CONFIG_HOME/agent-bar`, `$XDG_CACHE_HOME/agent-bar`,
 and `$XDG_STATE_HOME/agent-bar` before the handoff. Purge and the delegated

--- a/docs/guide/runtime.md
+++ b/docs/guide/runtime.md
@@ -4,7 +4,7 @@
 
 | Path | Purpose |
 | --- | --- |
-| `$HOME/.config/omarchy/plugins/agent-bar.usage/` | Complete plugin bundle |
+| `$HOME/.config/omarchy/plugins/othavi0.agent-bar/` | Complete plugin bundle |
 | `$XDG_CONFIG_HOME/agent-bar/settings.json` | Canonical product settings |
 | `$XDG_CACHE_HOME/agent-bar/status-v2.json` | Normalized provider cache |
 | `$XDG_CACHE_HOME/agent-bar/status.lock` | Cross-process collection lock |

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -3,7 +3,7 @@
 Resolve the private helper:
 
 ```bash
-PLUGIN="$HOME/.config/omarchy/plugins/agent-bar.usage/bin/agent-bar"
+PLUGIN="$HOME/.config/omarchy/plugins/othavi0.agent-bar/bin/agent-bar"
 ```
 
 ## Start with doctor
@@ -61,7 +61,7 @@ Context is no longer a product window.
 Check:
 
 ```bash
-omarchy plugin validate "$HOME/.config/omarchy/plugins/agent-bar.usage"
+omarchy plugin validate "$HOME/.config/omarchy/plugins/othavi0.agent-bar"
 omarchy-shell shell rescanPlugins
 ```
 
@@ -69,7 +69,7 @@ Then inspect:
 
 - manifest ID and version;
 - `service` and `bar-widget` entry points;
-- one exact `agent-bar.usage` entry in `shell.json`;
+- one exact `othavi0.agent-bar` entry in `shell.json`;
 - helper/manifest version equality.
 
 Do not run `omarchy bar plugin add` over an existing entry; it can reset
@@ -91,7 +91,7 @@ until then.
 
 ## Update failed
 
-`update apply` only hands off to `omarchy plugin update agent-bar.usage
+`update apply` only hands off to `omarchy plugin update othavi0.agent-bar
 --yes`; that command owns the actual result. Its failure modes:
 
 - **Non-fast-forward**: `omarchy plugin update` refuses to update a plugin
@@ -109,7 +109,7 @@ until then.
   the one-time migration instruction:
 
   ```bash
-  omarchy plugin remove agent-bar.usage
+  omarchy plugin remove othavi0.agent-bar
   omarchy plugin add https://github.com/othavi0/omarchy-agent-bar.git
   ```
 

--- a/docs/specs/v10/06-migration-and-legacy-removal.md
+++ b/docs/specs/v10/06-migration-and-legacy-removal.md
@@ -54,7 +54,10 @@ The manifest records:
 ## v9-to-v10 migration
 
 - `MIG-007`: Migration is data migration only. No v9 behavior remains callable.
-- `MIG-008`: Keep plugin ID `agent-bar.usage`.
+- `MIG-008`: Keep plugin ID `agent-bar.usage`. (Superseded 2026-08-06: the
+  live ID is `othavi0.agent-bar`. The v9 migration matcher still recognizes
+  the literal `agent-bar.usage` in legacy `shell.json` data on disk; see
+  `docs/superpowers/specs/2026-08-06-plugin-id-rename-design.md`.)
 - `MIG-009`: Preserve valid provider enablement, order, display metric, refresh
   interval, notification preference, bar section, index, and compatible inline
   layout.

--- a/docs/specs/v10/08-plugin-bundle-and-release.md
+++ b/docs/specs/v10/08-plugin-bundle-and-release.md
@@ -90,7 +90,9 @@ The final Quattro-validated manifest is:
 It must:
 
 - use schema version 1;
-- retain ID `agent-bar.usage`;
+- retain ID `agent-bar.usage` (superseded 2026-08-06: the ID is
+  `othavi0.agent-bar`, renamed before the marketplace listing went live; see
+  `docs/superpowers/specs/2026-08-06-plugin-id-rename-design.md`);
 - declare `service` and `bar-widget`;
 - map the service to `Service.qml`;
 - map the bar widget to `BarWidget.qml`;

--- a/docs/superpowers/specs/2026-08-06-plugin-id-rename-design.md
+++ b/docs/superpowers/specs/2026-08-06-plugin-id-rename-design.md
@@ -1,0 +1,52 @@
+# Rename plugin ID to othavi0.agent-bar
+
+Date: 2026-08-06
+Status: approved
+
+## Context
+
+The plugin ID `agent-bar.usage` predates the marketplace submission. Quattro's
+ID convention is `<vendor>.<plugin>` (`omarchy.clock`, `omarchy.model-usage`),
+so the current ID reads as vendor "agent-bar", plugin "usage". The owner finds
+it unprofessional and the marketplace listing (HANCORE-linux/
+omarchy-plugin-marketplace#36, approved-for-listing) is not live yet:
+the marketplace shows zero published community plugins, so no external
+install exists. This is the last cheap moment to rename — after listing,
+the ID freezes forever because `omarchy plugin update` cannot rename an
+install directory.
+
+## Decision
+
+The plugin ID becomes `othavi0.agent-bar` everywhere current: manifest,
+QML `moduleName`, Rust constants (`PLUGIN_ID`, `OMARCHY_PLUGIN_ID`),
+delegated update/uninstall commands, workflow paths, tests, contract
+(`CLAUDE.md`), and active docs. The dist repository name
+(`omarchy-agent-bar`) and all XDG paths (`agent-bar`) are unchanged.
+
+## The one non-mechanical spot
+
+`src/settings/migration.rs` matches plugin entries in **v9-era
+`shell.json` data on disk**, which contains the historical ID. That
+matcher must keep the literal `agent-bar.usage` via a dedicated
+`LEGACY_PLUGIN_ID` constant; renaming it would silently turn the v9
+migration into a no-op. The v9 fixtures
+(`tests/fixtures/migration/v9/*.json`) represent that on-disk data and
+also keep the old ID.
+
+## Consequences for existing installs
+
+`omarchy plugin update` pulls into the existing directory name, so an
+install created as `agent-bar.usage` that receives the renamed tree
+becomes incoherent (`update check` fails on the dist receipt pluginId
+mismatch by design — maintenance.rs guards it). The only existing
+install is the owner's machine; the migration is `omarchy plugin remove
+agent-bar.usage` + `omarchy plugin add <dist-url>`. Settings survive:
+they live under XDG paths that do not carry the plugin ID.
+
+## Out of scope
+
+Historical documents keep the old ID as a build record: `docs/history/`,
+`docs/releases/`, `docs/superpowers/`, `CHANGELOG.md`. The v10 specs get
+one amendment note at the normative declaration of the ID rather than a
+rewrite. The marketplace submission issue is updated after the release
+lands on the dist repo.

--- a/scripts/agent-bar-open-terminal
+++ b/scripts/agent-bar-open-terminal
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Interactive provider login launcher for the agent-bar.usage plugin bundle.
+# Interactive provider login launcher for the othavi0.agent-bar plugin bundle.
 # Exact contract: login <provider> → xdg-terminal-exec → private bin/agent-bar.
 set -euo pipefail
 

--- a/src/app_identity.rs
+++ b/src/app_identity.rs
@@ -3,7 +3,7 @@
 pub const APP_NAME: &str = "agent-bar";
 pub const TERMINAL_HELPER_NAME: &str = "agent-bar-open-terminal";
 /// Omarchy Quattro plugin ID (bar-widget). The `omarchy.*` prefix is reserved.
-pub const OMARCHY_PLUGIN_ID: &str = "agent-bar.usage";
+pub const OMARCHY_PLUGIN_ID: &str = "othavi0.agent-bar";
 /// Omarchy Quickshell root — detection signal only.
 pub const OMARCHY_SHELL_DIR: &str = "/usr/share/omarchy/shell";
 
@@ -18,7 +18,7 @@ mod tests {
 
     #[test]
     fn omarchy_plugin_id_is_namespaced_and_not_reserved() {
-        assert_eq!(OMARCHY_PLUGIN_ID, "agent-bar.usage");
+        assert_eq!(OMARCHY_PLUGIN_ID, "othavi0.agent-bar");
         assert!(!OMARCHY_PLUGIN_ID.starts_with("omarchy."));
         assert!(OMARCHY_PLUGIN_ID.contains('.'));
         assert!(OMARCHY_SHELL_DIR.starts_with('/'));

--- a/src/cli/command.rs
+++ b/src/cli/command.rs
@@ -106,7 +106,7 @@ pub enum ConfigInput {
 
 /// Update subcommands. `Apply` takes no argument: `update apply` is an
 /// unconditional detached delegation to `omarchy plugin update
-/// agent-bar.usage --yes` (git-plugin-distribution Task 2), not a
+/// othavi0.agent-bar --yes` (git-plugin-distribution Task 2), not a
 /// version-gated apply of a specific release.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UpdateCommand {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -30,7 +30,7 @@ pub fn help_text(topic: Option<HelpTopic>) -> String {
             let mut out = String::new();
             out.push_str("Agent Bar — Omarchy Quattro plugin helper\n");
             out.push('\n');
-            out.push_str("The normal interface is the agent-bar.usage Quickshell plugin.\n");
+            out.push_str("The normal interface is the othavi0.agent-bar Quickshell plugin.\n");
             out.push_str("This private helper is for diagnostics, recovery, and tests.\n");
             out.push('\n');
             out.push_str("Usage:\n");
@@ -70,12 +70,12 @@ pub fn help_text(topic: Option<HelpTopic>) -> String {
             .to_owned(),
         Some(HelpTopic::Setup) => {
             "setup — migrate settings to the current schema; takes no arguments\n\
-             Install and update are 'omarchy plugin add|update agent-bar.usage'.\n"
+             Install and update are 'omarchy plugin add|update othavi0.agent-bar'.\n"
                 .to_owned()
         }
         Some(HelpTopic::Update) => "update — print usage; no interactive flow\n\
              update check — report whether a newer release exists\n\
-             update apply — delegate to 'omarchy plugin update agent-bar.usage'\n"
+             update apply — delegate to 'omarchy plugin update othavi0.agent-bar'\n"
             .to_owned(),
         Some(HelpTopic::Uninstall) => {
             "uninstall — remove the plugin (keeps settings and backups)\n\
@@ -121,7 +121,7 @@ pub fn dispatch(command: Command) -> Result<(), CliFailure> {
 /// `setup`: settings migration only (git-plugin-distribution Task 4).
 ///
 /// The plugin tree install/activate that used to live here is gone —
-/// `omarchy plugin add agent-bar.usage` is the install now, and `update`
+/// `omarchy plugin add othavi0.agent-bar` is the install now, and `update`
 /// (Task 2) / `uninstall` (Task 3) already delegate their tree mutations to
 /// the omarchy CLI the same way. `setup` keeps the one piece of state only
 /// this helper owns: MIG-007..016 explicit settings/shell v9-to-v10
@@ -404,7 +404,7 @@ fn dispatch_uninstall(purge: bool) -> Result<(), CliFailure> {
         omarchy_bin.as_str(),
         "plugin",
         "remove",
-        "agent-bar.usage",
+        "othavi0.agent-bar",
         "--yes",
     ];
 
@@ -463,7 +463,7 @@ fn dispatch_update_check() -> Result<(), CliFailure> {
 /// Exact successful `update apply` stdout document (git-plugin-distribution
 /// Task 2). `update apply` no longer downloads, stages, or swaps the plugin
 /// tree itself — it hands the whole fast-forward to
-/// `omarchy plugin update agent-bar.usage --yes`, running as a detached
+/// `omarchy plugin update othavi0.agent-bar --yes`, running as a detached
 /// transient unit so this process can return as soon as the handoff is
 /// accepted.
 #[derive(Serialize)]
@@ -519,7 +519,7 @@ fn dispatch_update_apply() -> Result<(), CliFailure> {
         omarchy_bin.as_str(),
         "plugin",
         "update",
-        "agent-bar.usage",
+        "othavi0.agent-bar",
         "--yes",
     ];
 

--- a/src/plugin/bundle.rs
+++ b/src/plugin/bundle.rs
@@ -144,7 +144,7 @@ impl BundleReceipt {
     }
 }
 
-/// Builds a complete `agent-bar.usage/` tree and writes `bundle.json`.
+/// Builds a complete `othavi0.agent-bar/` tree and writes `bundle.json`.
 #[derive(Debug, Clone)]
 pub struct BundleBuilder {
     pub version: String,
@@ -815,7 +815,7 @@ mod tests {
         let parsed = BundleReceipt::parse_json(json.as_bytes()).expect("parse");
         assert_eq!(parsed, r);
         assert!(json.contains("\"schemaVersion\": 1"));
-        assert!(json.contains("\"pluginId\": \"agent-bar.usage\""));
+        assert!(json.contains("\"pluginId\": \"othavi0.agent-bar\""));
         assert!(json.contains("\"omarchyContract\": 1"));
         assert!(json.contains("\"minimumQuickshellVersion\": \"0.3.0\""));
     }
@@ -892,7 +892,7 @@ mod tests {
             format!(
                 r#"{{
   "schemaVersion": 1,
-  "id": "agent-bar.usage",
+  "id": "othavi0.agent-bar",
   "name": "Agent Bar",
   "version": "{version}",
   "author": "othavi0",
@@ -962,7 +962,7 @@ mod tests {
     #[test]
     fn build_receipt_and_validate_tree() {
         let dir = tempdir().unwrap();
-        let root = dir.path().join("agent-bar.usage");
+        let root = dir.path().join("othavi0.agent-bar");
         write_minimal_plugin(&root, "10.0.0");
         let builder = BundleBuilder::new("10.0.0", ZERO_COMMIT).unwrap();
         let receipt = BundleValidator::build_receipt(&builder, &root).unwrap();
@@ -984,7 +984,7 @@ mod tests {
     #[test]
     fn validate_detects_version_mismatch_and_extra_file() {
         let dir = tempdir().unwrap();
-        let root = dir.path().join("agent-bar.usage");
+        let root = dir.path().join("othavi0.agent-bar");
         write_minimal_plugin(&root, "10.0.0");
         let builder = BundleBuilder::new("10.0.0", ZERO_COMMIT).unwrap();
         let receipt = BundleValidator::build_receipt(&builder, &root).unwrap();
@@ -1005,7 +1005,7 @@ mod tests {
     #[test]
     fn validate_detects_checksum_and_mode_mismatch() {
         let dir = tempdir().unwrap();
-        let root = dir.path().join("agent-bar.usage");
+        let root = dir.path().join("othavi0.agent-bar");
         write_minimal_plugin(&root, "10.0.0");
         let builder = BundleBuilder::new("10.0.0", ZERO_COMMIT).unwrap();
         let mut receipt = BundleValidator::build_receipt(&builder, &root).unwrap();
@@ -1025,7 +1025,7 @@ mod tests {
     #[test]
     fn validate_rejects_symlink_in_tree() {
         let dir = tempdir().unwrap();
-        let root = dir.path().join("agent-bar.usage");
+        let root = dir.path().join("othavi0.agent-bar");
         write_minimal_plugin(&root, "10.0.0");
         std::os::unix::fs::symlink("/etc/passwd", root.join("link")).unwrap();
         let builder = BundleBuilder::new("10.0.0", ZERO_COMMIT).unwrap();
@@ -1049,7 +1049,7 @@ mod tests {
         .unwrap();
         fs::set_permissions(&helper, fs::Permissions::from_mode(0o755)).unwrap();
 
-        let out = dir.path().join("agent-bar.usage");
+        let out = dir.path().join("othavi0.agent-bar");
         let builder = BundleBuilder::new(version, ZERO_COMMIT).unwrap();
         let receipt = builder.assemble(&out, &repo, &helper).unwrap();
         assert_eq!(receipt.version, version);
@@ -1068,7 +1068,7 @@ mod tests {
     #[test]
     fn validate_tree_rejects_helper_version_mismatch() {
         let dir = tempdir().unwrap();
-        let root = dir.path().join("agent-bar.usage");
+        let root = dir.path().join("othavi0.agent-bar");
         write_minimal_plugin(&root, "10.0.0");
         // Helper reports a different version than the receipt/manifest.
         fs::write(

--- a/src/plugin/maintenance.rs
+++ b/src/plugin/maintenance.rs
@@ -909,7 +909,7 @@ mod tests {
         fs::write(
             root.join("manifest.json"),
             format!(
-                r#"{{"schemaVersion":1,"id":"agent-bar.usage","name":"Agent Bar","version":"{version}","author":"othavi0","license":"MIT","description":"x","kinds":["service","bar-widget"],"entryPoints":{{"service":"Service.qml","barWidget":"BarWidget.qml"}},"barWidget":{{"displayName":"Agent Bar","description":"x","category":"AI","aliases":["agent-bar"],"allowMultiple":false,"defaults":{{}},"schema":[]}}}}"#
+                r#"{{"schemaVersion":1,"id":"othavi0.agent-bar","name":"Agent Bar","version":"{version}","author":"othavi0","license":"MIT","description":"x","kinds":["service","bar-widget"],"entryPoints":{{"service":"Service.qml","barWidget":"BarWidget.qml"}},"barWidget":{{"displayName":"Agent Bar","description":"x","category":"AI","aliases":["agent-bar"],"allowMultiple":false,"defaults":{{}},"schema":[]}}}}"#
             ),
         )
         .unwrap();
@@ -953,7 +953,7 @@ mod tests {
     fn no_global_executable_in_bundle_layout() {
         // Product is plugin-only: helper lives at bin/agent-bar inside the plugin.
         let dir = tempdir().unwrap();
-        let root = dir.path().join("agent-bar.usage");
+        let root = dir.path().join("othavi0.agent-bar");
         write_min_plugin(&root, "10.0.0");
         write_receipt(&root, "10.0.0");
         assert!(root.join("bin/agent-bar").is_file());

--- a/src/plugin/paths.rs
+++ b/src/plugin/paths.rs
@@ -6,7 +6,7 @@ use std::path::{Component, Path, PathBuf};
 use thiserror::Error;
 
 /// Canonical product plugin ID and directory name.
-pub const PLUGIN_ID: &str = "agent-bar.usage";
+pub const PLUGIN_ID: &str = "othavi0.agent-bar";
 
 #[derive(Debug, Error)]
 pub enum PathError {
@@ -28,7 +28,7 @@ pub struct PluginPaths {
     pub home: PathBuf,
     /// `$HOME/.config/omarchy/plugins`.
     pub plugins_dir: PathBuf,
-    /// `plugins_dir/agent-bar.usage` — production install root.
+    /// `plugins_dir/othavi0.agent-bar` — production install root.
     pub plugin_root: PathBuf,
     pub xdg_state: PathBuf,
     pub backups_dir: PathBuf,
@@ -125,7 +125,7 @@ mod tests {
         );
         assert_eq!(
             p.plugin_root,
-            PathBuf::from("/home/alice/.config/omarchy/plugins/agent-bar.usage")
+            PathBuf::from("/home/alice/.config/omarchy/plugins/othavi0.agent-bar")
         );
         assert_eq!(
             p.maintenance_lock,

--- a/src/providers/adapter.rs
+++ b/src/providers/adapter.rs
@@ -64,7 +64,7 @@ pub struct CollectionContext<'a> {
     pub fs: &'a dyn FileSystem,
     pub process: &'a dyn ProcessRunner,
     pub http: &'a dyn HttpClient,
-    /// Absolute plugin root for login IPC refresh (`…/agent-bar.usage`).
+    /// Absolute plugin root for login IPC refresh (`…/othavi0.agent-bar`).
     pub plugin_root: Option<&'a Path>,
 }
 
@@ -168,13 +168,13 @@ pub async fn run_login<R: ProcessRunner + ?Sized, I: ProcessRunner + ?Sized>(
     let refresh_argv = vec![
         "omarchy-shell".to_owned(),
         "-q".to_owned(),
-        "agent-bar.usage".to_owned(),
+        "othavi0.agent-bar".to_owned(),
         "refresh".to_owned(),
         provider_id.to_owned(),
     ];
     let refresh_spec = ProcessSpec::new(
         "omarchy-shell",
-        ["-q", "agent-bar.usage", "refresh", provider_id],
+        ["-q", "othavi0.agent-bar", "refresh", provider_id],
     )
     .with_timeout(std::time::Duration::from_secs(5))
     .with_max_output(64 * 1024);

--- a/src/settings/migration.rs
+++ b/src/settings/migration.rs
@@ -11,7 +11,10 @@ use super::schema::{
     DisplayMetric, DisplaySettings, NotificationSettings, ProviderIdJson, ProviderSetting, Settings,
 };
 use crate::cli::ProviderId;
-use crate::plugin::paths::PLUGIN_ID;
+/// The v9-era plugin ID exactly as legacy `shell.json` files carry it on
+/// disk. The live plugin ID was renamed to `othavi0.agent-bar` (2026-08-06);
+/// this module must keep recognizing what v9 actually wrote.
+const LEGACY_PLUGIN_ID: &str = "agent-bar.usage";
 use crate::support::atomic_file::replace_atomically;
 
 /// Keys that Agent Bar previously stored inline on the shell entry.
@@ -274,7 +277,7 @@ fn extract_inline_refresh_seconds(raw: &[u8]) -> Result<Option<u32>, MigrationEr
                 let is_entry = map
                     .get("id")
                     .and_then(|v| v.as_str())
-                    .is_some_and(|id| id == PLUGIN_ID);
+                    .is_some_and(|id| id == LEGACY_PLUGIN_ID);
                 if is_entry {
                     for key in AGENT_BAR_INLINE_KEYS {
                         if let Some(v) = map.get(*key) {
@@ -493,7 +496,7 @@ fn strip_inline_in_value(value: &mut Value, changed: &mut bool) {
             let is_entry = map
                 .get("id")
                 .and_then(|v| v.as_str())
-                .is_some_and(|id| id == PLUGIN_ID);
+                .is_some_and(|id| id == LEGACY_PLUGIN_ID);
             if is_entry {
                 for key in AGENT_BAR_INLINE_KEYS {
                     if map.remove(*key).is_some() {
@@ -526,7 +529,7 @@ pub fn find_plugin_entry_path(shell: &Value) -> Option<String> {
                 if map
                     .get("id")
                     .and_then(|v| v.as_str())
-                    .is_some_and(|id| id == PLUGIN_ID)
+                    .is_some_and(|id| id == LEGACY_PLUGIN_ID)
                 {
                     return Some(path.to_string());
                 }
@@ -557,7 +560,7 @@ pub fn count_plugin_entries(shell: &Value) -> usize {
                 if map
                     .get("id")
                     .and_then(|v| v.as_str())
-                    .is_some_and(|id| id == PLUGIN_ID)
+                    .is_some_and(|id| id == LEGACY_PLUGIN_ID)
                 {
                     *count += 1;
                 }
@@ -583,7 +586,7 @@ pub fn remaining_inline_keys(shell_raw: &[u8]) -> Result<Vec<String>, MigrationE
                 let is_entry = map
                     .get("id")
                     .and_then(|v| v.as_str())
-                    .is_some_and(|id| id == PLUGIN_ID);
+                    .is_some_and(|id| id == LEGACY_PLUGIN_ID);
                 if is_entry {
                     for key in AGENT_BAR_INLINE_KEYS {
                         if map.contains_key(*key) {
@@ -603,7 +606,7 @@ pub fn remaining_inline_keys(shell_raw: &[u8]) -> Result<Vec<String>, MigrationE
 /// Build a minimal shell.json object for fixtures (bar.left style).
 pub fn fixture_shell_with_entry(section: &str, index: usize, with_inline: bool) -> Value {
     let mut entry = Map::new();
-    entry.insert("id".into(), Value::String(PLUGIN_ID.into()));
+    entry.insert("id".into(), Value::String(LEGACY_PLUGIN_ID.into()));
     if with_inline {
         entry.insert("refreshIntervalSec".into(), Value::from(90));
     }
@@ -709,7 +712,7 @@ mod tests {
         // Section left still has three entries; agent-bar at index 1
         let left = value["bar"]["left"].as_array().unwrap();
         assert_eq!(left.len(), 3);
-        assert_eq!(left[1]["id"], PLUGIN_ID);
+        assert_eq!(left[1]["id"], LEGACY_PLUGIN_ID);
         assert!(left[1].get("refreshIntervalSec").is_none());
         // Unrelated plugins untouched
         assert_eq!(left[0]["id"], "omarchy.menu");

--- a/tests/active_docs.rs
+++ b/tests/active_docs.rs
@@ -232,13 +232,14 @@ fn extract_helper_argv(line: &str) -> Option<Vec<String>> {
     } else if rest.starts_with("$PLUGIN") {
         rest = rest["$PLUGIN".len()..].trim_start();
     } else if let Some(after) = rest.strip_prefix("agent-bar") {
-        // Reject archive/product filenames like `agent-bar.usage-10.0.0-…`.
+        // Reject archive/product filenames like `othavi0.agent-bar-10.0.0-…`.
         if !after.is_empty() && !after.starts_with(char::is_whitespace) {
             return None;
         }
         rest = after.trim_start();
-    } else if rest.starts_with("\"$HOME/.config/omarchy/plugins/agent-bar.usage/bin/agent-bar\"") {
-        rest = rest["\"$HOME/.config/omarchy/plugins/agent-bar.usage/bin/agent-bar\"".len()..]
+    } else if rest.starts_with("\"$HOME/.config/omarchy/plugins/othavi0.agent-bar/bin/agent-bar\"")
+    {
+        rest = rest["\"$HOME/.config/omarchy/plugins/othavi0.agent-bar/bin/agent-bar\"".len()..]
             .trim_start();
     } else {
         return None;
@@ -602,6 +603,8 @@ fn active_docs_release_notes_10_0_0_exist() {
         body.contains("10.0.0"),
         "release notes must mention version 10.0.0"
     );
+    // Historical document: 10.0.0 shipped under the original plugin ID and
+    // keeps it (the ID became othavi0.agent-bar on 2026-08-06).
     assert!(
         body.contains("agent-bar.usage"),
         "release notes must name the plugin product agent-bar.usage"

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -605,7 +605,7 @@ fn update_apply_emits_delegation_document() {
     // record argv (git-plugin-distribution Task 2): `update apply` never
     // downloads/stages/exchanges anymore, it hands off to
     // `systemd-run --user --collect --unit=... -- <omarchy> plugin update
-    // agent-bar.usage --yes` and prints the delegation document.
+    // othavi0.agent-bar --yes` and prints the delegation document.
     let dir = tempdir().unwrap();
     let home = dir.path().join("home");
     std::fs::create_dir_all(&home).unwrap();
@@ -660,7 +660,7 @@ fn update_apply_emits_delegation_document() {
         argv.ends_with(&[
             "plugin".to_string(),
             "update".to_string(),
-            "agent-bar.usage".to_string(),
+            "othavi0.agent-bar".to_string(),
             "--yes".to_string(),
         ]),
         "argv={argv:?}"
@@ -708,7 +708,7 @@ fn seed_uninstall_fixture(root: &Path) -> UninstallFixture {
 
     let shell_path = home.join(".config/omarchy/shell.json");
     std::fs::create_dir_all(shell_path.parent().unwrap()).unwrap();
-    let shell_before: &'static [u8] = br#"{"bar":{"left":[{"id":"agent-bar.usage"}]}}"#;
+    let shell_before: &'static [u8] = br#"{"bar":{"left":[{"id":"othavi0.agent-bar"}]}}"#;
     std::fs::write(&shell_path, shell_before).unwrap();
 
     let path_dir = root.join("pathbin");
@@ -815,7 +815,7 @@ fn uninstall_purge_removes_xdg_state_and_delegates_remove() {
         argv.ends_with(&[
             "plugin".to_string(),
             "remove".to_string(),
-            "agent-bar.usage".to_string(),
+            "othavi0.agent-bar".to_string(),
             "--yes".to_string(),
         ]),
         "argv={argv:?}"
@@ -873,7 +873,7 @@ fn uninstall_without_purge_preserves_xdg_state_and_delegates_remove() {
         argv.ends_with(&[
             "plugin".to_string(),
             "remove".to_string(),
-            "agent-bar.usage".to_string(),
+            "othavi0.agent-bar".to_string(),
             "--yes".to_string(),
         ]),
         "argv={argv:?}"

--- a/tests/dist_tree_validate.rs
+++ b/tests/dist_tree_validate.rs
@@ -1,6 +1,6 @@
 //! Distribution-tree completeness (git-plugin-distribution Task 6).
 //!
-//! The assembled `agent-bar.usage/` tree is pushed verbatim as the
+//! The assembled `othavi0.agent-bar/` tree is pushed verbatim as the
 //! distribution repo's complete state, so it has to satisfy two things at
 //! once: the Omarchy plugin contract the shell enforces at install time, and
 //! the marketplace expectation of a README/LICENSE/preview at the repo root.
@@ -151,7 +151,7 @@ fn assemble_fake_tree(dir: &Path) -> (PathBuf, agent_bar::plugin::bundle::Bundle
     let helper = dir.join("agent-bar");
     fake_helper(&helper, version);
 
-    let out = dir.join("agent-bar.usage");
+    let out = dir.join("othavi0.agent-bar");
     let builder = BundleBuilder::new(version, "0".repeat(40)).unwrap();
     let receipt = builder.assemble(&out, &repo_root, &helper).unwrap();
     (out, receipt)

--- a/tests/login.rs
+++ b/tests/login.rs
@@ -112,7 +112,7 @@ async fn successful_login_runs_exact_refresh_ipc_argv() {
         &vec![
             "omarchy-shell".to_owned(),
             "-q".to_owned(),
-            "agent-bar.usage".to_owned(),
+            "othavi0.agent-bar".to_owned(),
             "refresh".to_owned(),
             "claude".to_owned(),
         ]
@@ -124,7 +124,7 @@ async fn successful_login_runs_exact_refresh_ipc_argv() {
         ipc_specs[0].args,
         vec![
             "-q".to_owned(),
-            "agent-bar.usage".to_owned(),
+            "othavi0.agent-bar".to_owned(),
             "refresh".to_owned(),
             "claude".to_owned(),
         ]

--- a/tests/qml/tst_BarWidget.qml
+++ b/tests/qml/tst_BarWidget.qml
@@ -84,7 +84,7 @@ TestCase {
   // Chip logic matching BarWidget.qml agentService resolution (without qs.Ui).
   component AgentChip: Item {
     property var bar: null
-    property string moduleName: "agent-bar.usage"
+    property string moduleName: "othavi0.agent-bar"
     readonly property var agentService: bar && bar.shell
         ? bar.shell.serviceFor(moduleName)
         : null
@@ -129,15 +129,15 @@ TestCase {
 
   function test_two_widgets_resolve_same_service() {
     var svc = Qt.createQmlObject('import QtQuick; Item { property string helperVersion: "10.0.0"; property bool versionReady: true; property bool versionFailed: false }', testCase)
-    fakeShell.registerService("agent-bar.usage", svc)
+    fakeShell.registerService("othavi0.agent-bar", svc)
 
     var w1 = agentChipComp.createObject(testCase, {
       bar: fakeBar,
-      moduleName: "agent-bar.usage"
+      moduleName: "othavi0.agent-bar"
     })
     var w2 = agentChipComp.createObject(testCase, {
       bar: fakeBar,
-      moduleName: "agent-bar.usage"
+      moduleName: "othavi0.agent-bar"
     })
     verify(w1.agentService !== null)
     verify(w2.agentService !== null)
@@ -154,7 +154,7 @@ TestCase {
   function test_widget_without_shell_has_null_service() {
     var w = agentChipComp.createObject(testCase, {
       bar: null,
-      moduleName: "agent-bar.usage"
+      moduleName: "othavi0.agent-bar"
     })
     compare(w.agentService, null)
     w.destroy()
@@ -166,7 +166,7 @@ TestCase {
     xhr.send()
     var src = String(xhr.responseText)
     verify(src.indexOf("serviceFor(moduleName)") >= 0)
-    verify(src.indexOf("moduleName: \"agent-bar.usage\"") >= 0)
+    verify(src.indexOf("moduleName: \"othavi0.agent-bar\"") >= 0)
     verify(src.indexOf("Qt.resolvedUrl") >= 0) // icons only
   }
 

--- a/tests/qml/tst_Maintenance.qml
+++ b/tests/qml/tst_Maintenance.qml
@@ -27,9 +27,9 @@ TestCase {
   // ---- Login argv ----
 
   function test_login_detached_argv() {
-    var argv = Core.loginDetachedArgv("/home/u/.config/omarchy/plugins/agent-bar.usage", "claude")
+    var argv = Core.loginDetachedArgv("/home/u/.config/omarchy/plugins/othavi0.agent-bar", "claude")
     compare(argv.length, 3)
-    compare(argv[0], "/home/u/.config/omarchy/plugins/agent-bar.usage/scripts/agent-bar-open-terminal")
+    compare(argv[0], "/home/u/.config/omarchy/plugins/othavi0.agent-bar/scripts/agent-bar-open-terminal")
     compare(argv[1], "login")
     compare(argv[2], "claude")
     compare(Core.loginDetachedArgv("/x", "nope"), null)
@@ -114,7 +114,7 @@ TestCase {
     compare(ui.phase, "reinstall_required")
     compare(ui.targetVersion, "")
     compare(ui.releaseNotesUrl, "")
-    verify(ui.message.indexOf("omarchy plugin remove agent-bar.usage") >= 0)
+    verify(ui.message.indexOf("omarchy plugin remove othavi0.agent-bar") >= 0)
     verify(ui.message.indexOf("omarchy plugin add https://github.com/othavi0/omarchy-agent-bar.git") >= 0)
   }
 

--- a/tests/qml/tst_Service.qml
+++ b/tests/qml/tst_Service.qml
@@ -210,7 +210,7 @@ TestCase {
 
   function test_manifest_shape() {
     var m = loadManifest()
-    compare(m.id, "agent-bar.usage")
+    compare(m.id, "othavi0.agent-bar")
     verify(m.kinds.indexOf("service") >= 0)
     verify(m.kinds.indexOf("bar-widget") >= 0)
     compare(m.barWidget.schema.length, 0)
@@ -403,7 +403,7 @@ TestCase {
     verify(src.indexOf("id: maintenanceCheckProcess") >= 0)
     verify(src.indexOf("id: maintenanceHandoffProcess") >= 0)
     verify(src.indexOf("id: pollTimer") >= 0)
-    verify(src.indexOf('target: "agent-bar.usage"') >= 0)
+    verify(src.indexOf('target: "othavi0.agent-bar"') >= 0)
   }
 
   // Live Quattro: duplicate Component.onCompleted → "Property value set multiple times"

--- a/tests/terminal_helper.rs
+++ b/tests/terminal_helper.rs
@@ -21,7 +21,7 @@ fn write_executable(path: &Path, body: &str) {
 
 /// Minimal plugin root: scripts/helper + bin/agent-bar stub + PATH fake xdg-terminal-exec.
 fn fixture_plugin_root(tmp: &Path) -> PathBuf {
-    let plugin = tmp.join("agent-bar.usage");
+    let plugin = tmp.join("othavi0.agent-bar");
     let scripts = plugin.join("scripts");
     let bin = plugin.join("bin");
     fs::create_dir_all(&scripts).unwrap();


### PR DESCRIPTION
## Summary

- The plugin ID becomes `othavi0.agent-bar`, following Quattro's `<vendor>.<plugin>` convention (`omarchy.clock`, `omarchy.model-usage`). The old `agent-bar.usage` read as vendor "agent-bar", plugin "usage".
- **Why now:** the marketplace listing (HANCORE-linux/omarchy-plugin-marketplace#36) is approved but not live yet — zero external installs exist. Once listed, the ID freezes forever: `omarchy plugin update` cannot rename an install directory.
- Sweep covers manifest, QML `moduleName`, Rust constants (`PLUGIN_ID`, `OMARCHY_PLUGIN_ID`), delegated update/uninstall commands, workflow paths, tests, the contract (`CLAUDE.md`), and active docs — 33 files.
- **Deliberately kept on the old ID:** the v9 migration matcher (`src/settings/migration.rs`, new `LEGACY_PLUGIN_ID`) and its fixtures — they match what v9 actually wrote to `shell.json` on disk; renaming there would silently no-op the migration. Historical docs (`docs/releases/`, `docs/history/`, `CHANGELOG.md`, `docs/superpowers/`) keep the old ID as a build record; `active_docs.rs` pins the 10.0.0 notes to the historical name. UX spec points MIG-008 and the bundle "retain ID" clause carry supersession notes.
- Dist repo name (`omarchy-agent-bar`) and XDG paths (`agent-bar`) are unchanged. Design: `docs/superpowers/specs/2026-08-06-plugin-id-rename-design.md`.

## Migration for existing installs

The only existing install is the owner's machine: `omarchy plugin remove agent-bar.usage` + `omarchy plugin add <dist-url>` after the release lands. Settings survive (XDG paths carry no plugin ID). An un-migrated install would see `update check` fail on the dist receipt pluginId guard — by design.

## Verification

- `cargo fmt --check`, `cargo test` (254), `cargo clippy -D warnings`, `git diff --check`, ShellCheck
- Qt6 `qmllint`, `omarchy plugin validate`, Qt6 `qmltestrunner` (243 passed, 0 failed)
- After merge: update-path verification per `docs/dev/releasing.md` + marketplace submission update + local reinstall.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The plugin is now identified as `othavi0.agent-bar`.
  * Installation, updates, removal, validation, and CLI commands now use the new plugin name and path.
  * Release bundles are generated and distributed using the updated identifier.

* **Migration**
  * Existing installations must be removed and re-added using the new plugin name.
  * User settings remain preserved during migration.

* **Documentation**
  * User and developer documentation, troubleshooting steps, and release instructions now reflect the updated plugin identity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->