### PR TITLE
feat: reproducible helper build and provenance

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -14,6 +14,7 @@ on:
       - 'scripts/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
+      - 'rust-toolchain.toml'
       - '*.qml'
       - 'Core*.js'
       - 'components/**'
@@ -23,6 +24,9 @@ on:
 
 permissions:
   contents: write
+  id-token: write
+  attestations: write
+  actions: write
 
 concurrency:
   group: auto-release
@@ -30,7 +34,9 @@ concurrency:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    # Pinned image: scripts/agent-bar-build-helper must reproduce the same
+    # bytes on the verify-release runner.
+    runs-on: ubuntu-24.04
     if: >-
       github.event_name == 'workflow_dispatch' ||
       !startsWith(github.event.head_commit.message, 'release:')
@@ -40,11 +46,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install Rust (gnu host target)
-        run: |
-          rustup toolchain install stable --profile minimal
-          rustup default stable
-          rustup target list --installed
+      - name: Install pinned toolchain (rust-toolchain.toml)
+        run: rustup toolchain install && rustup show active-toolchain
 
       - name: Fetch dependencies
         run: cargo fetch
@@ -63,17 +66,24 @@ jobs:
           cargo test
           cargo clippy --all-targets -- -D warnings
 
-      - name: Build release helper (x86_64-unknown-linux-gnu)
-        run: cargo build --release --target x86_64-unknown-linux-gnu
+      - name: Build release helper reproducibly
+        run: scripts/agent-bar-build-helper
 
       - name: Stamp plugin artifacts into the repo root
         run: |
           set -euo pipefail
           SOURCE_COMMIT="$(git rev-parse HEAD)"
+          BUILD_RUN="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           mkdir -p target/release
           cp -f target/x86_64-unknown-linux-gnu/release/agent-bar target/release/agent-bar
-          cargo run --bin agent-bar-bundle -- stamp source-commit "$SOURCE_COMMIT"
+          cargo run --bin agent-bar-bundle -- stamp \
+            source-commit "$SOURCE_COMMIT" build-run "$BUILD_RUN"
           scripts/check-version "v${{ steps.cut.outputs.version }}" .
+
+      - name: Attest helper provenance (SLSA)
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: bin/agent-bar
 
       - name: Root inventory / modes / architecture
         run: |
@@ -103,3 +113,13 @@ jobs:
           gh release create "v${VERSION}" \
             --title "Agent Bar ${VERSION}" \
             --notes-file "docs/releases/${VERSION}.md"
+
+      # Pushes made with GITHUB_TOKEN never trigger other workflows, so the
+      # exact-commit verification is dispatched explicitly on the new tag.
+      # It runs after publication: a red Verify release does not roll the
+      # release back, it flags it (docs/dev/releasing.md#provenance).
+      - name: Dispatch verify-release on the tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.cut.outputs.version }}
+        run: gh workflow run verify-release.yml --ref "v${VERSION}"

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -1,0 +1,103 @@
+name: Verify release
+
+# Runs ON the `release:` commit itself (the one that carries bin/agent-bar),
+# which the auto-release workflow cannot do for its own push. It rebuilds
+# the helper from the tagged source with scripts/agent-bar-build-helper,
+# requires the digest to equal the committed binary and its bundle.json
+# entry, and checks the SLSA provenance attestation the release run
+# recorded. A green run here is the exact-commit proof marketplace
+# reviewers ask for.
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Release tag or commit to verify (defaults to the run ref)
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  attestations: read
+  id-token: write
+
+jobs:
+  verify:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout exact release commit
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+          fetch-depth: 2
+
+      - name: Install pinned toolchain
+        run: rustup toolchain install && rustup show active-toolchain
+
+      - name: Release commit shape
+        run: |
+          set -euo pipefail
+          test -x bin/agent-bar
+          test -f bundle.json
+          git log -1 --format=%s | grep -E '^release: v[0-9]+\.[0-9]+\.[0-9]+$'
+          SOURCE_COMMIT="$(python3 -c 'import json;print(json.load(open("bundle.json"))["sourceCommit"])')"
+          PARENT="$(git rev-parse HEAD^)"
+          test "$SOURCE_COMMIT" = "$PARENT" \
+            || { echo "bundle.json sourceCommit $SOURCE_COMMIT != parent $PARENT" >&2; exit 1; }
+          VERSION="$(grep -m1 '^version' Cargo.toml | sed -E 's/.*"(.*)".*/\1/')"
+          scripts/check-version "v${VERSION}" .
+
+      - name: Rebuild helper reproducibly
+        run: scripts/agent-bar-build-helper
+
+      - name: Committed binary equals rebuilt binary
+        run: |
+          set -euo pipefail
+          REBUILT="$(sha256sum target/x86_64-unknown-linux-gnu/release/agent-bar | cut -d' ' -f1)"
+          COMMITTED="$(sha256sum bin/agent-bar | cut -d' ' -f1)"
+          echo "rebuilt   $REBUILT"
+          echo "committed $COMMITTED"
+          test "$REBUILT" = "$COMMITTED" || { echo "bin/agent-bar is not reproducible from this commit" >&2; exit 1; }
+
+      - name: Every bundle.json entry matches the committed tree
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import hashlib, json, os, stat, sys
+          receipt = json.load(open("bundle.json"))
+          bad = []
+          for f in receipt["files"]:
+              p = f["path"]
+              st = os.lstat(p)
+              if not stat.S_ISREG(st.st_mode):
+                  bad.append(f"{p}: not a regular file"); continue
+              digest = hashlib.sha256(open(p, "rb").read()).hexdigest()
+              mode = f"{stat.S_IMODE(st.st_mode):04o}"
+              if digest != f["sha256"]: bad.append(f"{p}: sha256 {digest} != receipt {f['sha256']}")
+              if st.st_size != f["size"]: bad.append(f"{p}: size {st.st_size} != receipt {f['size']}")
+              if mode != f["mode"]: bad.append(f"{p}: mode {mode} != receipt {f['mode']}")
+          if bad: sys.exit("\n".join(bad))
+          print(f"{len(receipt['files'])} receipt entries match the tree")
+          PY
+
+      - name: Provenance attestation matches the recorded build run
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          BUILD_RUN="$(python3 -c 'import json;print(json.load(open("bundle.json")).get("buildRun",""))')"
+          test -n "$BUILD_RUN" || { echo "bundle.json has no buildRun" >&2; exit 1; }
+          echo "buildRun  $BUILD_RUN"
+          gh attestation verify bin/agent-bar \
+            --repo "${GITHUB_REPOSITORY}" \
+            --signer-workflow "${GITHUB_REPOSITORY}/.github/workflows/auto-release.yml" \
+            --format json > attestation.json
+          RUN_ID="${BUILD_RUN##*/}"
+          SOURCE_COMMIT="$(python3 -c 'import json;print(json.load(open("bundle.json"))["sourceCommit"])')"
+          grep -q "/actions/runs/${RUN_ID}\b" attestation.json \
+            || { echo "attestation was not produced by buildRun ${BUILD_RUN}" >&2; exit 1; }
+          grep -q "\"sourceRepositoryDigest\": *\"${SOURCE_COMMIT}\"" attestation.json \
+            || { echo "attestation source digest is not sourceCommit ${SOURCE_COMMIT}" >&2; exit 1; }
+          echo "attestation signed by run ${RUN_ID} from ${SOURCE_COMMIT}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   providers read as their catalog default until the next settings apply.
 - fix: type `IpcHandler` parameters in `Service.qml`
   (`health(expectedVersion: string)`, `refresh(providerId: string)`).
+- feat: reproducible helper build (`scripts/agent-bar-build-helper`, pinned
+  `rust-toolchain.toml`), SLSA provenance attestation for `bin/agent-bar`,
+  `buildRun` in `bundle.json`, and a `Verify release` workflow that rebuilds
+  and checks the binary on the exact release commit.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,10 @@ This repository is the plugin tree and its source in one place. See
 [Architecture](docs/dev/architecture.md), [Releasing](docs/dev/releasing.md)
 and [Contributing](CONTRIBUTING.md) for build, test and release.
 
-CI commits `bin/agent-bar` and `bundle.json`. Don't edit them by hand.
+CI commits `bin/agent-bar` and `bundle.json`. Don't edit them by hand. The
+helper is built reproducibly on CI and carries a SLSA provenance
+attestation; see [Provenance](docs/dev/releasing.md#provenance) to verify
+a release commit.
 
 ## More
 

--- a/docs/dev/releasing.md
+++ b/docs/dev/releasing.md
@@ -32,14 +32,20 @@ installation.
 2. Rust gates run against the bumped tree: `cargo fmt --check`,
    `cargo test`, `cargo clippy --all-targets -- -D warnings`. A red gate
    stops the run before anything is committed.
-3. The helper builds for `x86_64-unknown-linux-gnu`.
-4. `agent-bar-bundle stamp source-commit <hex>` stamps the release
+3. `scripts/agent-bar-build-helper` builds the helper for
+   `x86_64-unknown-linux-gnu` reproducibly: pinned Rust toolchain
+   (`rust-toolchain.toml`), `--locked`, `--remap-path-prefix`, no
+   incremental compilation, on the pinned `ubuntu-24.04` runner image.
+4. `agent-bar-bundle stamp source-commit <hex> build-run <url>` stamps the release
    artifacts directly into the repository root: it copies the built
    helper to `bin/agent-bar` (mode `0755`), refreshes `preview.png`,
    normalizes the shipped tree's file modes, and writes `bundle.json`
-   from the current, already-versioned root tree. `scripts/check-version`
+   from the current, already-versioned root tree, including `buildRun`,
+   the URL of the Actions run doing the stamping. `scripts/check-version`
    then confirms `Cargo.toml`, `manifest.json`, `bundle.json`, and the
    stamped helper's own `version` output all agree.
+   `actions/attest-build-provenance` then records a SLSA provenance
+   attestation for `bin/agent-bar` in the repository's attestation store.
 5. A root inventory step checks required files, executable modes, and the
    target architecture directly against the working tree (no separate
    assembled output directory to check).
@@ -50,6 +56,9 @@ installation.
    pushed straight to `master`. The GitHub Release is created from that
    same tag with generated notes and no attached files; the commit itself
    is the release.
+7. The run dispatches `.github/workflows/verify-release.yml` on the new
+   tag (a `GITHUB_TOKEN` push never triggers workflows by itself). See
+   [Provenance](#provenance).
 
 Guards:
 
@@ -62,6 +71,53 @@ The QML/Quattro gates (`omarchy plugin validate`, Qt6 `qmllint`, ShellCheck
 of the bundled terminal helper) do not run on the Ubuntu release runner,
 which has no Omarchy runtime. They run at the pre-merge checkpoints on
 Omarchy hosts; the release consumes that accepted evidence.
+
+## Provenance
+
+The shipped `bin/agent-bar` is a 4 MB ELF that no source scan can inspect,
+so every release carries two independent proofs that it was built from the
+reviewed Rust source:
+
+1. **Exact-commit check run.** `Verify release` runs on the `release:`
+   commit itself. It checks out that commit, rebuilds the helper with
+   `scripts/agent-bar-build-helper`, and fails unless the rebuilt digest
+   equals both the committed `bin/agent-bar` and its `bundle.json` entry,
+   `bundle.json`'s `sourceCommit` is the release commit's parent, and the
+   attestation below was signed by the run named in `buildRun`.
+2. **SLSA provenance attestation.** The release run attests the helper's
+   digest with `actions/attest-build-provenance`. Anyone with `gh`
+   authenticated (the attestation is fetched from GitHub) can verify it
+   against a checkout of the release commit:
+
+   ```bash
+   gh attestation verify bin/agent-bar \
+     --repo othavi0/omarchy-agent-bar \
+     --signer-workflow othavi0/omarchy-agent-bar/.github/workflows/auto-release.yml
+   ```
+
+   The attestation names the source commit (`sourceRepositoryDigest`, which
+   `Verify release` compares with `bundle.json`'s `sourceCommit`) and the
+   workflow run (`buildRun` in `bundle.json` points at the same run).
+
+`Verify release` runs after publication. A red run does not retract the
+tag or the GitHub Release; it is the signal to cut a fixed release and to
+tell the marketplace not to verify the red one.
+
+Reproducing the digest outside the runner: the Rust side is pinned, but
+the `-gnu` target links with the host `gcc`, `binutils`, and glibc crt
+objects, whose versions end up in the ELF (`.comment` section and crt
+code). The same digest therefore requires the same runner image as the
+release (`ubuntu-24.04` at the time of the release); a build on another
+distribution, or on a later roll of the image, yields a different digest
+for the same source. To reproduce a specific release, rerun
+`Verify release` via `workflow_dispatch` with the tag as `ref` soon after
+the release, or match the `cc`/`ld` versions the script prints against
+the release run's log. For the source-to-binary claim itself, rely on the
+attestation, which does not depend on rebuilding.
+
+The toolchain pin in `rust-toolchain.toml` is part of the contract:
+bumping it changes the digest of every subsequent release (and cuts one,
+since the file is a release-triggering path).
 
 ## Update-path verification
 

--- a/docs/guide/runtime.md
+++ b/docs/guide/runtime.md
@@ -23,7 +23,8 @@ production.
 The plugin bundle contains manifest, `bundle.json`, QML, approved icons, the
 terminal helper, private Rust helper, `README.md`, `LICENSE`, and
 `preview.png`. `bundle.json` records ID, version, target, Omarchy contract,
-minimum Quickshell version, source commit, and hash/size/mode for every
+minimum Quickshell version, source commit, the CI run that built and
+attested the private helper (`buildRun`), and hash/size/mode for every
 other file.
 
 The installed plugin directory is a git checkout of this repository

--- a/docs/specs/v10/08-plugin-bundle-and-release.md
+++ b/docs/specs/v10/08-plugin-bundle-and-release.md
@@ -128,6 +128,7 @@ The exact receipt shape is:
   "omarchyContract": 1,
   "minimumQuickshellVersion": "0.3.0",
   "sourceCommit": "0123456789abcdef0123456789abcdef01234567",
+  "buildRun": "https://github.com/othavi0/omarchy-agent-bar/actions/runs/1",
   "files": [
     {
       "path": "BarWidget.qml",
@@ -138,6 +139,14 @@ The exact receipt shape is:
   ]
 }
 ```
+
+`buildRun` is optional and names the GitHub Actions run of this repository
+that built and attested the helper
+(`https://github.com/othavi0/omarchy-agent-bar/actions/runs/<numeric id>`);
+CI always stamps it, a local stamp omits it. The release contract in
+[docs/dev/releasing.md](../../dev/releasing.md#provenance) requires every
+published `bin/agent-bar` to be reproducible from its release commit and
+covered by a SLSA provenance attestation.
 
 `files` contains every regular bundle file except `bundle.json`, sorted by raw
 UTF-8 path bytes. Paths use `/`, are relative to the plugin root, and contain

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,8 @@
+# Pinned so `scripts/agent-bar-build-helper` yields the same bytes on the
+# release runner, the verify-release runner, and a developer machine. Bump
+# deliberately; every bump changes the shipped helper's digest.
+[toolchain]
+channel = "1.98.0"
+profile = "minimal"
+components = ["rustfmt", "clippy"]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/scripts/agent-bar-build-helper
+++ b/scripts/agent-bar-build-helper
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Reproducible build of the private helper `bin/agent-bar`.
+#
+# The release workflow and the verify-release workflow both call this
+# script, so the bytes committed as `bin/agent-bar` can be regenerated from
+# the tagged source and compared digest-for-digest. Determinism comes from:
+#   - the Rust toolchain pinned in rust-toolchain.toml,
+#   - `--locked` against Cargo.lock,
+#   - `--remap-path-prefix` for the workspace and CARGO_HOME,
+#   - no incremental compilation.
+# The C toolchain (gcc, binutils, glibc crt objects) is NOT pinned here:
+# the same digest requires the same runner image (see
+# docs/dev/releasing.md#provenance). Its versions are printed so a
+# mismatch can be diagnosed.
+#
+# Usage: scripts/agent-bar-build-helper
+# Output: target/x86_64-unknown-linux-gnu/release/agent-bar (+ sha256 on stdout)
+set -euo pipefail
+
+TARGET="x86_64-unknown-linux-gnu"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CARGO_HOME_DIR="${CARGO_HOME:-$HOME/.cargo}"
+CARGO_HOME_DIR="$(cd "$CARGO_HOME_DIR" && pwd)"
+
+# Cargo reads exactly one of these; anything inherited would silently
+# replace the remap flags below.
+unset CARGO_ENCODED_RUSTFLAGS CARGO_BUILD_RUSTFLAGS RUSTC_WRAPPER RUSTC_WORKSPACE_WRAPPER
+export CARGO_INCREMENTAL=0
+export RUSTFLAGS="--remap-path-prefix=${ROOT}=/src --remap-path-prefix=${CARGO_HOME_DIR}=/cargo"
+
+cd "$ROOT"
+echo "rustc: $(rustc --version)" >&2
+echo "cc:    $(cc --version | head -1)" >&2
+echo "ld:    $(ld --version | head -1)" >&2
+cargo build --release --locked --target "$TARGET" --bin agent-bar
+
+OUT="target/${TARGET}/release/agent-bar"
+test -x "$OUT"
+sha256sum "$OUT"

--- a/src/bin/agent-bar-bundle.rs
+++ b/src/bin/agent-bar-bundle.rs
@@ -1,7 +1,7 @@
 //! Internal release-stamp builder (not installed in the plugin bundle).
 //!
 //! Grammar (exact):
-//!   agent-bar-bundle stamp source-commit <40-hex>
+//!   agent-bar-bundle stamp source-commit <40-hex> [build-run <actions-run-url>]
 //!
 //! CI stamps the repo root in place, and the release workflow commits and
 //! pushes this repository's own `master` -- there is no separate
@@ -44,30 +44,40 @@ fn main() -> ExitCode {
 }
 
 fn usage() -> String {
-    "agent-bar-bundle stamp source-commit <40-lowercase-hex>\n".to_string()
+    "agent-bar-bundle stamp source-commit <40-lowercase-hex> \
+     [build-run https://github.com/othavi0/omarchy-agent-bar/actions/runs/<id>]\n"
+        .to_string()
 }
 
 fn run_stamp(args: &mut [String]) -> Result<PathBuf, String> {
-    let map = parse_kv(args, &["source-commit"])?;
+    let map = parse_kv(args, &["source-commit"], &["build-run"])?;
     let source_commit = map
         .get("source-commit")
         .ok_or("missing source-commit")?
         .clone();
 
+    let version = env!("CARGO_PKG_VERSION").to_string();
+    let mut builder = BundleBuilder::new(version, source_commit).map_err(|e| e.to_string())?;
+    if let Some(run) = map.get("build-run") {
+        builder = builder
+            .with_build_run(run.clone())
+            .map_err(|e| e.to_string())?;
+    }
+
     let repo_root = repo_root()?;
     let helper = find_helper_bin(&repo_root)?;
-    let version = env!("CARGO_PKG_VERSION").to_string();
-    let builder = BundleBuilder::new(version, source_commit).map_err(|e| e.to_string())?;
     builder
         .stamp(&repo_root, &helper)
         .map_err(|e| e.to_string())?;
     Ok(repo_root)
 }
 
-/// Parse alternating keyword value pairs. Keywords must match exactly once.
+/// Parse alternating keyword value pairs. Required keywords must appear
+/// exactly once; optional ones at most once.
 fn parse_kv(
     args: &[String],
     required: &[&str],
+    optional: &[&str],
 ) -> Result<std::collections::HashMap<String, String>, String> {
     if !args.len().is_multiple_of(2) {
         return Err("arguments must be keyword/value pairs".into());
@@ -76,7 +86,7 @@ fn parse_kv(
     let mut i = 0;
     while i < args.len() {
         let key = args[i].as_str();
-        if !required.contains(&key) {
+        if !required.contains(&key) && !optional.contains(&key) {
             return Err(format!("unknown or misplaced keyword '{key}'"));
         }
         if map.contains_key(key) {

--- a/src/plugin/bundle.rs
+++ b/src/plugin/bundle.rs
@@ -93,6 +93,11 @@ pub struct BundleReceipt {
     pub omarchy_contract: u32,
     pub minimum_quickshell_version: String,
     pub source_commit: String,
+    /// GitHub Actions run that built `bin/agent-bar` and attested it
+    /// (`https://github.com/othavi0/omarchy-agent-bar/actions/runs/<id>`).
+    /// Absent for local stamps that never went through CI.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub build_run: Option<String>,
     pub files: Vec<BundleFileEntry>,
 }
 
@@ -142,6 +147,9 @@ impl BundleReceipt {
             )));
         }
         validate_source_commit(&self.source_commit)?;
+        if let Some(run) = &self.build_run {
+            validate_build_run(run)?;
+        }
         validate_semver_strict(&self.version)?;
 
         let mut seen = BTreeSet::new();
@@ -180,6 +188,7 @@ pub struct BundleBuilder {
     pub version: String,
     pub target: String,
     pub source_commit: String,
+    pub build_run: Option<String>,
     pub omarchy_contract: u32,
     pub minimum_quickshell_version: String,
 }
@@ -197,9 +206,19 @@ impl BundleBuilder {
             version,
             target: OFFICIAL_TARGET.to_string(),
             source_commit,
+            build_run: None,
             omarchy_contract: OMARCHY_CONTRACT,
             minimum_quickshell_version: MINIMUM_QUICKSHELL_VERSION.to_string(),
         })
+    }
+
+    /// Record the CI run that built and attested the helper. Validated
+    /// eagerly so a bad URL fails before any file is touched.
+    pub fn with_build_run(mut self, build_run: impl Into<String>) -> Result<Self, BundleError> {
+        let build_run = build_run.into();
+        validate_build_run(&build_run)?;
+        self.build_run = Some(build_run);
+        Ok(self)
     }
 
     /// Stamp release artifacts directly into the repo root and write
@@ -309,6 +328,7 @@ impl BundleValidator {
             omarchy_contract: builder.omarchy_contract,
             minimum_quickshell_version: builder.minimum_quickshell_version.clone(),
             source_commit: builder.source_commit.clone(),
+            build_run: builder.build_run.clone(),
             files,
         };
         receipt.validate_shape()?;
@@ -447,6 +467,22 @@ pub fn validate_source_commit(s: &str) -> Result<(), BundleError> {
     if !s.chars().all(|c| matches!(c, '0'..='9' | 'a'..='f')) {
         return Err(BundleError::msg(
             "sourceCommit must be 40 lowercase hex characters",
+        ));
+    }
+    Ok(())
+}
+
+/// Prefix every `buildRun` must carry: only this repository's own Actions
+/// runs count as provenance for the shipped helper.
+pub const BUILD_RUN_PREFIX: &str = "https://github.com/othavi0/omarchy-agent-bar/actions/runs/";
+
+pub fn validate_build_run(s: &str) -> Result<(), BundleError> {
+    let id = s
+        .strip_prefix(BUILD_RUN_PREFIX)
+        .ok_or_else(|| BundleError::msg(format!("buildRun must start with {BUILD_RUN_PREFIX}")))?;
+    if id.is_empty() || !id.bytes().all(|b| b.is_ascii_digit()) {
+        return Err(BundleError::msg(
+            "buildRun must end with the numeric Actions run id only",
         ));
     }
     Ok(())
@@ -824,6 +860,7 @@ mod tests {
             omarchy_contract: 1,
             minimum_quickshell_version: MINIMUM_QUICKSHELL_VERSION.to_string(),
             source_commit: "0123456789abcdef0123456789abcdef01234567".to_string(),
+            build_run: None,
             files: vec![BundleFileEntry {
                 path: "BarWidget.qml".to_string(),
                 sha256: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
@@ -844,6 +881,39 @@ mod tests {
         assert!(json.contains("\"pluginId\": \"othavi0.agent-bar\""));
         assert!(json.contains("\"omarchyContract\": 1"));
         assert!(json.contains("\"minimumQuickshellVersion\": \"0.3.0\""));
+    }
+
+    #[test]
+    fn receipt_build_run_is_optional_and_round_trips() {
+        let mut r = sample_receipt();
+        assert!(r.validate_shape().is_ok());
+        let json = r.to_pretty_json().expect("json");
+        assert!(!json.contains("buildRun"));
+        r.build_run = Some(
+            "https://github.com/othavi0/omarchy-agent-bar/actions/runs/32612772134".to_string(),
+        );
+        assert!(r.validate_shape().is_ok());
+        let json = r.to_pretty_json().expect("json");
+        assert!(json.contains("\"buildRun\": \"https://github.com/othavi0/omarchy-agent-bar/actions/runs/32612772134\""));
+        let parsed = BundleReceipt::parse_json(json.as_bytes()).expect("parse");
+        assert_eq!(parsed, r);
+    }
+
+    #[test]
+    fn receipt_rejects_foreign_or_malformed_build_run() {
+        for bad in [
+            "",
+            "http://github.com/othavi0/omarchy-agent-bar/actions/runs/1",
+            "https://example.com/othavi0/omarchy-agent-bar/actions/runs/1",
+            "https://github.com/someone-else/omarchy-agent-bar/actions/runs/1",
+            "https://github.com/othavi0/omarchy-agent-bar/actions/runs/",
+            "https://github.com/othavi0/omarchy-agent-bar/actions/runs/12abc",
+            "https://github.com/othavi0/omarchy-agent-bar/actions/runs/1/attempts/2",
+        ] {
+            let mut r = sample_receipt();
+            r.build_run = Some(bad.to_string());
+            assert!(r.validate_shape().is_err(), "accepted {bad:?}");
+        }
     }
 
     #[test]
@@ -1140,6 +1210,37 @@ mod tests {
             .iter()
             .any(|f| f.path == "docs/media/demo.png"));
         BundleValidator::validate_tree(&root).unwrap();
+    }
+
+    #[test]
+    fn stamp_with_build_run_writes_it_to_the_receipt_file() {
+        let dir = tempdir().unwrap();
+        let root = dir.path().join("othavi0.agent-bar");
+        let version = "10.0.0";
+        write_stamp_source_root(&root, version);
+        let helper = dir.path().join("agent-bar");
+        fs::write(
+            &helper,
+            format!("#!/bin/sh\nif [ \"$1\" = version ]; then echo {version}; fi\n"),
+        )
+        .unwrap();
+        fs::set_permissions(&helper, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let run = "https://github.com/othavi0/omarchy-agent-bar/actions/runs/42";
+        let builder = BundleBuilder::new(version, ZERO_COMMIT)
+            .unwrap()
+            .with_build_run(run)
+            .unwrap();
+        let receipt = builder.stamp(&root, &helper).unwrap();
+        assert_eq!(receipt.build_run.as_deref(), Some(run));
+        let on_disk = fs::read(root.join("bundle.json")).unwrap();
+        assert!(String::from_utf8_lossy(&on_disk).contains(&format!("\"buildRun\": \"{run}\"")));
+        assert_eq!(BundleValidator::validate_tree(&root).unwrap(), receipt);
+
+        assert!(BundleBuilder::new(version, ZERO_COMMIT)
+            .unwrap()
+            .with_build_run("https://example.com/run/1")
+            .is_err());
     }
 
     #[test]

--- a/tests/agent_bar_bundle_cli.rs
+++ b/tests/agent_bar_bundle_cli.rs
@@ -16,6 +16,7 @@ fn help_exits_zero_and_names_only_stamp() {
     let stdout = String::from_utf8_lossy(&out.stdout);
     assert!(stdout.contains("stamp"));
     assert!(stdout.contains("source-commit"));
+    assert!(stdout.contains("build-run"));
     assert!(!stdout.contains("assemble"));
     assert!(!stdout.contains("output"));
     assert!(!stdout.contains("release bundle"));
@@ -74,4 +75,21 @@ fn unknown_command_exits_two() {
         .output()
         .expect("spawn");
     assert_eq!(out.status.code(), Some(2));
+}
+
+#[test]
+fn stamp_rejects_malformed_build_run_before_touching_the_tree() {
+    let out = Command::new(bin())
+        .args([
+            "stamp",
+            "source-commit",
+            "0123456789abcdef0123456789abcdef01234567",
+            "build-run",
+            "https://example.com/not-a-run",
+        ])
+        .output()
+        .expect("spawn");
+    assert!(!out.status.success());
+    let err = String::from_utf8_lossy(&out.stderr);
+    assert!(err.contains("buildRun"), "stderr={err}");
 }


### PR DESCRIPTION
## Why

HANCORE-linux/omarchy-plugin-marketplace#2246 declined verification of v10.3.13: the committed `bin/agent-bar` (4.1 MB ELF) has no check run on the exact `release:` commit and no provenance tying it to the reviewed Rust source. The `release:` commit is produced by CI itself, so no workflow ever ran on it.

## What

- `scripts/agent-bar-build-helper` + `rust-toolchain.toml`: reproducible helper build (pinned Rust 1.98.0, `--locked`, `--remap-path-prefix`, no incremental). Same digest across three separate checkouts locally.
- `auto-release.yml`: builds through the script on pinned `ubuntu-24.04`, stamps `buildRun` into `bundle.json`, records a SLSA provenance attestation for `bin/agent-bar` (`actions/attest-build-provenance@v4`), and dispatches `Verify release` on the new tag (GITHUB_TOKEN pushes never trigger workflows).
- `verify-release.yml` (new): runs on the release commit itself — rebuilds the helper and requires the same sha256 as the committed binary, checks every `bundle.json` entry against the tree, checks `sourceCommit` is the parent commit, and verifies the attestation was signed by `auto-release.yml` from `buildRun` and `sourceCommit`.
- `bundle.json` gains optional `buildRun` (validated: this repo's Actions run URL only). The installed helper's remote receipt parser tolerates unknown fields, so existing installs keep updating.
- Docs: `docs/dev/releasing.md#provenance` (how to verify, what reproducibility does and does not cover), spec 08, runtime guide, README, CHANGELOG.

## Verification

- `cargo fmt --check`, `cargo test` (21 suites, 0 failed), `cargo clippy --all-targets -- -D warnings`, `git diff --check`: all green.
- New tests: receipt `buildRun` round-trip and rejection cases, `stamp … build-run` writes the field, CLI rejects a malformed URL before touching the tree.
- ShellCheck and actionlint were not run (not installed on the dev host).
- The workflows themselves only prove out on the first release after merge: watch the `Auto release` run, then the dispatched `Verify release` run on the new tag, before re-submitting to the marketplace.