### PR TITLE
fix: keep symlink paths so mise shims dispatch

### DIFF
--- a/docs/specs/v10/02-target-architecture.md
+++ b/docs/specs/v10/02-target-architecture.md
@@ -179,7 +179,10 @@ pub struct ProviderDescriptor {
 `ExecutablePath` is a typed path template rooted in `HOME` or a
 provider-specific home variable. It is not an arbitrary shell-expanded string.
 Discovery checks `PATH` first, then the descriptor's fallback paths in order,
-and accepts only a regular file with an executable bit. The resolved absolute
+and accepts only a regular file with an executable bit. Discovery returns that
+path exactly as found and never resolves symlinks: version managers such as
+mise install their tools as shims that dispatch on `argv[0]`, so canonicalizing
+a shim would execute the manager binary instead of the tool. The discovered
 path replaces element zero of `login_argv`; every remaining element is passed
 unchanged.
 

--- a/docs/superpowers/plans/2026-08-11-mise-shim-discovery.md
+++ b/docs/superpowers/plans/2026-08-11-mise-shim-discovery.md
@@ -1,0 +1,117 @@
+# Mise Shim Discovery Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Provider executable discovery returns the PATH-resolved path as-is (no symlink canonicalization), so mise shims run in shim mode and `amp usage` reaches the real Amp CLI.
+
+**Architecture:** One function changes: `resolve_executable` in `src/providers/catalog.rs` stops calling `canonicalize_best_effort` in both branches (PATH scan and fallback templates). `canonicalize_best_effort` becomes unused and is deleted. A regression test proves a symlink whose target has a different basename (the mise shim shape) is returned as the symlink path, not the target.
+
+**Tech Stack:** Rust (cargo test, tempfile), no new dependencies.
+
+## Global Constraints
+
+- Rust/Cargo and QML only; no Node runtime or test tooling.
+- Use temporary plugin roots and isolated XDG directories for tests (tempfile already used in `catalog.rs` tests).
+- Do not run live setup, update, uninstall, rescan, shell restart, or config mutation.
+- Do not edit `/usr/share/omarchy`.
+- Do not touch the installed bundle in `~/.config/omarchy/plugins` (final QA gate only).
+- Gates for shared contract changes: `cargo fmt --check`, `cargo test`, `cargo clippy --all-targets -- -D warnings`.
+- Commits authorized by the user on 2026-08-11 ("Pode continuar e pode comitar sim!"). No push.
+
+---
+
+### Task 1: Discovery preserves symlink paths (mise shim regression)
+
+**Files:**
+- Modify: `src/providers/catalog.rs:314-331` (`resolve_executable`)
+- Delete: `src/providers/catalog.rs:365-367` (`canonicalize_best_effort`)
+- Test: `src/providers/catalog.rs` (tests module, after `fallback_used_when_path_empty`)
+
+**Interfaces:**
+- Consumes: existing test helper `write_exec(path: &Path, executable: bool)` in the same tests module; `discover(&AMP, &env)`.
+- Produces: `resolve_executable` keeps its signature `fn resolve_executable(&ProviderDescriptor, &ExecutionEnvironment) -> Result<Option<PathBuf>, CatalogError>`; only the returned path value changes (no callers need edits).
+
+- [ ] **Step 1: Write the failing regression test**
+
+Add to the `tests` module in `src/providers/catalog.rs` (after `fallback_used_when_path_empty`). It reproduces the mise shim shape: PATH contains `amp` as a symlink to a binary named `mise`.
+
+```rust
+    #[test]
+    fn discovery_returns_symlink_path_not_canonical_target() {
+        // Mise shims are symlinks named after the tool pointing at the mise
+        // binary. Executing the canonical target changes argv[0] to "mise",
+        // which disables shim dispatch, so discovery must preserve the
+        // symlink path (design 2026-08-11).
+        let dir = tempfile::tempdir().unwrap();
+        let home = dir.path().join("home");
+        let path_dir = dir.path().join("shims");
+        let target = dir.path().join("tools").join("mise");
+        write_exec(&target, true);
+        fs::create_dir_all(&path_dir).unwrap();
+        let shim = path_dir.join("amp");
+        std::os::unix::fs::symlink(&target, &shim).unwrap();
+        let env = ExecutionEnvironment {
+            home,
+            path_dirs: vec![path_dir],
+            grok_home: None,
+        };
+        let discovery = discover(&AMP, &env).unwrap();
+        assert_eq!(discovery.collection_executable().unwrap(), shim.as_path());
+        assert_eq!(discovery.login_executable().unwrap(), shim.as_path());
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test discovery_returns_symlink_path_not_canonical_target`
+Expected: FAIL — the assertion reports the canonical `…/tools/mise` path instead of `…/shims/amp`.
+
+- [ ] **Step 3: Implement the fix**
+
+In `resolve_executable`, return the candidate unchanged in both branches, and delete the now-unused `canonicalize_best_effort` function:
+
+```rust
+fn resolve_executable(
+    descriptor: &ProviderDescriptor,
+    env: &ExecutionEnvironment,
+) -> Result<Option<PathBuf>, CatalogError> {
+    // Return the candidate as found. Following symlinks here breaks version
+    // managers such as mise, whose shims are symlinks to the manager binary
+    // and rely on argv[0] to dispatch to the real tool (design 2026-08-11).
+    for dir in &env.path_dirs {
+        let candidate = dir.join(descriptor.executable_name);
+        if is_executable_file(&candidate) {
+            return Ok(Some(candidate));
+        }
+    }
+    for template in descriptor.fallback_executable_paths {
+        let candidate = expand_template(template, env)?;
+        if is_executable_file(&candidate) {
+            return Ok(Some(candidate));
+        }
+    }
+    Ok(None)
+}
+```
+
+Delete:
+
+```rust
+fn canonicalize_best_effort(path: &Path) -> PathBuf {
+    fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+```
+
+Note: `is_executable_file` uses `fs::metadata`, which follows symlinks, so a symlink to an executable still qualifies. The existing test `fallback_used_when_path_empty` compares both sides through `fs::canonicalize` and keeps passing unchanged.
+
+- [ ] **Step 4: Run the full gates**
+
+Run: `cargo fmt --check && cargo test && cargo clippy --all-targets -- -D warnings`
+Expected: all pass. Clippy is the guard that `canonicalize_best_effort` was actually removed (dead code fails `-D warnings`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/providers/catalog.rs
+git commit -m "fix: discovery preserves symlink paths so mise shims dispatch"
+```

--- a/docs/superpowers/specs/2026-08-11-mise-shim-discovery-design.md
+++ b/docs/superpowers/specs/2026-08-11-mise-shim-discovery-design.md
@@ -1,0 +1,64 @@
+# Design: descoberta de executável não deve canonicalizar shims (mise)
+
+Data: 2026-08-11
+Status: aprovado (opção A)
+
+## Problema
+
+Com o Amp CLI instalado via mise, o único `amp` no PATH do Quickshell é o shim
+`~/.local/share/mise/shims/amp`, um symlink para `/usr/bin/mise`. A descoberta
+(`resolve_executable` em `src/providers/catalog.rs`) canonicaliza o candidato
+encontrado, então o helper executa `/usr/bin/mise usage` em vez do shim. O mise
+vê `argv[0]` = `mise`, não entra em modo shim e roda o subcomando próprio
+`mise usage` (usage-spec, ~213 KB, exit 0, ~15 ms). O parser não encontra
+nenhuma linha do Amp, o resultado vira `Ready` com `windows: []` e a UI mostra
+"Amp reports no quota / This account is billed another way."
+
+Reproduzido na máquina do usuário em 2026-08-11 com o ambiente exato do
+Quickshell. Testes decisivos:
+
+- `amp` → symlink para `/usr/bin/mise` no PATH: coleta falha (`ready`, 0
+  janelas, 33 ms).
+- `amp` → symlink para o binário Node real: coleta funciona (`ready`, 3
+  janelas, ~1,2 s).
+
+## Alcance do defeito
+
+- Coleta do Amp (`amp usage`): quebrada quando instalado via mise.
+- Codex app-server: mesma falha; o adapter cai no fallback de session log e
+  serve dados velhos.
+- `login` de qualquer provider via mise: executaria `/usr/bin/mise login`.
+- Claude não é afetado na coleta (HTTP/OAuth). Grok lê JSON do disco na coleta,
+  mas o `login` seria afetado.
+
+## Correção (opção A, aprovada)
+
+`resolve_executable` retorna o caminho encontrado **sem** seguir symlinks, nos
+dois ramos (PATH e fallbacks). Executar o path que o PATH resolveu preserva o
+`argv[0]` do shim e ativa o modo shim do mise — comportamento POSIX padrão.
+`canonicalize_best_effort` deixa de ser usado na resolução (remover se ficar
+sem uso).
+
+Alternativas rejeitadas:
+
+- Canonicalizar apenas quando o basename do alvo coincide: branch extra sem
+  benefício, já que nada exige paths canônicos na execução.
+- Forçar `argv[0]` via `CommandExt::arg0` mantendo o path canônico: frágil,
+  depende de detalhe interno do mise e exige estender `ProcessSpec`.
+
+## Testes
+
+- Regressão em `catalog.rs`: num diretório temporário no PATH, `amp` como
+  symlink para outro binário de basename diferente (simulando o shim); a
+  descoberta deve retornar o path do symlink, não o alvo.
+- Atualizar o teste existente que espera o path canonicalizado
+  (`fs::canonicalize` em `catalog.rs`, ~linha 517).
+- Gates de contrato: `cargo fmt --check`, `cargo test`,
+  `cargo clippy --all-targets -- -D warnings`.
+
+## Fora de escopo
+
+- Investigar por que o Grok reporta `windows: []` (fluxo distinto, lê billing
+  JSON do disco).
+- Atualizar o bundle instalado em `~/.config/omarchy/plugins` — segue o gate
+  de QA final definido em `CLAUDE.md`.

--- a/docs/superpowers/specs/2026-08-11-mise-shim-discovery-design.md
+++ b/docs/superpowers/specs/2026-08-11-mise-shim-discovery-design.md
@@ -1,64 +1,70 @@
-# Design: descoberta de executável não deve canonicalizar shims (mise)
+# Design: Executable Discovery Must Not Canonicalize Shims (mise)
 
-Data: 2026-08-11
-Status: aprovado (opção A)
+Date: 2026-08-11
+Status: approved (option A)
 
-## Problema
+## Problem
 
-Com o Amp CLI instalado via mise, o único `amp` no PATH do Quickshell é o shim
-`~/.local/share/mise/shims/amp`, um symlink para `/usr/bin/mise`. A descoberta
-(`resolve_executable` em `src/providers/catalog.rs`) canonicaliza o candidato
-encontrado, então o helper executa `/usr/bin/mise usage` em vez do shim. O mise
-vê `argv[0]` = `mise`, não entra em modo shim e roda o subcomando próprio
-`mise usage` (usage-spec, ~213 KB, exit 0, ~15 ms). O parser não encontra
-nenhuma linha do Amp, o resultado vira `Ready` com `windows: []` e a UI mostra
-"Amp reports no quota / This account is billed another way."
+With the Amp CLI installed through mise, the only `amp` on the Quickshell PATH
+is the shim `~/.local/share/mise/shims/amp`, a symlink to `/usr/bin/mise`.
+Discovery (`resolve_executable` in `src/providers/catalog.rs`) canonicalized the
+candidate it found, so the helper executed `/usr/bin/mise usage` instead of the
+shim. mise sees `argv[0]` = `mise`, never enters shim mode, and runs its own
+`mise usage` subcommand (usage-spec output, ~213 KB, exit 0, ~15 ms). The parser
+finds no Amp line, the result becomes `Ready` with `windows: []`, and the UI
+shows "Amp reports no quota / This account is billed another way."
 
-Reproduzido na máquina do usuário em 2026-08-11 com o ambiente exato do
-Quickshell. Testes decisivos:
+Reproduced on the user's machine on 2026-08-11 with the exact Quickshell
+environment. Decisive tests:
 
-- `amp` → symlink para `/usr/bin/mise` no PATH: coleta falha (`ready`, 0
-  janelas, 33 ms).
-- `amp` → symlink para o binário Node real: coleta funciona (`ready`, 3
-  janelas, ~1,2 s).
+- `amp` as a symlink to `/usr/bin/mise` on PATH: collection fails (`ready`, 0
+  windows, 33 ms).
+- `amp` as a symlink to the real Node binary: collection works (`ready`, 3
+  windows, ~1.2 s).
 
-## Alcance do defeito
+## Blast radius
 
-- Coleta do Amp (`amp usage`): quebrada quando instalado via mise.
-- Codex app-server: mesma falha; o adapter cai no fallback de session log e
-  serve dados velhos.
-- `login` de qualquer provider via mise: executaria `/usr/bin/mise login`.
-- Claude não é afetado na coleta (HTTP/OAuth). Grok lê JSON do disco na coleta,
-  mas o `login` seria afetado.
+- Amp collection (`amp usage`): broken when installed through mise.
+- Codex app-server: same failure; the adapter falls back to the session log and
+  serves stale data.
+- `login` for any provider installed through mise: would execute
+  `/usr/bin/mise login`.
+- Claude collection is unaffected (HTTP/OAuth). Grok reads billing JSON from
+  disk during collection, but its `login` would be affected.
 
-## Correção (opção A, aprovada)
+## Fix (option A, approved)
 
-`resolve_executable` retorna o caminho encontrado **sem** seguir symlinks, nos
-dois ramos (PATH e fallbacks). Executar o path que o PATH resolveu preserva o
-`argv[0]` do shim e ativa o modo shim do mise — comportamento POSIX padrão.
-`canonicalize_best_effort` deixa de ser usado na resolução (remover se ficar
-sem uso).
+`resolve_executable` returns the path it found **without** following symlinks,
+in both branches (PATH scan and fallback templates). Executing the path that
+PATH resolved preserves the shim's `argv[0]` and activates mise's shim mode —
+standard POSIX behaviour. `canonicalize_best_effort` becomes unused during
+resolution and is removed.
 
-Alternativas rejeitadas:
+Rejected alternatives:
 
-- Canonicalizar apenas quando o basename do alvo coincide: branch extra sem
-  benefício, já que nada exige paths canônicos na execução.
-- Forçar `argv[0]` via `CommandExt::arg0` mantendo o path canônico: frágil,
-  depende de detalhe interno do mise e exige estender `ProcessSpec`.
+- Canonicalize only when the target basename matches: an extra branch with no
+  benefit, since nothing requires canonical paths at execution time.
+- Force `argv[0]` through `CommandExt::arg0` while keeping the canonical path:
+  fragile, depends on a mise implementation detail, and would require extending
+  `ProcessSpec`.
 
-## Testes
+## Tests
 
-- Regressão em `catalog.rs`: num diretório temporário no PATH, `amp` como
-  symlink para outro binário de basename diferente (simulando o shim); a
-  descoberta deve retornar o path do symlink, não o alvo.
-- Atualizar o teste existente que espera o path canonicalizado
-  (`fs::canonicalize` em `catalog.rs`, ~linha 517).
-- Gates de contrato: `cargo fmt --check`, `cargo test`,
+- Regression test in `catalog.rs` for the PATH branch: in a temporary directory
+  on PATH, `amp` is a symlink to another binary with a different basename (the
+  shim shape); discovery must return the symlink path, not the target.
+- A second regression test for the fallback-template branch, which returns from
+  a different point in `resolve_executable` and would otherwise be free to
+  reintroduce canonicalization unnoticed.
+- No existing test had to change: `fallback_used_when_path_empty` canonicalizes
+  both sides of its comparison and never had a symlink to resolve, so it is
+  insensitive to this behaviour either way.
+- Contract gates: `cargo fmt --check`, `cargo test`,
   `cargo clippy --all-targets -- -D warnings`.
 
-## Fora de escopo
+## Out of scope
 
-- Investigar por que o Grok reporta `windows: []` (fluxo distinto, lê billing
-  JSON do disco).
-- Atualizar o bundle instalado em `~/.config/omarchy/plugins` — segue o gate
-  de QA final definido em `CLAUDE.md`.
+- Investigating why Grok reports `windows: []` (a distinct flow that reads
+  billing JSON from disk).
+- Updating the installed bundle in `~/.config/omarchy/plugins` — that follows
+  the final QA gate defined in `CLAUDE.md`.

--- a/src/providers/catalog.rs
+++ b/src/providers/catalog.rs
@@ -315,16 +315,19 @@ fn resolve_executable(
     descriptor: &ProviderDescriptor,
     env: &ExecutionEnvironment,
 ) -> Result<Option<PathBuf>, CatalogError> {
+    // Return the candidate as found. Following symlinks here breaks version
+    // managers such as mise, whose shims are symlinks to the manager binary
+    // and rely on argv[0] to dispatch to the real tool (design 2026-08-11).
     for dir in &env.path_dirs {
         let candidate = dir.join(descriptor.executable_name);
         if is_executable_file(&candidate) {
-            return Ok(Some(canonicalize_best_effort(&candidate)));
+            return Ok(Some(candidate));
         }
     }
     for template in descriptor.fallback_executable_paths {
         let candidate = expand_template(template, env)?;
         if is_executable_file(&candidate) {
-            return Ok(Some(canonicalize_best_effort(&candidate)));
+            return Ok(Some(candidate));
         }
     }
     Ok(None)
@@ -360,10 +363,6 @@ fn is_executable_file(path: &Path) -> bool {
     {
         true
     }
-}
-
-fn canonicalize_best_effort(path: &Path) -> PathBuf {
-    fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
 }
 
 #[cfg(test)]
@@ -517,6 +516,30 @@ mod tests {
             fs::canonicalize(exe).unwrap(),
             fs::canonicalize(&fallback).unwrap()
         );
+    }
+
+    #[test]
+    fn discovery_returns_symlink_path_not_canonical_target() {
+        // Mise shims are symlinks named after the tool pointing at the mise
+        // binary. Executing the canonical target changes argv[0] to "mise",
+        // which disables shim dispatch, so discovery must preserve the
+        // symlink path (design 2026-08-11).
+        let dir = tempfile::tempdir().unwrap();
+        let home = dir.path().join("home");
+        let path_dir = dir.path().join("shims");
+        let target = dir.path().join("tools").join("mise");
+        write_exec(&target, true);
+        fs::create_dir_all(&path_dir).unwrap();
+        let shim = path_dir.join("amp");
+        std::os::unix::fs::symlink(&target, &shim).unwrap();
+        let env = ExecutionEnvironment {
+            home,
+            path_dirs: vec![path_dir],
+            grok_home: None,
+        };
+        let discovery = discover(&AMP, &env).unwrap();
+        assert_eq!(discovery.collection_executable().unwrap(), shim.as_path());
+        assert_eq!(discovery.login_executable().unwrap(), shim.as_path());
     }
 
     #[test]

--- a/src/providers/catalog.rs
+++ b/src/providers/catalog.rs
@@ -293,7 +293,7 @@ pub fn discover(
     Ok(Discovery { collection, login })
 }
 
-/// Build login argv with the resolved absolute executable as element zero.
+/// Build login argv with the discovered executable path as element zero.
 pub fn login_process_argv(
     descriptor: &ProviderDescriptor,
     discovery: &Discovery,
@@ -535,6 +535,28 @@ mod tests {
         let env = ExecutionEnvironment {
             home,
             path_dirs: vec![path_dir],
+            grok_home: None,
+        };
+        let discovery = discover(&AMP, &env).unwrap();
+        assert_eq!(discovery.collection_executable().unwrap(), shim.as_path());
+        assert_eq!(discovery.login_executable().unwrap(), shim.as_path());
+    }
+
+    #[test]
+    fn fallback_discovery_returns_symlink_path_not_canonical_target() {
+        // The fallback templates resolve shims too: a version manager may own
+        // $HOME/.local/bin. Both resolution branches must preserve the symlink
+        // path, so this covers the branch the PATH test cannot reach.
+        let dir = tempfile::tempdir().unwrap();
+        let home = dir.path().join("home");
+        let target = dir.path().join("tools").join("mise");
+        write_exec(&target, true);
+        let shim = home.join(".local/bin/amp");
+        fs::create_dir_all(shim.parent().unwrap()).unwrap();
+        std::os::unix::fs::symlink(&target, &shim).unwrap();
+        let env = ExecutionEnvironment {
+            home,
+            path_dirs: vec![dir.path().join("empty-path")],
             grok_home: None,
         };
         let discovery = discover(&AMP, &env).unwrap();


### PR DESCRIPTION
## Problem

On a machine where the provider CLIs are installed through a version manager,
the bar showed "Amp reports no quota / This account is billed another way" for
an account that had quota, and Codex quietly served day-old numbers.

Discovery canonicalized the executable it found. mise installs each tool as a
shim — `~/.local/share/mise/shims/amp` is a symlink to `/usr/bin/mise` — and
mise dispatches on `argv[0]`. Canonicalized, the helper executed
`/usr/bin/mise usage`: mise saw `argv[0] = mise`, never entered shim mode, and
ran its own unrelated `usage` subcommand (exit 0, ~15 ms). Nothing in that
output parses as a quota window, so the provider normalized to `ready` with
`windows: []`.

The same defect broke the Codex app-server call, which fell through to the
bounded session-log fallback and served whatever the last logged run held, and
it would have broken `login` for any provider installed through mise.

## Fix

`resolve_executable` returns the path exactly as found, in both the PATH branch
and the fallback-template branch. Executing the path PATH resolved preserves
the shim's `argv[0]`, which is ordinary POSIX behaviour. `canonicalize_best_effort`
had no other caller and is gone.

Rejected alternatives: canonicalizing only when the target basename matches (an
extra branch buying nothing, since nothing needs canonical paths at exec time),
and forcing `argv[0]` through `CommandExt::arg0` (fragile, depends on a mise
implementation detail, and would have to extend `ProcessSpec`).

## Verification

Both branches of `resolve_executable` have a regression test, each confirmed to
fail against a reintroduced canonicalization.

Measured with the exact Quickshell environment (PATH/HOME/XDG lifted from
`/proc/$(pgrep quickshell)/environ`), the installed 10.3.7 helper against this
build:

| Provider | 10.3.7 | This branch |
| --- | --- | --- |
| Amp | `ready`, no plan, 0 windows | `ready`, Megawatt, 3 windows |
| Codex | `lastSuccessAt` 27 h old (session log) | `lastSuccessAt` = collection time (app-server) |
| Claude | unchanged | unchanged |

Gates: `cargo fmt --check`, `cargo test` (274 passing), `cargo clippy
--all-targets -- -D warnings`, `git diff --check`. No QML or bundle files
change.

## Documentation

`docs/specs/v10/02-target-architecture.md` promised "the resolved absolute
path" and is amended to state that discovery never resolves symlinks, and why.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Executable discovery now preserves symlink paths exactly as found on the system.
  - Version-manager shims, including mise shims, now dispatch to the intended tool instead of incorrectly launching the manager.
  - Improved consistency for executables discovered through both `PATH` and fallback lookup.

- **Documentation**
  - Updated technical documentation to clarify executable path preservation and shim behavior.
  - Added implementation and design guidance covering the corrected discovery behavior and regression coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->