### PR TITLE
feat: stop marking stale as a fault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- A provider whose refresh fails no longer looks broken. Its last good
+  reading stays on the bar at full strength — same opacity, same severity
+  colour, no clock glyph — and the popup drops the urgent banner in favour of
+  one neutral `Updated <age>` caption. Waking a machine after hours away used
+  to dim every icon and raise an alert for one poll interval, because an
+  expired Claude token counts as a refresh failure even though the displayed
+  numbers were still the correct last reading. The status JSON is unchanged:
+  `agent-bar status` still reports `"state": "stale"` with its typed error.
 - Distribution is entirely git-native: install with `omarchy plugin add
   https://github.com/othavi0/omarchy-agent-bar.git`, update with
   `omarchy plugin update agent-bar.usage`, and remove with

--- a/README.md
+++ b/README.md
@@ -16,9 +16,10 @@ usage track.
 
 Windows are normalized across providers, so Claude's `Session (5h)`,
 `Weekly (7d)`, and per-model windows render the same way Codex's do.
-A chip shows `!` when a provider crosses the critical threshold and an
-hourglass when its data is stale. A connected provider with no
-percentage window is valid and shows `—`.
+A chip shows `!` when a provider crosses the critical threshold. When a
+refresh fails, the last good reading stays on the bar unchanged — the
+popup notes when it was taken and nothing is marked as broken. A
+connected provider with no percentage window is valid and shows `—`.
 
 When a provider needs attention, the popup offers a safe action:
 opening the login in a terminal, installation guidance, or a retry.

--- a/assets/omarchy/CoreView.js
+++ b/assets/omarchy/CoreView.js
@@ -160,27 +160,37 @@ function providerSeverity(provider) {
   return worst
 }
 
-// Severity tints the bar only for a ready provider: any other state already
-// dims the whole chip and spends the cue on the state itself, so an urgent
-// tint there would mean two things at once. Approved mockup: critical Claude
-// is urgent, disconnected Grok is not.
+// UX-028 (amended): a stale provider holds a real reading that the helper
+// retained through a failed refresh, so the bar renders it exactly like a
+// ready one. `presentsReading` is the single place that decides which states
+// own a number worth showing; everything below asks it instead of testing
+// `=== "ready"` on its own, so the bar can never disagree with itself.
+function presentsReading(state) {
+  var s = String(state || "")
+  return s === "ready" || s === "stale"
+}
+
+// Severity tints the bar for any provider presenting a reading: the remaining
+// states dim the whole chip and spend the cue on the state itself, so an
+// urgent tint there would mean two things at once. Approved mockup: critical
+// Claude is urgent, disconnected Grok is not. A retained reading keeps its
+// severity — UsageWindow already paints a critical stale window urgent, and
+// suppressing it here would make bar and popup contradict each other.
 function chipSeverityUrgent(provider) {
   if (!provider)
     return false
-  return String(provider.state || "") === "ready"
+  return presentsReading(provider.state)
       && providerSeverity(provider) === "critical"
 }
 
-// UX-012: text cue beyond color for stale/error. No leading space — the
-// chip separates cue from numeral with layout spacing (visual design §5).
-// 󰅐 is U+F0150 from the bar's Nerd Font family, replacing the old
-// emoji-font hourglass glyph that broke the monospace surface.
+// UX-012 (amended): text cue beyond color for error states. No leading space
+// — the chip separates cue from numeral with layout spacing (visual design
+// §5). Stale is deliberately absent: it is retained data, not a fault, and
+// marking it made a woken machine look broken for one poll interval.
 function chipStateCue(provider) {
   if (!provider)
     return ""
   var state = String(provider.state || "")
-  if (state === "stale")
-    return "󰅐"
   if (ERROR_STATES[state])
     return "!"
   if (chipSeverityUrgent(provider))
@@ -190,14 +200,16 @@ function chipStateCue(provider) {
 
 // Plan 02 deferred minor: the cue exposed its raw glyph to screen readers.
 // It now carries a word — the severity when severity produced the cue,
-// otherwise the same qualifier the tooltip already speaks.
+// otherwise the same qualifier the tooltip already speaks. Stale produces no
+// cue, so it contributes no word either (A11Y-012 parity: assistive tech
+// hears what the eye sees, never more).
 function chipCueLabel(provider) {
   if (!provider)
     return ""
   if (chipSeverityUrgent(provider))
     return "critical"
   var state = String(provider.state || "")
-  if (state === "stale" || ERROR_STATES[state])
+  if (ERROR_STATES[state])
     return stateQualifier(state)
   return ""
 }
@@ -232,18 +244,22 @@ function chipNumeralText(provider, metric, nowMs) {
   return chipPercentText(provider, metric, nowMs)
 }
 
+// Dimming means "no number to trust here" — missing CLI (PROD-022/UX-029),
+// the error states, and the loading placeholder. Stale is excluded: it has a
+// number, so it renders at full strength like ready.
 function chipDimmed(provider) {
   if (!provider)
     return true
-  var state = String(provider.state || "")
-  return state !== "ready"
+  return !presentsReading(provider.state)
 }
 
 // UX-011 (superseded 2026-08-06): the chip renders no hover tooltip. The
 // former tooltip's first line survives as the chip's accessible name — the
 // provider, the displayed percentage when one exists, and a plain-language
-// qualifier when not ready. The raw enum value never renders (copy design
-// §5.4). Single-line by construction: no window detail, no live clock.
+// qualifier when the provider presents no reading. The raw enum value never
+// renders (copy design §5.4). Single-line by construction: no window detail,
+// no live clock. A stale chip is visually identical to a ready one, so it
+// reads identically too (A11Y-012).
 function chipAccessibleLabel(provider, metric, nowMs) {
   if (!provider)
     return ""
@@ -251,11 +267,13 @@ function chipAccessibleLabel(provider, metric, nowMs) {
   var parts = [name]
   var state = provider.state ? String(provider.state) : "unknown"
   var pct = chipPercentText(provider, metric, nowMs)
-  if (pct !== "—" || state === "ready")
+  if (pct !== "—" || presentsReading(state))
     parts.push(pct)
-  var qualifier = stateQualifier(state)
-  if (qualifier.length)
-    parts.push(qualifier)
+  if (!presentsReading(state)) {
+    var qualifier = stateQualifier(state)
+    if (qualifier.length)
+      parts.push(qualifier)
+  }
   return parts.join(" · ")
 }
 
@@ -383,11 +401,13 @@ function stateTitle(provider) {
     return ""
   var name = plainText(provider.name || providerDisplayName(provider.id))
   var s = String(provider.state || "")
-  if (s === "loading" || s === "stale")
+  if (s === "loading")
     return ""
-  if (s === "ready" && (!provider.windows || provider.windows.length === 0))
+  // Stale walks the ready branch: a retained empty reading still means the
+  // account reports no quota, not that something failed.
+  if (presentsReading(s) && (!provider.windows || provider.windows.length === 0))
     return name + " reports no quota"
-  if (s === "ready")
+  if (presentsReading(s))
     return ""
   if (s === "cli_missing")
     return name + " CLI is not installed"
@@ -407,10 +427,14 @@ function stateBody(provider) {
     return ""
   var name = plainText(provider.name || providerDisplayName(provider.id))
   var s = String(provider.state || "")
-  if (s === "loading" || s === "stale")
+  if (s === "loading")
     return ""
-  if (s === "ready" && (!provider.windows || provider.windows.length === 0))
+  if (presentsReading(s) && (!provider.windows || provider.windows.length === 0))
     return emptyWindowsMessage()
+  // Reached only by the states with no reading: a stale provider carries a
+  // retryable error in JSON, but the pane must never surface it as a fault.
+  if (presentsReading(s))
+    return ""
   var err = errorMessage(provider)
   if (err.length)
     return err
@@ -441,6 +465,13 @@ function stateActions(provider) {
   if (!provider)
     return out
   var state = String(provider.state || "")
+  // UX-028 (amended): a provider presenting a reading offers no recovery
+  // action. Stale still carries `action: retry` in JSON — the helper's
+  // contract — but surfacing it would put a repair button next to a perfectly
+  // good number, which is the fault impression this pane exists to avoid. The
+  // header's refresh control remains available in every state.
+  if (presentsReading(state))
+    return out
   var seen = {}
 
   function pushAction(kind, label, target) {
@@ -460,7 +491,7 @@ function stateActions(provider) {
 
   if (state === "cli_missing")
     pushAction("retry", "Check again", null)
-  if (state === "stale" || state === "rate_limited" || state === "network_error" || state === "provider_error")
+  if (state === "rate_limited" || state === "network_error" || state === "provider_error")
     pushAction("retry", "Retry", null)
   if (state === "unauthenticated" && !seen.login && !seen.view_installation)
     pushAction("login", "Sign in", null)
@@ -700,34 +731,31 @@ function headerModel(provider, refreshing) {
       name: "",
       plan: "",
       lastSuccessAt: null,
-      refreshing: !!refreshing,
-      showStale: false
+      refreshing: !!refreshing
     }
   }
   return {
     name: plainText(provider.name || providerDisplayName(provider.id)),
     plan: plainText(planBadge(provider)),
     lastSuccessAt: provider.lastSuccessAt ? String(provider.lastSuccessAt) : null,
-    refreshing: !!refreshing,
-    showStale: String(provider.state) === "stale"
+    refreshing: !!refreshing
   }
 }
 
+// UX-028 (amended): stale shares the ready path — the dedicated
+// "stale_windows" mode is gone, so a retained reading draws the same pane a
+// fresh one would. Its age is the only difference, and ProviderView carries
+// that as one neutral line.
 function contentMode(provider) {
   if (!provider)
     return "skeleton"
   var s = String(provider.state || "")
   if (s === "loading")
     return "skeleton"
-  if (s === "ready") {
+  if (presentsReading(s)) {
     if (!provider.windows || provider.windows.length === 0)
       return "empty_windows"
     return "windows"
-  }
-  if (s === "stale") {
-    if (provider.windows && provider.windows.length > 0)
-      return "stale_windows"
-    return "state"
   }
   return "state"
 }

--- a/assets/omarchy/ProviderView.qml
+++ b/assets/omarchy/ProviderView.qml
@@ -5,10 +5,11 @@ import "CoreView.js" as Core
 import "components"
 
 // Single selected-provider content pane, visual design §3.4/§8:
-// header -> [stale banner] -> lead window (large) -> compact rows
-// -> state message (non-window, non-stale modes). Plan 03 removed the meta
-// footer; last-success age now lives in the stale banner and is otherwise
-// implied structurally (windows render only when ready).
+// header -> [age line] -> lead window (large) -> compact rows
+// -> state message (non-window modes). Plan 03 removed the meta footer;
+// last-success age now lives in one neutral caption shown while the reading
+// is retained (UX-028 amended). Staleness changes no colour, no opacity, and
+// no layout — only that caption's presence.
 Item {
   id: root
 
@@ -43,13 +44,16 @@ Item {
   readonly property var windows: Core.windowLayout(provider, displayMetric, nowMs)
   readonly property string severity: Core.providerSeverity(provider)
   readonly property var actions: Core.stateActions(provider)
-  // Adjusted (plan 03): was mode === "stale_windows" only, which fed the
-  // banner's Retry Repeater and left the no-windows stale mode ("state")
-  // without a Retry control. Both stale modes share one provider.state
-  // check; dimmed: root.isStale on the windows Column is unaffected since
-  // that Column is only visible in the "windows"/"stale_windows" modes,
-  // where state === "stale" iff mode === "stale_windows" anyway.
-  readonly property bool isStale: String(root.provider && root.provider.state || "") === "stale"
+  // UX-028 (amended): staleness is reported as a fact, never as a fault. The
+  // pane states when the reading was taken and stops there — no glyph, no
+  // urgent colour, no error text, no Retry (the header's own refresh control
+  // already covers the action).
+  readonly property bool showsAge: String(root.provider && root.provider.state || "") === "stale"
+  readonly property string ageText: {
+    var age = Core.formatAgoText(
+      root.header.lastSuccessAt ? root.header.lastSuccessAt : "", root.nowMs)
+    return age.length ? "Updated " + age : ""
+  }
   readonly property string unitText: root.displayMetric === "used" ? "used" : "left"
   readonly property color accentColor: Color.accent
 
@@ -67,7 +71,6 @@ Item {
       name: root.header.name
       plan: root.header.plan
       refreshing: root.header.refreshing
-      showStale: root.header.showStale
       severityText: Core.severityTagText(root.severity)
       severityUrgent: root.severity === "critical"
       foreground: root.foreground
@@ -83,67 +86,20 @@ Item {
       foreground: root.foreground
     }
 
-    // Stale banner (UX-028): carries last-success age + safe error + Retry.
-    // Never color-only (A11Y-012): glyph and words, urgent-tinted per the
-    // approved mockup.
-    Row {
-      visible: root.isStale
+    // Age line (UX-028 amended): one caption in the pane's own foreground at
+    // the same 0.72 alpha the header tags use. Plain statement of when the
+    // reading was taken — the eye reads it as metadata, not as an alert, and
+    // assistive tech hears exactly the same words (A11Y-012).
+    Text {
+      visible: root.showsAge && root.ageText.length > 0
       width: parent.width
-      spacing: Style.space(8)
-
-      Text {
-        text: "󰅐"
-        color: Color.urgent
-        font.family: root.fontFamily
-        font.pixelSize: Style.font.body
-        textFormat: Text.PlainText
-        Accessible.ignored: true
-      }
-      Text {
-        width: Math.max(0, parent.width - Style.space(120))
-        text: {
-          var age = Core.formatAgoText(
-            root.header.lastSuccessAt ? root.header.lastSuccessAt : "", root.nowMs)
-          var line = "Last data " + (age.length ? age : "unknown")
-          var err = Core.errorMessage(root.provider)
-          if (err.length)
-            line += " · " + err
-          return line
-        }
-        color: Color.urgent
-        font.family: root.fontFamily
-        font.pixelSize: Style.font.caption
-        wrapMode: Text.WordWrap
-        textFormat: Text.PlainText
-        Accessible.name: text
-      }
-      Repeater {
-        model: root.isStale ? root.actions : []
-        Text {
-          required property var modelData
-          visible: String(modelData.kind || "") === "retry"
-          text: modelData.label
-          color: root.foreground
-          font.family: root.fontFamily
-          font.pixelSize: Style.font.caption
-          font.underline: true
-          textFormat: Text.PlainText
-          Accessible.name: text
-          Accessible.role: Accessible.Button
-          Accessible.onPressAction: activate()
-          MouseArea {
-            anchors.fill: parent
-            cursorShape: Qt.PointingHandCursor
-            onClicked: parent.activate()
-          }
-          function activate() {
-            if (!root.provider)
-              return
-            root.actionRequested(String(root.provider.id),
-                                 String(modelData.kind || ""), modelData.target)
-          }
-        }
-      }
+      text: root.ageText
+      color: Util.alpha(root.foreground, 0.72)
+      font.family: root.fontFamily
+      font.pixelSize: Style.font.caption
+      wrapMode: Text.WordWrap
+      textFormat: Text.PlainText
+      Accessible.name: text
     }
 
     // §3.4/§8: one elected lead window rendered large, every other window as
@@ -152,7 +108,7 @@ Item {
     Column {
       width: parent.width
       spacing: Style.spacing.xxxl
-      visible: root.mode === "windows" || root.mode === "stale_windows"
+      visible: root.mode === "windows"
 
       Repeater {
         model: root.windows.lead ? [root.windows.lead] : []
@@ -173,7 +129,6 @@ Item {
           severity: modelData.severity ? modelData.severity : ""
           unitText: root.unitText
           emphasis: true
-          dimmed: root.isStale
           foreground: root.foreground
           accent: root.accentColor
           fontFamily: root.fontFamily
@@ -199,7 +154,6 @@ Item {
             severity: modelData.severity ? modelData.severity : ""
             unitText: root.unitText
             emphasis: false
-            dimmed: root.isStale
             foreground: root.foreground
             accent: root.accentColor
             fontFamily: root.fontFamily
@@ -221,8 +175,10 @@ Item {
 
     StateMessage {
       width: parent.width
-      visible: (root.mode === "skeleton" || root.mode === "empty_windows" || root.mode === "state")
-          && String(root.provider && root.provider.state || "") !== "stale"
+      // No stale exception is needed: contentMode routes stale through the
+      // ready branch, so it lands on "windows"/"empty_windows" like any other
+      // provider holding a reading.
+      visible: root.mode === "skeleton" || root.mode === "empty_windows" || root.mode === "state"
       skeleton: root.mode === "skeleton"
       title: root.mode === "skeleton" ? "" : Core.stateTitle(root.provider)
       body: root.mode === "skeleton" ? "" : Core.stateBody(root.provider)

--- a/assets/omarchy/components/ProviderHeader.qml
+++ b/assets/omarchy/components/ProviderHeader.qml
@@ -4,7 +4,7 @@ import qs.Ui
 
 // Provider content header — name, plan tag, severity tag, refresh only
 // (Fase 2 slim-down). Connection state is implied structurally (UX-017);
-// last-success age appears in the stale banner, not here.
+// last-success age appears in the pane's own age caption, not here.
 // UX-016: deliberately no provider icon here (icon lives only on the rail).
 Item {
   id: root
@@ -12,7 +12,6 @@ Item {
   property string name: ""
   property string plan: ""
   property bool refreshing: false
-  property bool showStale: false
   property string severityText: ""
   property bool severityUrgent: false
   property color foreground: Color.foreground

--- a/assets/omarchy/components/UsageWindow.qml
+++ b/assets/omarchy/components/UsageWindow.qml
@@ -36,11 +36,12 @@ Item {
   readonly property bool isCritical: root.severity === "critical"
   readonly property color valueColor: root.isCritical ? Color.urgent : root.foreground
   // Severity describes the numbers on screen, so it outranks dimming: a
-  // stale window still shows the last reading, and a critical last reading
-  // is still critical. Staleness is carried by the root opacity, the reduced
-  // fill opacity, and the stale banner — not by hiding the severity colour.
-  // valueColor and fillColor must agree on this; they disagreed once, and
-  // the numeral and its own track rendered two different verdicts.
+  // window still shows its reading, and a critical reading is still
+  // critical. valueColor and fillColor must agree on this; they disagreed
+  // once, and the numeral and its own track rendered two different verdicts.
+  // UX-028 (amended) retired the one caller that ever set `dimmed` — stale
+  // no longer dims anything. The property stays because it is the component's
+  // own low-emphasis mode, not a staleness signal; no caller sets it today.
   readonly property color fillColor: root.isCritical
       ? Color.urgent
       : (root.dimmed ? root.foreground : root.accent)

--- a/docs/specs/v10/01-product-contract.md
+++ b/docs/specs/v10/01-product-contract.md
@@ -77,7 +77,7 @@ Notifications: enabled
 2. Left-clicking a chip opens that provider in the consolidated popup.
 3. The popup shows plan, usage windows, reset times, and typed error/action
    state; connection state is implied structurally and the last-success age
-   appears in the stale banner.
+   appears as a neutral caption while a reading is retained (`UX-028`).
 4. Clicking the same chip closes the popup; clicking another chip switches
    provider without closing it.
 

--- a/docs/specs/v10/04-quickshell-ux-and-accessibility.md
+++ b/docs/specs/v10/04-quickshell-ux-and-accessibility.md
@@ -28,7 +28,10 @@ verified Quattro-native glyphs or explicit English text labels.
   ready — survives as the chip's accessible name. Raw state identifiers
   never render. Reset detail lives only in the popup. See
   `docs/superpowers/specs/2026-08-06-remove-chip-tooltip-design.md`.
-- `UX-012`: Stale and error states use an icon/text cue in addition to color.
+- `UX-012` (amended 2026-08-10): Error states use an icon/text cue in addition
+  to color. Stale is excluded — it presents a real reading and is rendered
+  like ready (`UX-028`), so it carries no cue and adds no qualifier to the
+  chip's accessible name.
 
 ## Popup layout
 
@@ -58,8 +61,8 @@ not literal UI.
 - `UX-016`: The provider header does not repeat the provider icon.
 - `UX-017`: The header shows the provider name, the plan tag, severity when
   present, and the provider refresh control. Connection state is implied
-  structurally (windows render only when ready) and update age lives in the
-  stale banner.
+  structurally (windows render only when a reading exists) and update age
+  lives in the pane's neutral age caption (`UX-028`).
 - `UX-018`: Only one provider's content is visible at a time.
 - `UX-019`: Section backgrounds and separators extend through the full content
   width.
@@ -100,9 +103,20 @@ not literal UI.
 - `UX-026`: Initial collection with no prior data uses skeleton placeholders.
 - `UX-027`: Refresh with prior data keeps content and shows a subtle progress
   indicator.
-- `UX-028`: Stale content stays visible. The stale banner carries the
-  `󰅐` cue, the last success age, the safe error summary, and Retry; it
-  renders whenever the provider state is stale.
+- `UX-028` (amended 2026-08-10): Stale is retained data, not a fault, and
+  renders as such. Bar and popup treat a stale provider exactly like a ready
+  one — same opacity, same severity colour, no cue, no urgent tint, no error
+  text, and no recovery action. The popup's only acknowledgement is one
+  neutral caption, `Updated <age>`, in the pane foreground; the header's
+  refresh control remains the way to force a collection. The typed error and
+  the `retry` action stay in the status JSON for `agent-bar status`; the UI
+  does not surface them.
+
+  Rationale: the previous banner fired on the first failed refresh with no
+  grace period, so a machine woken from suspend showed dimmed icons and an
+  urgent banner for one poll interval — reporting a fault where the only fact
+  was an expired Claude OAuth token that self-heals. The reading it described
+  was still the correct last reading.
 - `UX-029`: Missing CLI keeps the enabled provider icon dimmed and shows
   `Install guide` and `Check again`.
 - `UX-030`: Unauthenticated shows `Sign in` when login discovery succeeds;

--- a/tests/qml/tst_Accessibility.qml
+++ b/tests/qml/tst_Accessibility.qml
@@ -81,11 +81,16 @@ TestCase {
   }
 
   function test_state_cues_not_color_only() {
-    // Chip and state message use text cues beyond color
-    verify(Core.chipStateCue({ state: "stale" }).length > 0)
+    // Chip and state message use text cues beyond color. UX-012 (amended)
+    // scopes this to states with no usable reading; stale keeps showing its
+    // retained number and is deliberately unmarked on the bar.
     verify(Core.chipStateCue({ state: "cli_missing" }).length > 0)
+    verify(Core.chipStateCue({ state: "network_error" }).length > 0)
     verify(Core.stateTitle({ state: "network_error", windows: [] }).length > 0)
+    // The qualifier table stays a pure translator — the chip simply stops
+    // asking it about stale (CoreView.js chipCueLabel/chipAccessibleLabel).
     compare(Core.stateQualifier("stale"), "stale")
+    compare(Core.chipCueLabel({ state: "stale", windows: [] }), "")
   }
 
   function test_glyphs_and_text_labels() {

--- a/tests/qml/tst_BarWidget.qml
+++ b/tests/qml/tst_BarWidget.qml
@@ -264,16 +264,22 @@ TestCase {
     compare(lines[0].percentText, "100%")
   }
 
+  // UX-028 (amended): stale is retained data, not a fault. The bar renders it
+  // exactly as ready — dimming is reserved for states with no usable reading.
   function test_chip_dimmed_reflects_ready_state() {
-    verify(Core.chipDimmed(makeProvider("claude", "stale", 1, 99)))
+    verify(!Core.chipDimmed(makeProvider("claude", "stale", 1, 99)))
     verify(!Core.chipDimmed(makeProvider("claude", "ready", 1, 99)))
+    verify(Core.chipDimmed(makeProvider("claude", "cli_missing", 1, 99)))
+    verify(Core.chipDimmed(makeProvider("claude", "network_error", 1, 99)))
+    verify(Core.chipDimmed(makeProvider("claude", "loading", 1, 99)))
   }
 
   function test_chip_state_cue() {
     compare(Core.chipStateCue(null), "")
     compare(Core.chipStateCue({ state: "ready" }), "")
     compare(Core.chipStateCue({ state: "loading" }), "")
-    compare(Core.chipStateCue({ state: "stale" }), "󰅐")
+    // UX-012 (amended): stale carries no cue; the bar must not mark it.
+    compare(Core.chipStateCue({ state: "stale" }), "")
     compare(Core.chipStateCue({ state: "cli_missing" }), "!")
     compare(Core.chipStateCue({ state: "unauthenticated" }), "!")
     compare(Core.chipStateCue({ state: "rate_limited" }), "!")
@@ -282,24 +288,32 @@ TestCase {
     // §7: a ready provider over the critical threshold earns the same cue.
     compare(Core.chipStateCue({ state: "ready", windows: [{ usedPercent: 96 }] }), "!")
     compare(Core.chipStateCue({ state: "ready", windows: [{ usedPercent: 92 }] }), "")
-    // A state cue outranks severity: the clock keeps the stale meaning.
-    compare(Core.chipStateCue({ state: "stale", windows: [{ usedPercent: 96 }] }), "󰅐")
+    // Severity survives staleness: a critical retained reading is still
+    // critical, so the cue comes from severity alone.
+    compare(Core.chipStateCue({ state: "stale", windows: [{ usedPercent: 96 }] }), "!")
+    compare(Core.chipStateCue({ state: "stale", windows: [{ usedPercent: 92 }] }), "")
   }
 
   // The urgent tint belongs to severity, never to the error cue — the
   // approved mockup shows critical Claude urgent and disconnected Grok plain.
+  // Stale joins ready here: UsageWindow already keeps the severity colour on
+  // a stale reading, so suppressing it on the chip would make bar and popup
+  // disagree about the same number.
   function test_chip_severity_urgent_only_when_ready_and_critical() {
     compare(Core.chipSeverityUrgent(null), false)
     compare(Core.chipSeverityUrgent({ state: "ready", windows: [{ usedPercent: 96 }] }), true)
     compare(Core.chipSeverityUrgent({ state: "ready", windows: [{ usedPercent: 92 }] }), false)
-    compare(Core.chipSeverityUrgent({ state: "stale", windows: [{ usedPercent: 96 }] }), false)
+    compare(Core.chipSeverityUrgent({ state: "stale", windows: [{ usedPercent: 96 }] }), true)
+    compare(Core.chipSeverityUrgent({ state: "stale", windows: [{ usedPercent: 92 }] }), false)
     compare(Core.chipSeverityUrgent({ state: "network_error", windows: [] }), false)
   }
 
   // Plan 02 deferred minor: the cue used to expose its raw glyph.
   function test_chip_cue_label_is_a_word() {
     compare(Core.chipCueLabel({ state: "ready", windows: [{ usedPercent: 96 }] }), "critical")
-    compare(Core.chipCueLabel({ state: "stale", windows: [] }), "stale")
+    // Stale speaks nothing extra: the cue label must match what the eye sees.
+    compare(Core.chipCueLabel({ state: "stale", windows: [] }), "")
+    compare(Core.chipCueLabel({ state: "stale", windows: [{ usedPercent: 96 }] }), "critical")
     compare(Core.chipCueLabel({ state: "cli_missing", windows: [] }), "no CLI")
     compare(Core.chipCueLabel({ state: "unauthenticated", windows: [] }), "signed out")
     compare(Core.chipCueLabel({ state: "ready", windows: [{ usedPercent: 10 }] }), "")
@@ -351,9 +365,17 @@ TestCase {
     var loading = { name: "Claude", state: "loading", windows: [] }
     compare(Core.chipAccessibleLabel(loading, "remaining"), "Claude · loading")
 
+    // Parity with the eye (A11Y-012): the bar no longer marks stale, so the
+    // accessible name must not announce it either — same chip, same words.
     var stale = { name: "Claude", state: "stale",
                   windows: [{ usedPercent: 95, remainingPercent: 5 }] }
-    compare(Core.chipAccessibleLabel(stale, "remaining"), "Claude · 5% · stale")
+    compare(Core.chipAccessibleLabel(stale, "remaining"), "Claude · 5%")
+
+    // Mirrors emptyReady above. Only this case distinguishes
+    // presentsReading(state) from state === "ready" in the percentage branch,
+    // so without it that half of the change is untested.
+    var staleEmpty = { name: "Claude", state: "stale", windows: [] }
+    compare(Core.chipAccessibleLabel(staleEmpty, "remaining"), "Claude · —")
 
     // Single-line by construction; no provider stays empty.
     compare(Core.chipAccessibleLabel(null, "remaining"), "")
@@ -580,9 +602,10 @@ TestCase {
     verify(widget.indexOf("fontPixelSize:") < 0)
   }
 
-  // Plan 03: the popup banner drops its ⌛ for 󰅐 (glyph parity with the chip
-  // stale cue) — ban the emoji repo-wide across every file that could render
-  // provider-facing copy, not just CoreView.js.
+  // Plan 03 replaced the emoji hourglass with a Nerd Font glyph; UX-028
+  // (amended) then retired the glyph itself. The ban outlives both: the
+  // emoji breaks the monospace surface, so no file that renders
+  // provider-facing copy may reintroduce it.
   function test_no_emoji_hourglass_in_assets() {
     var files = [
       "assets/omarchy/CoreView.js",

--- a/tests/qml/tst_Popup.qml
+++ b/tests/qml/tst_Popup.qml
@@ -125,24 +125,47 @@ TestCase {
     // forever regardless of ProviderView.qml's contents. Fixed to match the
     // established convention.
     var view = read("assets/omarchy/ProviderView.qml")
-    // §6/§9: the meta footer is removed in all states; its age moved to the
-    // stale banner and connection state is structural.
+    // §6/§9: the meta footer is removed in all states; connection state is
+    // structural. The `"Updated "` ban lifted with UX-028 (amended) — the age
+    // is now a neutral line owned by test_stale_age_line_is_neutral. What this
+    // test still guards is the footer's own vocabulary never coming back.
     verify(view.indexOf("connection") < 0)
-    verify(view.indexOf('"Updated "') < 0)
     verify(view.indexOf('"Cache"') < 0)
     verify(view.indexOf('"Live"') < 0)
   }
 
-  function test_stale_banner_carries_age_and_retry() {
+  // UX-028 (amended): the urgent stale banner is replaced by one neutral age
+  // line. No glyph, no urgent colour, no Retry — the header's own refresh
+  // control already covers the action, and nothing may read as a fault.
+  function test_stale_age_line_is_neutral() {
     var view = read("assets/omarchy/ProviderView.qml")
-    verify(view.indexOf("󰅐") >= 0)
-    verify(view.indexOf('"Last data "') >= 0)
+    verify(view.length > 0)
     verify(view.indexOf("formatAgoText") >= 0)
+    verify(view.indexOf('"Updated "') >= 0)
+    // The alarming shapes the old banner used must all be gone.
+    verify(view.indexOf("󰅐") < 0)
     verify(view.indexOf("⌛") < 0)
+    verify(view.indexOf('"Last data "') < 0)
+    verify(view.indexOf("Color.urgent") < 0)
+    verify(view.indexOf("errorMessage") < 0)
     // formatAgoText already returns "5m ago"/"just now" — an appended " ago"
     // literal is the regression shape this test exists to catch.
     verify(view.indexOf('+ " ago"') < 0)
-    verify(view.indexOf('"Last data " + (age.length ? age : "unknown")') >= 0)
+  }
+
+  // The retained reading must render at full strength: no opacity knob may
+  // reappear keyed on staleness.
+  function test_stale_windows_are_not_dimmed() {
+    var view = read("assets/omarchy/ProviderView.qml")
+    verify(view.length > 0)
+    verify(view.indexOf("isStale") < 0)
+    verify(view.indexOf("stale_windows") < 0)
+    verify(view.indexOf("dimmed:") < 0)
+    // Banning the `dimmed` property alone only bans one spelling. An inline
+    // `opacity:` binding keyed on provider.state would restore the same
+    // visual result under a different name, so the pane may assign none.
+    // (Prose may still say "opacity" — only the binding is banned.)
+    verify(view.indexOf("opacity:") < 0)
   }
 
   function test_full_width_separator_present() {

--- a/tests/qml/tst_ProviderStates.qml
+++ b/tests/qml/tst_ProviderStates.qml
@@ -53,19 +53,38 @@ TestCase {
     verify(Core.stateBody(p).indexOf("billed another way") >= 0)
   }
 
+  // UX-028 (amended): stale renders through the ready path. The dedicated
+  // "stale_windows" mode is gone — retained data is data, so the pane draws
+  // the same windows it would draw for a fresh reading.
   function test_stale_retains_windows_and_label() {
     var p = firstProvider("valid-stale.json")
-    compare(Core.contentMode(p), "stale_windows")
+    compare(Core.contentMode(p), "windows")
     compare(Core.stateTitle(p), "")
     compare(Core.stateBody(p), "")
+    // The typed error survives in the JSON for `agent-bar status`; the pane
+    // simply stops rendering it.
     verify(Core.errorMessage(p).length > 0)
-    var acts = Core.stateActions(p)
-    var kinds = acts.map(function (a) { return a.kind })
-    verify(kinds.indexOf("retry") >= 0)
+    // No recovery action either: a repair button beside a good number is the
+    // fault impression this change removes. The fixture still carries
+    // action.kind === "retry", so this proves the view filters it, not that
+    // the helper stopped sending it.
+    compare(String(p.action && p.action.kind || ""), "retry")
+    compare(Core.stateActions(p).length, 0)
     var lines = Core.windowDisplayLines(p, "used")
     compare(lines.length, 1)
     compare(lines[0].percentText, "90%")
     compare(lines[0].percent, 90)
+  }
+
+  // A stale provider whose retained reading carries no window must not fall
+  // back to the error pane: it takes the same empty-windows path as ready.
+  function test_stale_without_windows_uses_empty_windows_mode() {
+    var p = { id: "amp", name: "Amp", state: "stale", windows: [],
+              lastSuccessAt: "2026-07-26T18:42:00Z",
+              error: { code: "network_error", message: "Cannot reach Amp.",
+                       retryable: true } }
+    compare(Core.contentMode(p), "empty_windows")
+    compare(Core.stateBody(p), Core.emptyWindowsMessage())
   }
 
   function test_cli_missing_view_installation_and_check_again() {
@@ -129,7 +148,11 @@ TestCase {
     verify(h.plan.length > 0)
     verify(h.connection === undefined)
     compare(h.refreshing, true)
-    compare(h.showStale, false)
+    // showStale was computed, passed to ProviderHeader and asserted here, but
+    // never rendered by anything. UX-028 (amended) retired the concept it
+    // stood for, so the dead field goes with it.
+    verify(h.showStale === undefined)
+    verify(h.lastSuccessAt.length > 0)
   }
 
   function test_plain_text_strips_ansi_and_controls() {
@@ -397,8 +420,17 @@ TestCase {
     compare(layout.lead.resetPhrase, "resets in")
   }
 
-  function test_chip_state_cue_stale_is_clock_glyph() {
-    compare(Core.chipStateCue({ state: "stale" }), "󰅐")
+  // UX-012 (amended): the clock glyph is retired. Stale earns no cue, and no
+  // file may reintroduce one — the bar must stay silent about staleness.
+  function test_chip_state_cue_stale_is_silent() {
+    compare(Core.chipStateCue({ state: "stale" }), "")
+    var view = read("assets/omarchy/CoreView.js")
+    var pane = read("assets/omarchy/ProviderView.qml")
+    // Guard against a vacuous pass: read() returns "" for a bad path.
+    verify(view.length > 0)
+    verify(pane.length > 0)
+    verify(view.indexOf("󰅐") < 0)
+    verify(pane.indexOf("󰅐") < 0)
   }
 
   function test_state_actions_respect_retryable() {

--- a/tests/qml/tst_Screenshots.qml
+++ b/tests/qml/tst_Screenshots.qml
@@ -126,9 +126,12 @@ TestCase {
       stage.badgeText = "Connected · refreshing"
       stage.bodyText = "Weekly (7d) · resets in 23h 1m · 74% left (prior data kept)"
     } else if (name.indexOf("stale-dark") === 0) {
-      stage.titleText = "Grok"
-      stage.badgeText = "STALE"
-      stage.bodyText = "Last data 14m ago · Temporary network failure."
+      // UX-028 (amended): a retained reading is presented as a reading. The
+      // badge stays "Connected" like ready, the windows render unchanged, and
+      // the only difference from ready-dark is the neutral age caption.
+      stage.titleText = "Claude"
+      stage.badgeText = "Connected"
+      stage.bodyText = "Updated 14m ago · Session (5h) · resets in 3h 1m · 58% left · Weekly (7d) 60% · 23h 1m"
     } else if (name.indexOf("critical-dark") === 0) {
       stage.titleText = "Claude"
       stage.badgeText = "CRITICAL"

--- a/tests/qml/tst_Screenshots.qml
+++ b/tests/qml/tst_Screenshots.qml
@@ -41,6 +41,10 @@ TestCase {
     property string titleText: ""
     property string bodyText: ""
     property string badgeText: ""
+    // UX-028 (amended): the age is its own neutral caption, never merged into
+    // the usage text. Modelled separately so the evidence cannot approve a
+    // presentation the pane does not produce.
+    property string captionText: ""
     property color fg: "#e4e4e7"
     property color muted: "#a1a1aa"
     property color badgeColor: "#e4e4e7"
@@ -72,6 +76,19 @@ TestCase {
         textFormat: Text.PlainText
       }
       Text {
+        // No `visible` binding: under the offscreen software backend a Text
+        // that flips visible false->true stays blank in the very next
+        // grabToImage, which is why the badge above has never rendered in any
+        // captured evidence. An always-present Text painting an empty string
+        // keeps the caption reliable and the layout identical across panels.
+        width: parent.width
+        text: stage.captionText
+        color: stage.muted
+        font.pixelSize: 11
+        wrapMode: Text.WordWrap
+        textFormat: Text.PlainText
+      }
+      Text {
         width: parent.width
         text: stage.bodyText
         color: stage.muted
@@ -97,6 +114,9 @@ TestCase {
   }
 
   function paintState(name) {
+    // Clear per-state fields first: the stage is reused across captures, so an
+    // unset field would leak the previous panel's value into this one.
+    stage.captionText = ""
     // Map evidence basename → deterministic fixture panel
     if (name.indexOf("ready-light") === 0) {
       applyTheme("light")
@@ -126,12 +146,14 @@ TestCase {
       stage.badgeText = "Connected · refreshing"
       stage.bodyText = "Weekly (7d) · resets in 23h 1m · 74% left (prior data kept)"
     } else if (name.indexOf("stale-dark") === 0) {
-      // UX-028 (amended): a retained reading is presented as a reading. The
-      // badge stays "Connected" like ready, the windows render unchanged, and
-      // the only difference from ready-dark is the neutral age caption.
+      // UX-028 (amended): a retained reading is presented as a reading. This
+      // panel is ready-dark plus one neutral age caption — same title, same
+      // badge, same usage text. Any other difference would be evidence of a
+      // presentation the pane no longer produces.
       stage.titleText = "Claude"
       stage.badgeText = "Connected"
-      stage.bodyText = "Updated 14m ago · Session (5h) · resets in 3h 1m · 58% left · Weekly (7d) 60% · 23h 1m"
+      stage.captionText = "Updated 14m ago"
+      stage.bodyText = "Session (5h) · resets in 3h 1m · 58% left · Weekly (7d) 60% · 23h 1m"
     } else if (name.indexOf("critical-dark") === 0) {
       stage.titleText = "Claude"
       stage.badgeText = "CRITICAL"
@@ -188,6 +210,10 @@ TestCase {
 
   function captureOne(name) {
     paintState(name)
+    // Let the Column relayout before grabbing. Toggling a child's `visible`
+    // (the age caption) re-runs the positioner, and grabToImage otherwise
+    // captures the previous frame — the caption rendered blank without this.
+    wait(50)
     var path = evidenceDir + "/" + name
     var finished = false
     stage.grabToImage(function (result) {

--- a/tests/qml/tst_Tokens.qml
+++ b/tests/qml/tst_Tokens.qml
@@ -54,7 +54,7 @@ TestCase {
 
   // Every numeric literal that appears in the opacity slot of a
   // Util.alpha(color, opacity) call, read from source. Handles both plain
-  // literals and conditional expressions (the showStale ternary).
+  // literals and conditional expressions.
   function alphaArgValues(code) {
     var values = []
     var callRe = /Util\.alpha\(([^()]*)\)/g


### PR DESCRIPTION
## Why

A stale provider is not broken. It holds a real reading that the coordinator
deliberately retained through a failed refresh (`CACHE-022`). The UI reported it
as a fault anyway:

- the bar dimmed the chip to `0.45` and appended a `󰅐` cue;
- the pane raised an urgent banner — `Last data 8h ago · <error>` — plus Retry;
- the usage windows dropped to 60% / 45% opacity.

Nothing in the pipeline grants a grace period, so one failed attempt was enough.
Waking a machine after hours away hits one reliably: `ClaudeAdapter` compares the
local OAuth token's `expiresAt` against the clock *before* any network call
(`src/providers/adapters.rs:390`), and that token only refreshes when Claude Code
itself runs. So the alarm fired for a condition that self-heals on the next poll,
about numbers that were still the correct last reading.

## What changed

`presentsReading(state) = ready | stale` is now the single axis the view layer
asks about, replacing nine independent `=== "ready"` checks. Stale routes through
the ready path.

| Surface | Before | After |
| --- | --- | --- |
| Chip opacity | `0.45` | full |
| Chip cue | `󰅐` | none |
| Accessible name | `Claude · 5% · stale` | `Claude · 5%` |
| Severity tint | suppressed | kept |
| Pane | urgent banner + Retry | `Updated 8h ago`, foreground @ 0.72 |
| Windows | dimmed | full |
| Content mode | `stale_windows` | `windows` / `empty_windows` |

Severity now survives staleness, matching `UsageWindow`, which already kept the
urgent colour on a critical retained reading — leaving the chip suppressed would
have made bar and pane disagree about the same number.

`stateActions` returns `[]` for any provider presenting a reading: no surface
renders actions for stale anymore, and a repair button beside a good number is
the impression this removes.

Also drops `showStale` — a header property that was computed, passed down and
asserted, but never rendered by anything.

## Not changed

`src/` is untouched. The status contract still emits `"state": "stale"` with its
typed error and `retry` action; `agent-bar status` reports it for debugging. Only
presentation changed.

Dimming still means "no number to trust here": missing CLI (`PROD-022`/`UX-029`),
the error states, and the loading placeholder all keep it.

## Trade-off

A provider that genuinely cannot refresh for days shows its last reading on the
bar as if current. The only signal in the product is `Updated 3d ago` inside the
popup, without a reason. This is deliberate.

## Spec

`UX-012` and `UX-028` amended with the rationale. `PROD-025` and `CACHE-022` are
unaffected — retention behaviour itself did not change.

## Verification

- `cargo fmt --check`, `cargo test` (21 suites), `cargo clippy --all-targets -D warnings`, `git diff --check` — clean
- `qmltestrunner` (Qt6): 253 passed, 0 failed
- `qmllint` (Qt6): 12 fewer warnings than baseline, none new
- `omarchy plugin validate assets/omarchy`: exit 0
- Perceptual: rendered the real `ProviderChip` and `ProviderView` against a
  frozen clock. The all-ready bar strip and the Claude-stale strip are pixel
  identical; the two panes differ only by the grey age caption.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Retained readings remain visible at full strength when refreshes fail.
  * Popups now show a neutral “Updated … ago” caption for older data.
  * Providers without percentage data remain valid and display `—`.

* **Bug Fixes**
  * Removed stale-state dimming, urgent banners, clock icons, error text, and retry actions from the interface.
  * Preserved severity indicators and accessibility information for retained readings.

* **Documentation**
  * Updated product guidance and changelog entries to reflect the revised stale-data experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->