### PR TITLE
docs: name the live plugin ID in the specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,42 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-### Changed
-
-- A provider whose refresh fails no longer looks broken. Its last good
-  reading stays on the bar at full strength — same opacity, same severity
-  colour, no clock glyph — and the popup drops the urgent banner in favour of
-  one neutral `Updated <age>` caption. Waking a machine after hours away used
-  to dim every icon and raise an alert for one poll interval, because an
-  expired Claude token counts as a refresh failure even though the displayed
-  numbers were still the correct last reading. The status JSON is unchanged:
-  `agent-bar status` still reports `"state": "stale"` with its typed error.
-- Distribution is entirely git-native: install with `omarchy plugin add
-  https://github.com/othavi0/omarchy-agent-bar.git`, update with
-  `omarchy plugin update agent-bar.usage`, and remove with
-  `omarchy plugin remove agent-bar.usage`. The Settings update and uninstall
-  buttons delegate to those same commands as a detached transient systemd
-  unit instead of staging and swapping the plugin directory themselves.
-- `update apply` no longer takes a version argument; it fast-forwards
-  unconditionally to whatever the distribution repository currently
-  publishes. `update check` reads that repository's `bundle.json` directly
-  and reports `reinstallRequired` for a pre-conversion (non-git) install
-  instead of a false "up to date".
-- If you installed Agent Bar before this release, the update button shows a
-  one-time migration notice. Run `omarchy plugin remove agent-bar.usage`
-  then `omarchy plugin add https://github.com/othavi0/omarchy-agent-bar.git`.
-  Settings, cache, and backups live outside the plugin directory and survive
-  the swap.
-
-### Removed
-
-- `install.sh` and the tarball/GitHub-Releases-asset bootstrap. Releases no
-  longer attach any archive; the release tag and notes are published
-  alongside a plain commit pushed to the distribution repository.
-- The staged plugin-directory transaction machinery (worker copy, journal,
-  `renameat2` exchange/quarantine, health-IPC polling) that used to back
-  in-app update and uninstall. The Omarchy CLI now owns that mutation.
-
 ## [10.3.8] - 2026-08-11
 
 ### Changed

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -39,7 +39,7 @@ The bundled Rust executable at `bin/agent-bar`. It is an implementation detail,
 not a standalone product.
 
 **Plugin bundle**
-The complete version-matched `agent-bar.usage` directory: manifest, QML, icons,
+The complete version-matched `othavi0.agent-bar` directory: manifest, QML, icons,
 scripts, receipt, and private helper.
 
 ## Provider model

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,9 +85,12 @@ stays behind the adapter. QML receives schema-v2 normalized data only.
 ## Documentation
 
 Active documentation is English and must match executable contracts.
-Changelog release sections 9.0.0 and older, ADR bodies 0001–0003, and
-`docs/superpowers/**` remain historical. Unreleased, the ADR index, and ADR
-0004 are active.
+Every versioned changelog release section, `docs/releases/**`,
+`docs/history/**`, ADR bodies 0001–0003, and `docs/superpowers/**` remain
+historical: they record how things were and are never rewritten. The
+`[Unreleased]` changelog section, the ADR index, ADR 0004, and everything
+under `docs/specs/v10/**` and `docs/guide/**` are active and must match the
+shipped behavior.
 
 ## Release
 

--- a/docs/adr/0004-quickshell-only-v10.md
+++ b/docs/adr/0004-quickshell-only-v10.md
@@ -2,6 +2,7 @@
 
 Status: Accepted
 Date: 2026-07-26
+Amended: 2026-08-05 (git-plugin-distribution), 2026-08-06 (plugin-ID rename)
 
 ## Context
 
@@ -19,7 +20,7 @@ testable Rust helper than QML.
 
 ## Decision
 
-Agent Bar v10 is only the Omarchy Quattro plugin `agent-bar.usage`.
+Agent Bar v10 is only the Omarchy Quattro plugin `othavi0.agent-bar`.
 
 - One Quickshell service owns runtime state.
 - Monitor-local widgets render shared state.
@@ -33,8 +34,10 @@ Agent Bar v10 is only the Omarchy Quattro plugin `agent-bar.usage`.
   schema-v1 status compatibility are deleted.
 - Login delegates to official provider CLIs through an argv-safe terminal
   helper.
-- Update and uninstall are available in Settings and use journaled
-  transactions.
+- Update and uninstall are available in Settings. They delegate the
+  plugin-directory mutation to the Omarchy plugin manager; the journaled
+  transaction machinery this ADR originally specified was removed by
+  git-plugin-distribution (2026-08-05).
 
 ## Consequences
 

--- a/docs/specs/v10/01-product-contract.md
+++ b/docs/specs/v10/01-product-contract.md
@@ -1,5 +1,10 @@
 # Product Contract
 
+Amended by the plugin-ID rename (2026-08-06):
+`docs/superpowers/specs/2026-08-06-plugin-id-rename-design.md`. The plugin ID
+is `othavi0.agent-bar`; it read `agent-bar.usage` when this document was
+approved.
+
 ## Purpose
 
 Agent Bar shows normalized quota and reset information for Claude, Codex, Amp,
@@ -9,7 +14,7 @@ connection actions, update, and uninstall.
 
 ## Goals
 
-- `PROD-001`: Make `agent-bar.usage` the only graphical Agent Bar surface.
+- `PROD-001`: Make `othavi0.agent-bar` the only graphical Agent Bar surface.
 - `PROD-002`: Use Omarchy Quattro and Quickshell native patterns.
 - `PROD-003`: Keep provider-specific logic in a testable private Rust helper.
 - `PROD-004`: Share provider state and polling across all monitors.
@@ -19,7 +24,7 @@ connection actions, update, and uninstall.
 - `PROD-007`: Give normal users complete configuration, update, and uninstall
   flows in the plugin UI. Update and uninstall remain UI journeys; since
   git-plugin-distribution (2026-08-05) they delegate their live mutation to
-  the Omarchy CLI (`omarchy plugin update|remove agent-bar.usage`) instead of
+  the Omarchy CLI (`omarchy plugin update|remove othavi0.agent-bar`) instead of
   performing it in-process.
 - `PROD-008`: Expose typed, safe, partial provider failures without parsing
   human error strings in QML.
@@ -110,14 +115,14 @@ Notifications: enabled
 
 1. Settings shows installed plugin version and `Check for updates`.
 2. An available release requires explicit confirmation before applying it.
-3. Confirming update delegates to `omarchy plugin update agent-bar.usage
+3. Confirming update delegates to `omarchy plugin update othavi0.agent-bar
    --yes`, which fetches, fast-forwards, re-validates, and rolls back
    automatically on a failed validation. A plugin directory without `.git`
    (a pre-conversion install) cannot be fast-forwarded; the check reports
    `reinstallRequired` and Settings shows the remove-then-add migration
    instruction instead of an update offer.
 4. `Uninstall Agent Bar` requires confirmation, then delegates to
-   `omarchy plugin remove agent-bar.usage --yes`.
+   `omarchy plugin remove othavi0.agent-bar --yes`.
 5. Settings are preserved by default; deleting settings requires an additional
    explicit purge selection, applied before the delegated remove.
 

--- a/docs/specs/v10/02-target-architecture.md
+++ b/docs/specs/v10/02-target-architecture.md
@@ -1,5 +1,10 @@
 # Target Architecture
 
+Amended by the plugin-ID rename (2026-08-06):
+`docs/superpowers/specs/2026-08-06-plugin-id-rename-design.md`. The plugin ID
+is `othavi0.agent-bar`; it read `agent-bar.usage` when this document was
+approved.
+
 ## System shape
 
 ```text
@@ -245,7 +250,7 @@ The table is product data, not an example:
 - `ARCH-019`: Collection mechanisms remain provider-specific and are not
   inferred from the login executable.
 - `ARCH-020`: `Service.qml` owns one `IpcHandler` target named
-  `agent-bar.usage` with only `health(expectedVersion)` and
+  `othavi0.agent-bar` with only `health(expectedVersion)` and
   `refresh(providerId)` methods.
 - `ARCH-021`: `health` returns `ok` only when the loaded manifest version and
   last verified helper version both equal `expectedVersion`. `refresh`
@@ -336,7 +341,7 @@ replacement.
 
 ```text
 Plugin bundle:
-  $HOME/.config/omarchy/plugins/agent-bar.usage/
+  $HOME/.config/omarchy/plugins/othavi0.agent-bar/
 
 Settings:
   $XDG_CONFIG_HOME/agent-bar/settings.json
@@ -405,7 +410,7 @@ After the official provider process exits `0`, the Rust login command performs
 a best-effort argv call:
 
 ```text
-omarchy-shell -q agent-bar.usage refresh <providerId>
+omarchy-shell -q othavi0.agent-bar refresh <providerId>
 ```
 
 It then returns the original provider exit status. A nonzero or signaled

--- a/docs/specs/v10/03-cli-and-json-contract.md
+++ b/docs/specs/v10/03-cli-and-json-contract.md
@@ -1,5 +1,10 @@
 # Private CLI and JSON Contract
 
+Amended by the plugin-ID rename (2026-08-06):
+`docs/superpowers/specs/2026-08-06-plugin-id-rename-design.md`. The plugin ID
+is `othavi0.agent-bar`; it read `agent-bar.usage` when this document was
+approved.
+
 The bundled helper is not the normal user interface. Its command contract is
 still strict because QML, tests, recovery procedures, and migration depend on
 it.
@@ -312,7 +317,7 @@ accepted.
 - `CLI-028`: QML passes structured intentions; it never concatenates command
   strings.
 - `CLI-029`: `update apply` takes no version argument. It delegates
-  unconditionally to `omarchy plugin update agent-bar.usage --yes`, which
+  unconditionally to `omarchy plugin update othavi0.agent-bar --yes`, which
   owns the git fetch, fast-forward, re-validation, and automatic
   `git reset --hard ORIG_HEAD` rollback on a failed validation.
 - `CLI-030`: Setup, update, doctor, and uninstall never touch unrelated Omarchy

--- a/docs/specs/v10/06-migration-and-legacy-removal.md
+++ b/docs/specs/v10/06-migration-and-legacy-removal.md
@@ -1,5 +1,10 @@
 # Migration and Legacy Removal
 
+Amended by the plugin-ID rename (2026-08-06):
+`docs/superpowers/specs/2026-08-06-plugin-id-rename-design.md`. The plugin ID
+is `othavi0.agent-bar`; it read `agent-bar.usage` when this document was
+approved.
+
 ## Transaction model
 
 Since git-plugin-distribution (2026-08-05), plugin-directory mutation (fresh
@@ -77,7 +82,7 @@ The manifest records:
   is `omarchy plugin add <dist-repo-url>`, which clones, validates, moves
   the tree, and, after a separate confirmation or `--enable`, enables it
   and adds a missing bar entry. An already-installed but disabled plugin may
-  still be enabled directly with `omarchy plugin enable agent-bar.usage`.
+  still be enabled directly with `omarchy plugin enable othavi0.agent-bar`.
   Neither path ever follows with `omarchy bar plugin add`.
 - `MIG-019B`: Update does not edit `shell.json`.
 - `MIG-019C`: Rollback restores the exact previous `shell.json` bytes.
@@ -209,7 +214,7 @@ return as soon as the handoff is accepted without depending on the QML
 service it may be running under.
 
 - `MIG-020`: `update apply` takes no version argument and detaches
-  unconditionally to `omarchy plugin update agent-bar.usage --yes`, which
+  unconditionally to `omarchy plugin update othavi0.agent-bar --yes`, which
   owns the git fetch, fast-forward, re-validation, and
   `git reset --hard ORIG_HEAD` rollback on a failed validation.
 - `MIG-021`: `update check` reads the distribution repository's
@@ -219,7 +224,7 @@ service it may be running under.
   fast-forwarded and must be reinstalled through `omarchy plugin add`.
 - `MIG-022`: `uninstall` purges only Agent Bar's own XDG state (with
   `purge`) under the exclusive maintenance lock, then detaches
-  unconditionally to `omarchy plugin remove agent-bar.usage --yes`, which
+  unconditionally to `omarchy plugin remove othavi0.agent-bar --yes`, which
   owns disabling the bar entry, deleting the plugin directory, and
   rescanning.
 - `MIG-023`: Standard uninstall preserves settings, cache configuration, and

--- a/docs/specs/v10/08-plugin-bundle-and-release.md
+++ b/docs/specs/v10/08-plugin-bundle-and-release.md
@@ -6,6 +6,11 @@ manifest and receipt shapes below carry forward; the release-files,
 update-transaction, and uninstall-transaction sections are replaced by the
 distribution-repository model.
 
+Amended by the plugin-ID rename (2026-08-06):
+`docs/superpowers/specs/2026-08-06-plugin-id-rename-design.md`. The plugin ID
+is `othavi0.agent-bar`; it read `agent-bar.usage` when this document was
+approved.
+
 ## Product artifact
 
 v10 builds one architecture-specific Omarchy plugin bundle. Since
@@ -14,7 +19,7 @@ distribution-repository commit that `omarchy plugin add` clones, so it
 carries its own `README.md`, `LICENSE`, and marketplace `preview.png`:
 
 ```text
-agent-bar.usage/
+othavi0.agent-bar/
 ├── manifest.json
 ├── bundle.json
 ├── README.md
@@ -42,7 +47,7 @@ directory sitting directly at the tree root and does not walk it; a `.git`
 anywhere deeper, or one that is itself a symlink, is not special-cased and
 still fails validation through the ordinary symlink/extra-file checks.
 
-- `BUNDLE-001`: The product is the `agent-bar.usage` plugin directory.
+- `BUNDLE-001`: The product is the `othavi0.agent-bar` plugin directory.
 - `BUNDLE-002`: `bin/agent-bar` is private and invoked by resolved absolute
   plugin path.
 - `BUNDLE-003`: No global executable, package, application entry, ManagedGit
@@ -53,7 +58,7 @@ still fails validation through the ordinary symlink/extra-file checks.
 - `BUNDLE-007`: The initial official target is
   `x86_64-unknown-linux-gnu`.
 - `BUNDLE-007A`: The installed plugin root is literal
-  `$HOME/.config/omarchy/plugins/agent-bar.usage`; Quattro does not apply
+  `$HOME/.config/omarchy/plugins/othavi0.agent-bar`; Quattro does not apply
   `XDG_CONFIG_HOME` to plugin discovery.
 
 ## Manifest
@@ -63,7 +68,7 @@ The final Quattro-validated manifest is:
 ```json
 {
   "schemaVersion": 1,
-  "id": "agent-bar.usage",
+  "id": "othavi0.agent-bar",
   "name": "Agent Bar",
   "version": "10.0.0",
   "author": "othavi0",
@@ -90,9 +95,7 @@ The final Quattro-validated manifest is:
 It must:
 
 - use schema version 1;
-- retain ID `agent-bar.usage` (superseded 2026-08-06: the ID is
-  `othavi0.agent-bar`, renamed before the marketplace listing went live; see
-  `docs/superpowers/specs/2026-08-06-plugin-id-rename-design.md`);
+- retain ID `othavi0.agent-bar`;
 - declare `service` and `bar-widget`;
 - map the service to `Service.qml`;
 - map the bar widget to `BarWidget.qml`;
@@ -119,7 +122,7 @@ The exact receipt shape is:
 ```json
 {
   "schemaVersion": 1,
-  "pluginId": "agent-bar.usage",
+  "pluginId": "othavi0.agent-bar",
   "version": "10.0.0",
   "target": "x86_64-unknown-linux-gnu",
   "omarchyContract": 1,
@@ -167,7 +170,7 @@ protection denies it independently, because `omarchy plugin update` is a
 fast-forward-only pull for every existing install. A rewritten history
 breaks the update check for all of them with no remote-side recovery.
 
-- `BUNDLE-008`: The pushed tree contains exactly one `agent-bar.usage`
+- `BUNDLE-008`: The pushed tree contains exactly one `othavi0.agent-bar`
   worth of content at the distribution repository root (plus that
   repository's own `.git/`).
 - `BUNDLE-009`: It contains no Rust source, tests, target directory,
@@ -210,7 +213,7 @@ installer; installation is the native Omarchy plugin flow end to end.
 - `BUNDLE-013`: **Retired.** `install.sh` is deleted. Installation is
   `omarchy plugin add <dist-repo-url>`: it clones the URL, validates the
   clone with `omarchy-plugin-validate`, and moves it to
-  `$HOME/.config/omarchy/plugins/agent-bar.usage`. No Agent Bar-authored
+  `$HOME/.config/omarchy/plugins/othavi0.agent-bar`. No Agent Bar-authored
   bootstrap, checksum verification, or staging step runs.
 - `BUNDLE-014`: **Retired.** `omarchy plugin add` owns its own install
   bookkeeping; Agent Bar's transaction state records nothing about
@@ -250,7 +253,7 @@ agent-bar update apply
   release-notes URL, target, and `reinstallRequired`. It carries no
   archive/checksum/source-commit fields.
 - `BUNDLE-022`: `update apply` takes no version argument; it delegates
-  unconditionally to `omarchy plugin update agent-bar.usage --yes`.
+  unconditionally to `omarchy plugin update othavi0.agent-bar --yes`.
 - `BUNDLE-023`: The Settings UI performs check and confirmation as separate
   states before triggering apply.
 - `BUNDLE-024`: `update check` reads only the distribution repository's own
@@ -358,7 +361,7 @@ What replaces it:
   "detached transient unit" idea is simpler: `update apply` and `uninstall`
   each start one `systemd-run --user --collect
   --unit=agent-bar-<update|remove>-<32-lowercase-hex-txid>.service -- <omarchy>
-  plugin <update|remove> agent-bar.usage --yes` and return once systemd has
+  plugin <update|remove> othavi0.agent-bar --yes` and return once systemd has
   accepted it, so the operation survives the initiating QML service being
   torn down by the rescan it triggers. `MIG-020`–`MIG-026` are the current
   contract.
@@ -369,7 +372,7 @@ Retired as a block. `BUNDLE-033`–`BUNDLE-038C` described uninstall's own
 quarantine/rescan/health/garbage-collection transaction, matching the
 update worker chain above. `MIG-020`–`MIG-026` are the current contract:
 `uninstall` purges only Agent Bar's own XDG state (with `purge`), then
-delegates unconditionally to `omarchy plugin remove agent-bar.usage --yes`,
+delegates unconditionally to `omarchy plugin remove othavi0.agent-bar --yes`,
 which owns disabling the bar entry, deleting (or, for a non-git directory,
 backing up) the plugin directory, and rescanning. The structured stdin
 confirmation document (`BUNDLE-036`'s schema) is unchanged and lives in

--- a/docs/specs/v10/09-implementation-plan.md
+++ b/docs/specs/v10/09-implementation-plan.md
@@ -1,5 +1,10 @@
 # Agent Bar v10 Implementation Plan
 
+Amended by the plugin-ID rename (2026-08-06):
+`docs/superpowers/specs/2026-08-06-plugin-id-rename-design.md`. This document
+is a build record and keeps the `agent-bar.usage` ID it was written against.
+The live ID is `othavi0.agent-bar`.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use
 > `superpowers:subagent-driven-development` (recommended) or
 > `superpowers:executing-plans` to implement this plan task-by-task. Steps use

--- a/docs/specs/v10/10-grok-execution-runbook.md
+++ b/docs/specs/v10/10-grok-execution-runbook.md
@@ -1,5 +1,10 @@
 # Grok Execution Runbook
 
+Amended by the plugin-ID rename (2026-08-06):
+`docs/superpowers/specs/2026-08-06-plugin-id-rename-design.md`. This document
+is a build record and keeps the `agent-bar.usage` ID it was written against.
+The live ID is `othavi0.agent-bar`.
+
 ## Objective
 
 Implement Agent Bar v10 exactly as specified in this directory. The canonical


### PR DESCRIPTION
## Why

The plugin ID became `othavi0.agent-bar` in #52, but the rename stopped at the
code. The v10 specs — which `CLAUDE.md` names as the product contract when
documentation and behavior disagree — still carried 37 occurrences of
`agent-bar.usage`, including runnable commands. Anyone reading `BUNDLE-022` or
`MIG-020` and pasting the command got one that resolves to nothing on a current
install.

## What changed

`01-product-contract`, `02-target-architecture`, `03-cli-and-json-contract`,
`06-migration-and-legacy-removal`, and `08-plugin-bundle-and-release` now name
the live ID, each with a note pointing at the rename design record. ADR 0004 is
amended the same way — `CONTRIBUTING.md` declares it active — and its
"journaled transactions" line now describes the delegation that replaced them.
`CONTEXT.md`'s glossary follows.

Two occurrences are deliberately preserved:

- `MIG-008` keeps the literal `agent-bar.usage`. The v9 `shell.json` matcher
  (`LEGACY_PLUGIN_ID` in `src/settings/migration.rs`) reads that string off
  disk; renaming it would turn the migration into a silent no-op.
- `09-implementation-plan` and `10-grok-execution-runbook` are build records
  pinned to the 10.0.0 execution — one embeds a verbatim prompt. They get a
  note at the top and keep their bodies.

Historical surfaces are untouched by design: released changelog sections,
`docs/releases/**`, `docs/history/**`, `docs/superpowers/**`.

## Changelog

`[Unreleased]` held 37 lines of hand-written prose describing work already
shipped between 10.3.1 and 10.3.7, and named `omarchy plugin update
agent-bar.usage`. `docs/dev/releasing.md` says that section stays empty because
release sections are generated from commit subjects at cut time — and
`scripts/agent-bar-cut-release` inserts each new section *below* it, so the
stale block would have stayed at the top of the file permanently. It is now
empty. `CONTRIBUTING.md` misdescribed the split (it claimed only sections
"9.0.0 and older" were historical); it now matches what the repository does.

## Verification

`cargo fmt --check`, `cargo test` (274 passing), `cargo clippy --all-targets --
-D warnings`, `git diff --check`. Docs-only, so no release is cut — the fix
this documents already shipped in 10.3.8.
