### PR TITLE
feat: enable only Claude and Codex on first run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- feat: a first run now enables Claude and Codex only. Amp, Grok, and
+  Antigravity are opt-in from Settings, so a provider whose CLI is absent no
+  longer renders as a chip nobody asked for. This is not limited to brand-new
+  machines: nothing writes `settings.json` at install or boot, so any install
+  where Settings was never saved picks up the new default on the next shell
+  restart. An existing `settings.json` is untouched, and a migrated v9
+  provider choice still outranks the default.
 - fix: key notification state by window, not reset
 - feat: repeat alerts on a configurable reminder
 

--- a/CoreService.js
+++ b/CoreService.js
@@ -307,8 +307,8 @@ function defaultSettings() {
     providers: [
       { id: "claude", enabled: true },
       { id: "codex", enabled: true },
-      { id: "amp", enabled: true },
-      { id: "grok", enabled: true },
+      { id: "amp", enabled: false },
+      { id: "grok", enabled: false },
       { id: "antigravity", enabled: false }
     ],
     display: { metric: "remaining" },

--- a/README.md
+++ b/README.md
@@ -1,16 +1,18 @@
 # Agent Bar
 
-Agent Bar puts your AI quota in the Omarchy bar. One chip per provider
-(Claude, Codex, Amp, Grok, Antigravity), a popup with every usage window,
-and a countdown to the next reset.
+Agent Bar puts your AI quota in the Omarchy bar. One chip per enabled
+provider, a popup with every usage window, and a countdown to the next
+reset. A fresh install shows Claude and Codex; Amp, Grok, and Antigravity
+are one toggle away in Settings.
 
 ![Agent Bar preview](preview.png)
 
 ## What you see
 
 Each enabled provider gets a chip with its icon and a percentage, used or
-remaining, whichever you prefer. Click it and the popup opens with the
-plan tag (`MAX 20X`, for example), a lead window showing both the
+remaining, whichever you prefer. Turning one on before its CLI is installed
+is fine: the chip dims and links to the install page. Click it and the
+popup opens with the plan tag (`MAX 20X`, for example), a lead window showing both the
 countdown and the wall-clock reset, and every other window as a row with
 its own usage track.
 

--- a/docs/guide/commands.md
+++ b/docs/guide/commands.md
@@ -62,7 +62,7 @@ argv, so `"$PLUGIN" login antigravity` never launches a CLI and fails with
 "$PLUGIN" config show
 "$PLUGIN" config apply stdin
 "$PLUGIN" config apply file /path/to/settings.json
-"$PLUGIN" config apply json '{"schemaVersion":1,"providers":[{"id":"claude","enabled":true},{"id":"codex","enabled":true},{"id":"amp","enabled":true},{"id":"grok","enabled":true},{"id":"antigravity","enabled":false}],"display":{"metric":"remaining"},"refreshIntervalSeconds":60,"notifications":{"enabled":true,"reminderMinutes":120}}'
+"$PLUGIN" config apply json '{"schemaVersion":1,"providers":[{"id":"claude","enabled":true},{"id":"codex","enabled":true},{"id":"amp","enabled":false},{"id":"grok","enabled":false},{"id":"antigravity","enabled":false}],"display":{"metric":"remaining"},"refreshIntervalSeconds":60,"notifications":{"enabled":true,"reminderMinutes":120}}'
 ```
 
 `show` is read-only. `apply` requires one complete valid settings document and

--- a/docs/guide/runtime.md
+++ b/docs/guide/runtime.md
@@ -46,8 +46,8 @@ exists.
   "providers": [
     { "id": "claude", "enabled": true },
     { "id": "codex", "enabled": true },
-    { "id": "amp", "enabled": true },
-    { "id": "grok", "enabled": true },
+    { "id": "amp", "enabled": false },
+    { "id": "grok", "enabled": false },
     { "id": "antigravity", "enabled": false }
   ],
   "display": {

--- a/docs/specs/v10/01-product-contract.md
+++ b/docs/specs/v10/01-product-contract.md
@@ -59,7 +59,7 @@ Fresh installations use:
 
 ```text
 Provider order: Claude, Codex, Amp, Grok, Antigravity
-Enabled providers: all except Antigravity (disabled by default)
+Enabled providers: Claude and Codex (the rest are opt-in)
 Display metric: remaining
 Refresh interval: 60 seconds
 Notifications: enabled

--- a/docs/specs/v10/05-settings-cache-and-notifications.md
+++ b/docs/specs/v10/05-settings-cache-and-notifications.md
@@ -8,8 +8,8 @@
   "providers": [
     { "id": "claude", "enabled": true },
     { "id": "codex", "enabled": true },
-    { "id": "amp", "enabled": true },
-    { "id": "grok", "enabled": true },
+    { "id": "amp", "enabled": false },
+    { "id": "grok", "enabled": false },
     { "id": "antigravity", "enabled": false }
   ],
   "display": {
@@ -95,6 +95,13 @@ closed
   document) moves the dialog to a terminal `load_failed` phase: controls stay
   locked, no snapshot is fabricated, and the view renders fixed copy naming
   the recovery step (restart the shell). It never stays in `loading`.
+- `SET-027`: A first run enables Claude and Codex only. Amp, Grok, and
+  Antigravity are opt-in from Settings, so a provider whose CLI is absent
+  never renders as a chip nobody asked for. The default table is an
+  exhaustive match over the catalog: adding a provider fails to compile
+  until its default is chosen. Existing documents are untouched, because a
+  read never rewrites a row it already has (`SET-007`), and a migrated v9
+  choice outranks this default (`MIG-009`, `PROD-024`).
 
 ## Cache files
 

--- a/src/settings/migration.rs
+++ b/src/settings/migration.rs
@@ -328,6 +328,32 @@ fn extract_inline_refresh_seconds(raw: &[u8]) -> Result<Option<u32>, MigrationEr
     Ok(found)
 }
 
+/// The provider IDs a v9 document could name in `waybar.providers`.
+///
+/// v9 shipped exactly these four; Antigravity and anything added later cannot
+/// appear in a v9 file, so no v9 document carries a choice for them.
+const V9_PROVIDERS: &[ProviderId] = &[
+    ProviderId::Claude,
+    ProviderId::Codex,
+    ProviderId::Amp,
+    ProviderId::Grok,
+];
+
+/// Whether a migrated row starts enabled.
+///
+/// MIG-009 / PROD-024: when the v9 document listed its providers, that list IS
+/// the user's explicit choice and outranks the v10 default — a provider that
+/// ships opt-in today must still come across enabled when the v9 file asked
+/// for it. Two cases fall back to `default_enabled`: an ID v9 never had, and a
+/// document that listed nothing, which recorded no choice to honour.
+fn v9_enabled(id: ProviderId, listed_providers: bool, enabled_set: &HashSet<ProviderId>) -> bool {
+    if listed_providers && V9_PROVIDERS.contains(&id) {
+        enabled_set.contains(&id)
+    } else {
+        default_enabled(id)
+    }
+}
+
 fn migrate_v9_settings(raw: &[u8]) -> Result<(Settings, Vec<String>, bool), MigrationError> {
     let value: Value = serde_json::from_slice(raw)
         .map_err(|e| MigrationError::msg(format!("invalid v9 settings JSON: {e}")))?;
@@ -399,6 +425,15 @@ fn migrate_v9_settings(raw: &[u8]) -> Result<(Settings, Vec<String>, bool), Migr
         .and_then(|v| v.as_bool())
         .unwrap_or(true);
 
+    // A present `waybar.providers` IS the user's choice; an absent one records
+    // no choice at all, and only the full catalog list below stands in for it
+    // so ordering and validation still see every ID. `v9_enabled` reads the
+    // distinction: absent means the v10 default decides.
+    let listed_providers = waybar
+        .and_then(|w| w.get("providers"))
+        .and_then(|v| v.as_array())
+        .is_some();
+
     let enabled_list: Vec<String> = waybar
         .and_then(|w| w.get("providers"))
         .and_then(|v| v.as_array())
@@ -448,7 +483,7 @@ fn migrate_v9_settings(raw: &[u8]) -> Result<(Settings, Vec<String>, bool), Migr
             if seen.insert(id) {
                 providers.push(ProviderSetting {
                     id: ProviderIdJson(id),
-                    enabled: default_enabled(id) && enabled_set.contains(&id),
+                    enabled: v9_enabled(id, listed_providers, &enabled_set),
                 });
             }
         }
@@ -457,12 +492,14 @@ fn migrate_v9_settings(raw: &[u8]) -> Result<(Settings, Vec<String>, bool), Migr
         if seen.insert(id) {
             providers.push(ProviderSetting {
                 id: ProviderIdJson(id),
-                enabled: default_enabled(id) && enabled_set.contains(&id),
+                enabled: v9_enabled(id, listed_providers, &enabled_set),
             });
         }
     }
 
-    // If enabled_list was empty after filtering, enable all (safe default).
+    // Nothing survived the mapping: the v9 document named no provider this
+    // catalog still knows. Fall back to the fresh-install defaults rather than
+    // handing the user an empty bar.
     if providers.iter().all(|p| !p.enabled) {
         for p in &mut providers {
             p.enabled = default_enabled(p.id.0);
@@ -683,6 +720,31 @@ mod tests {
     }
 
     #[test]
+    fn v9_provider_choice_outranks_the_v10_default() {
+        // MIG-009 / PROD-024: the v9 `waybar.providers` list IS the user's
+        // explicit choice. A provider that ships opt-in in v10 must still come
+        // across enabled when the v9 document asked for it.
+        let raw = read_fixture("settings-valid.json");
+        let plan = MigrationPlan::from_v9(Some(&raw), None).unwrap();
+        for id in [ProviderId::Codex, ProviderId::Amp, ProviderId::Grok] {
+            let row = plan
+                .settings
+                .providers
+                .iter()
+                .find(|p| p.id.0 == id)
+                .unwrap_or_else(|| panic!("{id} present"));
+            assert!(row.enabled, "{id} was chosen in v9 and must stay enabled");
+        }
+        let claude = plan
+            .settings
+            .providers
+            .iter()
+            .find(|p| p.id.0 == ProviderId::Claude)
+            .unwrap();
+        assert!(!claude.enabled, "claude was not chosen in v9");
+    }
+
+    #[test]
     fn rejects_invalid_interval() {
         let raw = read_fixture("settings-invalid-interval.json");
         let err = MigrationPlan::from_v9(Some(&raw), None).unwrap_err();
@@ -762,12 +824,27 @@ mod tests {
     #[test]
     fn injected_rows_follow_default_enabled() {
         // The injected row must be whatever `default_enabled` says, not a
-        // hard-coded false: the catalog is the single source for that.
+        // hard-coded false: the catalog is the single source for that. The
+        // four rows the document already carries are the user's and survive
+        // untouched, even where the fresh-install default now differs.
         let four = br#"{"schemaVersion":1,"providers":[{"id":"claude","enabled":true},{"id":"codex","enabled":true},{"id":"amp","enabled":true},{"id":"grok","enabled":true}],"display":{"metric":"remaining"},"refreshIntervalSeconds":60,"notifications":{"enabled":true}}"#;
         let plan = MigrationPlan::from_v9(Some(four), None).unwrap();
-        for row in &plan.settings.providers {
-            assert_eq!(row.enabled, default_enabled(row.id.0), "{}", row.id.0);
+        for id in V9_PROVIDERS {
+            let row = plan
+                .settings
+                .providers
+                .iter()
+                .find(|p| p.id.0 == *id)
+                .unwrap_or_else(|| panic!("{id} present"));
+            assert!(row.enabled, "{id} was written enabled and must stay so");
         }
+        let injected = plan
+            .settings
+            .providers
+            .iter()
+            .find(|p| p.id.0 == ProviderId::Antigravity)
+            .expect("antigravity injected");
+        assert_eq!(injected.enabled, default_enabled(ProviderId::Antigravity));
     }
 
     #[test]

--- a/src/settings/migration.rs
+++ b/src/settings/migration.rs
@@ -332,6 +332,11 @@ fn extract_inline_refresh_seconds(raw: &[u8]) -> Result<Option<u32>, MigrationEr
 ///
 /// v9 shipped exactly these four; Antigravity and anything added later cannot
 /// appear in a v9 file, so no v9 document carries a choice for them.
+///
+/// Identical today to `schema::ORIGINAL_V10_PROVIDERS` and deliberately kept
+/// separate: that one is the gate for repairing a v10 document, this one is a
+/// fact about what v9 shipped. Neither grows when the catalog does, but they
+/// answer different questions and would diverge for different reasons.
 const V9_PROVIDERS: &[ProviderId] = &[
     ProviderId::Claude,
     ProviderId::Codex,
@@ -339,18 +344,33 @@ const V9_PROVIDERS: &[ProviderId] = &[
     ProviderId::Grok,
 ];
 
+/// What a migrated document says about which providers the user wanted.
+enum V9Choice {
+    /// `waybar.providers` named them. That list IS the choice.
+    Listed(HashSet<ProviderId>),
+    /// A v9 document whose `waybar` block omits `providers`: v9 rendered every
+    /// provider it knew, so the user was seeing all four and never opted out.
+    AllV9Providers,
+    /// No `waybar` block at all — not a v9 document, so there is no choice to
+    /// carry over and the fresh-install defaults apply.
+    NoV9Block,
+}
+
 /// Whether a migrated row starts enabled.
 ///
-/// MIG-009 / PROD-024: when the v9 document listed its providers, that list IS
-/// the user's explicit choice and outranks the v10 default — a provider that
-/// ships opt-in today must still come across enabled when the v9 file asked
-/// for it. Two cases fall back to `default_enabled`: an ID v9 never had, and a
-/// document that listed nothing, which recorded no choice to honour.
-fn v9_enabled(id: ProviderId, listed_providers: bool, enabled_set: &HashSet<ProviderId>) -> bool {
-    if listed_providers && V9_PROVIDERS.contains(&id) {
-        enabled_set.contains(&id)
-    } else {
-        default_enabled(id)
+/// MIG-009 / PROD-024: migration preserves the user's choice instead of
+/// applying fresh defaults, so a provider that ships opt-in today still comes
+/// across enabled when the v9 install had it on. Only an ID v9 never had, or a
+/// document that was never v9 to begin with, falls back to `default_enabled`.
+fn v9_enabled(id: ProviderId, choice: &V9Choice) -> bool {
+    if !V9_PROVIDERS.contains(&id) {
+        // Added after v9: no v9 document carries a choice for it.
+        return default_enabled(id);
+    }
+    match choice {
+        V9Choice::Listed(chosen) => chosen.contains(&id),
+        V9Choice::AllV9Providers => true,
+        V9Choice::NoV9Block => default_enabled(id),
     }
 }
 
@@ -425,15 +445,6 @@ fn migrate_v9_settings(raw: &[u8]) -> Result<(Settings, Vec<String>, bool), Migr
         .and_then(|v| v.as_bool())
         .unwrap_or(true);
 
-    // A present `waybar.providers` IS the user's choice; an absent one records
-    // no choice at all, and only the full catalog list below stands in for it
-    // so ordering and validation still see every ID. `v9_enabled` reads the
-    // distinction: absent means the v10 default decides.
-    let listed_providers = waybar
-        .and_then(|w| w.get("providers"))
-        .and_then(|v| v.as_array())
-        .is_some();
-
     let enabled_list: Vec<String> = waybar
         .and_then(|w| w.get("providers"))
         .and_then(|v| v.as_array())
@@ -475,6 +486,17 @@ fn migrate_v9_settings(raw: &[u8]) -> Result<(Settings, Vec<String>, bool), Migr
         .filter_map(|s| ProviderId::parse_word(s))
         .collect();
 
+    // `enabled_list` stands in the full catalog when the key is absent so that
+    // ordering and validation still see every ID. Enablement needs the finer
+    // distinction, which only the raw document carries.
+    let choice = match waybar {
+        None => V9Choice::NoV9Block,
+        Some(w) => match w.get("providers").and_then(|v| v.as_array()) {
+            Some(_) => V9Choice::Listed(enabled_set.clone()),
+            None => V9Choice::AllV9Providers,
+        },
+    };
+
     // Build order: first closed IDs from providerOrder, then remaining ALL.
     let mut providers = Vec::new();
     let mut seen: HashSet<ProviderId> = HashSet::new();
@@ -483,7 +505,7 @@ fn migrate_v9_settings(raw: &[u8]) -> Result<(Settings, Vec<String>, bool), Migr
             if seen.insert(id) {
                 providers.push(ProviderSetting {
                     id: ProviderIdJson(id),
-                    enabled: v9_enabled(id, listed_providers, &enabled_set),
+                    enabled: v9_enabled(id, &choice),
                 });
             }
         }
@@ -492,14 +514,14 @@ fn migrate_v9_settings(raw: &[u8]) -> Result<(Settings, Vec<String>, bool), Migr
         if seen.insert(id) {
             providers.push(ProviderSetting {
                 id: ProviderIdJson(id),
-                enabled: v9_enabled(id, listed_providers, &enabled_set),
+                enabled: v9_enabled(id, &choice),
             });
         }
     }
 
-    // Nothing survived the mapping: the v9 document named no provider this
-    // catalog still knows. Fall back to the fresh-install defaults rather than
-    // handing the user an empty bar.
+    // Nothing survived the mapping: the document named zero providers, or only
+    // names this catalog no longer knows. Fall back to the fresh-install
+    // defaults rather than handing the user an empty bar.
     if providers.iter().all(|p| !p.enabled) {
         for p in &mut providers {
             p.enabled = default_enabled(p.id.0);
@@ -745,6 +767,52 @@ mod tests {
     }
 
     #[test]
+    fn a_v9_block_without_a_provider_list_keeps_every_v9_provider() {
+        // v9 rendered all four providers unless the user opted out through
+        // `waybar.providers`. A document that never wrote the key was showing
+        // all four, so migration must not read the absent key as consent to
+        // the v10 opt-in defaults (MIG-009, PROD-024) — the plan is written to
+        // disk, which would make the loss permanent.
+        for raw in [
+            br#"{"version":3,"waybar":{"displayMode":"remaining","interval":60}}"#.as_slice(),
+            br#"{"version":3,"waybar":{"providerOrder":["grok","claude"],"interval":60}}"#
+                .as_slice(),
+        ] {
+            let plan = MigrationPlan::from_v9(Some(raw), None).unwrap();
+            for id in V9_PROVIDERS {
+                let row = plan
+                    .settings
+                    .providers
+                    .iter()
+                    .find(|p| p.id.0 == *id)
+                    .unwrap_or_else(|| panic!("{id} present"));
+                assert!(row.enabled, "{id} was visible in v9 and must stay enabled");
+            }
+            let antigravity = plan
+                .settings
+                .providers
+                .iter()
+                .find(|p| p.id.0 == ProviderId::Antigravity)
+                .unwrap();
+            assert!(
+                !antigravity.enabled,
+                "v9 never had antigravity, so it takes the v10 default"
+            );
+        }
+    }
+
+    #[test]
+    fn an_empty_v9_provider_list_falls_back_to_the_defaults() {
+        // Naming zero providers leaves nothing to preserve. Rather than an
+        // empty bar, the user gets what a fresh install would give them.
+        let raw = br#"{"version":3,"waybar":{"providers":[],"interval":60}}"#;
+        let plan = MigrationPlan::from_v9(Some(raw), None).unwrap();
+        for row in &plan.settings.providers {
+            assert_eq!(row.enabled, default_enabled(row.id.0), "{}", row.id.0);
+        }
+    }
+
+    #[test]
     fn rejects_invalid_interval() {
         let raw = read_fixture("settings-invalid-interval.json");
         let err = MigrationPlan::from_v9(Some(&raw), None).unwrap_err();
@@ -824,9 +892,12 @@ mod tests {
     #[test]
     fn injected_rows_follow_default_enabled() {
         // The injected row must be whatever `default_enabled` says, not a
-        // hard-coded false: the catalog is the single source for that. The
-        // four rows the document already carries are the user's and survive
-        // untouched, even where the fresh-install default now differs.
+        // hard-coded false: the catalog is the single source for that. Today
+        // both spellings agree, since antigravity is the only injectable row
+        // and its default is false; the assertion starts biting when a
+        // provider that ships enabled joins the catalog. The four rows the
+        // document already carries are the user's and survive untouched, even
+        // where the fresh-install default now differs.
         let four = br#"{"schemaVersion":1,"providers":[{"id":"claude","enabled":true},{"id":"codex","enabled":true},{"id":"amp","enabled":true},{"id":"grok","enabled":true}],"display":{"metric":"remaining"},"refreshIntervalSeconds":60,"notifications":{"enabled":true}}"#;
         let plan = MigrationPlan::from_v9(Some(four), None).unwrap();
         for id in V9_PROVIDERS {

--- a/src/settings/schema.rs
+++ b/src/settings/schema.rs
@@ -409,12 +409,15 @@ mod tests {
     #[test]
     fn filled_rows_come_from_default_enabled_not_a_hard_coded_false() {
         // A document with the four original providers but without the later
-        // addition: the filled row must match what `Settings::defaults` would
-        // have written for it, so a future provider that ships enabled is not
-        // silently turned off by a read. The rows the user already has are
-        // theirs — a read never rewrites them to the default (SET-007), which
-        // is why amp and grok stay on here while a fresh install ships them
-        // off.
+        // addition. Two things are being pinned. The rows the user already has
+        // are theirs: a read never rewrites them to the default (SET-007),
+        // which is why amp and grok stay on here while a fresh install ships
+        // them off. And the filled row reads `default_enabled` rather than a
+        // hard-coded false, so a future provider that ships enabled is not
+        // silently turned off by a read. Only the second half is weakly
+        // covered today: antigravity is the sole injectable row and its
+        // default is already false, so the two spellings agree by accident.
+        // Adding a provider that ships enabled is what makes this bite.
         let four = br#"{"schemaVersion":1,"providers":[{"id":"claude","enabled":true},{"id":"codex","enabled":true},{"id":"amp","enabled":true},{"id":"grok","enabled":true}],"display":{"metric":"remaining"},"refreshIntervalSeconds":60,"notifications":{"enabled":true}}"#;
         let (filled, injected) =
             Settings::parse_with_policy(four, MissingProviders::FillFromCatalog).unwrap();

--- a/src/settings/schema.rs
+++ b/src/settings/schema.rs
@@ -121,11 +121,20 @@ impl std::error::Error for SettingsError {}
 ///
 /// Single source for "which providers start enabled": `Settings::defaults`
 /// and every v9 → v10 migration path read it instead of re-testing IDs.
-/// Antigravity ships opt-in (added 2026-08-22): the CLI is not installed for
-/// most users, so enabling it by default would show a permanent CLI-missing
-/// chip.
+///
+/// A first run enables only Claude and Codex (SET-027). Every other provider
+/// ships opt-in: its CLI is not installed for most users, so enabling it by
+/// default would show a permanent CLI-missing chip nobody asked for. Users
+/// turn the rest on from Settings.
+///
+/// The exhaustive `match` is deliberate. An exclusion list would let a new
+/// catalog entry inherit a default nobody decided; this way adding a
+/// `ProviderId` fails to compile until someone picks its arm.
 pub fn default_enabled(id: ProviderId) -> bool {
-    !matches!(id, ProviderId::Antigravity)
+    match id {
+        ProviderId::Claude | ProviderId::Codex => true,
+        ProviderId::Amp | ProviderId::Grok | ProviderId::Antigravity => false,
+    }
 }
 
 /// What a parse does when the document omits a catalog provider.
@@ -402,15 +411,32 @@ mod tests {
         // A document with the four original providers but without the later
         // addition: the filled row must match what `Settings::defaults` would
         // have written for it, so a future provider that ships enabled is not
-        // silently turned off by a read.
+        // silently turned off by a read. The rows the user already has are
+        // theirs — a read never rewrites them to the default (SET-007), which
+        // is why amp and grok stay on here while a fresh install ships them
+        // off.
         let four = br#"{"schemaVersion":1,"providers":[{"id":"claude","enabled":true},{"id":"codex","enabled":true},{"id":"amp","enabled":true},{"id":"grok","enabled":true}],"display":{"metric":"remaining"},"refreshIntervalSeconds":60,"notifications":{"enabled":true}}"#;
         let (filled, injected) =
             Settings::parse_with_policy(four, MissingProviders::FillFromCatalog).unwrap();
         assert!(injected);
-        assert_eq!(filled, Settings::defaults());
-        for row in &filled.providers {
-            assert_eq!(row.enabled, default_enabled(row.id.0), "{}", row.id.0);
+        for id in [
+            ProviderId::Claude,
+            ProviderId::Codex,
+            ProviderId::Amp,
+            ProviderId::Grok,
+        ] {
+            let row = filled.providers.iter().find(|p| p.id.0 == id).unwrap();
+            assert!(row.enabled, "{id} was written enabled and must stay so");
         }
+        let injected_row = filled
+            .providers
+            .iter()
+            .find(|p| p.id.0 == ProviderId::Antigravity)
+            .expect("antigravity injected");
+        assert_eq!(
+            injected_row.enabled,
+            default_enabled(ProviderId::Antigravity)
+        );
     }
 
     #[test]
@@ -442,6 +468,18 @@ mod tests {
         }
         assert!(!default_enabled(ProviderId::Antigravity));
         assert!(default_enabled(ProviderId::Claude));
+    }
+
+    #[test]
+    fn only_claude_and_codex_start_enabled() {
+        // SET-027: a first run shows the two providers nearly every user has a
+        // CLI for. Amp, Grok, and Antigravity are opt-in from Settings, so a
+        // missing CLI never renders as a permanent chip nobody asked for.
+        assert!(default_enabled(ProviderId::Claude));
+        assert!(default_enabled(ProviderId::Codex));
+        assert!(!default_enabled(ProviderId::Amp));
+        assert!(!default_enabled(ProviderId::Grok));
+        assert!(!default_enabled(ProviderId::Antigravity));
     }
 
     #[test]

--- a/tests/fixtures/settings-v1/valid-defaults.json
+++ b/tests/fixtures/settings-v1/valid-defaults.json
@@ -3,8 +3,8 @@
   "providers": [
     { "id": "claude", "enabled": true },
     { "id": "codex", "enabled": true },
-    { "id": "amp", "enabled": true },
-    { "id": "grok", "enabled": true },
+    { "id": "amp", "enabled": false },
+    { "id": "grok", "enabled": false },
     { "id": "antigravity", "enabled": false }
   ],
   "display": {

--- a/tests/qml/tst_Settings.qml
+++ b/tests/qml/tst_Settings.qml
@@ -34,15 +34,26 @@ TestCase {
     compare(v.ok, true)
   }
 
-  function test_default_settings_leaves_antigravity_disabled() {
-    var d = Service.defaultSettings()
-    var found = null
-    for (var i = 0; i < d.providers.length; i++) {
-      if (d.providers[i].id === "antigravity")
-        found = d.providers[i]
+  function test_default_settings_enable_only_claude_and_codex() {
+    // SET-027: a first run shows only the two providers nearly every user has
+    // a CLI for. This table must stay identical to `default_enabled` on the
+    // Rust side, which tests/servicecore_contract.rs enforces.
+    var expected = {
+      claude: true,
+      codex: true,
+      amp: false,
+      grok: false,
+      antigravity: false
     }
-    verify(found !== null)
-    compare(found.enabled, false)
+    var d = Service.defaultSettings()
+    var seen = 0
+    for (var i = 0; i < d.providers.length; i++) {
+      var row = d.providers[i]
+      verify(expected[row.id] !== undefined)
+      compare(row.enabled, expected[row.id], row.id)
+      seen += 1
+    }
+    compare(seen, 5)
   }
 
   function test_provider_toggle_and_order() {


### PR DESCRIPTION
## What changes

A fresh install now enables **Claude and Codex only**. Amp, Grok, and
Antigravity become opt-in from Settings, so a provider whose CLI is absent no
longer renders as a chip nobody asked for.

`default_enabled` becomes an exhaustive `match` over the catalog instead of an
exclusion list: adding a `ProviderId` now fails to compile until someone picks
its default, rather than inheriting one nobody decided. Recorded as `SET-027`.

## Who this affects

Nothing writes `settings.json` at install or at boot, so the defaults live in
memory until the user saves Settings or runs `setup`. That means this is not
limited to brand-new machines: **any install where Settings was never saved
picks up the new default on the next shell restart.** An existing
`settings.json` is untouched, because a read never rewrites a row it already
has (`SET-007`).

## The migration fix, which is the substantial half

The v9 path masked the enabled list with `default_enabled`. That mask was inert
while the only opt-in provider could never appear in a v9 file. With Amp and
Grok opt-in it would have vetoed the user's explicit v9 choice, against
`MIG-009` and `PROD-024` — and `apply_migration_plan` writes the result, so the
loss would have been permanent.

The first commit fixed the explicit-list case and got the absent-key case
wrong. Review caught it: v9 rendered all four providers unless the user opted
out through `waybar.providers`, so a document that never wrote the key was
showing all four, and reading that absence as consent dropped Amp and Grok.

Enablement now reads three distinct cases:

| v9 document | enabled after migration |
|---|---|
| `waybar` block, no `providers` key | claude codex amp grok |
| `providerOrder` only | grok claude codex amp |
| `providers: ["codex","amp","grok"]` | codex amp grok |
| `providers: []` | claude codex |
| no `waybar` block at all | claude codex |

Each row measured against the built helper, not reasoned about.

## Verification

| Command | Result |
|---|---|
| `cargo fmt --check` | clean |
| `cargo test` | 341 passed, 0 failed |
| `cargo clippy --all-targets -- -D warnings` | clean |
| `git diff --check` | clean |
| `qmltestrunner` (Qt6, offscreen) | 260 passed, 0 failed |
| `omarchy plugin validate .` | exit 0 |

`config show` against an isolated XDG root with no `settings.json`:
`claude:true codex:true amp:false grok:false antigravity:false`, and no file
created by the read.

## Not done

- **No perceptual proof.** The engineering contract forbids mutating live
  Omarchy/Hyprland paths outside the final QA gate, so there is no screenshot
  of a first-run bar showing two chips. Functional and data proofs are green;
  the visual needs the QA gate.
- `bundle.json` is left unstamped, per the convention that the release job
  stamps it.
