### PR TITLE
feat: codex full payload + reset count

### DIFF
--- a/assets/omarchy/CoreView.js
+++ b/assets/omarchy/CoreView.js
@@ -674,6 +674,18 @@ function windowLayout(provider, metric, nowMs) {
   return layout
 }
 
+// Codex rate-limit reset count (JSON-022C). Singular/plural, empty when
+// absent or zero so the popup stays byte-identical for every other provider.
+function rateLimitResetsText(provider) {
+  if (!provider)
+    return ""
+  var n = Number(provider.rateLimitResetsAvailable)
+  if (!isFinite(n) || n <= 0)
+    return ""
+  n = Math.floor(n)
+  return "↻ " + n + " rate-limit reset" + (n === 1 ? "" : "s") + " available"
+}
+
 function headerModel(provider, refreshing) {
   if (!provider) {
     return {

--- a/assets/omarchy/ProviderView.qml
+++ b/assets/omarchy/ProviderView.qml
@@ -206,6 +206,17 @@ Item {
           }
         }
       }
+
+      Text {
+        width: parent.width
+        visible: text.length > 0
+        text: Core.rateLimitResetsText(root.provider)
+        color: Util.alpha(root.foreground, 0.72)
+        font.family: root.fontFamily
+        font.pixelSize: Style.font.caption
+        textFormat: Text.PlainText
+        Accessible.name: text
+      }
     }
 
     StateMessage {

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -44,11 +44,11 @@ substitute percentage.
 
 ## Codex Retry loops with “rate limits not available”
 
-Ensure the Codex CLI is logged in. Agent Bar collects Codex rate limits in
-three ordered tiers: `codex app-server` JSON-RPC `account/rateLimits/read`
-first, then an explicit `~/.codex/rate-limits.json` read when the file
-exists, and finally the newest valid rate-limit events under
-`~/.codex/sessions`.
+Ensure the Codex CLI is logged in. Agent Bar collects Codex rate limits in two
+ordered tiers: `codex app-server` JSON-RPC `account/rateLimits/read` first,
+then the newest valid rate-limit event under `~/.codex/sessions`. When the
+session-log tier is used, `lastSuccessAt` reflects that event's own
+timestamp, not collection time — the data may be hours or days old.
 
 ## Grok shows `—` or missing Weekly
 

--- a/docs/specs/v10/03-cli-and-json-contract.md
+++ b/docs/specs/v10/03-cli-and-json-contract.md
@@ -184,6 +184,10 @@ provider_error
   its account exposes no percentage quota.
 - `JSON-022B`: The schema has no spend, balance, credits, currency, cost,
   arbitrary extras, or generic monetary facts.
+- `JSON-022C`: `rateLimitResetsAvailable`, when present, is a non-negative
+  integer count of provider-granted rate-limit resets. It is a quota-reset
+  count, not a monetary fact: it never carries balance, price, or currency,
+  and `JSON-022B` continues to ban those.
 
 ### Structural and semantic validation
 

--- a/docs/specs/v10/REQUIREMENTS_MATRIX.md
+++ b/docs/specs/v10/REQUIREMENTS_MATRIX.md
@@ -60,7 +60,7 @@ design doc that now govern the amended behavior. See
 | `JSON-009`–`JSON-015` | 1, 3 | structural schema, semantic validator, invalid fixtures |
 | `JSON-009A` | 1, 3, 8, 17 | helper/manifest semantic-version equality tests |
 | `JSON-016`–`JSON-022` | 3, 6–7 | order, explicit-provider, partial-failure tests |
-| `JSON-022A`–`JSON-022B` | 1, 3, 6 | empty-window and rejected-money fixtures |
+| `JSON-022A`–`JSON-022C` | 1, 3, 6 | empty-window and rejected-money fixtures |
 | `JSON-023`–`JSON-028` | 3, 5–6, 11 | URL/action enums, redaction, plain-text QML tests |
 
 ## Quickshell UX and accessibility

--- a/schemas/status-v2.schema.json
+++ b/schemas/status-v2.schema.json
@@ -207,7 +207,8 @@
         },
         "action": {
           "oneOf": [{ "type": "null" }, { "$ref": "#/$defs/action" }]
-        }
+        },
+        "rateLimitResetsAvailable": { "type": "integer", "minimum": 0 }
       }
     },
     "provider": {

--- a/src/providers/adapters.rs
+++ b/src/providers/adapters.rs
@@ -303,18 +303,17 @@ impl ProviderAdapter for CodexAdapter {
                 }
             }
 
-            // 2. Explicit rate-limits.json if present
-            let rates_path = home.join(".codex/rate-limits.json");
-            if let Ok(bytes) = context.fs.read(&rates_path) {
-                return codex_from_rate_limits_json(&bytes, context.clock.now_utc());
+            // 2. Bounded session-log fallback (~/.codex/sessions/**/*.jsonl).
+            // The log's own event timestamp — not collection time — becomes
+            // last_success_at, since this data may be hours or days old.
+            if let Some((bytes, log_timestamp)) =
+                find_latest_rate_limits(&home.join(".codex/sessions"))
+            {
+                let now = log_timestamp.unwrap_or_else(|| context.clock.now_utc());
+                return codex_from_rate_limits_json(&bytes, now);
             }
 
-            // 3. Bounded session-log fallback (~/.codex/sessions/**/*.jsonl)
-            if let Some(bytes) = find_latest_rate_limits(&home.join(".codex/sessions")) {
-                return codex_from_rate_limits_json(&bytes, context.clock.now_utc());
-            }
-
-            // 4. Typed miss / cli_missing
+            // 3. Typed miss / cli_missing
             if collection_exe(discovery).is_none() {
                 return missing_collection(
                     ProviderId::Codex,
@@ -1079,28 +1078,31 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn codex_from_home_rate_limits_file() {
-        let process = ScriptedProcess::one(ProcessOutput {
-            exit_code: Some(0),
-            stdout: String::new(),
-            stderr: String::new(),
-            timed_out: false,
-            stdout_truncated: false,
-            stderr_truncated: false,
-        });
+    async fn codex_session_log_last_success_at_uses_log_timestamp_not_clock() {
+        let process = empty_process();
         let http = ScriptedHttpClient::default();
-        let mut fs = MapFileSystem::default();
-        let home = std::path::PathBuf::from("/home/u");
-        fs.files.insert(
-            home.join(".codex/rate-limits.json"),
-            br#"{"primary":{"usedPercent":25.0,"windowDurationMins":300,"resetsAt":1700000000},"secondary":{"usedPercent":40.0,"windowDurationMins":10080,"resetsAt":1700000000}}"#.to_vec(),
+        let fs = MapFileSystem::default();
+
+        // Real tempdir: find_latest_rate_limits walks std::fs directly, not
+        // the injected fs seam.
+        let home_dir = tempfile::tempdir().expect("tempdir");
+        let home = home_dir.path().to_path_buf();
+        let sessions = home.join(".codex/sessions/2026/07/28");
+        std::fs::create_dir_all(&sessions).expect("mkdir sessions");
+        let jsonl = concat!(
+            r#"{"timestamp":"2026-07-28T10:00:00Z","type":"event","payload":{"type":"token_count","rate_limits":{"primary":{"used_percent":12.5,"window_minutes":10080}}}}"#,
+            "\n",
         );
+        std::fs::write(sessions.join("rollout.jsonl"), jsonl).expect("write jsonl");
+
         let env = ExecutionEnvironment {
             home,
             path_dirs: vec![],
             grok_home: None,
         };
-        let clock = FixedClock(datetime!(2026-07-26 18:00:00 UTC));
+        // Fake clock's "now" is far after the log's own timestamp — asserts
+        // last_success_at reflects data generation, not collection time.
+        let clock = FixedClock(datetime!(2026-08-06 12:00:00 UTC));
         let ctx = CollectionContext {
             env: &env,
             clock: &clock,
@@ -1109,16 +1111,20 @@ mod tests {
             http: &http,
             plugin_root: None,
         };
-        // Non-existent exe so app-server spawn fails immediately and collection
-        // falls through to rate-limits.json (no live Codex dependency).
+        // Non-existent exe so app-server spawn fails immediately and
+        // collection falls through to the session-log fallback (no live
+        // Codex dependency, no rate-limits.json — that stage is gone).
         let discovery = discovery_with_exe(Path::new("/nonexistent/codex"));
         let result = CODEX_ADAPTER.collect(&ctx, &discovery).await;
         assert_no_money(&result);
         match result {
-            ProviderResult::Ready { windows, .. } => {
-                assert_eq!(windows.len(), 2);
-                assert_eq!(windows[0].id(), "session");
-                assert_eq!(windows[1].id(), "weekly");
+            ProviderResult::Ready {
+                windows,
+                last_success_at,
+                ..
+            } => {
+                assert_eq!(windows[0].id(), "weekly");
+                assert_eq!(last_success_at, datetime!(2026-07-28 10:00:00 UTC));
             }
             other => panic!("{other:?}"),
         }

--- a/src/providers/codex_app_server.rs
+++ b/src/providers/codex_app_server.rs
@@ -37,6 +37,23 @@ struct CodexAppServerWindow {
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
+struct CodexAppServerIndividualLimit {
+    #[serde(default)]
+    remaining_percent: Option<f64>,
+    #[serde(default)]
+    resets_at: Option<i64>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CodexAppServerResetCredits {
+    #[serde(default)]
+    available_count: Option<u32>,
+}
+
+// credits{balance,...} is monetary and intentionally undeclared (JSON-022B).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct CodexAppServerLimitBucket {
     #[serde(default)]
     primary: Option<CodexAppServerWindow>,
@@ -44,6 +61,8 @@ struct CodexAppServerLimitBucket {
     secondary: Option<CodexAppServerWindow>,
     #[serde(default)]
     plan_type: Option<String>,
+    #[serde(default)]
+    individual_limit: Option<CodexAppServerIndividualLimit>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -55,6 +74,8 @@ struct CodexAppServerRateLimitsReadResult {
     rate_limits_by_limit_id: Option<BTreeMap<String, CodexAppServerLimitBucket>>,
     #[serde(default)]
     plan_type: Option<String>,
+    #[serde(default)]
+    rate_limit_reset_credits: Option<CodexAppServerResetCredits>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -134,6 +155,24 @@ fn normalize_to_rate_limits_json(
     }
     if let Some(pt) = plan_type {
         doc.insert("plan_type".into(), serde_json::Value::String(pt));
+    }
+    if let Some(il) = root.and_then(|r| r.individual_limit.as_ref()) {
+        if let Some(rem) = il.remaining_percent {
+            doc.insert(
+                "individualLimit".into(),
+                serde_json::json!({
+                    "remainingPercent": rem,
+                    "resetsAt": il.resets_at.unwrap_or(0),
+                }),
+            );
+        }
+    }
+    if let Some(n) = raw
+        .rate_limit_reset_credits
+        .as_ref()
+        .and_then(|c| c.available_count)
+    {
+        doc.insert("rateLimitResetsAvailable".into(), serde_json::json!(n));
     }
     serde_json::to_vec(&serde_json::Value::Object(doc)).ok()
 }
@@ -433,6 +472,25 @@ mod tests {
         }
         // Keep the stream open briefly so the client can finish.
         tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    #[test]
+    fn normalize_passes_individual_limit_and_reset_count_through() {
+        let raw: CodexAppServerRateLimitsReadResult = serde_json::from_value(serde_json::json!({
+            "rateLimits": {
+                "limitId": "codex",
+                "primary": {"usedPercent": 12.0, "windowDurationMins": 10080, "resetsAt": 1791000000},
+                "secondary": null,
+                "individualLimit": {"remainingPercent": 40.0, "resetsAt": 1791000000},
+                "planType": "plus"
+            },
+            "rateLimitResetCredits": {"availableCount": 2, "credits": []}
+        }))
+        .expect("wire parse");
+        let bytes = normalize_to_rate_limits_json(&raw, Some("plus")).expect("normalized");
+        let doc: serde_json::Value = serde_json::from_slice(&bytes).expect("json");
+        assert_eq!(doc["individualLimit"]["remainingPercent"], 40.0);
+        assert_eq!(doc["rateLimitResetsAvailable"], 2);
     }
 
     #[tokio::test]

--- a/src/providers/codex_app_server.rs
+++ b/src/providers/codex_app_server.rs
@@ -111,6 +111,27 @@ fn window_to_json(raw: &CodexAppServerWindow, fallback_minutes: i64) -> serde_js
     })
 }
 
+/// True when a bucket carries at least one populated window (i.e. it is not
+/// an empty placeholder like `premium` with `primary`/`secondary` both null).
+fn has_window_data(b: &CodexAppServerLimitBucket) -> bool {
+    b.primary.is_some() || b.secondary.is_some()
+}
+
+fn extra_bucket_to_json(limit_id: &str, bucket: &CodexAppServerLimitBucket) -> serde_json::Value {
+    let mut m = serde_json::Map::new();
+    m.insert(
+        "limitId".into(),
+        serde_json::Value::String(limit_id.to_string()),
+    );
+    if let Some(p) = bucket.primary.as_ref() {
+        m.insert("primary".into(), window_to_json(p, 300));
+    }
+    if let Some(s) = bucket.secondary.as_ref() {
+        m.insert("secondary".into(), window_to_json(s, 10080));
+    }
+    serde_json::Value::Object(m)
+}
+
 /// Build JSON bytes with `primary` / `secondary` / `plan_type` for
 /// [`crate::providers::v2_map::codex_from_rate_limits_json`].
 fn normalize_to_rate_limits_json(
@@ -120,18 +141,33 @@ fn normalize_to_rate_limits_json(
     let root = raw.rate_limits.as_ref();
     let mut primary = root.and_then(|r| r.primary.as_ref());
     let mut secondary = root.and_then(|r| r.secondary.as_ref());
+    let mut individual_limit = root.and_then(|r| r.individual_limit.as_ref());
 
+    // Preferred bucket: explicit `codex` key first (mirrors the upstream
+    // backend's own preference), then any bucket that actually carries
+    // windows. Every other data-carrying bucket is preserved as an extra
+    // bucket instead of being silently dropped.
+    let mut extra: Vec<serde_json::Value> = Vec::new();
     if primary.is_none() && secondary.is_none() {
         if let Some(by_id) = raw.rate_limits_by_limit_id.as_ref() {
-            for bucket in by_id.values() {
-                if primary.is_none() {
+            let preferred_key = if by_id.get("codex").is_some_and(has_window_data) {
+                Some("codex".to_string())
+            } else {
+                by_id
+                    .iter()
+                    .find(|(_, b)| has_window_data(b))
+                    .map(|(k, _)| k.clone())
+            };
+            if let Some(key) = preferred_key {
+                if let Some(bucket) = by_id.get(key.as_str()) {
                     primary = bucket.primary.as_ref();
-                }
-                if secondary.is_none() {
                     secondary = bucket.secondary.as_ref();
+                    individual_limit = bucket.individual_limit.as_ref();
                 }
-                if primary.is_some() || secondary.is_some() {
-                    break;
+                for (k, b) in by_id.iter() {
+                    if *k != key && has_window_data(b) {
+                        extra.push(extra_bucket_to_json(k, b));
+                    }
                 }
             }
         }
@@ -156,7 +192,7 @@ fn normalize_to_rate_limits_json(
     if let Some(pt) = plan_type {
         doc.insert("plan_type".into(), serde_json::Value::String(pt));
     }
-    if let Some(il) = root.and_then(|r| r.individual_limit.as_ref()) {
+    if let Some(il) = individual_limit {
         if let Some(rem) = il.remaining_percent {
             doc.insert(
                 "individualLimit".into(),
@@ -173,6 +209,9 @@ fn normalize_to_rate_limits_json(
         .and_then(|c| c.available_count)
     {
         doc.insert("rateLimitResetsAvailable".into(), serde_json::json!(n));
+    }
+    if !extra.is_empty() {
+        doc.insert("extraBuckets".into(), serde_json::Value::Array(extra));
     }
     serde_json::to_vec(&serde_json::Value::Object(doc)).ok()
 }
@@ -491,6 +530,40 @@ mod tests {
         let doc: serde_json::Value = serde_json::from_slice(&bytes).expect("json");
         assert_eq!(doc["individualLimit"]["remainingPercent"], 40.0);
         assert_eq!(doc["rateLimitResetsAvailable"], 2);
+    }
+
+    #[test]
+    fn normalize_prefers_codex_bucket_over_alphabetical() {
+        let raw: CodexAppServerRateLimitsReadResult = serde_json::from_value(serde_json::json!({
+            "rateLimitsByLimitId": {
+                "alpha": {"primary": {"usedPercent": 50.0, "windowDurationMins": 300, "resetsAt": 0}},
+                "codex": {"primary": {"usedPercent": 12.0, "windowDurationMins": 10080, "resetsAt": 0}}
+            }
+        }))
+        .expect("wire parse");
+        let bytes = normalize_to_rate_limits_json(&raw, None).expect("normalized");
+        let doc: serde_json::Value = serde_json::from_slice(&bytes).expect("json");
+        assert_eq!(doc["primary"]["usedPercent"], 12.0, "codex bucket must win");
+        assert_eq!(doc["extraBuckets"][0]["limitId"], "alpha");
+        assert_eq!(doc["extraBuckets"][0]["primary"]["usedPercent"], 50.0);
+    }
+
+    #[test]
+    fn normalize_skips_null_window_buckets_like_premium() {
+        let raw: CodexAppServerRateLimitsReadResult = serde_json::from_value(serde_json::json!({
+            "rateLimitsByLimitId": {
+                "codex": {"primary": {"usedPercent": 90.0, "windowDurationMins": 10080, "resetsAt": 0}},
+                "premium": {"primary": null, "secondary": null}
+            }
+        }))
+        .expect("wire parse");
+        let bytes = normalize_to_rate_limits_json(&raw, None).expect("normalized");
+        let doc: serde_json::Value = serde_json::from_slice(&bytes).expect("json");
+        assert_eq!(doc["primary"]["usedPercent"], 90.0);
+        assert!(
+            doc.get("extraBuckets").is_none(),
+            "empty premium bucket must not appear"
+        );
     }
 
     #[tokio::test]

--- a/src/providers/codex_app_server.rs
+++ b/src/providers/codex_app_server.rs
@@ -56,6 +56,8 @@ struct CodexAppServerResetCredits {
 #[serde(rename_all = "camelCase")]
 struct CodexAppServerLimitBucket {
     #[serde(default)]
+    limit_id: Option<String>,
+    #[serde(default)]
     primary: Option<CodexAppServerWindow>,
     #[serde(default)]
     secondary: Option<CodexAppServerWindow>,
@@ -143,13 +145,27 @@ fn normalize_to_rate_limits_json(
     let mut secondary = root.and_then(|r| r.secondary.as_ref());
     let mut individual_limit = root.and_then(|r| r.individual_limit.as_ref());
 
-    // Preferred bucket: explicit `codex` key first (mirrors the upstream
-    // backend's own preference), then any bucket that actually carries
-    // windows. Every other data-carrying bucket is preserved as an extra
-    // bucket instead of being silently dropped.
+    // Preferred bucket: root `rateLimits` first when it carries windows,
+    // otherwise explicit `codex` key (mirrors the upstream backend's own
+    // preference), then any bucket that actually carries windows. Every
+    // other data-carrying bucket in `rateLimitsByLimitId` is preserved as an
+    // extra bucket instead of being silently dropped — this must happen even
+    // when the root already supplied primary/secondary, since the real
+    // payload has root and the by-id map coexist.
+    let root_has_windows = primary.is_some() || secondary.is_some();
     let mut extra: Vec<serde_json::Value> = Vec::new();
-    if primary.is_none() && secondary.is_none() {
-        if let Some(by_id) = raw.rate_limits_by_limit_id.as_ref() {
+    if let Some(by_id) = raw.rate_limits_by_limit_id.as_ref() {
+        if root_has_windows {
+            // Root already won; skip only the map entry that IS the root
+            // bucket (same limit_id, falling back to "codex" when absent) so
+            // it isn't duplicated into extraBuckets.
+            let root_limit_id = root.and_then(|r| r.limit_id.as_deref()).unwrap_or("codex");
+            for (k, b) in by_id.iter() {
+                if k.as_str() != root_limit_id && has_window_data(b) {
+                    extra.push(extra_bucket_to_json(k, b));
+                }
+            }
+        } else {
             let preferred_key = if by_id.get("codex").is_some_and(has_window_data) {
                 Some("codex".to_string())
             } else {
@@ -564,6 +580,67 @@ mod tests {
             doc.get("extraBuckets").is_none(),
             "empty premium bucket must not appear"
         );
+    }
+
+    #[test]
+    fn normalize_keeps_extra_buckets_when_root_has_windows() {
+        let raw: CodexAppServerRateLimitsReadResult = serde_json::from_value(serde_json::json!({
+            "rateLimits": {
+                "limitId": "codex",
+                "primary": {"usedPercent": 12.0, "windowDurationMins": 10080, "resetsAt": 0}
+            },
+            "rateLimitsByLimitId": {
+                "codex": {"primary": {"usedPercent": 12.0, "windowDurationMins": 10080, "resetsAt": 0}},
+                "alpha": {"primary": {"usedPercent": 50.0, "windowDurationMins": 300, "resetsAt": 0}}
+            }
+        }))
+        .expect("wire parse");
+        let bytes = normalize_to_rate_limits_json(&raw, None).expect("normalized");
+        let doc: serde_json::Value = serde_json::from_slice(&bytes).expect("json");
+        assert_eq!(doc["primary"]["usedPercent"], 12.0);
+        let extras = doc["extraBuckets"].as_array().expect("extraBuckets array");
+        assert_eq!(
+            extras.len(),
+            1,
+            "codex must not duplicate itself: {extras:?}"
+        );
+        assert_eq!(extras[0]["limitId"], "alpha");
+    }
+
+    #[test]
+    fn normalize_uses_preferred_by_id_bucket_individual_limit() {
+        let raw: CodexAppServerRateLimitsReadResult = serde_json::from_value(serde_json::json!({
+            "rateLimitsByLimitId": {
+                "codex": {
+                    "primary": {"usedPercent": 12.0, "windowDurationMins": 10080, "resetsAt": 0},
+                    "individualLimit": {"remainingPercent": 40.0, "resetsAt": 1791000000}
+                }
+            }
+        }))
+        .expect("wire parse");
+        let bytes = normalize_to_rate_limits_json(&raw, None).expect("normalized");
+        let doc: serde_json::Value = serde_json::from_slice(&bytes).expect("json");
+        assert_eq!(doc["individualLimit"]["remainingPercent"], 40.0);
+    }
+
+    #[test]
+    fn normalize_root_individual_limit_wins_when_root_has_windows() {
+        let raw: CodexAppServerRateLimitsReadResult = serde_json::from_value(serde_json::json!({
+            "rateLimits": {
+                "primary": {"usedPercent": 12.0, "windowDurationMins": 10080, "resetsAt": 0},
+                "individualLimit": {"remainingPercent": 77.0, "resetsAt": 1791000000}
+            },
+            "rateLimitsByLimitId": {
+                "codex": {
+                    "primary": {"usedPercent": 12.0, "windowDurationMins": 10080, "resetsAt": 0},
+                    "individualLimit": {"remainingPercent": 5.0, "resetsAt": 0}
+                }
+            }
+        }))
+        .expect("wire parse");
+        let bytes = normalize_to_rate_limits_json(&raw, None).expect("normalized");
+        let doc: serde_json::Value = serde_json::from_slice(&bytes).expect("json");
+        assert_eq!(doc["individualLimit"]["remainingPercent"], 77.0);
     }
 
     #[tokio::test]

--- a/src/providers/codex_session_log.rs
+++ b/src/providers/codex_session_log.rs
@@ -6,9 +6,15 @@
 
 use std::path::Path;
 
+use time::format_description::well_known::Rfc3339;
+use time::OffsetDateTime;
+
 /// Reverse-scan JSONL bytes; first `payload.type == "token_count"` with a
-/// `payload.rate_limits` object wins. Returns re-serialized rate_limits JSON.
-pub fn extract_rate_limits_from_jsonl(bytes: &[u8]) -> Option<Vec<u8>> {
+/// `payload.rate_limits` object wins. Returns the re-serialized rate_limits
+/// JSON alongside that event's own RFC3339 `timestamp` field (when present
+/// and parseable), normalized to UTC — this is when the data was generated,
+/// not when it was read.
+pub fn extract_rate_limits_from_jsonl(bytes: &[u8]) -> Option<(Vec<u8>, Option<OffsetDateTime>)> {
     let text = std::str::from_utf8(bytes).ok()?;
     for line in text.lines().rev() {
         let line = line.trim();
@@ -32,7 +38,13 @@ pub fn extract_rate_limits_from_jsonl(bytes: &[u8]) -> Option<Vec<u8>> {
         if !rate_limits.is_object() {
             continue;
         }
-        return serde_json::to_vec(rate_limits).ok();
+        let raw = serde_json::to_vec(rate_limits).ok()?;
+        let timestamp = value
+            .get("timestamp")
+            .and_then(|v| v.as_str())
+            .and_then(|s| OffsetDateTime::parse(s, &Rfc3339).ok())
+            .map(|dt| dt.to_offset(time::UtcOffset::UTC));
+        return Some((raw, timestamp));
     }
     None
 }
@@ -44,7 +56,7 @@ const MAX_SESSION_JSONL_BYTES: u64 = 1024 * 1024;
 /// candidates ≤ 256 jsonl files, each file ≤ 1 MiB. Sort mtime desc then path
 /// asc; scan each candidate reverse for token_count; return first hit's
 /// rate_limits JSON.
-pub fn find_latest_rate_limits(sessions_dir: &Path) -> Option<Vec<u8>> {
+pub fn find_latest_rate_limits(sessions_dir: &Path) -> Option<(Vec<u8>, Option<OffsetDateTime>)> {
     use std::cmp::Ordering;
     use std::fs;
 
@@ -108,8 +120,8 @@ pub fn find_latest_rate_limits(sessions_dir: &Path) -> Option<Vec<u8>> {
         let Ok(bytes) = fs::read(path) else {
             continue;
         };
-        if let Some(raw) = extract_rate_limits_from_jsonl(&bytes) {
-            return Some(raw);
+        if let Some(hit) = extract_rate_limits_from_jsonl(&bytes) {
+            return Some(hit);
         }
     }
     None
@@ -126,7 +138,8 @@ mod tests {
     fn extract_token_count_rate_limits_from_jsonl() {
         let bytes =
             include_bytes!("../../tests/fixtures/providers/codex/session-token-count.jsonl");
-        let raw = extract_rate_limits_from_jsonl(bytes).expect("limits");
+        let (raw, timestamp) = extract_rate_limits_from_jsonl(bytes).expect("limits");
+        assert_eq!(timestamp, Some(datetime!(2026-07-25 23:01:00 UTC)));
         let now = datetime!(2026-07-26 18:00:00 UTC);
         match codex_from_rate_limits_json(&raw, now) {
             ProviderResult::Ready { windows, .. } => {
@@ -135,6 +148,13 @@ mod tests {
             }
             other => panic!("{other:?}"),
         }
+    }
+
+    #[test]
+    fn extract_rate_limits_returns_none_timestamp_when_absent() {
+        let jsonl = r#"{"payload":{"type":"token_count","rate_limits":{"primary":{"used_percent":1.0,"window_minutes":10080}}}}"#;
+        let (_raw, timestamp) = extract_rate_limits_from_jsonl(jsonl.as_bytes()).expect("limits");
+        assert_eq!(timestamp, None);
     }
 
     #[test]
@@ -147,7 +167,8 @@ mod tests {
             include_bytes!("../../tests/fixtures/providers/codex/session-token-count.jsonl");
         std::fs::write(nested.join("rollout.jsonl"), fixture).expect("write");
 
-        let raw = find_latest_rate_limits(&sessions).expect("limits from walk");
+        let (raw, timestamp) = find_latest_rate_limits(&sessions).expect("limits from walk");
+        assert_eq!(timestamp, Some(datetime!(2026-07-25 23:01:00 UTC)));
         let now = datetime!(2026-07-26 18:00:00 UTC);
         match codex_from_rate_limits_json(&raw, now) {
             ProviderResult::Ready { windows, .. } => {
@@ -168,7 +189,8 @@ mod tests {
             r#"{"payload":{"type":"token_count","rate_limits":{"primary":{"used_percent":99.0,"window_minutes":10080}}}}"#,
             "\n",
         );
-        let raw = extract_rate_limits_from_jsonl(jsonl.as_bytes()).expect("limits");
+        let (raw, timestamp) = extract_rate_limits_from_jsonl(jsonl.as_bytes()).expect("limits");
+        assert_eq!(timestamp, None);
         let now = datetime!(2026-07-26 18:00:00 UTC);
         match codex_from_rate_limits_json(&raw, now) {
             ProviderResult::Ready { windows, .. } => {
@@ -194,7 +216,8 @@ mod tests {
             include_bytes!("../../tests/fixtures/providers/codex/session-token-count.jsonl");
         std::fs::write(sessions.join("good.jsonl"), fixture).expect("write good");
 
-        let raw = find_latest_rate_limits(&sessions).expect("skip empty, use good");
+        let (raw, timestamp) = find_latest_rate_limits(&sessions).expect("skip empty, use good");
+        assert_eq!(timestamp, Some(datetime!(2026-07-25 23:01:00 UTC)));
         let now = datetime!(2026-07-26 18:00:00 UTC);
         match codex_from_rate_limits_json(&raw, now) {
             ProviderResult::Ready { windows, .. } => {
@@ -240,7 +263,7 @@ mod tests {
             include_bytes!("../../tests/fixtures/providers/codex/session-token-count.jsonl");
         std::fs::write(sessions.join("z-good.jsonl"), fixture).expect("write good");
 
-        let raw = find_latest_rate_limits(&sessions).expect("skip huge, use good");
+        let (raw, _timestamp) = find_latest_rate_limits(&sessions).expect("skip huge, use good");
         let now = datetime!(2026-07-26 18:00:00 UTC);
         match codex_from_rate_limits_json(&raw, now) {
             ProviderResult::Ready { windows, .. } => {

--- a/src/providers/v2_map.rs
+++ b/src/providers/v2_map.rs
@@ -115,6 +115,7 @@ pub fn amp_from_usage_text(stdout: &str, now: OffsetDateTime) -> ProviderResult 
         }),
         windows,
         last_success_at: now,
+        rate_limit_resets_available: None,
     }
 }
 
@@ -249,6 +250,7 @@ pub fn grok_from_billing_json(
         }),
         windows,
         last_success_at: now,
+        rate_limit_resets_available: None,
     }
 }
 
@@ -324,6 +326,7 @@ pub fn grok_from_auth_and_signals(
         }),
         windows,
         last_success_at: now,
+        rate_limit_resets_available: None,
     }
 }
 
@@ -352,6 +355,30 @@ struct CodexRateLimitsDoc {
     /// Explicitly ignored monetary field.
     #[serde(default)]
     credits: Option<Value>,
+    #[serde(default, rename = "individualLimit")]
+    individual_limit: Option<CodexIndividualLimitRaw>,
+    #[serde(default, rename = "extraBuckets")]
+    extra_buckets: Vec<CodexExtraBucketRaw>,
+    #[serde(default, rename = "rateLimitResetsAvailable")]
+    rate_limit_resets_available: Option<u32>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CodexIndividualLimitRaw {
+    #[serde(rename = "remainingPercent")]
+    remaining_percent: f64,
+    #[serde(default, rename = "resetsAt")]
+    resets_at: Option<i64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CodexExtraBucketRaw {
+    #[serde(rename = "limitId")]
+    limit_id: String,
+    #[serde(default)]
+    primary: Option<CodexWindowRaw>,
+    #[serde(default)]
+    secondary: Option<CodexWindowRaw>,
 }
 
 /// Parse Codex rate-limit JSON. Credits are discarded.
@@ -384,6 +411,42 @@ pub fn codex_from_rate_limits_json(bytes: &[u8], now: OffsetDateTime) -> Provide
             windows.push(w);
         }
     }
+
+    for bucket in &doc.extra_buckets {
+        let sanitized = sanitize_bucket_id(&bucket.limit_id);
+        if let Some(raw) = bucket.primary.as_ref() {
+            let id = format!("codex:{sanitized}");
+            let label = codex_extra_bucket_label(&sanitized, raw.window_minutes);
+            if let Some(w) = codex_window(&id, &label, raw) {
+                windows.push(w);
+            }
+        }
+        if let Some(raw) = bucket.secondary.as_ref() {
+            let id = format!("codex:{sanitized}:2");
+            let label = codex_extra_bucket_label(&sanitized, raw.window_minutes);
+            if let Some(w) = codex_window(&id, &label, raw) {
+                windows.push(w);
+            }
+        }
+    }
+
+    if let Some(il) = doc.individual_limit.as_ref() {
+        if il.remaining_percent.is_finite() {
+            let rem = il.remaining_percent.clamp(0.0, 100.0);
+            let used = (100.0 - rem).clamp(0.0, 100.0);
+            let resets = il
+                .resets_at
+                .filter(|&ts| ts > 0)
+                .and_then(|ts| OffsetDateTime::from_unix_timestamp(ts).ok())
+                .map(|ts| ts.to_offset(UtcOffset::UTC));
+            if let Ok(w) =
+                UsageWindow::try_new("workspace-limit", "Workspace limit", used, rem, resets)
+            {
+                windows.push(w);
+            }
+        }
+    }
+
     let _ = doc.credits; // discarded
 
     ProviderResult::Ready {
@@ -391,12 +454,38 @@ pub fn codex_from_rate_limits_json(bytes: &[u8], now: OffsetDateTime) -> Provide
         name: CODEX.display_name.to_owned(),
         source: DataSource::Live,
         plan: doc.plan_type.map(|id| Plan {
-            label: id.clone(),
+            label: format_plan_label(&id),
             id,
         }),
         account: None,
         windows,
         last_success_at: now,
+        rate_limit_resets_available: doc.rate_limit_resets_available,
+    }
+}
+
+/// Lowercase ASCII letters/digits/hyphens; empty input falls back to `bucket`.
+/// Mirrors the sanitization in [`weekly_model_id`].
+fn sanitize_bucket_id(raw: &str) -> String {
+    let sanitized: String = raw
+        .chars()
+        .flat_map(|c| c.to_lowercase())
+        .filter(|c| c.is_ascii_alphanumeric() || *c == '-')
+        .collect();
+    if sanitized.is_empty() {
+        "bucket".into()
+    } else {
+        sanitized
+    }
+}
+
+/// Display label for a Codex extra rate-limit bucket window.
+fn codex_extra_bucket_label(sanitized: &str, window_minutes: Option<i64>) -> String {
+    let name = format_plan_label(sanitized);
+    match window_minutes {
+        Some(10080) => format!("{name} (7d)"),
+        Some(mins) => format!("{name} ({mins}m)"),
+        None => name,
     }
 }
 
@@ -630,6 +719,7 @@ pub fn claude_from_usage_json(
         account,
         windows,
         last_success_at: now,
+        rate_limit_resets_available: None,
     }
 }
 
@@ -1016,6 +1106,38 @@ mod tests {
                 assert_eq!(windows[1].id(), "weekly");
                 assert_eq!(windows[1].label(), "Weekly (7d)");
                 assert!((windows[1].used_percent() - 40.0).abs() < 0.01);
+            }
+            other => panic!("expected ready, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn codex_maps_extra_buckets_individual_limit_and_resets() {
+        let json = serde_json::json!({
+            "primary": {"usedPercent": 36.0, "windowDurationMins": 10080, "resetsAt": 1791000000},
+            "plan_type": "plus",
+            "individualLimit": {"remainingPercent": 40.0, "resetsAt": 1791000000},
+            "extraBuckets": [{"limitId": "premium",
+                "primary": {"usedPercent": 10.0, "windowDurationMins": 10080, "resetsAt": 0}}],
+            "rateLimitResetsAvailable": 2
+        });
+        let bytes = serde_json::to_vec(&json).expect("fixture json");
+        let result = codex_from_rate_limits_json(&bytes, datetime!(2026-08-07 12:00:00 UTC));
+        assert_no_money(&result);
+        match result {
+            ProviderResult::Ready {
+                windows,
+                plan,
+                rate_limit_resets_available,
+                ..
+            } => {
+                let ids: Vec<&str> = windows.iter().map(|w| w.id()).collect();
+                assert_eq!(ids, vec!["weekly", "codex:premium", "workspace-limit"]);
+                assert_eq!(windows[1].label(), "Premium (7d)");
+                assert_eq!(windows[2].label(), "Workspace limit");
+                assert!((windows[2].remaining_percent() - 40.0).abs() < 0.01);
+                assert_eq!(rate_limit_resets_available, Some(2));
+                assert_eq!(plan.as_ref().map(|p| p.label.as_str()), Some("Plus"));
             }
             other => panic!("expected ready, got {other:?}"),
         }

--- a/src/providers/v2_map.rs
+++ b/src/providers/v2_map.rs
@@ -418,14 +418,14 @@ pub fn codex_from_rate_limits_json(bytes: &[u8], now: OffsetDateTime) -> Provide
             let id = format!("codex:{sanitized}");
             let label = codex_extra_bucket_label(&sanitized, raw.window_minutes);
             if let Some(w) = codex_window(&id, &label, raw) {
-                windows.push(w);
+                push_window_unique(&mut windows, w);
             }
         }
         if let Some(raw) = bucket.secondary.as_ref() {
             let id = format!("codex:{sanitized}:2");
             let label = codex_extra_bucket_label(&sanitized, raw.window_minutes);
             if let Some(w) = codex_window(&id, &label, raw) {
-                windows.push(w);
+                push_window_unique(&mut windows, w);
             }
         }
     }
@@ -1138,6 +1138,39 @@ mod tests {
                 assert!((windows[2].remaining_percent() - 40.0).abs() < 0.01);
                 assert_eq!(rate_limit_resets_available, Some(2));
                 assert_eq!(plan.as_ref().map(|p| p.label.as_str()), Some("Plus"));
+            }
+            other => panic!("expected ready, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn codex_dedupes_extra_bucket_window_ids_across_case_variants() {
+        // Two limitId keys that differ only by case sanitize to the same
+        // window id ("codex:team-a"); the second must be dropped, not
+        // silently pushed twice (duplicate window ids make
+        // ensure_unique_window_ids reject the entire status).
+        let json = serde_json::json!({
+            "primary": {"usedPercent": 36.0, "windowDurationMins": 10080, "resetsAt": 1791000000},
+            "extraBuckets": [
+                {"limitId": "Team-A",
+                    "primary": {"usedPercent": 10.0, "windowDurationMins": 10080, "resetsAt": 0}},
+                {"limitId": "TEAM-A",
+                    "primary": {"usedPercent": 20.0, "windowDurationMins": 10080, "resetsAt": 0}}
+            ]
+        });
+        let bytes = serde_json::to_vec(&json).expect("fixture json");
+        let result = codex_from_rate_limits_json(&bytes, datetime!(2026-08-07 12:00:00 UTC));
+        let status = crate::status::collect::provider_status_from_result(result.clone());
+        assert!(status.is_ok(), "row failed schema validation: {status:?}");
+        match result {
+            ProviderResult::Ready { windows, .. } => {
+                assert_eq!(windows.len(), 2, "got {windows:?}");
+                let team_a: Vec<_> = windows
+                    .iter()
+                    .filter(|w| w.id() == "codex:team-a")
+                    .collect();
+                assert_eq!(team_a.len(), 1, "duplicate codex:team-a windows");
+                assert!((team_a[0].used_percent() - 10.0).abs() < 0.01);
             }
             other => panic!("expected ready, got {other:?}"),
         }

--- a/src/status/collect.rs
+++ b/src/status/collect.rs
@@ -15,7 +15,9 @@ pub fn provider_status_from_result(result: ProviderResult) -> Result<ProviderSta
             account,
             windows,
             last_success_at,
-        } => ProviderStatus::ready(id, name, source, plan, account, windows, last_success_at),
+            rate_limit_resets_available,
+        } => ProviderStatus::ready(id, name, source, plan, account, windows, last_success_at)
+            .map(|status| status.with_rate_limit_resets_available(rate_limit_resets_available)),
         ProviderResult::Stale {
             id,
             name,
@@ -108,6 +110,7 @@ mod tests {
             account: None,
             windows: vec![UsageWindow::try_new("session", "Session", 10.0, 90.0, None).unwrap()],
             last_success_at: datetime!(2026-07-26 18:42:00 UTC),
+            rate_limit_resets_available: None,
         })
         .unwrap();
         assert_eq!(ready.state(), ProviderState::Ready);

--- a/src/status/schema.rs
+++ b/src/status/schema.rs
@@ -333,6 +333,8 @@ pub struct ProviderStatus {
     last_success_at: Option<OffsetDateTime>,
     error: Option<ProviderError>,
     action: Option<ProviderAction>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    rate_limit_resets_available: Option<u32>,
 }
 
 /// Serde adapter so [`ProviderId`] serializes as a lowercase string.
@@ -401,6 +403,18 @@ impl ProviderStatus {
         self.account.as_ref()
     }
 
+    pub fn rate_limit_resets_available(&self) -> Option<u32> {
+        self.rate_limit_resets_available
+    }
+
+    /// Attach a provider-granted rate-limit reset count after construction.
+    /// Used by the `ProviderResult::Ready` conversion and by stale/cache-hit
+    /// rebuilds that must carry the previous value through.
+    pub(crate) fn with_rate_limit_resets_available(mut self, value: Option<u32>) -> Self {
+        self.rate_limit_resets_available = value;
+        self
+    }
+
     /// When serving a previously live ready row from cache, label source as `cache`.
     pub fn for_cache_hit(&self) -> Result<Self, SchemaError> {
         match self.state {
@@ -417,6 +431,9 @@ impl ProviderStatus {
                     self.windows.clone(),
                     last,
                 )
+                .map(|status| {
+                    status.with_rate_limit_resets_available(self.rate_limit_resets_available)
+                })
             }
             // Stale already uses source=cache; other states keep their shape.
             _ => Ok(self.clone()),
@@ -443,6 +460,7 @@ impl ProviderStatus {
             error,
             ProviderAction::retry("Retry"),
         )
+        .map(|status| status.with_rate_limit_resets_available(self.rate_limit_resets_available))
     }
 
     /// Temporary failures eligible for stale retention. Rejected auth and
@@ -479,6 +497,7 @@ impl ProviderStatus {
             last_success_at: Some(last_success_at),
             error: None,
             action: None,
+            rate_limit_resets_available: None,
         })
     }
 
@@ -509,6 +528,7 @@ impl ProviderStatus {
             last_success_at: Some(last_success_at),
             error: Some(error),
             action: Some(action),
+            rate_limit_resets_available: None,
         })
     }
 
@@ -539,6 +559,7 @@ impl ProviderStatus {
             last_success_at: None,
             error: Some(error),
             action: Some(action),
+            rate_limit_resets_available: None,
         })
     }
 
@@ -572,6 +593,7 @@ impl ProviderStatus {
             last_success_at: None,
             error: Some(error),
             action: Some(action),
+            rate_limit_resets_available: None,
         })
     }
 
@@ -634,6 +656,7 @@ impl ProviderStatus {
             last_success_at: None,
             error: Some(error),
             action: Some(action),
+            rate_limit_resets_available: None,
         })
     }
 
@@ -739,6 +762,7 @@ fn failure_state(
         last_success_at: None,
         error: Some(error),
         action: Some(action),
+        rate_limit_resets_available: None,
     })
 }
 
@@ -932,6 +956,7 @@ pub enum ProviderResult {
         account: Option<Account>,
         windows: Vec<UsageWindow>,
         last_success_at: OffsetDateTime,
+        rate_limit_resets_available: Option<u32>,
     },
     Stale {
         id: ProviderId,
@@ -1428,5 +1453,24 @@ mod tests {
             .map(|e| e.to_string())
             .collect();
         assert!(errors.is_empty(), "{errors:?}");
+    }
+
+    #[test]
+    fn provider_status_serializes_reset_count_only_when_present() {
+        // ProviderStatus derives Deserialize: build both rows via serde and
+        // assert the key round-trips only when present.
+        let base = serde_json::json!({
+            "id": "codex", "name": "Codex", "state": "ready", "source": "live",
+            "plan": null, "account": null, "windows": [],
+            "lastSuccessAt": "2026-08-07T12:00:00Z", "error": null, "action": null
+        });
+        let mut with = base.clone();
+        with["rateLimitResetsAvailable"] = serde_json::json!(2);
+        let with: ProviderStatus = serde_json::from_value(with).expect("row with resets");
+        let text = serde_json::to_string(&with).expect("serialize");
+        assert!(text.contains("\"rateLimitResetsAvailable\":2"));
+        let without: ProviderStatus = serde_json::from_value(base).expect("row without resets");
+        let text = serde_json::to_string(&without).expect("serialize");
+        assert!(!text.contains("rateLimitResetsAvailable"));
     }
 }

--- a/tests/qml/tst_ProviderStates.qml
+++ b/tests/qml/tst_ProviderStates.qml
@@ -423,4 +423,21 @@ TestCase {
     verify(popup.indexOf("active: root.isOpen") >= 0,
         "Popup must drive ProviderView.active from its own open state")
   }
+
+  // JSON-022C: Codex's rate-limit reset count renders as a muted popup line,
+  // singular/plural, and stays empty for absent or zero (byte-identical
+  // popup for every other provider).
+  function test_reset_line_visible_only_when_positive() {
+    var withResets = { id: "codex", name: "Codex", state: "ready", windows: [],
+                        rateLimitResetsAvailable: 2 }
+    compare(Core.rateLimitResetsText(withResets), "↻ 2 rate-limit resets available")
+    var one = { id: "codex", name: "Codex", state: "ready", windows: [],
+                rateLimitResetsAvailable: 1 }
+    compare(Core.rateLimitResetsText(one), "↻ 1 rate-limit reset available")
+    var without = { id: "codex", name: "Codex", state: "ready", windows: [] }
+    compare(Core.rateLimitResetsText(without), "")
+    var zero = { id: "codex", name: "Codex", state: "ready", windows: [],
+                 rateLimitResetsAvailable: 0 }
+    compare(Core.rateLimitResetsText(zero), "")
+  }
 }


### PR DESCRIPTION
## Summary
- Declare the full `codex app-server` rate-limit payload: `individualLimit`, `rateLimitResetCredits`, `limitId` (monetary `credits` object intentionally undeclared per JSON-022B)
- Iterate `rateLimitsByLimitId` fully: prefer the `codex` bucket explicitly, preserve every other data-carrying bucket as extra windows (`codex:<slug>`), dedupe collisions via `push_window_unique`
- New windows: `workspace-limit` (spend-control percentage) and per-bucket extras
- New optional schema-v2 field `rateLimitResetsAvailable` (contract amendment JSON-022C: quota-reset count, not a monetary fact) + popup line "↻ N rate-limit resets available" shown only when N > 0
- Format `planType` for display ("plus" → "Plus") reusing the shared plan-label helper
- Remove dead cascade stage 2 (`~/.codex/rate-limits.json` — no upstream writer exists in codex-cli 0.146.x)
- Session-log-sourced data now reports the log event's own timestamp as `lastSuccessAt` (JSON-021)

## Verification
- `cargo fmt --check` / `cargo test` / `cargo clippy --all-targets -- -D warnings` / `git diff --check` / `cargo test --test dist_tree_validate` all green
- QML battery: Qt6 qmllint (no new warnings), `omarchy plugin validate`, Qt6 qmltestrunner 244/244
- Live smoke on a real install: Amp renders Megawatt + 3 windows; Codex renders "Plus" + weekly; `rateLimitResetsAvailable` present (0) with the popup line correctly hidden
- Whole-branch review ran clean after one fix wave (window-id dedupe)

Spec: docs/superpowers/specs/2026-08-07-amp-codex-usage-improvements-design.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Codex rate-limit reset information to provider usage views, including singular and plural wording.
  * Displays additional usage windows and provider-specific limits when available.
  * Preserves accurate timestamps for session-based rate-limit information.

* **Bug Fixes**
  * Improved rate-limit data selection and handling of empty or unavailable limits.
  * Removed reliance on the explicit local rate-limit file fallback.

* **Documentation**
  * Updated troubleshooting guidance and data specifications for rate-limit collection, reset counts, and usage metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->