### PR TITLE
fix: read Grok monthly limit and no-quota plans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - fix: key notification state by window, not reset
 - feat: repeat alerts on a configurable reminder
 
+### Fixed
+
+- fix: Grok accounts whose credits payload has no `creditUsagePercent`
+  (X Premium, monthly-limit teams) no longer read as "billed another way".
+  The helper now also reads `GET /v1/billing` and turns
+  `used / monthlyLimit` into a `monthly` percentage window (amounts
+  discarded, PROD-019A clarified); plans that publish neither shape stay a
+  valid ready reading with the popup copy
+  `This plan does not publish a usage percentage.` (PROD-031 / UX-032A
+  amended).
+
 ## [10.3.16] - 2026-08-25
 
 ### Changed

--- a/CoreView.js
+++ b/CoreView.js
@@ -397,7 +397,7 @@ function containsMoneyCopy(text) {
 }
 
 function emptyWindowsMessage() {
-  return "This account is billed another way."
+  return "This plan does not publish a usage percentage."
 }
 
 function stateTitle(provider) {

--- a/docs/specs/v10/01-product-contract.md
+++ b/docs/specs/v10/01-product-contract.md
@@ -51,7 +51,10 @@ connection actions, update, and uninstall.
   or global `agent-bar` executable.
 - `PROD-019`: No custom theme editor or v10 internationalization layer.
 - `PROD-019A`: No monetary values are displayed or serialized, including
-  provider-reported spend, dollar balance, and credits.
+  provider-reported spend, dollar balance, and credits. A percentage derived
+  from a provider's own limit ratio (Amp `$remaining/$total`, Grok
+  `used/monthlyLimit`) is a usage percentage, not a monetary value: the
+  amounts are discarded at normalization and never leave the adapter.
 
 ## Supported providers and defaults
 
@@ -139,4 +142,6 @@ Notifications: enabled
 - `PROD-030`: The plugin must never display an empty or silently malformed
   status result.
 - `PROD-031`: A connected provider with no percentage window shows `—` in its
-  chip and `This account is billed another way.` in its popup.
+  chip and `This plan does not publish a usage percentage.` in its popup.
+  This is a valid reading, not a failure: subscriptions such as X Premium
+  authenticate the Grok CLI without exposing a quota.

--- a/docs/specs/v10/02-target-architecture.md
+++ b/docs/specs/v10/02-target-architecture.md
@@ -210,7 +210,7 @@ Locked collection policy:
 | `claude` | `$HOME/.claude/.credentials.json`, then authenticated `GET https://api.anthropic.com/api/oauth/usage` | `session`, `weekly`, then provider-scoped `weekly-model:<sanitized-id>` | 300 s | 10 s | one network/timeout retry |
 | `codex` | resolved `codex app-server` JSON-RPC `rateLimits/read`, then newest valid rate-limit event below `$HOME/.codex/sessions` | `session`, `weekly`, then `other:<duration-minutes>:<ordinal>` | 90 s | 10 s | one app-server timeout retry before filesystem fallback |
 | `amp` | resolved `amp usage` with `NO_COLOR=1`, `TERM=dumb` | `daily`, or no windows when the account exposes no percentage | 90 s | 10 s | one timeout/process-I/O retry |
-| `grok` | `$GROK_HOME/auth.json`, then authenticated GET `https://cli-chat-proxy.grok.com/v1/billing?format=credits` (literal; headers Authorization Bearer + x-grok-client-mode) | `weekly` | 90 s | 10 s | one network/timeout retry |
+| `grok` | `$GROK_HOME/auth.json`, then authenticated GET `https://cli-chat-proxy.grok.com/v1/billing?format=credits` (literal; headers Authorization Bearer + x-grok-client-mode); when that payload has no `creditUsagePercent`, one GET `https://cli-chat-proxy.grok.com/v1/billing` (same headers) whose `used / monthlyLimit` ratio becomes `monthly` (amounts discarded); its HTTP failures are the same typed results as the first request so stale retention applies, and a 2xx body without a ratio keeps the credits reading | `weekly` (credits) or `monthly` (limit ratio), or no windows when the plan publishes neither | 90 s | 10 s | one network/timeout retry per request |
 | `antigravity` | resolved `agy --version` (requires 1.1.11 or newer, because older builds send `/usage` to the model as a prompt) then `agy --print /usage --output-format json` with `NO_COLOR=1`, `TERM=dumb`; windows come from the `gemini-weekly` and `gemini-5h` bucket ids, the `Claude and GPT models` group is ignored | `gemini-weekly`, `gemini-5h` | 90 s | 10 s | none |
 
 Antigravity was removed once (see `CHANGELOG.md`) when it read credentials and
@@ -240,7 +240,7 @@ nonzero usage-command results are never retried. Adapter source fallback is
 not counted as a retry.
 
 Provider labels are fixed English copy: Claude `Session`/`Weekly`, Codex
-`Session`/`Weekly`, Amp `Daily`, Grok `Weekly`, and Antigravity
+`Session`/`Weekly`, Amp `Daily`, Grok `Weekly (7d)`/`Monthly`, and Antigravity
 `Session (5h)`/`Weekly (7d)`. Dynamic model labels are
 sanitized plain text. A dynamic Claude model ID is lowercased, limited to
 ASCII letters/digits/hyphens, and prefixed with `weekly-model:`; collisions

--- a/docs/specs/v10/03-cli-and-json-contract.md
+++ b/docs/specs/v10/03-cli-and-json-contract.md
@@ -189,7 +189,9 @@ provider_error
 - `JSON-022A`: A connected provider may return an empty `windows` array when
   its account exposes no percentage quota.
 - `JSON-022B`: The schema has no spend, balance, credits, currency, cost,
-  arbitrary extras, or generic monetary facts.
+  arbitrary extras, or generic monetary facts. A window whose percentage was
+  derived from a limit ratio carries only `usedPercent`/`remainingPercent`
+  (PROD-019A).
 - `JSON-022C`: `rateLimitResetsAvailable`, when present, is a non-negative
   integer count of provider-granted rate-limit resets. It is a quota-reset
   count, not a monetary fact: it never carries balance, price, or currency,

--- a/docs/specs/v10/04-quickshell-ux-and-accessibility.md
+++ b/docs/specs/v10/04-quickshell-ux-and-accessibility.md
@@ -125,7 +125,8 @@ not literal UI.
   not imply authentication failure.
 - `UX-032`: Provider errors never render raw stderr or rich text.
 - `UX-032A`: A ready provider with no normalized percentage window shows `—`
-  in its chip and `This account is billed another way.` in the popup.
+  in its chip and `This plan does not publish a usage percentage.` in the
+  popup. The copy never implies pay-as-you-go billing.
 
 ## Settings
 
@@ -197,7 +198,8 @@ Requirements:
   creates no custom elevation or motion system.
 - `UX-057`: No theme-specific color is hardcoded.
 - `UX-058`: No spend, currency, credit balance, or other monetary value is
-  rendered.
+  rendered. Ratio-derived percentages (PROD-019A) render like any other
+  window.
 
 ## Keyboard and focus
 

--- a/src/providers/adapters.rs
+++ b/src/providers/adapters.rs
@@ -99,6 +99,9 @@ fn classify_amp_failure(out: &ProcessOutput, login_available: bool) -> ProviderR
 
 /// Authenticated billing endpoint (literal; equality-tested).
 pub const GROK_BILLING_URL: &str = "https://cli-chat-proxy.grok.com/v1/billing?format=credits";
+/// Monthly-limit billing shape, consulted only when the credits shape carries
+/// no percentage (literal; equality-tested).
+pub const GROK_MONTHLY_BILLING_URL: &str = "https://cli-chat-proxy.grok.com/v1/billing";
 
 pub struct GrokAdapter;
 
@@ -184,59 +187,133 @@ impl ProviderAdapter for GrokAdapter {
             )
             .await
             {
-                Ok(resp) if resp.status == 401 || resp.status == 403 => unauthenticated(
-                    ProviderId::Grok,
-                    GROK.display_name,
-                    "Grok authentication was rejected.",
-                    login,
-                    GROK.installation_url,
-                    false,
-                ),
                 Ok(resp) if (200..300).contains(&resp.status) => {
                     let _ = resp.final_url;
-                    grok_from_billing_json(&resp.body, account, now, login)
-                }
-                Ok(resp) if resp.status >= 500 => ProviderResult::ProviderError {
-                    id: ProviderId::Grok,
-                    name: GROK.display_name.to_owned(),
-                    message: "Grok billing request failed.".into(),
-                    retryable: true,
-                },
-                Ok(_) => ProviderResult::ProviderError {
-                    id: ProviderId::Grok,
-                    name: GROK.display_name.to_owned(),
-                    message: "Grok billing request failed.".into(),
-                    retryable: false,
-                },
-                Err(super::adapter::HttpError::Network(_)) => ProviderResult::NetworkError {
-                    id: ProviderId::Grok,
-                    name: GROK.display_name.to_owned(),
-                    message: "Network error while contacting Grok.".into(),
-                },
-                Err(super::adapter::HttpError::RedirectRefused(_)) => {
-                    ProviderResult::ProviderError {
-                        id: ProviderId::Grok,
-                        name: GROK.display_name.to_owned(),
-                        message: "Grok billing redirect refused.".into(),
-                        retryable: false,
+                    let credits = grok_from_billing_json(&resp.body, account.clone(), now, login);
+                    match &credits {
+                        ProviderResult::Ready { windows, .. } if windows.is_empty() => {
+                            grok_monthly_fallback(
+                                context, &headers, max_body, account, now, login, credits,
+                            )
+                            .await
+                        }
+                        _ => credits,
                     }
                 }
-                Err(super::adapter::HttpError::BodyTooLarge) => ProviderResult::ProviderError {
-                    id: ProviderId::Grok,
-                    name: GROK.display_name.to_owned(),
-                    message: "Grok billing response exceeded size limit.".into(),
-                    retryable: false,
-                },
-                Err(super::adapter::HttpError::InvalidResponse(_)) => {
-                    ProviderResult::ProviderError {
-                        id: ProviderId::Grok,
-                        name: GROK.display_name.to_owned(),
-                        message: "Invalid Grok billing response.".into(),
-                        retryable: false,
-                    }
-                }
+                other => grok_http_failure(other, login),
             }
         })
+    }
+}
+
+/// Second billing shape for accounts whose credits payload publishes no
+/// percentage (monthly-limit teams). Network errors and 5xx are the same
+/// typed operational results as the primary request, so the coordinator's
+/// stale retention keeps the last good reading instead of an empty `Ready`
+/// overwriting it. A 4xx, or a 2xx body without a window, keeps the credits
+/// reading, including its `plan`/`account`.
+async fn grok_monthly_fallback(
+    context: &CollectionContext<'_>,
+    headers: &[(&str, &str)],
+    max_body: usize,
+    account: Option<String>,
+    now: time::OffsetDateTime,
+    login: bool,
+    credits: ProviderResult,
+) -> ProviderResult {
+    let response = super::retry::http_get_with_retry(
+        context.http,
+        &GROK,
+        GROK_MONTHLY_BILLING_URL,
+        headers,
+        max_body,
+    )
+    .await;
+    // The credits request just proved the token, so a 4xx here (including
+    // 401/403 or a missing route) is not a fault of this account: keep the
+    // credits reading. Network errors and 5xx are typed failures so stale
+    // retention can protect a cached monthly window.
+    let resp = match response {
+        Ok(resp) if (200..300).contains(&resp.status) => resp,
+        Ok(resp) if resp.status < 500 => return credits,
+        other => return grok_http_failure(other, login),
+    };
+    let monthly = grok_from_billing_json(&resp.body, account, now, login);
+    match (monthly, credits) {
+        (
+            ProviderResult::Ready {
+                windows,
+                plan: monthly_plan,
+                ..
+            },
+            ProviderResult::Ready {
+                id,
+                name,
+                source,
+                plan,
+                account,
+                last_success_at,
+                rate_limit_resets_available,
+                ..
+            },
+        ) => ProviderResult::Ready {
+            id,
+            name,
+            source,
+            plan: plan.or(monthly_plan),
+            account,
+            windows,
+            last_success_at,
+            rate_limit_resets_available,
+        },
+        (_, credits) => credits,
+    }
+}
+
+/// Map a non-2xx or failed billing request to its typed result. Shared by
+/// the credits and monthly requests.
+fn grok_http_failure(
+    response: Result<super::adapter::HttpResponse, super::adapter::HttpError>,
+    login: bool,
+) -> ProviderResult {
+    match response {
+        Ok(resp) if resp.status == 401 || resp.status == 403 => unauthenticated(
+            ProviderId::Grok,
+            GROK.display_name,
+            "Grok authentication was rejected.",
+            login,
+            GROK.installation_url,
+            false,
+        ),
+        Ok(resp) => ProviderResult::ProviderError {
+            id: ProviderId::Grok,
+            name: GROK.display_name.to_owned(),
+            message: "Grok billing request failed.".into(),
+            retryable: resp.status >= 500,
+        },
+        Err(super::adapter::HttpError::Network(_)) => ProviderResult::NetworkError {
+            id: ProviderId::Grok,
+            name: GROK.display_name.to_owned(),
+            message: "Network error while contacting Grok.".into(),
+        },
+        Err(super::adapter::HttpError::RedirectRefused(_)) => ProviderResult::ProviderError {
+            id: ProviderId::Grok,
+            name: GROK.display_name.to_owned(),
+            message: "Grok billing redirect refused.".into(),
+            retryable: false,
+        },
+        Err(super::adapter::HttpError::BodyTooLarge) => ProviderResult::ProviderError {
+            id: ProviderId::Grok,
+            name: GROK.display_name.to_owned(),
+            message: "Grok billing response exceeded size limit.".into(),
+            retryable: false,
+        },
+        Err(super::adapter::HttpError::InvalidResponse(_)) => ProviderResult::ProviderError {
+            id: ProviderId::Grok,
+            name: GROK.display_name.to_owned(),
+            message: "Invalid Grok billing response.".into(),
+            retryable: false,
+        },
     }
 }
 
@@ -782,7 +859,7 @@ impl crate::support::FileSystem for MapFileSystem {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::providers::adapter::{CollectionContext, HttpResponse};
+    use crate::providers::adapter::{CollectionContext, HttpError, HttpResponse};
     use crate::providers::catalog::{
         CollectionAvailability, ExecutionEnvironment, LoginAvailability,
     };
@@ -949,6 +1026,244 @@ mod tests {
         assert!(
             !matches!(result, ProviderResult::Unauthenticated { .. }),
             "status 500 is operational, got {result:?}"
+        );
+    }
+
+    async fn grok_ctx_collect(http: &ScriptedHttpClient) -> ProviderResult {
+        let process = empty_process();
+        let mut fs = MapFileSystem::default();
+        let env = grok_test_env_and_auth(&mut fs);
+        let clock = FixedClock(datetime!(2026-08-26 12:00:00 UTC));
+        let ctx = CollectionContext {
+            env: &env,
+            clock: &clock,
+            fs: &fs,
+            process: &process,
+            http,
+            plugin_root: None,
+        };
+        let discovery = Discovery {
+            collection: CollectionAvailability::Missing,
+            login: LoginAvailability::Available {
+                executable: std::path::PathBuf::from("/usr/bin/grok"),
+            },
+        };
+        GROK_ADAPTER.collect(&ctx, &discovery).await
+    }
+
+    fn scripted_pair(
+        first: HttpResponse,
+        second: Result<HttpResponse, HttpError>,
+    ) -> ScriptedHttpClient {
+        // Responses pop from the end: push the second call first.
+        let client = ScriptedHttpClient::single(second);
+        client
+            .responses
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .push(Ok(first));
+        client
+    }
+
+    #[tokio::test]
+    async fn grok_credits_without_quota_falls_back_to_monthly_limit() {
+        let credits =
+            include_bytes!("../../tests/fixtures/providers/grok/billing-credits-no-quota.json");
+        let monthly =
+            include_bytes!("../../tests/fixtures/providers/grok/billing-monthly-limit.json");
+        let http = scripted_pair(
+            HttpResponse {
+                status: 200,
+                final_url: GROK_BILLING_URL.into(),
+                body: credits.to_vec(),
+            },
+            Ok(HttpResponse {
+                status: 200,
+                final_url: GROK_MONTHLY_BILLING_URL.into(),
+                body: monthly.to_vec(),
+            }),
+        );
+        let result = grok_ctx_collect(&http).await;
+        assert_no_money(&result);
+        assert_eq!(
+            http.last_url.lock().unwrap().as_deref(),
+            Some(GROK_MONTHLY_BILLING_URL)
+        );
+        match result {
+            ProviderResult::Ready { windows, .. } => {
+                assert_eq!(windows.len(), 1, "got {windows:?}");
+                assert_eq!(windows[0].id(), "monthly");
+                assert!((windows[0].used_percent() - 25.0).abs() < 0.01);
+            }
+            other => panic!("expected ready, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn grok_monthly_fallback_network_failure_is_typed() {
+        // A failed second request must not become an empty `Ready` that
+        // evicts a cached monthly window; it is a retryable operational result.
+        let credits =
+            include_bytes!("../../tests/fixtures/providers/grok/billing-credits-no-quota.json");
+        let http = scripted_pair(
+            HttpResponse {
+                status: 200,
+                final_url: GROK_BILLING_URL.into(),
+                body: credits.to_vec(),
+            },
+            Err(HttpError::Network("offline".into())),
+        );
+        let result = grok_ctx_collect(&http).await;
+        assert!(
+            matches!(result, ProviderResult::NetworkError { .. }),
+            "{result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn grok_monthly_fallback_5xx_is_retryable_provider_error() {
+        let credits =
+            include_bytes!("../../tests/fixtures/providers/grok/billing-credits-no-quota.json");
+        let http = scripted_pair(
+            HttpResponse {
+                status: 200,
+                final_url: GROK_BILLING_URL.into(),
+                body: credits.to_vec(),
+            },
+            Ok(HttpResponse {
+                status: 503,
+                final_url: GROK_MONTHLY_BILLING_URL.into(),
+                body: b"{}".to_vec(),
+            }),
+        );
+        let result = grok_ctx_collect(&http).await;
+        assert!(
+            matches!(
+                result,
+                ProviderResult::ProviderError {
+                    retryable: true,
+                    ..
+                }
+            ),
+            "{result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn grok_monthly_fallback_4xx_keeps_credits_reading() {
+        let credits =
+            include_bytes!("../../tests/fixtures/providers/grok/billing-credits-no-quota.json");
+        for status in [401u16, 403, 404, 429] {
+            let http = scripted_pair(
+                HttpResponse {
+                    status: 200,
+                    final_url: GROK_BILLING_URL.into(),
+                    body: credits.to_vec(),
+                },
+                Ok(HttpResponse {
+                    status,
+                    final_url: GROK_MONTHLY_BILLING_URL.into(),
+                    body: b"{}".to_vec(),
+                }),
+            );
+            let result = grok_ctx_collect(&http).await;
+            match result {
+                ProviderResult::Ready {
+                    windows, account, ..
+                } => {
+                    assert!(windows.is_empty(), "status {status}: {windows:?}");
+                    assert!(account.is_some(), "status {status}");
+                }
+                other => panic!("status {status}: expected ready, got {other:?}"),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn grok_monthly_fallback_keeps_plan_and_account_from_credits() {
+        let credits = br#"{"config": {"subscriptionTiers": "SuperGrok",
+            "currentPeriod": {"type": "USAGE_PERIOD_TYPE_WEEKLY"}}}"#;
+        let monthly =
+            include_bytes!("../../tests/fixtures/providers/grok/billing-monthly-limit.json");
+        let http = scripted_pair(
+            HttpResponse {
+                status: 200,
+                final_url: GROK_BILLING_URL.into(),
+                body: credits.to_vec(),
+            },
+            Ok(HttpResponse {
+                status: 200,
+                final_url: GROK_MONTHLY_BILLING_URL.into(),
+                body: monthly.to_vec(),
+            }),
+        );
+        let result = grok_ctx_collect(&http).await;
+        match result {
+            ProviderResult::Ready {
+                windows,
+                plan,
+                account,
+                ..
+            } => {
+                assert_eq!(windows.len(), 1);
+                assert_eq!(windows[0].id(), "monthly");
+                assert_eq!(plan.as_ref().map(|p| p.label.as_str()), Some("SuperGrok"));
+                assert!(
+                    account.is_some(),
+                    "account label from auth.json must survive"
+                );
+            }
+            other => panic!("expected ready, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn grok_no_quota_on_either_shape_keeps_credits_account() {
+        let credits =
+            include_bytes!("../../tests/fixtures/providers/grok/billing-credits-no-quota.json");
+        let monthly =
+            include_bytes!("../../tests/fixtures/providers/grok/billing-monthly-zero.json");
+        let http = scripted_pair(
+            HttpResponse {
+                status: 200,
+                final_url: GROK_BILLING_URL.into(),
+                body: credits.to_vec(),
+            },
+            Ok(HttpResponse {
+                status: 200,
+                final_url: GROK_MONTHLY_BILLING_URL.into(),
+                body: monthly.to_vec(),
+            }),
+        );
+        let result = grok_ctx_collect(&http).await;
+        match result {
+            ProviderResult::Ready {
+                windows,
+                account,
+                source,
+                ..
+            } => {
+                assert!(windows.is_empty());
+                assert!(account.is_some());
+                assert_eq!(source, crate::status::schema::DataSource::Live);
+            }
+            other => panic!("expected ready, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn grok_credits_with_quota_makes_a_single_request() {
+        let body = include_bytes!("../../tests/fixtures/providers/grok/billing-weekly.json");
+        let http = ScriptedHttpClient::single(Ok(HttpResponse {
+            status: 200,
+            final_url: GROK_BILLING_URL.into(),
+            body: body.to_vec(),
+        }));
+        let result = grok_ctx_collect(&http).await;
+        assert!(matches!(result, ProviderResult::Ready { .. }), "{result:?}");
+        assert_eq!(
+            http.last_url.lock().unwrap().as_deref(),
+            Some(GROK_BILLING_URL)
         );
     }
 

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -17,7 +17,7 @@ pub use adapter::{
 pub use adapters::{
     AmpAdapter, AntigravityAdapter, ClaudeAdapter, CodexAdapter, GrokAdapter, AMP_ADAPTER,
     ANTIGRAVITY_ADAPTER, CLAUDE_ADAPTER, CLAUDE_USAGE_URL, CODEX_ADAPTER, GROK_ADAPTER,
-    GROK_BILLING_URL,
+    GROK_BILLING_URL, GROK_MONTHLY_BILLING_URL,
 };
 pub use catalog::{
     descriptor, discover, login_process_argv, CatalogError, CollectionAvailability, Discovery,

--- a/src/providers/v2_map.rs
+++ b/src/providers/v2_map.rs
@@ -152,6 +152,14 @@ struct GrokBillingDoc {
     billing_period_end: Option<String>,
     #[serde(default, rename = "subscriptionTiers")]
     subscription_tiers: Option<String>,
+    /// Monthly-limit shape (`/v1/billing` without `format=credits`): only the
+    /// `used / monthlyLimit` ratio survives; the amounts are never emitted.
+    /// Kept as raw values (like the discarded fields below) so an unexpected
+    /// shape can never fail the whole payload.
+    #[serde(default, rename = "monthlyLimit")]
+    monthly_limit: Option<Value>,
+    #[serde(default)]
+    used: Option<Value>,
     /// Discarded monetary fields.
     #[serde(default, rename = "prepaidBalance")]
     prepaid_balance: Option<Value>,
@@ -185,12 +193,13 @@ fn grok_window_identity(period_type: Option<&str>) -> (String, String) {
     }
 }
 
-/// Parse Grok billing JSON into a single weekly percentage window.
+/// Parse Grok billing JSON into at most one percentage window.
 ///
-/// - `creditUsagePercent` → used; remaining = 100 − used
+/// - `creditUsagePercent` (subscription credits) → used; remaining = 100 − used
+/// - otherwise `used / monthlyLimit` (monthly-limit accounts) → `monthly`
 /// - `currentPeriod.end` or `billingPeriodEnd` → resetsAt
 /// - money-like fields discarded; never emits a `context` window
-/// - missing/invalid percent → Ready with empty windows
+/// - neither shape (plans without a published quota) → Ready, empty windows
 pub fn grok_from_billing_json(
     bytes: &[u8],
     account_label: Option<String>,
@@ -218,19 +227,26 @@ pub fn grok_from_billing_json(
     );
 
     let mut windows = Vec::new();
-    if let Some(used_raw) = doc.credit_usage_percent {
-        if used_raw.is_finite() {
-            let used = used_raw.clamp(0.0, 100.0);
-            let remaining = (100.0 - used).clamp(0.0, 100.0);
-            let resets = grok_billing_resets_at(&doc);
-            let (id, label) = grok_window_identity(
-                doc.current_period
-                    .as_ref()
-                    .and_then(|p| p.period_type.as_deref()),
-            );
-            if let Ok(w) = UsageWindow::try_new(&id, &label, used, remaining, resets) {
-                windows.push(w);
-            }
+    let credit = doc.credit_usage_percent.map(|used| {
+        let (id, label) = grok_window_identity(
+            doc.current_period
+                .as_ref()
+                .and_then(|p| p.period_type.as_deref()),
+        );
+        (id, label, used)
+    });
+    let monthly = || {
+        grok_monthly_used_percent(&doc).map(|used| {
+            let id = "monthly";
+            (id.to_owned(), format_plan_label(id), used)
+        })
+    };
+    if let Some((id, label, used_raw)) = credit.or_else(monthly) {
+        let used = used_raw.clamp(0.0, 100.0);
+        let remaining = (100.0 - used).clamp(0.0, 100.0);
+        let resets = grok_billing_resets_at(&doc);
+        if let Ok(w) = UsageWindow::try_new(&id, &label, used, remaining, resets) {
+            windows.push(w);
         }
     }
 
@@ -266,6 +282,26 @@ fn parse_grok_billing_doc(bytes: &[u8]) -> Result<GrokBillingDoc, serde_json::Er
         _ => value,
     };
     serde_json::from_value(payload)
+}
+
+/// `used / monthlyLimit` as a percentage. A zero, negative, or absent limit,
+/// or an absent `used`, is "no quota published", never a fabricated 0 %.
+/// The live shape is `{"val": N}`; a bare number is tolerated.
+fn grok_monthly_used_percent(doc: &GrokBillingDoc) -> Option<f64> {
+    let limit = grok_amount(doc.monthly_limit.as_ref()?)?;
+    let used = grok_amount(doc.used.as_ref()?)?;
+    if limit <= 0.0 {
+        return None;
+    }
+    Some(used / limit * 100.0)
+}
+
+fn grok_amount(value: &Value) -> Option<f64> {
+    match value {
+        Value::Number(n) => n.as_f64(),
+        Value::Object(map) => map.get("val").and_then(Value::as_f64),
+        _ => None,
+    }
 }
 
 fn grok_billing_resets_at(doc: &GrokBillingDoc) -> Option<OffsetDateTime> {
@@ -1382,6 +1418,99 @@ mod tests {
             ProviderResult::Ready { windows, .. } => {
                 assert_eq!(windows[0].id(), "weekly");
                 assert_eq!(windows[0].label(), "Weekly (7d)");
+            }
+            other => panic!("expected ready, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn grok_credits_without_percent_is_ready_with_no_windows() {
+        let body =
+            include_bytes!("../../tests/fixtures/providers/grok/billing-credits-no-quota.json");
+        let result = grok_from_billing_json(body, None, datetime!(2026-08-26 12:00:00 UTC), true);
+        assert_no_money(&result);
+        match result {
+            ProviderResult::Ready { windows, plan, .. } => {
+                assert!(windows.is_empty(), "got {windows:?}");
+                assert!(plan.is_none());
+            }
+            other => panic!("expected ready, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn grok_monthly_limit_becomes_percentage_window() {
+        let body = include_bytes!("../../tests/fixtures/providers/grok/billing-monthly-limit.json");
+        let result = grok_from_billing_json(body, None, datetime!(2026-08-26 12:00:00 UTC), true);
+        assert_no_money(&result);
+        match result {
+            ProviderResult::Ready { windows, .. } => {
+                assert_eq!(windows.len(), 1, "got {windows:?}");
+                assert_eq!(windows[0].id(), "monthly");
+                assert_eq!(windows[0].label(), "Monthly");
+                assert!((windows[0].used_percent() - 25.0).abs() < 0.01);
+                assert!((windows[0].remaining_percent() - 75.0).abs() < 0.01);
+                assert_eq!(
+                    windows[0].resets_at(),
+                    Some(datetime!(2026-09-01 00:00:00 UTC))
+                );
+            }
+            other => panic!("expected ready, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn grok_monthly_zero_limit_has_no_window() {
+        let body = include_bytes!("../../tests/fixtures/providers/grok/billing-monthly-zero.json");
+        let result = grok_from_billing_json(body, None, datetime!(2026-08-26 12:00:00 UTC), true);
+        assert_no_money(&result);
+        match result {
+            ProviderResult::Ready { windows, .. } => assert!(windows.is_empty()),
+            other => panic!("expected ready, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn grok_monthly_limit_without_used_has_no_window() {
+        let json = br#"{"monthlyLimit": {"val": 100}, "billingPeriodEnd": "2026-09-01T00:00:00Z"}"#;
+        let result = grok_from_billing_json(json, None, datetime!(2026-08-26 12:00:00 UTC), true);
+        match result {
+            ProviderResult::Ready { windows, .. } => assert!(windows.is_empty(), "{windows:?}"),
+            other => panic!("expected ready, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn grok_scalar_amounts_never_fail_the_credits_payload() {
+        // The same struct parses both endpoints: an unexpected scalar for
+        // `used`/`monthlyLimit` must not turn a SuperGrok reading into an error.
+        let json = br#"{"creditUsagePercent": 33.0, "used": 12.5, "monthlyLimit": 200}"#;
+        let result = grok_from_billing_json(json, None, datetime!(2026-08-26 12:00:00 UTC), true);
+        match result {
+            ProviderResult::Ready { windows, .. } => {
+                assert_eq!(windows.len(), 1);
+                assert_eq!(windows[0].id(), "weekly");
+            }
+            other => panic!("expected ready, got {other:?}"),
+        }
+        let json = br#"{"used": "12.5", "monthlyLimit": [200]}"#;
+        let result = grok_from_billing_json(json, None, datetime!(2026-08-26 12:00:00 UTC), true);
+        match result {
+            ProviderResult::Ready { windows, .. } => assert!(windows.is_empty()),
+            other => panic!("expected ready, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn grok_credit_percent_wins_over_monthly_limit() {
+        let json =
+            br#"{"creditUsagePercent": 40.0, "monthlyLimit": {"val": 100}, "used": {"val": 10}}"#;
+        let result = grok_from_billing_json(json, None, datetime!(2026-08-26 12:00:00 UTC), true);
+        match result {
+            ProviderResult::Ready { windows, .. } => {
+                assert_eq!(windows.len(), 1);
+                assert_eq!(windows[0].id(), "weekly");
+                assert!((windows[0].used_percent() - 40.0).abs() < 0.01);
             }
             other => panic!("expected ready, got {other:?}"),
         }

--- a/tests/fixtures/providers/grok/README.md
+++ b/tests/fixtures/providers/grok/README.md
@@ -1,0 +1,13 @@
+# Grok billing fixtures
+
+Captured on 2026-08-26 from Grok CLI 1.0.5 against
+`https://cli-chat-proxy.grok.com/v1/billing` with an X Premium account,
+values sanitized; no credentials, identifiers, or account labels are kept.
+
+| File | Endpoint | Provenance |
+| --- | --- | --- |
+| `billing-weekly.json`, `billing-weekly-wrapped.json` | `?format=credits` | SuperGrok account: `creditUsagePercent` and `subscriptionTiers` present. |
+| `billing-credits-no-quota.json` | `?format=credits` | X Premium account, verbatim shape: no `creditUsagePercent`, no `subscriptionTiers`. |
+| `billing-monthly-zero.json` | no `format` | X Premium account, verbatim shape: `monthlyLimit.val` and `used.val` are `0`. |
+| `billing-monthly-limit.json` | no `format` | Same shape as above with `monthlyLimit`/`used` set to non-zero values to exercise the ratio; a live positive-limit capture is still wanted. |
+| `signals-recent.json` | local `~/.grok` signals | Context tokens only. |

--- a/tests/fixtures/providers/grok/billing-credits-no-quota.json
+++ b/tests/fixtures/providers/grok/billing-credits-no-quota.json
@@ -1,0 +1,16 @@
+{
+  "config": {
+    "currentPeriod": {
+      "type": "USAGE_PERIOD_TYPE_WEEKLY",
+      "start": "2026-08-21T21:10:59.543182+00:00",
+      "end": "2026-08-28T21:10:59.543182+00:00"
+    },
+    "onDemandCap": { "val": 0 },
+    "onDemandUsed": { "val": 0 },
+    "isUnifiedBillingUser": true,
+    "prepaidBalance": { "val": 0 },
+    "topUpMethod": "TOP_UP_METHOD_SAVED_PAYMENT_METHOD",
+    "billingPeriodStart": "2026-08-21T21:10:59.543182+00:00",
+    "billingPeriodEnd": "2026-08-28T21:10:59.543182+00:00"
+  }
+}

--- a/tests/fixtures/providers/grok/billing-monthly-limit.json
+++ b/tests/fixtures/providers/grok/billing-monthly-limit.json
@@ -1,0 +1,12 @@
+{
+  "config": {
+    "monthlyLimit": { "val": 200 },
+    "used": { "val": 50 },
+    "onDemandCap": { "val": 0 },
+    "billingPeriodStart": "2026-08-01T00:00:00+00:00",
+    "billingPeriodEnd": "2026-09-01T00:00:00+00:00",
+    "history": [
+      { "billingCycle": { "year": 2026, "month": 7 }, "includedUsed": { "val": 0 }, "onDemandUsed": { "val": 0 }, "totalUsed": { "val": 0 } }
+    ]
+  }
+}

--- a/tests/fixtures/providers/grok/billing-monthly-zero.json
+++ b/tests/fixtures/providers/grok/billing-monthly-zero.json
@@ -1,0 +1,10 @@
+{
+  "config": {
+    "monthlyLimit": { "val": 0 },
+    "used": { "val": 0 },
+    "onDemandCap": { "val": 0 },
+    "billingPeriodStart": "2026-08-01T00:00:00+00:00",
+    "billingPeriodEnd": "2026-09-01T00:00:00+00:00",
+    "history": []
+  }
+}

--- a/tests/qml/tst_ProviderStates.qml
+++ b/tests/qml/tst_ProviderStates.qml
@@ -50,7 +50,7 @@ TestCase {
     var p = firstProvider("valid-empty-windows.json")
     compare(Core.contentMode(p), "empty_windows")
     compare(Core.stateBody(p), Core.emptyWindowsMessage())
-    verify(Core.stateBody(p).indexOf("billed another way") >= 0)
+    verify(Core.stateBody(p).indexOf("does not publish a usage percentage") >= 0)
   }
 
   // UX-028 (amended): stale renders through the ready path. The dedicated
@@ -492,7 +492,7 @@ TestCase {
   function test_state_copy_ready_no_quota() {
     var p = { id: "claude", name: "Claude", state: "ready", windows: [], error: null }
     compare(Core.stateTitle(p), "Claude reports no quota")
-    compare(Core.stateBody(p), "This account is billed another way.")
+    compare(Core.stateBody(p), "This plan does not publish a usage percentage.")
   }
 
   function test_state_body_error_message_precedence() {


### PR DESCRIPTION
## Problem

A Grok account on X Premium authenticates the CLI but `GET /v1/billing?format=credits` returns neither `creditUsagePercent` nor `subscriptionTiers`. The popup then showed **"Grok reports no quota / This account is billed another way."**, which reads as pay-as-you-go for a subscribed account.

Verified live against the CLI proxy (values redacted): the credits shape carries only `currentPeriod`, `prepaidBalance 0`, `onDemandCap 0`, `isUnifiedBillingUser`; the unformatted `GET /v1/billing` carries `monthlyLimit.val`, `used.val`, `billingPeriodEnd`, `history`. The Grok CLI 1.0.5 binary has no other quota endpoint.

## Change

- `v2_map.rs`: when `creditUsagePercent` is absent, `used / monthlyLimit` becomes a `monthly` percentage window. Amounts are discarded; zero/absent limit or absent `used` means no window, never a fabricated 0 %. `used`/`monthlyLimit` are parsed as raw values so an unexpected shape can never fail a SuperGrok payload.
- `adapters.rs`: when the credits payload yields no window, one extra `GET /v1/billing`. Network/5xx failures are typed results (stale retention keeps a cached window); 4xx or a 2xx body without a ratio keeps the credits reading, including its `plan`/`account`.
- Copy: `This account is billed another way.` → `This plan does not publish a usage percentage.`
- Specs: PROD-031 / UX-032A amended; PROD-019A / JSON-022B / UX-058 clarify that a ratio-derived percentage is not a monetary value (same rule Amp already applies to `$remaining/$total`); 02 collection table and label list updated.
- Fixtures with provenance in `tests/fixtures/providers/grok/README.md`.

## Verification

- `cargo fmt --check`, `cargo test` (367 passed), `cargo clippy --all-targets -- -D warnings`, `git diff --check`: clean.
- `qmltestrunner`: 260 passed. `omarchy plugin validate .`: ok. `qmllint`: only the two pre-existing `BarWidget.qml` warnings.
- Live helper on an X Premium account: `state: ready, windows: [], plan: null, error: null` (expected — the plan publishes no quota).

Not verified: a live positive `monthlyLimit` capture (the `billing-monthly-limit.json` fixture uses the real shape with synthetic values), and a screenshot of the new popup copy on a live install.
