### PR TITLE
feat: adaptive lead window for Amp subscriptions

### DIFF
--- a/assets/omarchy/BarWidget.qml
+++ b/assets/omarchy/BarWidget.qml
@@ -33,6 +33,15 @@ BarWidget {
   readonly property color chipForeground: bar ? bar.foreground : Color.foreground
   readonly property string chipFontFamily: bar ? bar.fontFamily : "monospace"
 
+  property double nowMs: Date.now()
+  Timer {
+    id: nowTimer
+    interval: 30000
+    running: true
+    repeat: true
+    onTriggered: root.nowMs = Date.now()
+  }
+
   // Popup is open on another monitor → this instance hosts dismiss-only overlay.
   readonly property bool foreignDismissActive: Service.foreignPopupOpen(
     agentService ? agentService.popupOwner : null,
@@ -91,11 +100,11 @@ BarWidget {
         bar: root.bar
         providerId: String(modelData.id || "")
         displayName: modelData.name ? String(modelData.name) : Core.providerDisplayName(providerId)
-        numeralText: Core.chipNumeralText(modelData, root.displayMetric)
+        numeralText: Core.chipNumeralText(modelData, root.displayMetric, root.nowMs)
         stateCue: Core.chipStateCue(modelData)
         cueLabel: Core.chipCueLabel(modelData)
         severityUrgent: Core.chipSeverityUrgent(modelData)
-        accessibleLabel: Core.chipAccessibleLabel(modelData, root.displayMetric)
+        accessibleLabel: Core.chipAccessibleLabel(modelData, root.displayMetric, root.nowMs)
         iconSource: root.iconUrl(providerId)
         tinted: Core.iconTinted(providerId)
         iconScale: Core.iconOpticalScale(providerId)

--- a/assets/omarchy/CoreView.js
+++ b/assets/omarchy/CoreView.js
@@ -92,8 +92,8 @@ function visibleProviders(snapshot, settings) {
 // window's used|remaining percent — the same election the popup runs — or an
 // em-dash when there is no window. Chip and popup can never disagree on
 // which window a number belongs to.
-function chipPercentText(provider, metric) {
-  var lines = windowDisplayLines(provider, metric, undefined)
+function chipPercentText(provider, metric, nowMs) {
+  var lines = windowDisplayLines(provider, metric, nowMs)
   var lead = electLeadIndex(lines)
   if (lead < 0)
     return "\u2014"
@@ -226,10 +226,10 @@ function stateQualifier(state) {
 
 // Numeral box content: loading renders the loading cue in place of the
 // number so the cue is visually distinct from the — no-data glyph (§5).
-function chipNumeralText(provider, metric) {
+function chipNumeralText(provider, metric, nowMs) {
   if (provider && String(provider.state || "") === "loading")
     return "···"
-  return chipPercentText(provider, metric)
+  return chipPercentText(provider, metric, nowMs)
 }
 
 function chipDimmed(provider) {
@@ -244,13 +244,13 @@ function chipDimmed(provider) {
 // provider, the displayed percentage when one exists, and a plain-language
 // qualifier when not ready. The raw enum value never renders (copy design
 // §5.4). Single-line by construction: no window detail, no live clock.
-function chipAccessibleLabel(provider, metric) {
+function chipAccessibleLabel(provider, metric, nowMs) {
   if (!provider)
     return ""
   var name = provider.name ? String(provider.name) : providerDisplayName(provider.id)
   var parts = [name]
   var state = provider.state ? String(provider.state) : "unknown"
-  var pct = chipPercentText(provider, metric)
+  var pct = chipPercentText(provider, metric, nowMs)
   if (pct !== "—" || state === "ready")
     parts.push(pct)
   var qualifier = stateQualifier(state)

--- a/assets/omarchy/CoreView.js
+++ b/assets/omarchy/CoreView.js
@@ -614,9 +614,10 @@ function remainingRank(line) {
   return line.remainingPercent === null ? Infinity : line.remainingPercent
 }
 
-// §8: deterministic lead election, replacing the old id allowlist that
-// silently demoted any window id it did not know. Returns an index into
-// `lines`, or -1 when there is nothing to lead.
+// §8: deterministic four-step lead election: critical, plan, nearest future
+// reset, then first delivered. This replaces the old id allowlist that silently
+// demoted any window id it did not know. Returns an index into `lines`, or -1
+// when there is nothing to lead.
 //
 // Delivered order is unique per line, so `<` on the index is already a total
 // tiebreak; the spec's further "then by window id" step is unreachable and is
@@ -638,7 +639,20 @@ function electLeadIndex(lines) {
   if (best >= 0)
     return best
 
-  // 2. Otherwise the nearest reset still in the future. A missing timestamp
+  // 2. UX-020D (amended 2026-08-07): a plan window (id prefix "plan-")
+  //    outranks every non-plan window; among plan windows the lowest
+  //    remaining leads. Ids are typed schema data authored by the Rust
+  //    mappers, so the prefix is a contract, not raw-output parsing.
+  for (i = 0; i < lines.length; i++) {
+    if (lines[i].id.indexOf("plan-") !== 0)
+      continue
+    if (best < 0 || remainingRank(lines[i]) < remainingRank(lines[best]))
+      best = i
+  }
+  if (best >= 0)
+    return best
+
+  // 3. Otherwise the nearest reset still in the future. A missing timestamp
   //    or one that already elapsed ("now") does not compete.
   var bestMs = NaN
   for (i = 0; i < lines.length; i++) {
@@ -655,7 +669,7 @@ function electLeadIndex(lines) {
   if (best >= 0)
     return best
 
-  // 3. Nothing has a future reset: the first delivered window leads.
+  // 4. Nothing has a future reset: the first delivered window leads.
   return 0
 }
 

--- a/assets/omarchy/CoreView.js
+++ b/assets/omarchy/CoreView.js
@@ -88,22 +88,16 @@ function visibleProviders(snapshot, settings) {
   return out
 }
 
-function primaryWindow(provider) {
-  if (!provider || !Kernel.isArrayLike(provider.windows) || provider.windows.length === 0)
-    return null
-  return provider.windows[0]
-}
-
-// UX-002 / UX-032A: used|remaining percent, or em-dash when empty.
+// UX-002 / UX-032A (amended 2026-08-07): the chip renders the elected lead
+// window's used|remaining percent — the same election the popup runs — or an
+// em-dash when there is no window. Chip and popup can never disagree on
+// which window a number belongs to.
 function chipPercentText(provider, metric) {
-  var w = primaryWindow(provider)
-  if (!w)
+  var lines = windowDisplayLines(provider, metric, undefined)
+  var lead = electLeadIndex(lines)
+  if (lead < 0)
     return "\u2014"
-  var mode = metric === "used" ? "used" : "remaining"
-  var v = mode === "used" ? Number(w.usedPercent) : Number(w.remainingPercent)
-  if (!isFinite(v))
-    return "\u2014"
-  return Math.round(v) + "%"
+  return lines[lead].percentText
 }
 
 // Typed error/collection-failure states shared by the chip cue and the

--- a/docs/specs/v10/04-quickshell-ux-and-accessibility.md
+++ b/docs/specs/v10/04-quickshell-ux-and-accessibility.md
@@ -11,7 +11,8 @@ verified Quattro-native glyphs or explicit English text labels.
 
 - `UX-001`: Render one compact chip per enabled provider in settings order.
 - `UX-002`: A chip contains the provider icon and the configured used or
-  remaining percentage.
+  remaining percentage of the elected lead window (per `UX-020D`), so the
+  chip and the popup always name the same number.
 - `UX-003`: Do not render `AB`, `Agent Bar`, or a generic leading product icon.
 - `UX-004`: Left click opens the clicked provider.
 - `UX-005`: Left-clicking the same provider while open closes the popup.
@@ -77,11 +78,13 @@ not literal UI.
   bar chip. Every level carries a word; no level is colour-only.
 - `UX-020D`: The popup renders exactly one lead window, elected
   deterministically: a critical window wins, and among criticals the one with
-  the lowest remaining percentage; otherwise the window whose reset comes
-  soonest; ties keep the delivered order; when no window has a future reset
-  the first delivered window leads. Every other window renders as a compact
-  row in delivered order. Reset times render as a countdown, in hours below
-  24 hours.
+  the lowest remaining percentage; otherwise a plan window (window id
+  starting `plan-`) wins, and among plan windows the one with the lowest
+  remaining percentage; otherwise the window whose reset comes soonest; ties
+  keep the delivered order; when no window has a future reset the first
+  delivered window leads. Every other window renders as a compact row in
+  delivered order. Reset times render as a countdown, in hours below 24
+  hours.
 - `UX-020B`: The selected rail icon uses a neutral soft plate only for the
   provider that owns the open content; no accent edge tick; Settings has no
   idle selected-looking border.

--- a/docs/superpowers/plans/2026-08-07-amp-subscription-lead-window.md
+++ b/docs/superpowers/plans/2026-08-07-amp-subscription-lead-window.md
@@ -1,0 +1,362 @@
+# Amp Subscription Adaptive Lead Window Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the chip and popup lead with the Amp subscription's most constrained bucket for subscriber accounts, while free-only accounts stay byte-identical.
+
+**Architecture:** One new rule in `electLeadIndex` (plan windows outrank non-plan when nothing is critical), the chip switches from `windows[0]` to the same elected lead, and the Rust mapper renames two labels. Approved spec: `docs/superpowers/specs/2026-08-07-amp-subscription-lead-window-design.md`.
+
+**Tech Stack:** Rust (parser labels + tests), QML/JS (`CoreView.js` pure functions, qmltestrunner Qt 6 binary path only).
+
+## Global Constraints
+
+- Contract: `CLAUDE.md`; product contract: `docs/specs/v10/` plus the approved design above. Status schema stays frozen at v2 — no new field.
+- No monetary data: the `Individual credits: $` line stays unparsed (JSON-022B).
+- All shipped UI copy is English. Window ids `plan-other`/`plan-orb` do not change; only labels do.
+- Commits require owner authorization. The owner authorizes execution of this plan; each task ends in exactly one commit with an English Conventional Commit subject ≤ 50 chars, no AI-attribution text anywhere.
+- Rust gates (Tasks 1): `cargo fmt --check` · `cargo test` · `cargo clippy --all-targets -- -D warnings` · `git diff --check`.
+- QML gates (Tasks 2–3): the Rust gates plus
+  ```bash
+  find assets/omarchy -type f -name '*.qml' -exec \
+    /usr/lib/qt6/bin/qmllint -I /usr/share/omarchy/shell {} +
+  omarchy plugin validate assets/omarchy
+  QT_QPA_PLATFORM=offscreen QML_XHR_ALLOW_FILE_READ=1 QT_LOGGING_TO_CONSOLE=1 \
+    /usr/lib/qt6/bin/qmltestrunner -input tests/qml \
+    -import /usr/share/omarchy/shell -import assets/omarchy -o -,txt
+  ```
+  `qmllint` from PATH is a silent stub and `qmltestrunner` from PATH is Qt 5 — the `/usr/lib/qt6/bin/` paths and both env vars are mandatory. The qmltestrunner bar is **0 failed**; never chase an exact total.
+- The three QML gates are blind to a dangling reference in plugin QML (nothing compiles files importing `qs.*`). Every deletion gets a hand-trace of references **and** a text guard banning the exact dead identifier.
+- Known flake: `binary_interactive_update_rejects_non_tty` (`ExecutableFileBusy` on a machine with a live plugin) — retry once; pre-existing isolation bug, not a regression.
+- Preserve unrelated worktree changes. Never bypass hooks, force-push, merge, tag, or publish.
+
+## File Structure
+
+- Modify: `src/providers/v2_map.rs` — two label strings (`:93-94`) and their test assertions (`:879`, `:882`).
+- Modify: `assets/omarchy/CoreView.js` — plan rule in `electLeadIndex` (after the critical loop, `:625-660` region); `chipPercentText` (`:98-106`) reads the elected lead; `primaryWindow` (`:91-95`) deleted.
+- Modify: `tests/qml/tst_ProviderStates.qml` — three new election tests next to the existing `test_lead_election_*` family (`:211+`).
+- Modify: `tests/qml/tst_BarWidget.qml` — subscriber chip test next to `test_used_versus_remaining_metric` (`:218`).
+- Modify: `tests/qml/tst_Popup.qml` — extend the dead-identifier guard `test_primary_window_allowlist_is_gone` (`:299-310`).
+- Modify: `docs/specs/v10/04-quickshell-ux-and-accessibility.md` — amend `UX-002` (`:13-14`) and `UX-020D` (`:78-84`).
+
+---
+
+### Task 1: Rust label rename (`Plan · agent` / `Plan · orbs`)
+
+**Files:**
+- Modify: `src/providers/v2_map.rs:93-94` (labels), `:879`, `:882` (test assertions)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `amp_from_usage_text` emits windows labeled `Plan · agent` (id `plan-other`) and `Plan · orbs` (id `plan-orb`). Tasks 2–3 use these labels only as opaque test data; ids are unchanged.
+
+- [ ] **Step 1: Make the test expect the new labels**
+
+In `src/providers/v2_map.rs`, test `amp_subscription_fixture_emits_plan_windows_and_plan` (`:871-893`), change the two assertions:
+
+```rust
+                assert_eq!(windows[1].label(), "Plan · agent");
+```
+and
+```rust
+                assert_eq!(windows[2].label(), "Plan · orbs");
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test amp_subscription_fixture_emits_plan_windows_and_plan`
+Expected: FAIL — left `"Plan · other"`, right `"Plan · agent"`.
+
+- [ ] **Step 3: Rename the labels in the mapper**
+
+In `amp_from_usage_text` (`src/providers/v2_map.rs:92-95`), the tuple array becomes:
+
+```rust
+        for (idx, id, label) in [
+            (2usize, "plan-other", "Plan · agent"),
+            (3usize, "plan-orb", "Plan · orbs"),
+        ] {
+```
+
+The comment above the `Subscription` regex (`:81-84`) already explains that "other usage" is included agent usage; extend its last sentence so the label choice is documented:
+
+```rust
+    // line is monetary and intentionally never parsed into a window (JSON-022B).
+    // Labels render the meaning, not the CLI word: "other" is included agent
+    // usage, "orb" is included orb-hours (design 2026-08-07).
+```
+
+- [ ] **Step 4: Run the Rust gates**
+
+Run: `cargo test amp` then `cargo fmt --check && cargo test && cargo clippy --all-targets -- -D warnings && git diff --check`
+Expected: all pass, 0 failures (retry the known flake once if it trips).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/providers/v2_map.rs
+git commit -m "feat: rename amp plan labels to agent/orbs"
+```
+
+---
+
+### Task 2: Plan-window rule in lead election
+
+**Files:**
+- Modify: `assets/omarchy/CoreView.js` (`electLeadIndex`, insert between the critical loop and the nearest-reset loop)
+- Test: `tests/qml/tst_ProviderStates.qml` (after `test_lead_election_lowest_remaining_among_criticals`, `:233`)
+
+**Interfaces:**
+- Consumes: `layoutOf(windows, nowIso)` helper (`tst_ProviderStates.qml:170-172`), `remainingRank(line)` (`CoreView.js:612-614`), line objects from `windowDisplayLines` whose `id` is always a string (`String(w.id || ("w" + i))`).
+- Produces: `electLeadIndex(lines)` rule order: critical → plan (`id` prefix `plan-`, lowest `remainingPercent`) → nearest future reset → first delivered. Task 3's chip relies on this exact order.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/qml/tst_ProviderStates.qml` after `test_lead_election_lowest_remaining_among_criticals`:
+
+```qml
+  // UX-020D step 2 (amended 2026-08-07): plan windows outrank non-plan
+  // windows when nothing is critical, so a subscriber leads with the
+  // subscription instead of the daily free window's nearer reset.
+  function test_lead_election_plan_beats_nearest_reset() {
+    var layout = layoutOf([
+      { id: "daily", label: "Daily (1d)", usedPercent: 31, remainingPercent: 69,
+        resetsAt: "2026-08-08T00:00:00Z" },
+      { id: "plan-other", label: "Plan · agent", usedPercent: 8, remainingPercent: 92,
+        resetsAt: null },
+      { id: "plan-orb", label: "Plan · orbs", usedPercent: 0, remainingPercent: 100,
+        resetsAt: null }
+    ], "2026-08-07T15:00:00Z")
+    compare(layout.lead.id, "plan-other")
+    // The rest keeps delivered order: free first, then the healthier bucket.
+    compare(layout.rest.length, 2)
+    compare(layout.rest[0].id, "daily")
+    compare(layout.rest[1].id, "plan-orb")
+  }
+
+  function test_lead_election_lowest_remaining_among_plan_windows() {
+    var layout = layoutOf([
+      { id: "plan-other", label: "Plan · agent", usedPercent: 20, remainingPercent: 80,
+        resetsAt: null },
+      { id: "plan-orb", label: "Plan · orbs", usedPercent: 65, remainingPercent: 35,
+        resetsAt: null }
+    ], "2026-08-07T15:00:00Z")
+    compare(layout.lead.id, "plan-orb")
+  }
+
+  // A critical plan window leads through rule 1 (severity), not rule 2 —
+  // same lead either way, but the severity tag must say Critical.
+  function test_lead_election_critical_plan_leads_by_severity() {
+    var layout = layoutOf([
+      { id: "daily", label: "Daily (1d)", usedPercent: 31, remainingPercent: 69,
+        resetsAt: "2026-08-08T00:00:00Z" },
+      { id: "plan-other", label: "Plan · agent", usedPercent: 97, remainingPercent: 3,
+        resetsAt: null },
+      { id: "plan-orb", label: "Plan · orbs", usedPercent: 0, remainingPercent: 100,
+        resetsAt: null }
+    ], "2026-08-07T15:00:00Z")
+    compare(layout.lead.id, "plan-other")
+    compare(layout.lead.severity, "critical")
+  }
+
+  // Severity is the one signal plan preference never displaces: an exhausted
+  // free window still takes the lead over a healthy subscription.
+  function test_lead_election_critical_free_beats_healthy_plan() {
+    var layout = layoutOf([
+      { id: "daily", label: "Daily (1d)", usedPercent: 96, remainingPercent: 4,
+        resetsAt: "2026-08-08T00:00:00Z" },
+      { id: "plan-other", label: "Plan · agent", usedPercent: 8, remainingPercent: 92,
+        resetsAt: null }
+    ], "2026-08-07T15:00:00Z")
+    compare(layout.lead.id, "daily")
+    compare(layout.lead.severity, "critical")
+  }
+```
+
+- [ ] **Step 2: Run the QML tests to verify the new ones fail**
+
+Run the qmltestrunner line from Global Constraints.
+Expected: `test_lead_election_plan_beats_nearest_reset` and
+`test_lead_election_lowest_remaining_among_plan_windows` FAIL (the old
+election picks `daily` / `plan-other` by delivered order).
+`test_lead_election_critical_plan_leads_by_severity` and
+`test_lead_election_critical_free_beats_healthy_plan` already PASS — they
+pin rule 1 as a regression guard. Every pre-existing test still passes.
+
+- [ ] **Step 3: Implement the plan rule**
+
+In `assets/omarchy/CoreView.js`, `electLeadIndex`: after the critical loop's `if (best >= 0) return best` and before the `// 2. Otherwise the nearest reset…` comment, insert (and renumber the two comments below it to 3. and 4.):
+
+```js
+  // 2. UX-020D (amended 2026-08-07): a plan window (id prefix "plan-")
+  //    outranks every non-plan window; among plan windows the lowest
+  //    remaining leads. Ids are typed schema data authored by the Rust
+  //    mappers, so the prefix is a contract, not raw-output parsing.
+  for (i = 0; i < lines.length; i++) {
+    if (lines[i].id.indexOf("plan-") !== 0)
+      continue
+    if (best < 0 || remainingRank(lines[i]) < remainingRank(lines[best]))
+      best = i
+  }
+  if (best >= 0)
+    return best
+```
+
+Also update the function's header comment (`// §8: deterministic lead election…`) to mention the four-step order.
+
+- [ ] **Step 4: Run the QML gates**
+
+Run: qmllint line, `omarchy plugin validate assets/omarchy`, qmltestrunner line (all from Global Constraints), then `git diff --check`.
+Expected: 0 failed; the three new tests print PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add assets/omarchy/CoreView.js tests/qml/tst_ProviderStates.qml
+git commit -m "feat: plan windows outrank free in election"
+```
+
+---
+
+### Task 3: Chip renders the elected lead window
+
+**Files:**
+- Modify: `assets/omarchy/CoreView.js` (`primaryWindow` `:91-95` deleted, `chipPercentText` `:97-106` rewritten)
+- Test: `tests/qml/tst_BarWidget.qml` (after `test_used_versus_remaining_metric`), `tests/qml/tst_Popup.qml` (`test_primary_window_allowlist_is_gone`)
+
+**Interfaces:**
+- Consumes: `windowDisplayLines(provider, metric, nowMs)` and `electLeadIndex(lines)` from Task 2. `windowDisplayLines` already handles array-like QVariantList windows and non-finite percentages (`percentText` falls back to `\u2014`).
+- Produces: `chipPercentText(provider, metric)` returns the elected lead's `percentText`. `chipNumeralText` and `chipAccessibleLabel` compose it unchanged. `primaryWindow` no longer exists anywhere in the plugin.
+
+- [ ] **Step 1: Write the failing chip test**
+
+Add to `tests/qml/tst_BarWidget.qml` after `test_used_versus_remaining_metric`:
+
+```qml
+  // UX-002 (amended 2026-08-07): the chip shows the elected lead window —
+  // for a subscriber that is the subscription bucket, not windows[0]
+  // (Amp Free), even though the free window has the nearer reset.
+  function test_chip_shows_elected_lead_for_subscriber() {
+    var p = {
+      id: "amp",
+      name: "Amp",
+      state: "ready",
+      windows: [
+        { id: "daily", label: "Daily (1d)", usedPercent: 31, remainingPercent: 69,
+          resetsAt: "2099-01-01T00:00:00Z" },
+        { id: "plan-other", label: "Plan · agent", usedPercent: 8, remainingPercent: 92 },
+        { id: "plan-orb", label: "Plan · orbs", usedPercent: 0, remainingPercent: 100 }
+      ]
+    }
+    compare(Core.chipPercentText(p, "remaining"), "92%")
+    compare(Core.chipPercentText(p, "used"), "8%")
+  }
+```
+
+- [ ] **Step 2: Extend the dead-identifier guard**
+
+In `tests/qml/tst_Popup.qml`, `test_primary_window_allowlist_is_gone`, after the `windowGroups` verify:
+
+```qml
+    verify(core.indexOf("primaryWindow") < 0,
+           "primaryWindow is replaced by the elected lead window")
+```
+
+- [ ] **Step 3: Run the QML tests to verify both fail**
+
+Run the qmltestrunner line.
+Expected: `test_chip_shows_elected_lead_for_subscriber` FAILS (`69%` vs `92%`) and `test_primary_window_allowlist_is_gone` FAILS (identifier still present). Everything else passes.
+
+- [ ] **Step 4: Rewrite the chip source and delete `primaryWindow`**
+
+In `assets/omarchy/CoreView.js`, delete the `primaryWindow` function (`:91-95`) and replace `chipPercentText`:
+
+```js
+// UX-002 / UX-032A (amended 2026-08-07): the chip renders the elected lead
+// window's used|remaining percent — the same election the popup runs — or an
+// em-dash when there is no window. Chip and popup can never disagree on
+// which window a number belongs to.
+function chipPercentText(provider, metric) {
+  var lines = windowDisplayLines(provider, metric, undefined)
+  var lead = electLeadIndex(lines)
+  if (lead < 0)
+    return "\u2014"
+  return lines[lead].percentText
+}
+```
+
+Hand-trace: `primaryWindow` had exactly one caller (`chipPercentText`, verified by `rg -n "primaryWindow" assets tests` before deleting). `chipAccessibleLabel` (`:253`) and `chipNumeralText` (`:235`) call `chipPercentText` and need no edit.
+
+- [ ] **Step 5: Run the QML gates**
+
+Run: qmllint line, `omarchy plugin validate assets/omarchy`, qmltestrunner line, `git diff --check`.
+Expected: 0 failed. Pre-existing chip tests (`test_empty_windows_render_em_dash`, `test_used_versus_remaining_metric`, `test_array_like_windows_render_percent`) still pass: a single window elects itself and empty windows yield `lead < 0`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add assets/omarchy/CoreView.js tests/qml/tst_BarWidget.qml tests/qml/tst_Popup.qml
+git commit -m "feat: chip renders elected lead window"
+```
+
+---
+
+### Task 4: Amend UX-002 and UX-020D
+
+**Files:**
+- Modify: `docs/specs/v10/04-quickshell-ux-and-accessibility.md:13-14` (`UX-002`), `:78-84` (`UX-020D`)
+
+**Interfaces:**
+- Consumes: the behavior shipped by Tasks 2–3.
+- Produces: the product contract Tasks 2–3 already conform to; no code reads this file.
+
+- [ ] **Step 1: Amend `UX-002`**
+
+Replace lines 13–14:
+
+```markdown
+- `UX-002`: A chip contains the provider icon and the configured used or
+  remaining percentage of the elected lead window (per `UX-020D`), so the
+  chip and the popup always name the same number.
+```
+
+- [ ] **Step 2: Amend `UX-020D`**
+
+Replace the requirement so the election reads:
+
+```markdown
+- `UX-020D`: The popup renders exactly one lead window, elected
+  deterministically: a critical window wins, and among criticals the one with
+  the lowest remaining percentage; otherwise a plan window (window id
+  starting `plan-`) wins, and among plan windows the one with the lowest
+  remaining percentage; otherwise the window whose reset comes soonest; ties
+  keep the delivered order; when no window has a future reset the first
+  delivered window leads. Every other window renders as a compact row in
+  delivered order. Reset times render as a countdown, in hours below 24
+  hours.
+```
+
+- [ ] **Step 3: Verify**
+
+Run: `git diff --check`
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/specs/v10/04-quickshell-ux-and-accessibility.md
+git commit -m "docs: amend UX-002/UX-020D for plan lead"
+```
+
+---
+
+## Final checkpoint (after Task 4)
+
+Run every gate from Global Constraints once more, end to end (Rust + QML). Also commit the approved design doc if the owner authorizes:
+
+```bash
+git add docs/superpowers/specs/2026-08-07-amp-subscription-lead-window-design.md \
+        docs/superpowers/plans/2026-08-07-amp-subscription-lead-window.md
+git commit -m "docs: amp subscription lead window design"
+```
+
+Live QA (only if the owner asks): with the plugin installed, a Megawatt account's Amp chip shows the subscription bucket percentage and the popup leads with `Plan · agent`, with `Daily (1d)` as a compact row keeping its countdown.

--- a/docs/superpowers/specs/2026-08-07-amp-subscription-lead-window-design.md
+++ b/docs/superpowers/specs/2026-08-07-amp-subscription-lead-window-design.md
@@ -1,0 +1,115 @@
+# Amp subscription: adaptive lead window
+
+Status: approved 2026-08-07. Scope: `electLeadIndex`/chip source in
+`CoreView.js`, two label strings in `v2_map.rs`, two spec amendments. No
+status-schema change, no new setting.
+
+## Problem
+
+Amp accounts now carry up to three quota surfaces at once (measured live on
+this machine, 2026-08-07, `amp usage` on a Megawatt account):
+
+```
+Amp Free: 69% remaining today (resets daily) - https://ampcode.com/settings#amp-free
+Subscription Megawatt: 100% other usage and 100% orb usage remaining
+Individual credits: $4.19 remaining (replenishes automatically) - https://ampcode.com/settings
+```
+
+- **Amp Free** — a daily allowance, closed to new signups but alive on
+  existing accounts, consumed *before* subscription usage. Resets daily.
+- **Subscription** (beta, 2026-07-18) — Megawatt ($20/mo) or Gigawatt
+  ($200/mo). Two buckets: `other usage` is the included agent usage and `orb
+  usage` is the included orb-hours. Monthly reset; the CLI exposes no
+  timestamp. `amp usage` text is the only interface — there is no JSON flag.
+- **Individual credits** — monetary; excluded by product rule (v10 removes
+  monetary data) and by JSON-022B. Stays excluded.
+
+The parser already emits the plan badge and the `plan-other`/`plan-orb`
+windows. The display does not follow: the chip renders `windows[0]`
+(`primaryWindow`), which is always the Amp Free daily window, and the popup's
+election (`UX-020D`) prefers the nearest future reset — plan windows carry no
+`resetsAt`, so Amp Free leads even at 5% subscription remaining. A subscriber
+never sees the thing they pay for without opening the popup and reading the
+compact rows.
+
+## Decisions
+
+| # | Decision | Rejected alternative |
+| --- | --- | --- |
+| 1 | Election gains one rule between critical and nearest-reset: plan windows (id prefix `plan-`) outrank non-plan windows; among plan windows the lowest remaining percentage leads. | Always leading with the agent bucket — burning orb-hours would stay invisible. |
+| 2 | The chip renders the elected lead window, not `windows[0]`. Chip and popup can never disagree on which window a number belongs to. | Reordering windows in Rust — it cannot fix the popup (nearest-reset still elects Amp Free) and braids display policy into a pure parser. |
+| 3 | Free-only accounts are byte-identical to today: with no plan window, rules 1 and 3–4 reproduce the current election exactly. | A settings toggle — adaptive needs no configuration surface. |
+| 4 | Labels become `Plan · agent` and `Plan · orbs`. Window ids stay `plan-other`/`plan-orb`. | Keeping the CLI's word `other`, which explains nothing; renaming ids, which churns tests for no user-visible gain. |
+| 5 | Plan windows keep `resetsAt: null`. No countdown renders for them. | Synthesizing a monthly reset timestamp the CLI does not expose — falso-preciso. |
+
+The critical rule stays first on purpose: an exhausted Amp Free window (≥95%
+used) still takes the lead over a healthy subscription. Severity is the one
+signal that must never be displaced by plan preference.
+
+## Election contract (amended UX-020D)
+
+1. A critical window wins; among criticals, the lowest remaining percentage.
+2. Otherwise a plan window (window id starting `plan-`) wins; among plan
+   windows, the lowest remaining percentage.
+3. Otherwise the window whose reset comes soonest; a missing or elapsed
+   timestamp does not compete.
+4. Otherwise the first delivered window.
+
+Ties keep the delivered order at every step. Every other window renders as a
+compact row in delivered order — for a subscriber that is where Amp Free
+lives, countdown intact.
+
+The `plan-` prefix is typed schema data — window ids reach QML through the
+frozen v2 schema, already sanitized by the Rust mappers — so QML matching on
+it does not violate the "QML never parses raw provider output" rule. Today
+only the Amp mapper emits `plan-` ids (`plan-other`, `plan-orb`). Grok and
+Codex derive some ids from payload enum values (`grok_window_identity`,
+`codex_window_identity`), so a novel upstream value could in principle start
+with `plan-`; the consequence is only lead preference among that provider's
+own windows, which is the intended meaning of the prefix, not a safety
+concern.
+
+## Chip contract (amended UX-002)
+
+`chipPercentText` reads the elected lead window via the same election the
+popup uses, instead of `primaryWindow(provider)`. `chipAccessibleLabel` and
+`chipNumeralText` follow for free since they compose `chipPercentText`.
+`primaryWindow` loses its last caller and is deleted, not left dormant.
+
+Chip severity (`chipSeverityUrgent`) keeps reading the *worst* window,
+independent of the displayed one — unchanged.
+
+## Rust change
+
+`amp_from_usage_text` label constants only: `Plan · other` → `Plan · agent`,
+`Plan · orb` → `Plan · orbs`. Emission order, ids, percentages, plan badge,
+and the credits exclusion are untouched.
+
+## Contract amendments
+
+`docs/specs/v10/04-quickshell-ux-and-accessibility.md`:
+
+- `UX-002` gains: the percentage is the elected lead window's (per
+  `UX-020D`), so chip and popup always name the same number.
+- `UX-020D` gains the plan-window rule as step 2 (wording above).
+
+## Tests
+
+- QML (`tst_Format`/`tst_ProviderStates`, direct JS calls): healthy
+  subscriber → plan window leads; free critical + plan healthy → free leads;
+  plan critical → lowest-remaining critical leads; free-only → today's
+  election, byte-identical; two plan windows → lowest remaining leads.
+- QML (`tst_BarWidget`): subscriber chip shows the plan percentage; free-only
+  chip unchanged.
+- Rust (`v2_map` tests): the two new labels; existing subscription fixture
+  already matches the live CLI format (verified against a real Megawatt
+  account).
+- Text guard: `primaryWindow` banned as a dead identifier after deletion.
+
+## Out of scope
+
+- Credits/monetary lines: still never parsed into windows (JSON-022B, v10
+  product boundary).
+- Workspace credit pools: no fixture exists; the parser's behavior on unknown
+  lines (ignore) is already correct.
+- Any new settings, schema fields, or notification changes.

--- a/src/providers/v2_map.rs
+++ b/src/providers/v2_map.rs
@@ -76,6 +76,8 @@ pub fn amp_from_usage_text(stdout: &str, now: OffsetDateTime) -> ProviderResult 
     // "orb usage" = included orb-hours allowance; "other usage" = included agent
     // usage. The plan name doubles as the Plan badge. The "Individual credits: $"
     // line is monetary and intentionally never parsed into a window (JSON-022B).
+    // Labels render the meaning, not the CLI word: "other" is included agent
+    // usage, "orb" is included orb-hours (design 2026-08-07).
     let mut plan = None;
     if let Some(caps) = Regex::new(
         r"Subscription\s+(\S+):\s*([0-9.]+)%\s*other usage and\s*([0-9.]+)%\s*orb usage remaining",
@@ -90,8 +92,8 @@ pub fn amp_from_usage_text(stdout: &str, now: OffsetDateTime) -> ProviderResult 
             });
         }
         for (idx, id, label) in [
-            (2usize, "plan-other", "Plan · other"),
-            (3usize, "plan-orb", "Plan · orb"),
+            (2usize, "plan-other", "Plan · agent"),
+            (3usize, "plan-orb", "Plan · orbs"),
         ] {
             if let Some(rem) = caps.get(idx).and_then(|m| m.as_str().parse::<f64>().ok()) {
                 let rem = rem.clamp(0.0, 100.0);
@@ -876,10 +878,10 @@ mod tests {
             ProviderResult::Ready { windows, plan, .. } => {
                 let ids: Vec<&str> = windows.iter().map(|w| w.id()).collect();
                 assert_eq!(ids, vec!["daily", "plan-other", "plan-orb"]);
-                assert_eq!(windows[1].label(), "Plan · other");
+                assert_eq!(windows[1].label(), "Plan · agent");
                 assert!((windows[1].remaining_percent() - 92.0).abs() < 0.01);
                 assert!((windows[1].used_percent() - 8.0).abs() < 0.01);
-                assert_eq!(windows[2].label(), "Plan · orb");
+                assert_eq!(windows[2].label(), "Plan · orbs");
                 assert!((windows[2].remaining_percent() - 100.0).abs() < 0.01);
                 // Amp exposes no subscription reset timestamp ("monthly" only).
                 assert!(windows[1].resets_at().is_none());

--- a/tests/qml/tst_BarWidget.qml
+++ b/tests/qml/tst_BarWidget.qml
@@ -499,7 +499,7 @@ TestCase {
            "the chip must not reference the host tooltip property")
   }
 
-  function test_source_guard_no_process_timer_shell() {
+  function test_source_guard_no_process_or_shell() {
     var files = [widgetUrl, chipUrl]
     for (var i = 0; i < files.length; i++) {
       var xhr = new XMLHttpRequest()
@@ -511,10 +511,16 @@ TestCase {
       // Strip line comments then re-check forbidden owners.
       var code = src.replace(/\/\/[^\n]*/g, "")
       verify(code.indexOf("Process") < 0, files[i] + " must not own Process")
-      verify(code.indexOf("Timer") < 0, files[i] + " must not own Timer")
+      if (files[i] === chipUrl)
+        verify(code.indexOf("Timer") < 0, files[i] + " must not own Timer")
       verify(src.indexOf("bash -lc") < 0, files[i])
       verify(src.indexOf("sh -c") < 0, files[i])
     }
+
+    var widget = sourceAt(widgetUrl)
+    verify(widget.indexOf("interval: 30000") >= 0)
+    verify(widget.indexOf("onTriggered: root.nowMs = Date.now()") >= 0)
+    verify(widget.indexOf("root.displayMetric, root.nowMs") >= 0)
   }
 
   function test_source_chip_is_widgetbutton_no_wheel() {

--- a/tests/qml/tst_BarWidget.qml
+++ b/tests/qml/tst_BarWidget.qml
@@ -225,6 +225,25 @@ TestCase {
     compare(Core.displayMetric(null), "remaining")
   }
 
+  // UX-002 (amended 2026-08-07): the chip shows the elected lead window —
+  // for a subscriber that is the subscription bucket, not windows[0]
+  // (Amp Free), even though the free window has the nearer reset.
+  function test_chip_shows_elected_lead_for_subscriber() {
+    var p = {
+      id: "amp",
+      name: "Amp",
+      state: "ready",
+      windows: [
+        { id: "daily", label: "Daily (1d)", usedPercent: 31, remainingPercent: 69,
+          resetsAt: "2099-01-01T00:00:00Z" },
+        { id: "plan-other", label: "Plan · agent", usedPercent: 8, remainingPercent: 92 },
+        { id: "plan-orb", label: "Plan · orbs", usedPercent: 0, remainingPercent: 100 }
+      ]
+    }
+    compare(Core.chipPercentText(p, "remaining"), "92%")
+    compare(Core.chipPercentText(p, "used"), "8%")
+  }
+
   // Live Quattro: snapshot windows arrive as array-like QVariantList where
   // Array.isArray is false but .length / [0] still work (chips stuck on "—").
   function test_array_like_windows_render_percent() {

--- a/tests/qml/tst_Popup.qml
+++ b/tests/qml/tst_Popup.qml
@@ -297,13 +297,39 @@ TestCase {
   // reference to a deleted function is invisible to them. These guards ban the
   // exact dead identifiers by name.
   function test_primary_window_allowlist_is_gone() {
+    var files = [
+      "assets/omarchy/BarWidget.qml",
+      "assets/omarchy/components/ConfirmDialog.qml",
+      "assets/omarchy/components/FocusController.qml",
+      "assets/omarchy/components/HeaderTag.qml",
+      "assets/omarchy/components/ProviderChip.qml",
+      "assets/omarchy/components/ProviderHeader.qml",
+      "assets/omarchy/components/SettingsProviderRow.qml",
+      "assets/omarchy/components/StateMessage.qml",
+      "assets/omarchy/components/UsageWindow.qml",
+      "assets/omarchy/CoreMaintenance.js",
+      "assets/omarchy/CoreScroll.js",
+      "assets/omarchy/CoreService.js",
+      "assets/omarchy/CoreSettings.js",
+      "assets/omarchy/CoreView.js",
+      "assets/omarchy/MaintenanceView.qml",
+      "assets/omarchy/Popup.qml",
+      "assets/omarchy/ProviderRail.qml",
+      "assets/omarchy/ProviderView.qml",
+      "assets/omarchy/Service.qml",
+      "assets/omarchy/SettingsView.qml"
+    ]
+    for (var i = 0; i < files.length; i++) {
+      var source = read(files[i])
+      verify(source.indexOf("primaryWindow") < 0,
+             files[i] + " still references the deleted lead selector")
+    }
+
     var core = read("assets/omarchy/CoreView.js")
     verify(core.indexOf("PRIMARY_WINDOW_IDS") < 0,
            "the id allowlist must be deleted, not left dormant")
     verify(core.indexOf("windowGroups") < 0,
            "windowGroups is replaced by windowLayout")
-    verify(core.indexOf("primaryWindow") < 0,
-           "primaryWindow is replaced by the elected lead window")
     verify(core.indexOf("function electLeadIndex") >= 0)
     var view = read("assets/omarchy/ProviderView.qml")
     verify(view.indexOf("groups.primary") < 0)

--- a/tests/qml/tst_Popup.qml
+++ b/tests/qml/tst_Popup.qml
@@ -302,6 +302,8 @@ TestCase {
            "the id allowlist must be deleted, not left dormant")
     verify(core.indexOf("windowGroups") < 0,
            "windowGroups is replaced by windowLayout")
+    verify(core.indexOf("primaryWindow") < 0,
+           "primaryWindow is replaced by the elected lead window")
     verify(core.indexOf("function electLeadIndex") >= 0)
     var view = read("assets/omarchy/ProviderView.qml")
     verify(view.indexOf("groups.primary") < 0)

--- a/tests/qml/tst_ProviderStates.qml
+++ b/tests/qml/tst_ProviderStates.qml
@@ -259,6 +259,16 @@ TestCase {
     compare(layout.lead.id, "plan-orb")
   }
 
+  function test_lead_election_equal_plan_remaining_keeps_delivered_order() {
+    var layout = layoutOf([
+      { id: "plan-other", label: "Plan · agent", usedPercent: 20, remainingPercent: 80,
+        resetsAt: null },
+      { id: "plan-orb", label: "Plan · orbs", usedPercent: 20, remainingPercent: 80,
+        resetsAt: null }
+    ], "2026-08-07T15:00:00Z")
+    compare(layout.lead.id, "plan-other")
+  }
+
   // A critical plan window leads through rule 1 (severity), not rule 2 —
   // same lead either way, but the severity tag must say Critical.
   function test_lead_election_critical_plan_leads_by_severity() {
@@ -330,6 +340,22 @@ TestCase {
         resetsAt: "2026-07-28T18:00:00Z" }
     ], "2026-07-28T15:00:00Z")
     compare(layout.lead.id, "first")
+  }
+
+  function test_chip_and_popup_re_elect_after_lead_reset() {
+    var provider = readyWith([
+      { id: "a", label: "A", usedPercent: 25, remainingPercent: 75,
+        resetsAt: "2026-08-07T15:30:00Z" },
+      { id: "b", label: "B", usedPercent: 40, remainingPercent: 60,
+        resetsAt: "2026-08-07T16:30:00Z" }
+    ])
+    var beforeReset = Date.parse("2026-08-07T15:00:00Z")
+    var afterReset = Date.parse("2026-08-07T15:45:00Z")
+
+    compare(Core.chipPercentText(provider, "remaining", beforeReset), "75%")
+    compare(Core.windowLayout(provider, "remaining", beforeReset).lead.id, "a")
+    compare(Core.chipPercentText(provider, "remaining", afterReset), "60%")
+    compare(Core.windowLayout(provider, "remaining", afterReset).lead.id, "b")
   }
 
   function test_single_window_leads_with_no_rest() {

--- a/tests/qml/tst_ProviderStates.qml
+++ b/tests/qml/tst_ProviderStates.qml
@@ -230,6 +230,63 @@ TestCase {
     compare(layout.lead.id, "b")
   }
 
+  // UX-020D step 2 (amended 2026-08-07): plan windows outrank non-plan
+  // windows when nothing is critical, so a subscriber leads with the
+  // subscription instead of the daily free window's nearer reset.
+  function test_lead_election_plan_beats_nearest_reset() {
+    var layout = layoutOf([
+      { id: "daily", label: "Daily (1d)", usedPercent: 31, remainingPercent: 69,
+        resetsAt: "2026-08-08T00:00:00Z" },
+      { id: "plan-other", label: "Plan · agent", usedPercent: 8, remainingPercent: 92,
+        resetsAt: null },
+      { id: "plan-orb", label: "Plan · orbs", usedPercent: 0, remainingPercent: 100,
+        resetsAt: null }
+    ], "2026-08-07T15:00:00Z")
+    compare(layout.lead.id, "plan-other")
+    // The rest keeps delivered order: free first, then the healthier bucket.
+    compare(layout.rest.length, 2)
+    compare(layout.rest[0].id, "daily")
+    compare(layout.rest[1].id, "plan-orb")
+  }
+
+  function test_lead_election_lowest_remaining_among_plan_windows() {
+    var layout = layoutOf([
+      { id: "plan-other", label: "Plan · agent", usedPercent: 20, remainingPercent: 80,
+        resetsAt: null },
+      { id: "plan-orb", label: "Plan · orbs", usedPercent: 65, remainingPercent: 35,
+        resetsAt: null }
+    ], "2026-08-07T15:00:00Z")
+    compare(layout.lead.id, "plan-orb")
+  }
+
+  // A critical plan window leads through rule 1 (severity), not rule 2 —
+  // same lead either way, but the severity tag must say Critical.
+  function test_lead_election_critical_plan_leads_by_severity() {
+    var layout = layoutOf([
+      { id: "daily", label: "Daily (1d)", usedPercent: 31, remainingPercent: 69,
+        resetsAt: "2026-08-08T00:00:00Z" },
+      { id: "plan-other", label: "Plan · agent", usedPercent: 97, remainingPercent: 3,
+        resetsAt: null },
+      { id: "plan-orb", label: "Plan · orbs", usedPercent: 0, remainingPercent: 100,
+        resetsAt: null }
+    ], "2026-08-07T15:00:00Z")
+    compare(layout.lead.id, "plan-other")
+    compare(layout.lead.severity, "critical")
+  }
+
+  // Severity is the one signal plan preference never displaces: an exhausted
+  // free window still takes the lead over a healthy subscription.
+  function test_lead_election_critical_free_beats_healthy_plan() {
+    var layout = layoutOf([
+      { id: "daily", label: "Daily (1d)", usedPercent: 96, remainingPercent: 4,
+        resetsAt: "2026-08-08T00:00:00Z" },
+      { id: "plan-other", label: "Plan · agent", usedPercent: 8, remainingPercent: 92,
+        resetsAt: null }
+    ], "2026-08-07T15:00:00Z")
+    compare(layout.lead.id, "daily")
+    compare(layout.lead.severity, "critical")
+  }
+
   function test_lead_election_nearest_future_reset_when_healthy() {
     var layout = layoutOf([
       { id: "weekly", label: "Weekly (7d)", usedPercent: 40, remainingPercent: 60,


### PR DESCRIPTION
## Summary

Amp accounts now carry a daily free allowance and monthly subscription buckets at once, but the chip and popup always led with the Amp Free daily window. Subscribers never saw the thing they pay for without opening the popup.

- `electLeadIndex` gains one rule between critical and nearest-reset: plan windows (id prefix `plan-`) outrank non-plan windows, lowest remaining first (UX-020D amended)
- The bar chip renders the elected lead window instead of `windows[0]`; `primaryWindow` is deleted with a production-wide dead-identifier guard (UX-002 amended)
- Chip election shares the popup's reactive 30s clock so both surfaces always name the same number
- Amp mapper labels renamed: `Plan · other` → `Plan · agent`, `Plan · orb` → `Plan · orbs` (ids unchanged)
- Free-only accounts behave byte-identically to before

Approved design: `docs/superpowers/specs/2026-08-07-amp-subscription-lead-window-design.md`

## Tests

- Rust: full suite green (`cargo fmt --check`, `cargo test`, `cargo clippy -D warnings`)
- QML: 251 passed / 0 failed (Qt 6 qmltestrunner), qmllint, `omarchy plugin validate`
- New election tests: plan beats nearest reset, lowest remaining among plans, equal-remaining tie keeps delivered order, critical free/plan still leads by severity, chip/popup elect the same window across a reset boundary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Provider chips and popups now consistently display the most relevant subscription window.
  * Critical windows take priority, followed by plan windows and upcoming resets.
  * Displays refresh automatically as subscription windows approach their reset times.
  * Updated Amp labels for plan-based usage categories.

* **Bug Fixes**
  * Corrected chip percentages when the first subscription window is not the active lead window.
  * Lead-window selection now re-evaluates after a window resets.

* **Documentation**
  * Added and updated specifications for subscription lead-window behavior and accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->