### PR TITLE
fix: stop the per-poll notification loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- fix: key notification state by window, not reset
+- feat: repeat alerts on a configurable reminder
+
 ## [10.3.10] - 2026-08-12
 
 ### Changed

--- a/CoreService.js
+++ b/CoreService.js
@@ -311,6 +311,6 @@ function defaultSettings() {
     ],
     display: { metric: "remaining" },
     refreshIntervalSeconds: 60,
-    notifications: { enabled: true }
+    notifications: { enabled: true, reminderMinutes: 120 }
   }
 }

--- a/CoreSettings.js
+++ b/CoreSettings.js
@@ -220,6 +220,17 @@ function setNotificationsEnabled(draft, enabled) {
   return next
 }
 
+function setReminderMinutes(draft, minutes) {
+  var next = cloneDraft(draft)
+  if (!next.notifications)
+    next.notifications = { enabled: true, reminderMinutes: 120 }
+  var n = Math.round(Number(minutes))
+  if (!isFinite(n))
+    n = 120
+  next.notifications.reminderMinutes = n
+  return next
+}
+
 function validateSettingsDraft(draft) {
   if (!draft || typeof draft !== "object")
     return { ok: false, reason: "not an object" }
@@ -232,6 +243,10 @@ function validateSettingsDraft(draft) {
     return { ok: false, reason: "refreshIntervalSeconds" }
   if (!draft.notifications || typeof draft.notifications.enabled !== "boolean")
     return { ok: false, reason: "notifications" }
+  var reminder = Number(draft.notifications.reminderMinutes)
+  if (!isFinite(reminder) || reminder !== Math.floor(reminder)
+      || reminder < 15 || reminder > 1440)
+    return { ok: false, reason: "notifications.reminderMinutes" }
   if (!Array.isArray(draft.providers) || draft.providers.length !== 4)
     return { ok: false, reason: "providers length" }
   var seen = {}

--- a/Service.qml
+++ b/Service.qml
@@ -232,6 +232,12 @@ Item {
     })
   }
 
+  function setReminderMinutes(minutes) {
+    mutateSettingsDraft(function (d) {
+      return Settings.setReminderMinutes(d, minutes)
+    })
+  }
+
   function restoreSettingsDefaults() {
     if (settingsLocked())
       return

--- a/SettingsView.qml
+++ b/SettingsView.qml
@@ -13,9 +13,12 @@ Item {
   property string fontFamily: Style.font.family
   property url iconBase: Qt.resolvedUrl("icons/")
   // A11Y-008: true while NumberField (or other editor) owns focus.
-  property bool editorOwnsFocus: intervalField && intervalField.field
-      ? !!intervalField.field.activeFocus
-      : false
+  property bool editorOwnsFocus: (intervalField && intervalField.field
+        ? !!intervalField.field.activeFocus
+        : false)
+      || (reminderField && reminderField.field
+        ? !!reminderField.field.activeFocus
+        : false)
 
   readonly property var state: agentService ? agentService.settingsState : null
   readonly property var draft: agentService ? agentService.settingsDraft : null

--- a/SettingsView.qml
+++ b/SettingsView.qml
@@ -51,6 +51,13 @@ Item {
     return true
   }
 
+  readonly property int reminderMinutes: {
+    if (draft && draft.notifications
+        && isFinite(Number(draft.notifications.reminderMinutes)))
+      return Number(draft.notifications.reminderMinutes)
+    return 120
+  }
+
   width: parent ? parent.width : implicitWidth
   implicitHeight: col.implicitHeight
 
@@ -259,6 +266,39 @@ Item {
         onClicked: {
           if (root.agentService)
             root.agentService.setNotificationsEnabled(!root.notificationsOn)
+        }
+      }
+
+      Row {
+        spacing: Style.spacing.lg
+
+        NumberField {
+          id: reminderField
+          label: "Remind me every"
+          value: root.reminderMinutes
+          from: 15
+          to: 1440
+          stepSize: 15
+          foreground: root.foreground
+          fontFamily: root.fontFamily
+          onModified: function (v) {
+            if (root.agentService)
+              root.agentService.setReminderMinutes(v)
+          }
+        }
+
+        // Same sibling-label technique as the refresh interval above: the
+        // host NumberField exposes no suffix property, and the spin box is a
+        // child of a sibling, which QML refuses to anchor to.
+        Text {
+          y: reminderField.y + reminderField.field.y
+             + (reminderField.field.height - height) / 2
+          text: "minutes"
+          color: Util.alpha(root.foreground, 0.72)
+          font.family: root.fontFamily
+          font.pixelSize: Style.font.bodySmall
+          textFormat: Text.PlainText
+          Accessible.ignored: true
         }
       }
     }

--- a/docs/guide/commands.md
+++ b/docs/guide/commands.md
@@ -58,7 +58,7 @@ credentials and preserves the meaningful provider exit status.
 "$PLUGIN" config show
 "$PLUGIN" config apply stdin
 "$PLUGIN" config apply file /path/to/settings.json
-"$PLUGIN" config apply json '{"schemaVersion":1,"providers":[{"id":"claude","enabled":true},{"id":"codex","enabled":true},{"id":"amp","enabled":true},{"id":"grok","enabled":true}],"display":{"metric":"remaining"},"refreshIntervalSeconds":60,"notifications":{"enabled":true}}'
+"$PLUGIN" config apply json '{"schemaVersion":1,"providers":[{"id":"claude","enabled":true},{"id":"codex","enabled":true},{"id":"amp","enabled":true},{"id":"grok","enabled":true}],"display":{"metric":"remaining"},"refreshIntervalSeconds":60,"notifications":{"enabled":true,"reminderMinutes":120}}'
 ```
 
 `show` is read-only. `apply` requires one complete valid settings document and

--- a/docs/guide/runtime.md
+++ b/docs/guide/runtime.md
@@ -8,7 +8,7 @@
 | `$XDG_CONFIG_HOME/agent-bar/settings.json` | Canonical product settings |
 | `$XDG_CACHE_HOME/agent-bar/status-v2.json` | Normalized provider cache |
 | `$XDG_CACHE_HOME/agent-bar/status.lock` | Cross-process collection lock |
-| `$XDG_CACHE_HOME/agent-bar/notification-state-v1.json` | Alert deduplication |
+| `$XDG_CACHE_HOME/agent-bar/notification-state-v2.json` | Alert deduplication |
 | `$XDG_CACHE_HOME/agent-bar/notification.lock` | Alert evaluation/dispatch lock |
 | `$XDG_STATE_HOME/agent-bar/backups/` | Exact settings-migration and `doctor clean` backups |
 | `$XDG_STATE_HOME/agent-bar/maintenance.lock` | Stable shared/exclusive mutation gate |

--- a/docs/specs/v10/02-target-architecture.md
+++ b/docs/specs/v10/02-target-architecture.md
@@ -349,7 +349,7 @@ Settings:
 Cache:
   $XDG_CACHE_HOME/agent-bar/status-v2.json
   $XDG_CACHE_HOME/agent-bar/status.lock
-  $XDG_CACHE_HOME/agent-bar/notification-state-v1.json
+  $XDG_CACHE_HOME/agent-bar/notification-state-v2.json
 
 Backups:
   $XDG_STATE_HOME/agent-bar/backups/

--- a/docs/specs/v10/05-settings-cache-and-notifications.md
+++ b/docs/specs/v10/05-settings-cache-and-notifications.md
@@ -16,7 +16,8 @@
   },
   "refreshIntervalSeconds": 60,
   "notifications": {
-    "enabled": true
+    "enabled": true,
+    "reminderMinutes": 120
   }
 }
 ```
@@ -73,7 +74,7 @@ closed
 ```text
 $XDG_CACHE_HOME/agent-bar/status-v2.json
 $XDG_CACHE_HOME/agent-bar/status.lock
-$XDG_CACHE_HOME/agent-bar/notification-state-v1.json
+$XDG_CACHE_HOME/agent-bar/notification-state-v2.json
 $XDG_CACHE_HOME/agent-bar/notification.lock
 $XDG_STATE_HOME/agent-bar/maintenance.lock
 ```
@@ -181,14 +182,20 @@ warning:  used >= 90
 critical: used >= 95
 ```
 
-- `NOTIFY-001`: Notification key is provider ID, window ID, and the nullable
-  reset timestamp. Unknown reset is the single canonical `null` key.
+- `NOTIFY-001`: Notification key is provider ID and window ID. The reset
+  timestamp is recorded as an observation, never as identity: providers may
+  derive it from their own clock and return a different value for the same
+  window on every collection.
 - `NOTIFY-002`: Notifications only escalate normal -> warning -> critical.
-- `NOTIFY-003`: During uninterrupted execution, the same level is emitted once
-  per key.
+- `NOTIFY-003`: While a window stays at the same severity, the alert repeats at
+  most once per `notifications.reminderMinutes`, measured from the last
+  successful dispatch.
 - `NOTIFY-004`: Runtime notification state persists across shell restarts.
-- `NOTIFY-005`: Recovery below 90 or a changed reset key, including a change
-  between `null` and a timestamp, silently rearms.
+- `NOTIFY-005`: Recovery below 90, a change between `null` and a timestamp, or
+  a reset moving by more than the jitter tolerance silently rearms. A window a
+  ready provider stops reporting is pruned. A window whose reset has elapsed
+  is pruned only when that same cycle reached the provider live rather than
+  replaying it from cache.
 - `NOTIFY-006`: Stale data and provider failures do not trigger usage alerts.
 - `NOTIFY-007`: Disabling notifications produces no message and deletes no
   provider/cache data.
@@ -207,6 +214,12 @@ critical: used >= 95
   desktop notification is accepted but before state fsync may repeat that one
   notification on recovery; the product does not claim impossible exactly-once
   desktop delivery.
+- `NOTIFY-013`: Two observed resets describe the same window when they differ
+  by at most 60 seconds. Sub-second drift is expected: a provider may compute
+  `resets_at` from its own clock per response.
+- `NOTIFY-014`: `notifications.reminderMinutes` is an integer in `15..=1440`,
+  default `120`. It is optional on read so documents written before the field
+  existed stay valid, and is written on every explicit apply.
 
 Notification evaluation acquires `notification.lock`, reloads state, evaluates,
 dispatches, and persists before releasing the lock. Entries are processed in
@@ -215,27 +228,29 @@ persisted atomically before the next entry, so a later failure does not lose
 earlier acknowledgements. Recovery/rearm transitions that require no message
 are persisted under the same lock.
 
-The state document is closed and sorted by provider/window/reset:
+The state document is closed and sorted by provider/window:
 
 ```json
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "entries": [
     {
       "providerId": "claude",
       "windowId": "session",
       "resetAt": "2026-07-26T22:00:00Z",
-      "level": "warning"
+      "level": "warning",
+      "notifiedAt": "2026-07-26T18:42:00Z"
     }
   ]
 }
 ```
 
-`resetAt` is either a UTC RFC 3339 string or `null`. Allowed persisted levels
-are `warning` and `critical`; normal/rearmed keys are removed. Duplicate
-composite keys (including duplicate null-reset keys), unknown providers,
-unknown fields, or invalid timestamps quarantine the state and start a safe
-empty evaluation.
+`resetAt` is either a UTC RFC 3339 string or `null`. `notifiedAt` is the UTC
+RFC 3339 timestamp of the last successful dispatch for this key; `NOTIFY-003`
+measures the reminder from it. Allowed persisted levels are `warning` and
+`critical`; normal/rearmed keys are removed. Duplicate provider/window keys,
+unknown providers, unknown fields, or invalid timestamps quarantine the state
+and start a safe empty evaluation.
 
 The backend is the resolved executable `notify-send`. Rust waits at most five
 seconds for:

--- a/docs/specs/v10/07-testing-and-acceptance.md
+++ b/docs/specs/v10/07-testing-and-acceptance.md
@@ -127,7 +127,6 @@ settings.json                            Agent Bar settings schema 1
 bundle.json                              Agent Bar bundle receipt schema 1
 *.metadata.json                          Agent Bar release metadata schema 1
 update check                             Agent Bar update document schema 1
-notification-state-v1.json               notification-state schema 1
 uninstall confirmation stdin             confirmation schema 1
 ```
 

--- a/docs/specs/v10/REQUIREMENTS_MATRIX.md
+++ b/docs/specs/v10/REQUIREMENTS_MATRIX.md
@@ -92,6 +92,7 @@ design doc that now govern the amended behavior. See
 | `CACHE-019B` | 7, 15–18 | external-status versus maintenance barrier tests |
 | `CACHE-020`–`CACHE-025` | 7, 9, 11 | loading/stale/auth/provider refresh tests |
 | `NOTIFY-001`–`NOTIFY-010` | 7 | transition, persistence, recovery, dispatch tests |
+| `NOTIFY-013`–`NOTIFY-014` | 7 | jitter-tolerance, reminder-cadence, settings-range tests |
 | `NOTIFY-011` | 7, 9 | evaluate-mode and one-service tests |
 | `NOTIFY-012` | 7 | crash-window and at-least-once contract tests |
 

--- a/schemas/settings-v1.schema.json
+++ b/schemas/settings-v1.schema.json
@@ -42,10 +42,17 @@
     "notifications": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["enabled"],
+      "required": [
+        "enabled"
+      ],
       "properties": {
         "enabled": {
           "type": "boolean"
+        },
+        "reminderMinutes": {
+          "type": "integer",
+          "minimum": 15,
+          "maximum": 1440
         }
       }
     }

--- a/src/notifications/mod.rs
+++ b/src/notifications/mod.rs
@@ -13,7 +13,7 @@ use std::time::Duration;
 use crate::cli::ProviderId;
 use crate::providers::process::{ProcessRunner, ProcessSpec};
 use crate::settings::schema::{DisplayMetric, Settings as SettingsDocument};
-use crate::status::schema::{ProviderState, StatusEnvelope};
+use crate::status::schema::{DataSource, ProviderState, StatusEnvelope};
 use crate::support::redact::strip_ansi_and_controls;
 
 /// Planned notification before dispatch.
@@ -162,6 +162,17 @@ impl<'a, D: NotificationDispatcher> NotificationEvaluator<'a, D> {
                 // NOTIFY-006: stale/failures do not trigger.
                 continue;
             }
+
+            // Pruning runs before the window loop, so the rearms, upserts and
+            // de-escalations below are never undone by it. The elapsed-reset
+            // branch needs a live reading: a Ready provider can be replayed
+            // from cache for up to its TTL while still reporting the
+            // pre-reset timestamp, and treating that as proof the window
+            // restarted would fire an alert about a window that already reset.
+            let live_reading = provider.source() == Some(DataSource::Live);
+            let live: Vec<&str> = provider.windows().iter().map(|w| w.id()).collect();
+            state.prune_ready_provider(id, &live, self.now, live_reading);
+
             for window in provider.windows() {
                 let used = window.used_percent();
                 let observed = window.resets_at();
@@ -736,6 +747,142 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(dispatcher.runner.specs.lock().unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn evaluate_prunes_rows_for_windows_a_ready_provider_no_longer_reports() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = store_in(&dir);
+        let mut seeded = NotificationState::empty();
+        seeded.upsert(NotificationEntry {
+            provider_id: "claude".into(),
+            window_id: "weekly-model:retired".into(),
+            reset_at: Some(datetime!(2026-08-28 12:00:00 UTC)),
+            level: NotificationLevel::Critical,
+            notified_at: datetime!(2026-08-20 10:00:00 UTC),
+        });
+        store.save(&seeded).unwrap();
+
+        let runner = ScriptedNotify {
+            specs: Mutex::new(Vec::new()),
+            fail: false,
+        };
+        let dispatcher = NotifySendDispatcher::new(runner);
+        let settings = SettingsDocument::defaults();
+        NotificationEvaluator {
+            store: &store,
+            dispatcher: &dispatcher,
+            settings: &settings,
+            now: datetime!(2026-08-21 10:00:00 UTC),
+        }
+        .evaluate(&envelope_with_used(10.0))
+        .await
+        .unwrap();
+
+        let state = store.load().unwrap();
+        assert!(
+            state.entries.is_empty(),
+            "a window the provider stopped reporting must not linger forever"
+        );
+    }
+
+    #[tokio::test]
+    async fn evaluate_keeps_rows_for_providers_absent_from_the_envelope() {
+        // Pruning is Ready-only. A provider missing from this envelope has
+        // confirmed nothing, so its dedupe must survive or it notifies again
+        // the moment it recovers. The sibling case — present but not Ready —
+        // is covered by evaluate_keeps_rows_for_a_stale_provider below.
+        let dir = tempfile::tempdir().unwrap();
+        let store = store_in(&dir);
+        let mut seeded = NotificationState::empty();
+        seeded.upsert(NotificationEntry {
+            provider_id: "amp".into(),
+            window_id: "daily".into(),
+            reset_at: Some(datetime!(2026-08-12 00:00:00 UTC)),
+            level: NotificationLevel::Critical,
+            notified_at: datetime!(2026-08-11 23:00:00 UTC),
+        });
+        store.save(&seeded).unwrap();
+
+        let runner = ScriptedNotify {
+            specs: Mutex::new(Vec::new()),
+            fail: false,
+        };
+        let dispatcher = NotifySendDispatcher::new(runner);
+        let settings = SettingsDocument::defaults();
+        NotificationEvaluator {
+            store: &store,
+            dispatcher: &dispatcher,
+            settings: &settings,
+            now: datetime!(2026-08-21 10:00:00 UTC),
+        }
+        .evaluate(&envelope_with_used(10.0))
+        .await
+        .unwrap();
+
+        assert_eq!(store.load().unwrap().entries.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn evaluate_keeps_rows_for_a_stale_provider() {
+        // Present in the envelope but not Ready: the provider confirmed
+        // nothing this cycle, so neither pruning nor rearming may touch it
+        // (NOTIFY-006). No pre-existing test covered this — the guard was
+        // only a comment.
+        use crate::status::schema::{ErrorCode, ProviderAction, ProviderError};
+
+        let dir = tempfile::tempdir().unwrap();
+        let store = store_in(&dir);
+        let mut seeded = NotificationState::empty();
+        seeded.upsert(NotificationEntry {
+            provider_id: "claude".into(),
+            window_id: "session".into(),
+            reset_at: Some(datetime!(2026-08-12 00:00:00 UTC)),
+            level: NotificationLevel::Critical,
+            notified_at: datetime!(2026-08-11 23:00:00 UTC),
+        });
+        store.save(&seeded).unwrap();
+
+        let window = UsageWindow::try_new("session", "Session", 5.0, 95.0, None).unwrap();
+        let stale = ProviderStatus::stale(
+            ProviderId::Claude,
+            "Claude",
+            None,
+            None,
+            vec![window],
+            datetime!(2026-08-20 10:00:00 UTC),
+            ProviderError::new(ErrorCode::NetworkError, "Network error.", true),
+            ProviderAction::retry("Retry"),
+        )
+        .unwrap();
+        let envelope = StatusEnvelope::try_new_for_package(
+            datetime!(2026-08-21 10:00:00 UTC),
+            StatusRequest {
+                provider: None,
+                cache: CacheMode::Use,
+            },
+            vec![stale],
+        )
+        .unwrap();
+
+        let runner = ScriptedNotify {
+            specs: Mutex::new(Vec::new()),
+            fail: false,
+        };
+        let dispatcher = NotifySendDispatcher::new(runner);
+        let settings = SettingsDocument::defaults();
+        NotificationEvaluator {
+            store: &store,
+            dispatcher: &dispatcher,
+            settings: &settings,
+            now: datetime!(2026-08-21 10:00:00 UTC),
+        }
+        .evaluate(&envelope)
+        .await
+        .unwrap();
+
+        assert_eq!(store.load().unwrap().entries.len(), 1);
+        assert!(dispatcher.runner.specs.lock().unwrap().is_empty());
     }
 
     #[test]

--- a/src/notifications/mod.rs
+++ b/src/notifications/mod.rs
@@ -238,7 +238,16 @@ impl<'a, D: NotificationDispatcher> NotificationEvaluator<'a, D> {
                         notified_at: self.now,
                     });
                     // Persist after each success (at-least-once algorithm).
-                    self.store.save(&state).map_err(|err| err.to_string())?;
+                    if let Err(err) = self.store.save(&state) {
+                        // The incident this replaces ran for days behind a bare
+                        // stderr line nobody reads.
+                        log::warn!(
+                            "notification state save failed for {}/{}: {err}",
+                            item.provider_id.as_str(),
+                            item.window_id
+                        );
+                        return Err(err.to_string());
+                    }
                 }
                 Err(err) => {
                     // Leave the row unadvanced; stop later notifications.

--- a/src/notifications/mod.rs
+++ b/src/notifications/mod.rs
@@ -146,6 +146,8 @@ impl<'a, D: NotificationDispatcher> NotificationEvaluator<'a, D> {
         if !self.settings.notifications.enabled {
             return Ok(());
         }
+        let reminder =
+            time::Duration::minutes(i64::from(self.settings.notifications.reminder_minutes));
 
         let mut state = self.store.load().map_err(|err| err.to_string())?;
         let order: Vec<ProviderId> = self.settings.providers.iter().map(|p| p.id.0).collect();
@@ -162,16 +164,36 @@ impl<'a, D: NotificationDispatcher> NotificationEvaluator<'a, D> {
             }
             for window in provider.windows() {
                 let used = window.used_percent();
+                let observed = window.resets_at();
                 let Some(level) = NotificationLevel::from_used_percent(used) else {
                     // Recovery below the warning threshold rearms.
                     state.remove_key(id, window.id());
                     continue;
                 };
-                let prev = state.entry_for(id, window.id()).map(|e| e.level);
-                let should_emit = match prev {
+                let saved = state.entry_for(id, window.id()).cloned();
+                let should_emit = match saved.as_ref() {
+                    // Never spoken for this window.
                     None => true,
-                    Some(prev_level) if level > prev_level => true,
-                    Some(_) => false, // same level once (NOTIFY-003)
+                    // The window advanced; a genuinely new quota period.
+                    Some(prev) if !NotificationState::same_window(prev.reset_at, observed) => true,
+                    // NOTIFY-002: severity only ever escalates.
+                    Some(prev) if level > prev.level => true,
+                    // Same severity: the reminder decides, not the poll.
+                    Some(prev) if level == prev.level => self.now - prev.notified_at >= reminder,
+                    // De-escalation inside the same window. NOTIFY-002 forbids
+                    // speaking, but the tracked severity must follow the window
+                    // down or the reminder can never match again, silencing a
+                    // window that is still above its threshold.
+                    Some(prev) => {
+                        state.upsert(NotificationEntry {
+                            provider_id: id.as_str().to_owned(),
+                            window_id: window.id().to_owned(),
+                            reset_at: observed,
+                            level,
+                            notified_at: prev.notified_at,
+                        });
+                        false
+                    }
                 };
                 if should_emit {
                     pending.push(PendingNotification {
@@ -182,9 +204,8 @@ impl<'a, D: NotificationDispatcher> NotificationEvaluator<'a, D> {
                         used_percent: used,
                         remaining_percent: window.remaining_percent(),
                         metric: self.settings.display.metric,
-                        reset_at: window.resets_at(),
-                        reset_in: window
-                            .resets_at()
+                        reset_at: observed,
+                        reset_in: observed
                             .map(|ts| crate::support::countdown::reset_countdown(self.now, ts)),
                         level,
                     });
@@ -192,7 +213,7 @@ impl<'a, D: NotificationDispatcher> NotificationEvaluator<'a, D> {
             }
         }
 
-        // Persist silent rearms first.
+        // Persist silent rearms and de-escalations first.
         self.store.save(&state).map_err(|err| err.to_string())?;
 
         for item in pending {
@@ -209,7 +230,7 @@ impl<'a, D: NotificationDispatcher> NotificationEvaluator<'a, D> {
                     self.store.save(&state).map_err(|err| err.to_string())?;
                 }
                 Err(err) => {
-                    // Leave key unadvanced; stop later notifications.
+                    // Leave the row unadvanced; stop later notifications.
                     return Err(err);
                 }
             }
@@ -569,6 +590,152 @@ mod tests {
         pending.metric = DisplayMetric::Used;
         let spec = NotifySendDispatcher::<ScriptedNotify>::build_spec(&pending);
         assert_eq!(spec.args[3], "96% used.");
+    }
+
+    #[tokio::test]
+    async fn a_new_window_renotifies() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = store_in(&dir);
+        let runner = ScriptedNotify {
+            specs: Mutex::new(Vec::new()),
+            fail: false,
+        };
+        let dispatcher = NotifySendDispatcher::new(runner);
+        let settings = SettingsDocument::defaults();
+        let eval = NotificationEvaluator {
+            store: &store,
+            dispatcher: &dispatcher,
+            settings: &settings,
+            now: datetime!(2026-08-21 10:31:56 UTC),
+        };
+        eval.evaluate(&envelope_with_reset(
+            96.0,
+            datetime!(2026-08-21 11:59:59 UTC),
+        ))
+        .await
+        .unwrap();
+        eval.evaluate(&envelope_with_reset(
+            96.0,
+            datetime!(2026-08-28 11:59:59 UTC),
+        ))
+        .await
+        .unwrap();
+        assert_eq!(dispatcher.runner.specs.lock().unwrap().len(), 2);
+        let state = store.load().unwrap();
+        assert_eq!(
+            state.entries.len(),
+            1,
+            "the advance replaces, never appends"
+        );
+    }
+
+    #[tokio::test]
+    async fn the_same_level_repeats_only_after_the_reminder_elapses() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = store_in(&dir);
+        let runner = ScriptedNotify {
+            specs: Mutex::new(Vec::new()),
+            fail: false,
+        };
+        let dispatcher = NotifySendDispatcher::new(runner);
+        let settings = SettingsDocument::defaults(); // reminderMinutes == 120
+        let reset = datetime!(2026-08-21 22:00:00 UTC);
+        let first = datetime!(2026-08-21 10:00:00 UTC);
+        let envelope = envelope_with_reset(96.0, reset);
+
+        // A fresh evaluator per instant: `now` is a field, not an argument.
+        NotificationEvaluator {
+            store: &store,
+            dispatcher: &dispatcher,
+            settings: &settings,
+            now: first,
+        }
+        .evaluate(&envelope)
+        .await
+        .unwrap();
+
+        NotificationEvaluator {
+            store: &store,
+            dispatcher: &dispatcher,
+            settings: &settings,
+            now: first + time::Duration::minutes(119),
+        }
+        .evaluate(&envelope)
+        .await
+        .unwrap();
+        assert_eq!(
+            dispatcher.runner.specs.lock().unwrap().len(),
+            1,
+            "one minute short of the reminder must stay silent"
+        );
+
+        NotificationEvaluator {
+            store: &store,
+            dispatcher: &dispatcher,
+            settings: &settings,
+            now: first + time::Duration::minutes(120),
+        }
+        .evaluate(&envelope)
+        .await
+        .unwrap();
+        assert_eq!(dispatcher.runner.specs.lock().unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn de_escalation_lowers_the_tracked_level_without_notifying() {
+        // Critical -> Warning while still above 90 must not dispatch
+        // (NOTIFY-002), but the stored level has to follow the window down.
+        // If it stays Critical, the reminder arm never matches again and the
+        // user stops hearing about a window that is still at 92 percent.
+        let dir = tempfile::tempdir().unwrap();
+        let store = store_in(&dir);
+        let runner = ScriptedNotify {
+            specs: Mutex::new(Vec::new()),
+            fail: false,
+        };
+        let dispatcher = NotifySendDispatcher::new(runner);
+        let settings = SettingsDocument::defaults();
+        let reset = datetime!(2026-08-21 22:00:00 UTC);
+        let first = datetime!(2026-08-21 10:00:00 UTC);
+
+        NotificationEvaluator {
+            store: &store,
+            dispatcher: &dispatcher,
+            settings: &settings,
+            now: first,
+        }
+        .evaluate(&envelope_with_reset(96.0, reset))
+        .await
+        .unwrap();
+
+        NotificationEvaluator {
+            store: &store,
+            dispatcher: &dispatcher,
+            settings: &settings,
+            now: first + time::Duration::minutes(5),
+        }
+        .evaluate(&envelope_with_reset(92.0, reset))
+        .await
+        .unwrap();
+        assert_eq!(
+            dispatcher.runner.specs.lock().unwrap().len(),
+            1,
+            "dropping a level never speaks"
+        );
+        let state = store.load().unwrap();
+        assert_eq!(state.entries[0].level, NotificationLevel::Warning);
+
+        // The reminder now fires at the level the window is actually at.
+        NotificationEvaluator {
+            store: &store,
+            dispatcher: &dispatcher,
+            settings: &settings,
+            now: first + time::Duration::minutes(121),
+        }
+        .evaluate(&envelope_with_reset(92.0, reset))
+        .await
+        .unwrap();
+        assert_eq!(dispatcher.runner.specs.lock().unwrap().len(), 2);
     }
 
     #[test]

--- a/src/notifications/mod.rs
+++ b/src/notifications/mod.rs
@@ -163,11 +163,11 @@ impl<'a, D: NotificationDispatcher> NotificationEvaluator<'a, D> {
             for window in provider.windows() {
                 let used = window.used_percent();
                 let Some(level) = NotificationLevel::from_used_percent(used) else {
-                    // Recovery below 90 → rearm (remove key).
-                    state.remove_key(id, window.id(), window.resets_at());
+                    // Recovery below the warning threshold rearms.
+                    state.remove_key(id, window.id());
                     continue;
                 };
-                let prev = state.level_for(id, window.id(), window.resets_at());
+                let prev = state.entry_for(id, window.id()).map(|e| e.level);
                 let should_emit = match prev {
                     None => true,
                     Some(prev_level) if level > prev_level => true,
@@ -203,6 +203,7 @@ impl<'a, D: NotificationDispatcher> NotificationEvaluator<'a, D> {
                         window_id: item.window_id.clone(),
                         reset_at: item.reset_at,
                         level: item.level,
+                        notified_at: self.now,
                     });
                     // Persist after each success (at-least-once algorithm).
                     self.store.save(&state).map_err(|err| err.to_string())?;
@@ -316,6 +317,76 @@ mod tests {
             vec![provider],
         )
         .unwrap()
+    }
+
+    fn store_in(dir: &tempfile::TempDir) -> NotificationStateStore {
+        NotificationStateStore::new(
+            NotificationPaths {
+                state: dir.path().join("nstate.json"),
+                lock: dir.path().join("n.lock"),
+            },
+            Arc::new(MaintenanceGate::open(dir.path().join("m.lock")).unwrap()),
+        )
+    }
+
+    #[tokio::test]
+    async fn sub_second_reset_jitter_does_not_renotify() {
+        // The incident, end to end: three consecutive collections of the same
+        // Claude window, each carrying a different microsecond reset. Before
+        // this task that dispatched three times and persisted nothing.
+        let dir = tempfile::tempdir().unwrap();
+        let store = store_in(&dir);
+        let runner = ScriptedNotify {
+            specs: Mutex::new(Vec::new()),
+            fail: false,
+        };
+        let dispatcher = NotifySendDispatcher::new(runner);
+        let settings = SettingsDocument::defaults();
+        let eval = NotificationEvaluator {
+            store: &store,
+            dispatcher: &dispatcher,
+            settings: &settings,
+            now: datetime!(2026-08-21 10:31:56 UTC),
+        };
+        for reset in [
+            datetime!(2026-08-21 11:59:59.707742 UTC),
+            datetime!(2026-08-21 11:59:59.854947 UTC),
+            datetime!(2026-08-21 12:00:00.024238 UTC),
+        ] {
+            eval.evaluate(&envelope_with_reset(96.0, reset))
+                .await
+                .unwrap();
+        }
+        assert_eq!(dispatcher.runner.specs.lock().unwrap().len(), 1);
+        let state = store.load().unwrap();
+        assert_eq!(state.entries.len(), 1, "one row per window, not per reset");
+    }
+
+    #[tokio::test]
+    async fn recovery_below_the_threshold_clears_the_row() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = store_in(&dir);
+        let runner = ScriptedNotify {
+            specs: Mutex::new(Vec::new()),
+            fail: false,
+        };
+        let dispatcher = NotifySendDispatcher::new(runner);
+        let settings = SettingsDocument::defaults();
+        let reset = datetime!(2026-08-21 22:00:00 UTC);
+        let eval = NotificationEvaluator {
+            store: &store,
+            dispatcher: &dispatcher,
+            settings: &settings,
+            now: datetime!(2026-08-21 10:00:00 UTC),
+        };
+        eval.evaluate(&envelope_with_reset(96.0, reset))
+            .await
+            .unwrap();
+        assert_eq!(store.load().unwrap().entries.len(), 1);
+        eval.evaluate(&envelope_with_reset(10.0, reset))
+            .await
+            .unwrap();
+        assert!(store.load().unwrap().entries.is_empty());
     }
 
     #[tokio::test]

--- a/src/notifications/state.rs
+++ b/src/notifications/state.rs
@@ -1,6 +1,5 @@
-//! Persisted notification deduplication state (schema v1).
+//! Persisted notification deduplication state (schema v2).
 
-use std::cmp::Ordering;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -13,7 +12,17 @@ use crate::cli::ProviderId;
 use crate::support::atomic_file::replace_atomically;
 use crate::support::maintenance_gate::SharedMaintenanceGate;
 
-pub const NOTIFICATION_STATE_VERSION: u32 = 1;
+pub const NOTIFICATION_STATE_VERSION: u32 = 2;
+
+/// How far two observed reset timestamps may drift and still describe the same
+/// quota window.
+///
+/// The Claude usage endpoint derives `resets_at` from its own clock on every
+/// response — within one envelope its three windows come back with distinct
+/// microseconds — so no two collections ever agree byte-for-byte. Sixty
+/// seconds swallows that drift with orders of magnitude to spare and stays
+/// negligible against a 5h or 7d window.
+pub const RESET_JITTER_TOLERANCE: time::Duration = time::Duration::seconds(60);
 
 /// Severity thresholds on `usedPercent`. Duplicated in
 /// `CoreView.js` because the status schema is frozen at v2 and
@@ -53,9 +62,25 @@ impl NotificationLevel {
 pub struct NotificationEntry {
     pub provider_id: String,
     pub window_id: String,
+    /// Last observed reset for this window. Evidence, not identity: see
+    /// `RESET_JITTER_TOLERANCE`.
     #[serde(with = "time::serde::rfc3339::option")]
     pub reset_at: Option<OffsetDateTime>,
     pub level: NotificationLevel,
+    /// When the last successful dispatch happened; drives the reminder.
+    #[serde(with = "time::serde::rfc3339")]
+    pub notified_at: OffsetDateTime,
+}
+
+impl NotificationEntry {
+    /// The one definition of a notification's identity.
+    ///
+    /// v1 spelled this comparison out by hand in four places; `validate`
+    /// truncated the reset to whole seconds while the other three compared
+    /// nanoseconds, and the disagreement blocked every write.
+    pub fn key(&self) -> (&str, &str) {
+        (self.provider_id.as_str(), self.window_id.as_str())
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -84,12 +109,7 @@ impl NotificationState {
                     entry.provider_id.clone(),
                 ));
             }
-            let key = (
-                entry.provider_id.clone(),
-                entry.window_id.clone(),
-                entry.reset_at.map(|t| t.unix_timestamp()),
-            );
-            if !keys.insert(key) {
+            if !keys.insert(entry.key()) {
                 return Err(NotificationStateError::DuplicateKey);
             }
         }
@@ -97,59 +117,62 @@ impl NotificationState {
     }
 
     pub fn sort_entries(&mut self) {
-        self.entries
-            .sort_by(|a, b| match a.provider_id.cmp(&b.provider_id) {
-                Ordering::Equal => match a.window_id.cmp(&b.window_id) {
-                    Ordering::Equal => match (a.reset_at, b.reset_at) {
-                        (None, None) => Ordering::Equal,
-                        (None, Some(_)) => Ordering::Less,
-                        (Some(_), None) => Ordering::Greater,
-                        (Some(x), Some(y)) => x.cmp(&y),
-                    },
-                    other => other,
-                },
-                other => other,
-            });
+        self.entries.sort_by(|a, b| a.key().cmp(&b.key()));
     }
 
-    pub fn level_for(
-        &self,
-        provider: ProviderId,
-        window_id: &str,
-        reset_at: Option<OffsetDateTime>,
-    ) -> Option<NotificationLevel> {
-        self.entries.iter().find_map(|e| {
-            if e.provider_id == provider.as_str()
-                && e.window_id == window_id
-                && e.reset_at == reset_at
-            {
-                Some(e.level)
-            } else {
-                None
-            }
-        })
+    /// True when two observed resets describe the same quota window.
+    pub fn same_window(saved: Option<OffsetDateTime>, observed: Option<OffsetDateTime>) -> bool {
+        match (saved, observed) {
+            (None, None) => true,
+            (Some(a), Some(b)) => (a - b).abs() <= RESET_JITTER_TOLERANCE,
+            _ => false,
+        }
+    }
+
+    pub fn entry_for(&self, provider: ProviderId, window_id: &str) -> Option<&NotificationEntry> {
+        self.entries
+            .iter()
+            .find(|e| e.key() == (provider.as_str(), window_id))
     }
 
     pub fn upsert(&mut self, entry: NotificationEntry) {
-        self.entries.retain(|e| {
-            !(e.provider_id == entry.provider_id
-                && e.window_id == entry.window_id
-                && e.reset_at == entry.reset_at)
-        });
+        self.entries.retain(|e| e.key() != entry.key());
         self.entries.push(entry);
         self.sort_entries();
     }
 
-    pub fn remove_key(
+    pub fn remove_key(&mut self, provider: ProviderId, window_id: &str) {
+        self.entries
+            .retain(|e| e.key() != (provider.as_str(), window_id));
+    }
+
+    /// Drop rows for one `Ready` provider whose window vanished from the
+    /// envelope, or whose reset already elapsed on a live reading.
+    ///
+    /// `is_live` guards the elapsed branch specifically. A `Ready` provider
+    /// can be served straight from cache for up to its TTL while still
+    /// reporting the pre-reset timestamp (`for_cache_hit` in
+    /// `src/status/schema.rs` clones the windows unchanged and keeps the state
+    /// `Ready`), so an elapsed reset is only evidence the window restarted
+    /// when this cycle actually reached the provider.
+    pub fn prune_ready_provider(
         &mut self,
         provider: ProviderId,
-        window_id: &str,
-        reset_at: Option<OffsetDateTime>,
+        live_windows: &[&str],
+        now: OffsetDateTime,
+        is_live: bool,
     ) {
         self.entries.retain(|e| {
-            !(e.provider_id == provider.as_str()
-                && e.window_id == window_id
-                && e.reset_at == reset_at)
+            if e.provider_id != provider.as_str() {
+                return true;
+            }
+            if !live_windows.contains(&e.window_id.as_str()) {
+                return false;
+            }
+            if !is_live {
+                return true;
+            }
+            e.reset_at.map(|ts| ts > now).unwrap_or(true)
         });
     }
 }
@@ -165,7 +188,10 @@ pub enum NotificationStateError {
 impl std::fmt::Display for NotificationStateError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Version => write!(f, "notification state schemaVersion must be 1"),
+            Self::Version => write!(
+                f,
+                "notification state schemaVersion must be {NOTIFICATION_STATE_VERSION}"
+            ),
             Self::UnknownProvider(id) => write!(f, "unknown notification provider '{id}'"),
             Self::DuplicateKey => write!(f, "duplicate notification key"),
             Self::InvalidJson(msg) => write!(f, "invalid notification state: {msg}"),
@@ -185,7 +211,7 @@ impl NotificationPaths {
     pub fn from_cache_home(cache_home: impl Into<PathBuf>) -> Self {
         let root = cache_home.into().join("agent-bar");
         Self {
-            state: root.join("notification-state-v1.json"),
+            state: root.join("notification-state-v2.json"),
             lock: root.join("notification.lock"),
         }
     }
@@ -298,21 +324,124 @@ mod tests {
     }
 
     #[test]
-    fn rearm_on_reset_change() {
+    fn sub_second_reset_jitter_is_the_same_window() {
+        // The Claude usage endpoint derives resets_at from its own clock per
+        // response, so the same window returns with millisecond drift. v1
+        // treated that as a new key, which is what produced the notification
+        // loop this test exists to prevent.
+        let a = datetime!(2026-08-21 11:59:59.707742 UTC);
+        let b = datetime!(2026-08-21 11:59:59.854947 UTC);
+        let c = datetime!(2026-08-21 12:00:00.024238 UTC);
+        assert!(NotificationState::same_window(Some(a), Some(b)));
+        assert!(NotificationState::same_window(Some(a), Some(c)));
+        assert!(NotificationState::same_window(None, None));
+    }
+
+    #[test]
+    fn a_real_window_advance_is_not_the_same_window() {
+        let now = datetime!(2026-08-21 11:59:59 UTC);
+        let next_week = datetime!(2026-08-28 11:59:59 UTC);
+        assert!(!NotificationState::same_window(Some(now), Some(next_week)));
+        assert!(!NotificationState::same_window(Some(now), None));
+        assert!(!NotificationState::same_window(None, Some(now)));
+        // Just outside the tolerance, so the boundary is pinned, not implied.
+        let just_past = datetime!(2026-08-21 12:01:00.001 UTC);
+        assert!(!NotificationState::same_window(Some(now), Some(just_past)));
+    }
+
+    #[test]
+    fn upsert_replaces_a_jittered_row_instead_of_appending() {
+        let mut state = NotificationState::empty();
+        state.upsert(NotificationEntry {
+            provider_id: "claude".into(),
+            window_id: "weekly-model:fable".into(),
+            reset_at: Some(datetime!(2026-08-21 11:59:59.854947 UTC)),
+            level: NotificationLevel::Warning,
+            notified_at: datetime!(2026-08-21 10:31:56 UTC),
+        });
+        state.upsert(NotificationEntry {
+            provider_id: "claude".into(),
+            window_id: "weekly-model:fable".into(),
+            reset_at: Some(datetime!(2026-08-21 11:59:59.707742 UTC)),
+            level: NotificationLevel::Critical,
+            notified_at: datetime!(2026-08-21 10:37:56 UTC),
+        });
+        assert_eq!(state.entries.len(), 1);
+        assert_eq!(state.entries[0].level, NotificationLevel::Critical);
+        // The exact document that made save() fail with "duplicate
+        // notification key" on the reporting install.
+        state.validate().unwrap();
+    }
+
+    #[test]
+    fn prune_drops_elapsed_and_absent_windows_on_a_live_reading() {
+        let now = datetime!(2026-08-21 12:00:00 UTC);
+        let mut state = NotificationState::empty();
+        for (window, reset) in [
+            ("live", Some(datetime!(2026-08-28 12:00:00 UTC))),
+            ("elapsed", Some(datetime!(2026-08-12 00:00:00 UTC))),
+            ("vanished", Some(datetime!(2026-08-28 12:00:00 UTC))),
+        ] {
+            state.upsert(NotificationEntry {
+                provider_id: "claude".into(),
+                window_id: window.into(),
+                reset_at: reset,
+                level: NotificationLevel::Warning,
+                notified_at: datetime!(2026-08-21 10:00:00 UTC),
+            });
+        }
+        state.prune_ready_provider(ProviderId::Claude, &["live", "elapsed"], now, true);
+        let kept: Vec<&str> = state.entries.iter().map(|e| e.window_id.as_str()).collect();
+        assert_eq!(kept, vec!["live"]);
+    }
+
+    #[test]
+    fn prune_keeps_elapsed_rows_when_the_reading_came_from_cache() {
+        // A Ready provider can be served straight from cache for up to its
+        // TTL (300s for Claude) while still reporting the pre-reset
+        // timestamp. Treating that as proof the window restarted would rearm
+        // against a reading the provider never confirmed.
+        let now = datetime!(2026-08-21 12:00:00 UTC);
+        let mut state = NotificationState::empty();
+        state.upsert(NotificationEntry {
+            provider_id: "claude".into(),
+            window_id: "weekly".into(),
+            reset_at: Some(datetime!(2026-08-21 11:59:59 UTC)),
+            level: NotificationLevel::Critical,
+            notified_at: datetime!(2026-08-21 10:00:00 UTC),
+        });
+        state.prune_ready_provider(ProviderId::Claude, &["weekly"], now, false);
+        assert_eq!(state.entries.len(), 1, "cache reading is not evidence");
+    }
+
+    #[test]
+    fn prune_leaves_other_providers_untouched() {
+        let now = datetime!(2026-08-21 12:00:00 UTC);
+        let mut state = NotificationState::empty();
+        state.upsert(NotificationEntry {
+            provider_id: "amp".into(),
+            window_id: "daily".into(),
+            reset_at: Some(datetime!(2026-08-12 00:00:00 UTC)),
+            level: NotificationLevel::Critical,
+            notified_at: datetime!(2026-08-11 23:00:00 UTC),
+        });
+        state.prune_ready_provider(ProviderId::Claude, &[], now, true);
+        assert_eq!(state.entries.len(), 1);
+    }
+
+    #[test]
+    fn entry_for_finds_a_row_regardless_of_reset_drift() {
         let mut state = NotificationState::empty();
         state.upsert(NotificationEntry {
             provider_id: "claude".into(),
             window_id: "session".into(),
             reset_at: Some(datetime!(2026-07-26 22:00:00 UTC)),
             level: NotificationLevel::Warning,
+            notified_at: datetime!(2026-07-26 18:42:00 UTC),
         });
-        assert!(state
-            .level_for(
-                ProviderId::Claude,
-                "session",
-                Some(datetime!(2026-07-26 23:00:00 UTC))
-            )
-            .is_none());
+        let found = state.entry_for(ProviderId::Claude, "session").unwrap();
+        assert_eq!(found.level, NotificationLevel::Warning);
+        assert!(state.entry_for(ProviderId::Claude, "weekly").is_none());
     }
 
     #[test]
@@ -320,7 +449,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let store = NotificationStateStore::new(
             NotificationPaths {
-                state: dir.path().join("notification-state-v1.json"),
+                state: dir.path().join("notification-state-v2.json"),
                 lock: dir.path().join("notification.lock"),
             },
             Arc::new(MaintenanceGate::open(dir.path().join("m.lock")).unwrap()),
@@ -331,6 +460,7 @@ mod tests {
             window_id: "session".into(),
             reset_at: None,
             level: NotificationLevel::Critical,
+            notified_at: datetime!(2026-07-26 18:42:00 UTC),
         });
         store.save(&state).unwrap();
         let loaded = store.load().unwrap();

--- a/src/plugin/doctor.rs
+++ b/src/plugin/doctor.rs
@@ -49,8 +49,9 @@ pub fn default_legacy_candidates(home: &Path) -> Vec<PathBuf> {
         // History database from the removed local-usage engine
         cache.join("agent-bar").join(legacy_usage_db),
         cache.join("agent-bar/history"),
-        // Old notification state filenames (v9)
+        // Old notification state filenames (v9, and v1 superseded by v2)
         cache.join("agent-bar/notify-state.json"),
+        cache.join("agent-bar/notification-state-v1.json"),
         // Standalone install leftovers
         local.join("share/agent-bar"),
         // Old global bin is not auto-removed without hash proof — listed for scan only
@@ -204,6 +205,15 @@ mod tests {
 
     fn legacy_usage_db_name() -> &'static str {
         concat!("usage", ".", "re", "db")
+    }
+
+    #[test]
+    fn legacy_candidates_include_the_v1_notification_state() {
+        let home = Path::new("/home/example");
+        let candidates = default_legacy_candidates(home);
+        assert!(candidates.contains(&home.join(".cache/agent-bar/notification-state-v1.json")));
+        // The v9 filename stays listed; v1 joins it rather than replacing it.
+        assert!(candidates.contains(&home.join(".cache/agent-bar/notify-state.json")));
     }
 
     #[test]

--- a/src/settings/migration.rs
+++ b/src/settings/migration.rs
@@ -455,6 +455,7 @@ fn migrate_v9_settings(raw: &[u8]) -> Result<(Settings, Vec<String>, bool), Migr
         refresh_interval_seconds: refresh,
         notifications: NotificationSettings {
             enabled: notify_enabled,
+            reminder_minutes: crate::settings::schema::default_reminder_minutes(),
         },
     };
     settings

--- a/src/settings/schema.rs
+++ b/src/settings/schema.rs
@@ -11,6 +11,15 @@ use crate::cli::ProviderId;
 const SCHEMA_VERSION: u32 = 1;
 const MIN_REFRESH: u32 = 30;
 const MAX_REFRESH: u32 = 3600;
+const MIN_REMINDER_MINUTES: u32 = 15;
+const MAX_REMINDER_MINUTES: u32 = 1440;
+/// Two hours. Hourly was judged too frequent by the product owner; the field
+/// exists so this is a default, not a floor.
+const DEFAULT_REMINDER_MINUTES: u32 = 120;
+
+pub(crate) fn default_reminder_minutes() -> u32 {
+    DEFAULT_REMINDER_MINUTES
+}
 
 /// Display metric for chips and windows.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -65,6 +74,10 @@ pub struct DisplaySettings {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct NotificationSettings {
     pub enabled: bool,
+    /// Minutes between repeats of an alert that is still above its threshold.
+    /// Optional on read so documents written before this field stay valid.
+    #[serde(default = "default_reminder_minutes")]
+    pub reminder_minutes: u32,
 }
 
 /// Canonical settings document (schema v1).
@@ -131,7 +144,10 @@ impl Settings {
                 metric: DisplayMetric::Remaining,
             },
             refresh_interval_seconds: 60,
-            notifications: NotificationSettings { enabled: true },
+            notifications: NotificationSettings {
+                enabled: true,
+                reminder_minutes: DEFAULT_REMINDER_MINUTES,
+            },
         }
     }
 
@@ -156,6 +172,13 @@ impl Settings {
         if !(MIN_REFRESH..=MAX_REFRESH).contains(&self.refresh_interval_seconds) {
             return Err(SettingsError::new(format!(
                 "refreshIntervalSeconds must be in {MIN_REFRESH}..={MAX_REFRESH}"
+            )));
+        }
+        if !(MIN_REMINDER_MINUTES..=MAX_REMINDER_MINUTES)
+            .contains(&self.notifications.reminder_minutes)
+        {
+            return Err(SettingsError::new(format!(
+                "reminderMinutes must be in {MIN_REMINDER_MINUTES}..={MAX_REMINDER_MINUTES}"
             )));
         }
         if self.providers.len() != ProviderId::ALL.len() {
@@ -224,7 +247,7 @@ fn reject_unknown_top_level(value: &Value) -> Result<(), SettingsError> {
             .as_object()
             .ok_or_else(|| SettingsError::new("notifications must be an object"))?;
         for key in notifications.keys() {
-            if key != "enabled" {
+            if key != "enabled" && key != "reminderMinutes" {
                 return Err(SettingsError::new(format!(
                     "unknown notifications key '{key}'"
                 )));
@@ -274,5 +297,44 @@ mod tests {
 
         let dup = br#"{"schemaVersion":1,"providers":[{"id":"claude","enabled":true},{"id":"claude","enabled":false},{"id":"amp","enabled":true},{"id":"grok","enabled":true}],"display":{"metric":"remaining"},"refreshIntervalSeconds":60,"notifications":{"enabled":true}}"#;
         assert!(Settings::parse_strict(dup).is_err());
+    }
+
+    #[test]
+    fn reminder_minutes_defaults_when_absent() {
+        // Settings reads never rewrite (SET-007), so an existing settings.json
+        // predating this field must parse and take the default silently.
+        let doc = br#"{"schemaVersion":1,"providers":[{"id":"claude","enabled":true},{"id":"codex","enabled":true},{"id":"amp","enabled":true},{"id":"grok","enabled":true}],"display":{"metric":"remaining"},"refreshIntervalSeconds":60,"notifications":{"enabled":true}}"#;
+        let parsed = Settings::parse_strict(doc).unwrap();
+        assert_eq!(
+            parsed.notifications.reminder_minutes,
+            DEFAULT_REMINDER_MINUTES
+        );
+        assert_eq!(parsed.notifications.reminder_minutes, 120);
+    }
+
+    #[test]
+    fn reminder_minutes_round_trips_and_rejects_out_of_range() {
+        let mut doc = Settings::defaults();
+        doc.notifications.reminder_minutes = MIN_REMINDER_MINUTES;
+        doc.validate().unwrap();
+        doc.notifications.reminder_minutes = MAX_REMINDER_MINUTES;
+        doc.validate().unwrap();
+
+        doc.notifications.reminder_minutes = MIN_REMINDER_MINUTES - 1;
+        let err = doc.validate().unwrap_err();
+        assert!(err.message().contains("reminderMinutes"));
+
+        doc.notifications.reminder_minutes = MAX_REMINDER_MINUTES + 1;
+        assert!(doc.validate().is_err());
+    }
+
+    #[test]
+    fn reminder_minutes_survives_the_hand_written_allowlist() {
+        // deny_unknown_fields is not the only gate: reject_unknown_top_level
+        // walks raw JSON before deserialization and would reject the key on
+        // its own.
+        let doc = br#"{"schemaVersion":1,"providers":[{"id":"claude","enabled":true},{"id":"codex","enabled":true},{"id":"amp","enabled":true},{"id":"grok","enabled":true}],"display":{"metric":"remaining"},"refreshIntervalSeconds":60,"notifications":{"enabled":true,"reminderMinutes":240}}"#;
+        let parsed = Settings::parse_strict(doc).unwrap();
+        assert_eq!(parsed.notifications.reminder_minutes, 240);
     }
 }

--- a/src/status/coordinator.rs
+++ b/src/status/coordinator.rs
@@ -212,7 +212,7 @@ where
                 now: requested_at,
             };
             if let Err(err) = evaluator.evaluate(&envelope).await {
-                eprintln!("notification dispatch failed: {err}");
+                log::warn!("notification evaluation failed: {err}");
             }
         }
 

--- a/tests/fixtures/settings-v1/invalid-reminder-minutes.json
+++ b/tests/fixtures/settings-v1/invalid-reminder-minutes.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": 1,
+  "providers": [
+    { "id": "claude", "enabled": true },
+    { "id": "codex", "enabled": true },
+    { "id": "amp", "enabled": true },
+    { "id": "grok", "enabled": true }
+  ],
+  "display": {
+    "metric": "remaining"
+  },
+  "refreshIntervalSeconds": 60,
+  "notifications": {
+    "enabled": true,
+    "reminderMinutes": 5
+  }
+}

--- a/tests/fixtures/settings-v1/valid-used-metric.json
+++ b/tests/fixtures/settings-v1/valid-used-metric.json
@@ -11,6 +11,7 @@
   },
   "refreshIntervalSeconds": 30,
   "notifications": {
-    "enabled": false
+    "enabled": false,
+    "reminderMinutes": 120
   }
 }

--- a/tests/qml/tst_Accessibility.qml
+++ b/tests/qml/tst_Accessibility.qml
@@ -124,6 +124,15 @@ TestCase {
 
   function test_settings_editor_owns_focus_flag() {
     var src = read("SettingsView.qml")
-    verify(src.indexOf("editorOwnsFocus") >= 0)
+    var prop = src.indexOf("property bool editorOwnsFocus")
+    verify(prop >= 0)
+    var propEnd = src.indexOf("readonly property var state", prop)
+    verify(propEnd > prop)
+    var body = src.substring(prop, propEnd)
+    // A11Y-008 must cover every NumberField editor, not just the refresh
+    // interval — a user editing the reminder field is entitled to the same
+    // stay-open protection as one editing the refresh interval.
+    verify(body.indexOf("intervalField") >= 0)
+    verify(body.indexOf("reminderField") >= 0)
   }
 }

--- a/tests/qml/tst_Settings.qml
+++ b/tests/qml/tst_Settings.qml
@@ -67,6 +67,22 @@ TestCase {
     compare(Core.validateSettingsDraft(bad).ok, false)
   }
 
+  function test_reminder_minutes_bounds() {
+    var d = Service.defaultSettings()
+    compare(d.notifications.reminderMinutes, 120)
+    compare(Core.validateSettingsDraft(d).ok, true)
+
+    d = Core.setReminderMinutes(d, 15)
+    compare(d.notifications.reminderMinutes, 15)
+    d = Core.setReminderMinutes(d, 1440)
+    compare(d.notifications.reminderMinutes, 1440)
+
+    var bad = Core.setReminderMinutes(d, 5)
+    compare(Core.validateSettingsDraft(bad).ok, false)
+    bad = Core.setReminderMinutes(d, 2000)
+    compare(Core.validateSettingsDraft(bad).ok, false)
+  }
+
   function test_notifications_toggle() {
     var d = Service.defaultSettings()
     d = Core.setNotificationsEnabled(d, false)
@@ -159,6 +175,8 @@ TestCase {
     // The host NumberField has no suffix property, so the unit is a sibling
     // label positioned against the spin box.
     verify(src.indexOf('text: "seconds"') >= 0)
+    verify(src.indexOf("Remind me every") >= 0)
+    verify(src.indexOf('text: "minutes"') >= 0)
   }
 
   function test_settings_row_has_icon_name_chevrons() {

--- a/tests/qml/tst_SettingsRaces.qml
+++ b/tests/qml/tst_SettingsRaces.qml
@@ -244,4 +244,18 @@ TestCase {
     compare(JSON.parse(h.pendingSettingsPayload).display.metric, "used")
     compare(h.settingsState.pendingPayload.display.metric, "used")
   }
+
+  function test_reminder_minutes_immutable_after_edit_during_save() {
+    h.reset()
+    h.openSettings("a")
+    h.applyRead(h.activeSettingsReadGeneration, Service.defaultSettings(), 0)
+    h.mutate(function (d) { return Core.setReminderMinutes(d, 240) })
+    h.save()
+    var captured = JSON.parse(h.pendingSettingsPayload)
+    compare(captured.notifications.reminderMinutes, 240)
+    // Edits while saving are locked
+    h.mutate(function (d) { return Core.setReminderMinutes(d, 60) })
+    compare(JSON.parse(h.pendingSettingsPayload).notifications.reminderMinutes, 240)
+    compare(h.settingsState.pendingPayload.notifications.reminderMinutes, 240)
+  }
 }


### PR DESCRIPTION
## The incident

On a live install, `Claude Fable is almost out` fired once every 60 seconds for
hours. The alert was not re-triggering: the deduplication state failed to persist
on every cycle, so the notifier never learned it had already spoken.

Reproduced against the installed helper with an isolated `XDG_CACHE_HOME` and a
`notify-send` shim:

```
run 1 stderr: notification dispatch failed: duplicate notification key
run 2 stderr: notification dispatch failed: duplicate notification key
run 3 stderr: notification dispatch failed: duplicate notification key
-> 3 dispatches, 0 entries written
```

## Root cause

`NotificationState::validate` derived its uniqueness key by truncating the reset
timestamp to whole seconds, while `upsert`, `level_for` and `remove_key` compared
the full `OffsetDateTime`, nanoseconds included.

The Claude usage endpoint derives `resets_at` from its own clock on every
response. Within a single envelope its three windows come back with distinct
microseconds, so two collections never produce the same key. The first dispatch
persisted one timestamp; the next collection observed another in the same second;
`upsert` did not recognise it as the same row and appended; `validate` truncated
both to the same second and rejected the document; `save` returned an error; the
level was never recorded; the next poll notified again.

No existing test could catch it: every fixture in the suite used round timestamps,
leaving the sub-second path unreachable.

## What changes

- A notification's identity is `(providerId, windowId)`. The reset timestamp
  becomes observed data, compared with a 60-second jitter tolerance.
- One key definition, used by `validate`, `upsert`, `entry_for` and `remove_key`.
  Four hand-written comparisons are what allowed the original divergence. With a
  per-window key and an `upsert` that removes by that same key, `DuplicateKey`
  becomes unreachable on write rather than merely unlikely.
- State moves to `notification-state-v2.json`, adding `notifiedAt`. The v1 file
  joins the doctor's legacy list. No content migration: the state is ephemeral and
  losing it costs at most one repeated notification, which NOTIFY-012 permits.
- Alerts repeat on `notifications.reminderMinutes` (15..=1440, default 120)
  instead of once and never again. Settings gains a control for it.
- De-escalation inside a window no longer dispatches but does lower the stored
  level, so a window sitting at 92 percent keeps being reported.
- Rows are pruned for windows a provider stops reporting and for elapsed resets.
  Both only while the provider is `ready`, and the elapsed branch additionally
  requires a live reading, since a ready provider can be replayed from cache while
  still carrying the pre-reset timestamp.
- Persistence failures become structured `log::warn!` naming provider and window,
  replacing a bare `eprintln!`. The defect ran for days without a single signal.

## Spec amendments

NOTIFY-001 (key), NOTIFY-003 (reminder cadence) and NOTIFY-005 (rearm conditions)
are rewritten; NOTIFY-013 (jitter tolerance) and NOTIFY-014 (`reminderMinutes`) are
new. The cache file list, `docs/guide/runtime.md`, `docs/guide/commands.md`,
`02-target-architecture.md`, `07-testing-and-acceptance.md` and the requirements
matrix follow.

## Verification

```
cargo fmt --check          clean
cargo clippy -D warnings   clean
git diff --check           clean
cargo test                 0 failed
qmltestrunner (Qt6)        255 passed, 0 failed
omarchy plugin validate .  exit 0
```

The incident itself is covered two ways: `upsert_replaces_a_jittered_row_instead_of_appending`
rebuilds the exact document that failed to save, and
`sub_second_reset_jitter_does_not_renotify` drives three jittered collections
end to end and asserts one dispatch and one row. Fixtures gained sub-second
timestamps, which the suite had nowhere.

Replaying the original frozen 95 percent cache against this branch produces one
dispatch, empty stderr and one persisted row, where it previously produced three
dispatches and three `duplicate notification key` errors.

## Upgrade note

Existing installs abandon `notification-state-v1.json` rather than migrating it,
so a window already above its threshold at upgrade time produces one repeated
notification on first run.
