### PR TITLE
fix: recover from stalled service after plugin reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- fix: bound every service process lane with a deadline, report repeated lane
+  timeouts as a stalled runtime, and offer a shell restart from the popup and
+  failed Settings load state ([#73](https://github.com/othavi0/omarchy-agent-bar/issues/73)).
 - fix: Grok accounts whose credits payload has no `creditUsagePercent`
   (X Premium, monthly-limit teams) no longer read as "billed another way".
   The helper now also reads `GET /v1/billing` and turns

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,9 +46,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-- fix: bound every service process lane with a deadline, report repeated lane
-  timeouts as a stalled runtime, and offer a shell restart from the popup and
-  failed Settings load state ([#73](https://github.com/othavi0/omarchy-agent-bar/issues/73)).
+- fix: bound every service process lane with a deadline. Timeouts in two
+  distinct lanes before any accepted helper callback report a stalled runtime
+  and offer a shell restart from the popup and failed Settings load state
+  ([#73](https://github.com/othavi0/omarchy-agent-bar/issues/73)).
 - fix: Grok accounts whose credits payload has no `creditUsagePercent`
   (X Premium, monthly-limit teams) no longer read as "billed another way".
   The helper now also reads `GET /v1/billing` and turns

--- a/CoreMaintenance.js
+++ b/CoreMaintenance.js
@@ -41,6 +41,10 @@ function loginDetachedArgv(pluginRoot, providerId) {
   ]
 }
 
+function restartShellArgv() {
+  return ["omarchy-restart-shell"]
+}
+
 // Exact xdg-terminal-exec argv the Bash helper must exec (ARCH login flow).
 function terminalHelperXdgArgv(pluginRoot, providerId) {
   if (!pluginRoot || !Kernel.isClosedProvider(providerId))

--- a/CoreService.js
+++ b/CoreService.js
@@ -29,13 +29,32 @@ var PROVIDER_STATES = {
 // Version / health / IPC refresh
 // ---------------------------------------------------------------------------
 
-function health(versionReady, versionFailed, helperVersion, manifestVersion, expectedVersion) {
+function health(versionReady, versionFailed, helperVersion, manifestVersion, expectedVersion, runtimeHealthValue) {
+  if (runtimeHealthValue === "stalled")
+    return "stalled"
   var expected = String(expectedVersion || "")
   if (!versionReady || versionFailed)
     return "unknown"
   if (String(helperVersion) === expected && String(manifestVersion) === expected)
     return "ok"
   return "unknown"
+}
+
+function runtimeHealth(timedOutLanes) {
+  var count = 0
+  for (var lane in (timedOutLanes || {})) {
+    if (timedOutLanes[lane])
+      count++
+  }
+  return count >= 2 ? "stalled" : "ok"
+}
+
+function recordLaneTimeout(timedOutLanes, lane) {
+  var next = {}
+  for (var key in (timedOutLanes || {}))
+    next[key] = !!timedOutLanes[key]
+  next[String(lane)] = true
+  return next
 }
 
 function isClosedProvider(providerId) {

--- a/CoreService.js
+++ b/CoreService.js
@@ -57,6 +57,33 @@ function recordLaneTimeout(timedOutLanes, lane) {
   return next
 }
 
+function settleLane(settledLanes, lane, generation) {
+  var next = {}
+  for (var key in (settledLanes || {}))
+    next[key] = settledLanes[key]
+  next[String(lane)] = Number(generation)
+  return next
+}
+
+function isLaneSettled(settledLanes, lane, generation) {
+  if (!settledLanes)
+    return false
+  var key = String(lane)
+  return Object.prototype.hasOwnProperty.call(settledLanes, key)
+      && Number(settledLanes[key]) === Number(generation)
+}
+
+function clearSettledLane(settledLanes, lane, generation) {
+  if (!isLaneSettled(settledLanes, lane, generation))
+    return settledLanes || {}
+  var next = {}
+  for (var key in settledLanes) {
+    if (key !== String(lane))
+      next[key] = settledLanes[key]
+  }
+  return next
+}
+
 function isClosedProvider(providerId) {
   return !!CLOSED_PROVIDERS[String(providerId || "")]
 }

--- a/CoreService.js
+++ b/CoreService.js
@@ -57,6 +57,15 @@ function recordLaneTimeout(timedOutLanes, lane) {
   return next
 }
 
+function clearLaneTimeout(timedOutLanes, lane) {
+  var next = {}
+  for (var key in (timedOutLanes || {})) {
+    if (key !== String(lane))
+      next[key] = !!timedOutLanes[key]
+  }
+  return next
+}
+
 function settleLane(settledLanes, lane, generation) {
   var next = {}
   for (var key in (settledLanes || {}))
@@ -74,7 +83,7 @@ function isLaneSettled(settledLanes, lane, generation) {
 }
 
 function clearSettledLane(settledLanes, lane, generation) {
-  if (!isLaneSettled(settledLanes, lane, generation))
+  if (generation !== undefined && !isLaneSettled(settledLanes, lane, generation))
     return settledLanes || {}
   var next = {}
   for (var key in settledLanes) {

--- a/Popup.qml
+++ b/Popup.qml
@@ -165,6 +165,7 @@ KeyboardPanel {
     id: focusController
     flickable: contentFlick
     lineHeight: root.contentLineHeight
+    focusBlocked: root.editorActive
   }
 
   function rebuildFocusTargets() {

--- a/Popup.qml
+++ b/Popup.qml
@@ -173,6 +173,8 @@ KeyboardPanel {
     var list = []
     if (rail && typeof rail.collectFocusTargets === "function")
       list = list.concat(rail.collectFocusTargets())
+    if (stalledMessage && typeof stalledMessage.collectFocusTargets === "function")
+      list = list.concat(stalledMessage.collectFocusTargets())
     if (contentLoader.item && typeof contentLoader.item.collectFocusTargets === "function")
       list = list.concat(contentLoader.item.collectFocusTargets())
     focusController.setTargets(list)
@@ -192,6 +194,9 @@ KeyboardPanel {
       focusController.clampScroll()
     if (typeof root.rebuildFocusTargets === "function")
       root.rebuildFocusTargets()
+  })
+  onAgentServiceChanged: Qt.callLater(function () {
+    root.rebuildFocusTargets()
   })
 
   PanelKeyCatcher {
@@ -307,6 +312,28 @@ KeyboardPanel {
           Column {
             id: contentColumn
             width: contentFlick.width
+            spacing: Style.space(12)
+
+            StateMessage {
+              id: stalledMessage
+              width: parent.width
+              visible: root.agentService
+                  && root.agentService.runtimeHealth === "stalled"
+              title: "Agent Bar lost contact with its helper"
+              body: "Restart the shell to recover."
+              actions: [{
+                kind: "restart_shell",
+                label: "Restart shell",
+                target: null
+              }]
+              foreground: Color.foreground
+              fontFamily: Style.font.family
+              onActionActivated: function (kind, target) {
+                if (kind === "restart_shell" && root.agentService)
+                  root.agentService.restartShell()
+              }
+              onVisibleChanged: Qt.callLater(root.rebuildFocusTargets)
+            }
 
             Loader {
               id: contentLoader

--- a/Service.qml
+++ b/Service.qml
@@ -146,9 +146,10 @@ Item {
       settledLanes = Core.settleLane(settledLanes, lane, generation)
   }
 
-  function recordCompletedCallback(fromTimeout) {
+  function recordCompletedCallback(fromTimeout, lane) {
     if (fromTimeout)
       return
+    settledLanes = Core.clearSettledLane(settledLanes, lane)
     completedCallbackCount++
     timedOutLanes = ({})
   }
@@ -156,7 +157,7 @@ Item {
   function shouldApplyProcessExit(lane, generation, activeGeneration) {
     if (Core.isLaneSettled(settledLanes, lane, generation)) {
       settledLanes = Core.clearSettledLane(settledLanes, lane, generation)
-      recordCompletedCallback(false)
+      timedOutLanes = Core.clearLaneTimeout(timedOutLanes, lane)
       return false
     }
     return Core.shouldApplyGeneration(activeGeneration, generation)
@@ -384,10 +385,6 @@ Item {
     maintenanceUi = Maintenance.maintenanceUiChecking(maintenanceUi)
     maintenanceCheckBusy = true
     maintenanceCheckTimeout.restart()
-    if (testMode) {
-      maintenanceCheckStartedGeneration = activeMaintenanceCheckGeneration
-      return
-    }
     var helper = resolvedHelperPath()
     if (!helper.length) {
       maintenanceCheckBusy = false
@@ -395,6 +392,10 @@ Item {
       return
     }
     maintenanceCheckProcess.command = Maintenance.updateCheckArgv(helper)
+    maintenanceCheckStartedGeneration = activeMaintenanceCheckGeneration
+    if (testMode) {
+      return
+    }
     maintenanceCheckProcess.running = true
   }
 
@@ -403,7 +404,7 @@ Item {
       return
     maintenanceCheckTimeout.stop()
     maintenanceCheckBusy = false
-    recordCompletedCallback(!!fromTimeout)
+    recordCompletedCallback(!!fromTimeout, "maintenanceCheck")
     maintenanceUi = Maintenance.maintenanceUiFromCheck(
       maintenanceUi,
       stdout,
@@ -504,7 +505,7 @@ Item {
   function applyVersionProbeResult(generation, stdout, stderr, exitCode, fromTimeout) {
     if (!Core.shouldApplyGeneration(activeVersionProbeGeneration, generation))
       return
-    recordCompletedCallback(!!fromTimeout)
+    recordCompletedCallback(!!fromTimeout, "versionProbe")
     var version = Core.parseVersionStdout(stdout, stderr, exitCode)
     if (version)
       finishVersionProbeSuccess(version)
@@ -544,6 +545,7 @@ Item {
     activeVersionProbeGeneration = versionProbeGeneration
     // StdioCollector.text is read-only; waitForEnd replaces content per run.
     versionProbe.command = [helper, "version"]
+    versionProbeStartedGeneration = activeVersionProbeGeneration
     versionProbe.running = true
     versionTimeout.restart()
   }
@@ -610,12 +612,12 @@ Item {
     statusStartCount++
     statusTimeout.restart()
     // StdioCollector.text is read-only; waitForEnd replaces content per run.
+    statusProcess.command = argv
+    statusStartedGeneration = gen
     if (testMode) {
-      statusStartedGeneration = gen
       // Tests call applyStatusResult(gen, stdout, stderr, code)
       return
     }
-    statusProcess.command = argv
     statusProcess.running = true
   }
 
@@ -625,7 +627,7 @@ Item {
     statusTimeout.stop()
     statusBusy = false
     refreshing = false
-    recordCompletedCallback(!!fromTimeout)
+    recordCompletedCallback(!!fromTimeout, "status")
 
     if (exitCode !== 0) {
       // Keep last snapshot (CACHE-021 / malformed retention).
@@ -668,11 +670,11 @@ Item {
     activeSettingsBootstrapGeneration = settingsBootstrapGeneration
     settingsBootstrapBusy = true
     settingsBootstrapTimeout.restart()
+    settingsBootstrapProcess.command = Settings.settingsArgvShow(helper)
+    settingsBootstrapStartedGeneration = activeSettingsBootstrapGeneration
     if (testMode) {
-      settingsBootstrapStartedGeneration = activeSettingsBootstrapGeneration
       return
     }
-    settingsBootstrapProcess.command = Settings.settingsArgvShow(helper)
     settingsBootstrapProcess.running = true
   }
 
@@ -681,7 +683,7 @@ Item {
       return
     settingsBootstrapTimeout.stop()
     settingsBootstrapBusy = false
-    recordCompletedCallback(!!fromTimeout)
+    recordCompletedCallback(!!fromTimeout, "settingsBootstrap")
     appliedSettings = Settings.settingsBootstrapResult(appliedSettings, stdout, exitCode)
   }
 
@@ -694,11 +696,11 @@ Item {
       return
     settingsReadBusy = true
     settingsReadTimeout.restart()
+    settingsReadProcess.command = Settings.settingsArgvShow(helper)
+    settingsReadStartedGeneration = activeSettingsReadGeneration
     if (testMode) {
-      settingsReadStartedGeneration = activeSettingsReadGeneration
       return
     }
-    settingsReadProcess.command = Settings.settingsArgvShow(helper)
     settingsReadProcess.running = true
   }
 
@@ -707,7 +709,7 @@ Item {
       return
     settingsReadTimeout.stop()
     settingsReadBusy = false
-    recordCompletedCallback(!!fromTimeout)
+    recordCompletedCallback(!!fromTimeout, "settingsRead")
     if (!settingsState || settingsState.phase === "closed")
       return
     // SET-026: any failure is a visible terminal state, never an endless
@@ -744,13 +746,13 @@ Item {
       return
     settingsWriteBusy = true
     settingsWriteTimeout.restart()
-    if (testMode) {
-      settingsWriteStartedGeneration = activeSettingsWriteGeneration
-      return
-    }
     // Re-arm stdin: each save closes it after writing (EOF delivery below).
     settingsWriteProcess.stdinEnabled = true
     settingsWriteProcess.command = Settings.settingsArgvApplyStdin(helper)
+    settingsWriteStartedGeneration = activeSettingsWriteGeneration
+    if (testMode) {
+      return
+    }
     settingsWriteProcess.running = true
   }
 
@@ -759,7 +761,7 @@ Item {
       return
     settingsWriteTimeout.stop()
     settingsWriteBusy = false
-    recordCompletedCallback(!!fromTimeout)
+    recordCompletedCallback(!!fromTimeout, "settingsWrite")
     if (pendingSettingsPayloadGeneration === generation) {
       pendingSettingsPayload = ""
       pendingSettingsPayloadGeneration = 0
@@ -801,10 +803,6 @@ Item {
     else
       argv = helper && helper.length ? [helper, "doctor", "scan"] : null
 
-    if (testMode) {
-      maintenanceHandoffStartedGeneration = activeMaintenanceHandoffGeneration
-      return
-    }
     if (!argv) {
       maintenanceHandoffBusy = false
       return
@@ -816,6 +814,10 @@ Item {
       maintenanceHandoffProcess.stdinEnabled = false
     }
     maintenanceHandoffProcess.command = argv
+    maintenanceHandoffStartedGeneration = activeMaintenanceHandoffGeneration
+    if (testMode) {
+      return
+    }
     maintenanceHandoffProcess.running = true
   }
 
@@ -824,7 +826,7 @@ Item {
       return
     maintenanceHandoffTimeout.stop()
     maintenanceHandoffBusy = false
-    recordCompletedCallback(!!fromTimeout)
+    recordCompletedCallback(!!fromTimeout, "maintenanceHandoff")
     var intention = pendingMaintenanceIntention
     pendingMaintenanceIntention = null
     pendingMaintenancePayload = ""
@@ -938,7 +940,6 @@ Item {
     id: versionProbe
     stdout: StdioCollector { id: versionOut; waitForEnd: true }
     stderr: StdioCollector { id: versionErr; waitForEnd: true }
-    onStarted: root.versionProbeStartedGeneration = root.activeVersionProbeGeneration
     onExited: function (exitCode) { root.versionProbeExited(exitCode) }
   }
 
@@ -946,7 +947,6 @@ Item {
     id: statusProcess
     stdout: StdioCollector { id: statusOut; waitForEnd: true }
     stderr: StdioCollector { id: statusErr; waitForEnd: true }
-    onStarted: root.statusStartedGeneration = root.activeStatusGeneration
     onExited: function (exitCode) { root.statusExited(exitCode) }
   }
 
@@ -954,7 +954,6 @@ Item {
     id: settingsReadProcess
     stdout: StdioCollector { id: settingsReadOut; waitForEnd: true }
     stderr: StdioCollector { id: settingsReadErr; waitForEnd: true }
-    onStarted: root.settingsReadStartedGeneration = root.activeSettingsReadGeneration
     onExited: function (exitCode) { root.settingsReadExited(exitCode) }
   }
 
@@ -962,7 +961,6 @@ Item {
     id: settingsBootstrapProcess
     stdout: StdioCollector { id: settingsBootstrapOut; waitForEnd: true }
     stderr: StdioCollector { id: settingsBootstrapErr; waitForEnd: true }
-    onStarted: root.settingsBootstrapStartedGeneration = root.activeSettingsBootstrapGeneration
     onExited: function (exitCode) { root.settingsBootstrapExited(exitCode) }
   }
 
@@ -972,7 +970,6 @@ Item {
     stdout: StdioCollector { id: settingsWriteOut; waitForEnd: true }
     stderr: StdioCollector { id: settingsWriteErr; waitForEnd: true }
     onStarted: {
-      root.settingsWriteStartedGeneration = root.activeSettingsWriteGeneration
       // Write the immutable captured payload; never re-read live draft (SET-018).
       // config apply stdin reads until EOF — write() alone does not deliver it;
       // stdinEnabled=false closes the write channel (same as maintenance handoff).
@@ -989,7 +986,6 @@ Item {
     id: maintenanceCheckProcess
     stdout: StdioCollector { id: maintenanceCheckOut; waitForEnd: true }
     stderr: StdioCollector { id: maintenanceCheckErr; waitForEnd: true }
-    onStarted: root.maintenanceCheckStartedGeneration = root.activeMaintenanceCheckGeneration
     onExited: function (exitCode) { root.maintenanceCheckExited(exitCode) }
   }
 
@@ -999,7 +995,6 @@ Item {
     stdout: StdioCollector { id: maintenanceHandoffOut; waitForEnd: true }
     stderr: StdioCollector { id: maintenanceHandoffErr; waitForEnd: true }
     onStarted: {
-      root.maintenanceHandoffStartedGeneration = root.activeMaintenanceHandoffGeneration
       // BUNDLE-036 / UX-048: non-TTY uninstall confirmation uses read_to_end.
       // write() alone does not deliver EOF; stdinEnabled=false closes the write channel.
       if (root.pendingMaintenancePayload && root.pendingMaintenancePayload.length

--- a/Service.qml
+++ b/Service.qml
@@ -27,6 +27,9 @@ Item {
   property bool testMode: false
   property int versionProbeTimeoutMs: 2000
   property int statusTimeoutMs: 60000
+  property int settingsTimeoutMs: 15000
+  property int maintenanceCheckTimeoutMs: 30000
+  property int maintenanceHandoffTimeoutMs: 120000
   property int pollIntervalMs: Core.pollIntervalMs(appliedSettings)
   property int collectionDelayMs: 0
 
@@ -50,6 +53,9 @@ Item {
   // Pending maintenance intention after confirm (update apply / uninstall).
   property var pendingMaintenanceIntention: null
   property string pendingMaintenancePayload: ""
+  property var timedOutLanes: ({})
+  property int completedCallbackCount: 0
+  readonly property string runtimeHealth: Core.runtimeHealth(timedOutLanes)
 
   // Version probe
   property string helperVersion: ""
@@ -107,7 +113,25 @@ Item {
   }
 
   function health(expectedVersion) {
-    return Core.health(versionReady, versionFailed, helperVersion, manifestVersion, expectedVersion)
+    return Core.health(
+      versionReady,
+      versionFailed,
+      helperVersion,
+      manifestVersion,
+      expectedVersion,
+      runtimeHealth
+    )
+  }
+
+  function recordLaneTimeout(lane) {
+    timedOutLanes = Core.recordLaneTimeout(timedOutLanes, lane)
+  }
+
+  function recordCompletedCallback(fromTimeout) {
+    if (fromTimeout)
+      return
+    completedCallbackCount++
+    timedOutLanes = ({})
   }
 
   // IPC refresh(providerId) — queue one cache-bypass provider refresh.
@@ -328,6 +352,7 @@ Item {
     syncMaintenanceVersion()
     maintenanceUi = Maintenance.maintenanceUiChecking(maintenanceUi)
     maintenanceCheckBusy = true
+    maintenanceCheckTimeout.restart()
     if (testMode)
       return
     var helper = resolvedHelperPath()
@@ -340,8 +365,10 @@ Item {
     maintenanceCheckProcess.running = true
   }
 
-  function applyUpdateCheckResult(stdout, exitCode) {
+  function applyUpdateCheckResult(stdout, exitCode, fromTimeout) {
+    maintenanceCheckTimeout.stop()
     maintenanceCheckBusy = false
+    recordCompletedCallback(!!fromTimeout)
     maintenanceUi = Maintenance.maintenanceUiFromCheck(
       maintenanceUi,
       stdout,
@@ -439,7 +466,8 @@ Item {
   // Version probe lane
   // -------------------------------------------------------------------------
 
-  function applyVersionProbeResult(stdout, stderr, exitCode) {
+  function applyVersionProbeResult(stdout, stderr, exitCode, fromTimeout) {
+    recordCompletedCallback(!!fromTimeout)
     var version = Core.parseVersionStdout(stdout, stderr, exitCode)
     if (version)
       finishVersionProbeSuccess(version)
@@ -541,6 +569,7 @@ Item {
     statusBusy = true
     refreshing = true
     statusStartCount++
+    statusTimeout.restart()
     // StdioCollector.text is read-only; waitForEnd replaces content per run.
     if (testMode) {
       // Tests call applyStatusResult(gen, stdout, stderr, code)
@@ -548,15 +577,15 @@ Item {
     }
     statusProcess.command = argv
     statusProcess.running = true
-    statusTimeout.restart()
   }
 
-  function applyStatusResult(generation, stdout, stderr, exitCode) {
+  function applyStatusResult(generation, stdout, stderr, exitCode, fromTimeout) {
     if (!Core.shouldApplyGeneration(activeStatusGeneration, generation))
       return
     statusTimeout.stop()
     statusBusy = false
     refreshing = false
+    recordCompletedCallback(!!fromTimeout)
 
     if (exitCode !== 0) {
       // Keep last snapshot (CACHE-021 / malformed retention).
@@ -596,14 +625,17 @@ Item {
     if (!helper.length)
       return
     settingsBootstrapBusy = true
+    settingsBootstrapTimeout.restart()
     if (testMode)
       return
     settingsBootstrapProcess.command = Settings.settingsArgvShow(helper)
     settingsBootstrapProcess.running = true
   }
 
-  function applySettingsBootstrapResult(stdout, exitCode) {
+  function applySettingsBootstrapResult(stdout, exitCode, fromTimeout) {
+    settingsBootstrapTimeout.stop()
     settingsBootstrapBusy = false
+    recordCompletedCallback(!!fromTimeout)
     appliedSettings = Settings.settingsBootstrapResult(appliedSettings, stdout, exitCode)
   }
 
@@ -615,16 +647,19 @@ Item {
     if (!helper.length)
       return
     settingsReadBusy = true
+    settingsReadTimeout.restart()
     if (testMode)
       return
     settingsReadProcess.command = Settings.settingsArgvShow(helper)
     settingsReadProcess.running = true
   }
 
-  function applySettingsReadResult(generation, stdout, exitCode) {
+  function applySettingsReadResult(generation, stdout, exitCode, fromTimeout) {
     if (!Core.shouldApplyGeneration(activeSettingsReadGeneration, generation))
       return
+    settingsReadTimeout.stop()
     settingsReadBusy = false
+    recordCompletedCallback(!!fromTimeout)
     if (!settingsState || settingsState.phase === "closed")
       return
     // SET-026: any failure is a visible terminal state, never an endless
@@ -660,6 +695,7 @@ Item {
     if (!helper.length)
       return
     settingsWriteBusy = true
+    settingsWriteTimeout.restart()
     if (testMode)
       return
     // Re-arm stdin: each save closes it after writing (EOF delivery below).
@@ -668,10 +704,12 @@ Item {
     settingsWriteProcess.running = true
   }
 
-  function applySettingsWriteResult(generation, ok, canonical) {
+  function applySettingsWriteResult(generation, ok, canonical, fromTimeout) {
     if (!Core.shouldApplyGeneration(activeSettingsWriteGeneration, generation))
       return
+    settingsWriteTimeout.stop()
     settingsWriteBusy = false
+    recordCompletedCallback(!!fromTimeout)
     pendingSettingsPayload = ""
     settingsState = Settings.settingsFinishSave(settingsState, generation, ok, canonical)
     settingsDraft = settingsState ? settingsState.draft : null
@@ -697,6 +735,7 @@ Item {
     if (!Core.canStartLane(maintenanceHandoffBusy))
       return
     maintenanceHandoffBusy = true
+    maintenanceHandoffTimeout.restart()
     var helper = resolvedHelperPath()
     var intention = pendingMaintenanceIntention
     var argv = null
@@ -723,8 +762,10 @@ Item {
     maintenanceHandoffProcess.running = true
   }
 
-  function applyMaintenanceHandoffDone(exitCode) {
+  function applyMaintenanceHandoffDone(exitCode, fromTimeout) {
+    maintenanceHandoffTimeout.stop()
     maintenanceHandoffBusy = false
+    recordCompletedCallback(!!fromTimeout)
     var intention = pendingMaintenanceIntention
     pendingMaintenanceIntention = null
     pendingMaintenancePayload = ""
@@ -882,7 +923,78 @@ Item {
         return
       if (statusProcess.running)
         statusProcess.running = false
-      root.applyStatusResult(root.activeStatusGeneration, "", "timeout", 1)
+      root.recordLaneTimeout("status")
+      root.applyStatusResult(root.activeStatusGeneration, "", "timeout", 1, true)
+    }
+  }
+
+  Timer {
+    id: settingsReadTimeout
+    interval: root.settingsTimeoutMs
+    repeat: false
+    onTriggered: {
+      if (!root.settingsReadBusy)
+        return
+      if (settingsReadProcess.running)
+        settingsReadProcess.running = false
+      root.recordLaneTimeout("settingsRead")
+      root.applySettingsReadResult(root.activeSettingsReadGeneration, "", 1, true)
+    }
+  }
+
+  Timer {
+    id: settingsBootstrapTimeout
+    interval: root.settingsTimeoutMs
+    repeat: false
+    onTriggered: {
+      if (!root.settingsBootstrapBusy)
+        return
+      if (settingsBootstrapProcess.running)
+        settingsBootstrapProcess.running = false
+      root.recordLaneTimeout("settingsBootstrap")
+      root.applySettingsBootstrapResult("", 1, true)
+    }
+  }
+
+  Timer {
+    id: settingsWriteTimeout
+    interval: root.settingsTimeoutMs
+    repeat: false
+    onTriggered: {
+      if (!root.settingsWriteBusy)
+        return
+      if (settingsWriteProcess.running)
+        settingsWriteProcess.running = false
+      root.recordLaneTimeout("settingsWrite")
+      root.applySettingsWriteResult(root.activeSettingsWriteGeneration, false, null, true)
+    }
+  }
+
+  Timer {
+    id: maintenanceCheckTimeout
+    interval: root.maintenanceCheckTimeoutMs
+    repeat: false
+    onTriggered: {
+      if (!root.maintenanceCheckBusy)
+        return
+      if (maintenanceCheckProcess.running)
+        maintenanceCheckProcess.running = false
+      root.recordLaneTimeout("maintenanceCheck")
+      root.applyUpdateCheckResult("", 1, true)
+    }
+  }
+
+  Timer {
+    id: maintenanceHandoffTimeout
+    interval: root.maintenanceHandoffTimeoutMs
+    repeat: false
+    onTriggered: {
+      if (!root.maintenanceHandoffBusy)
+        return
+      if (maintenanceHandoffProcess.running)
+        maintenanceHandoffProcess.running = false
+      root.recordLaneTimeout("maintenanceHandoff")
+      root.applyMaintenanceHandoffDone(1, true)
     }
   }
 
@@ -921,5 +1033,31 @@ Item {
   Component.onCompleted: {
     root.syncMaintenanceVersion()
     root.tryStartProduction()
+  }
+
+  Component.onDestruction: {
+    versionTimeout.stop()
+    statusTimeout.stop()
+    settingsReadTimeout.stop()
+    settingsBootstrapTimeout.stop()
+    settingsWriteTimeout.stop()
+    maintenanceCheckTimeout.stop()
+    maintenanceHandoffTimeout.stop()
+    collectionDelay.stop()
+    pollTimer.stop()
+    if (versionProbe.running)
+      versionProbe.running = false
+    if (statusProcess.running)
+      statusProcess.running = false
+    if (settingsReadProcess.running)
+      settingsReadProcess.running = false
+    if (settingsBootstrapProcess.running)
+      settingsBootstrapProcess.running = false
+    if (settingsWriteProcess.running)
+      settingsWriteProcess.running = false
+    if (maintenanceCheckProcess.running)
+      maintenanceCheckProcess.running = false
+    if (maintenanceHandoffProcess.running)
+      maintenanceHandoffProcess.running = false
   }
 }

--- a/Service.qml
+++ b/Service.qml
@@ -54,6 +54,7 @@ Item {
   property var pendingMaintenanceIntention: null
   property string pendingMaintenancePayload: ""
   property var timedOutLanes: ({})
+  property var settledLanes: ({})
   property int completedCallbackCount: 0
   readonly property string runtimeHealth: Core.runtimeHealth(timedOutLanes)
 
@@ -75,11 +76,27 @@ Item {
   // Generation counters for stale-callback rejection
   property int statusGeneration: 0
   property int settingsGeneration: 0
+  property int versionProbeGeneration: 0
+  property int settingsBootstrapGeneration: 0
+  property int maintenanceCheckGeneration: 0
+  property int maintenanceHandoffGeneration: 0
+  property int activeVersionProbeGeneration: 0
   property int activeStatusGeneration: 0
   property int activeSettingsReadGeneration: 0
+  property int activeSettingsBootstrapGeneration: 0
   property int activeSettingsWriteGeneration: 0
+  property int activeMaintenanceCheckGeneration: 0
+  property int activeMaintenanceHandoffGeneration: 0
+  property int versionProbeStartedGeneration: 0
+  property int statusStartedGeneration: 0
+  property int settingsReadStartedGeneration: 0
+  property int settingsBootstrapStartedGeneration: 0
+  property int settingsWriteStartedGeneration: 0
+  property int maintenanceCheckStartedGeneration: 0
+  property int maintenanceHandoffStartedGeneration: 0
   // Immutable captured JSON for the in-flight config apply (SET-018).
   property string pendingSettingsPayload: ""
+  property int pendingSettingsPayloadGeneration: 0
 
   // Bookkeeping
   property int refreshRequestCount: 0
@@ -123,8 +140,10 @@ Item {
     )
   }
 
-  function recordLaneTimeout(lane) {
+  function recordLaneTimeout(lane, generation) {
     timedOutLanes = Core.recordLaneTimeout(timedOutLanes, lane)
+    if (generation !== undefined)
+      settledLanes = Core.settleLane(settledLanes, lane, generation)
   }
 
   function recordCompletedCallback(fromTimeout) {
@@ -132,6 +151,15 @@ Item {
       return
     completedCallbackCount++
     timedOutLanes = ({})
+  }
+
+  function shouldApplyProcessExit(lane, generation, activeGeneration) {
+    if (Core.isLaneSettled(settledLanes, lane, generation)) {
+      settledLanes = Core.clearSettledLane(settledLanes, lane, generation)
+      recordCompletedCallback(false)
+      return false
+    }
+    return Core.shouldApplyGeneration(activeGeneration, generation)
   }
 
   // IPC refresh(providerId) — queue one cache-bypass provider refresh.
@@ -296,6 +324,7 @@ Item {
     settingsGeneration++
     var gen = settingsGeneration
     pendingSettingsPayload = JSON.stringify(payloadObj)
+    pendingSettingsPayloadGeneration = gen
     settingsState = Settings.settingsBeginSave(settingsState, gen, payloadObj)
     settingsDraft = settingsState.draft
     activeSettingsWriteGeneration = gen
@@ -350,11 +379,15 @@ Item {
     if (!Core.canStartLane(maintenanceCheckBusy))
       return
     syncMaintenanceVersion()
+    maintenanceCheckGeneration++
+    activeMaintenanceCheckGeneration = maintenanceCheckGeneration
     maintenanceUi = Maintenance.maintenanceUiChecking(maintenanceUi)
     maintenanceCheckBusy = true
     maintenanceCheckTimeout.restart()
-    if (testMode)
+    if (testMode) {
+      maintenanceCheckStartedGeneration = activeMaintenanceCheckGeneration
       return
+    }
     var helper = resolvedHelperPath()
     if (!helper.length) {
       maintenanceCheckBusy = false
@@ -365,7 +398,9 @@ Item {
     maintenanceCheckProcess.running = true
   }
 
-  function applyUpdateCheckResult(stdout, exitCode, fromTimeout) {
+  function applyUpdateCheckResult(generation, stdout, exitCode, fromTimeout) {
+    if (!Core.shouldApplyGeneration(activeMaintenanceCheckGeneration, generation))
+      return
     maintenanceCheckTimeout.stop()
     maintenanceCheckBusy = false
     recordCompletedCallback(!!fromTimeout)
@@ -466,7 +501,9 @@ Item {
   // Version probe lane
   // -------------------------------------------------------------------------
 
-  function applyVersionProbeResult(stdout, stderr, exitCode, fromTimeout) {
+  function applyVersionProbeResult(generation, stdout, stderr, exitCode, fromTimeout) {
+    if (!Core.shouldApplyGeneration(activeVersionProbeGeneration, generation))
+      return
     recordCompletedCallback(!!fromTimeout)
     var version = Core.parseVersionStdout(stdout, stderr, exitCode)
     if (version)
@@ -503,6 +540,8 @@ Item {
     }
     versionProbeRunning = true
     versionFailed = false
+    versionProbeGeneration++
+    activeVersionProbeGeneration = versionProbeGeneration
     // StdioCollector.text is read-only; waitForEnd replaces content per run.
     versionProbe.command = [helper, "version"]
     versionProbe.running = true
@@ -572,6 +611,7 @@ Item {
     statusTimeout.restart()
     // StdioCollector.text is read-only; waitForEnd replaces content per run.
     if (testMode) {
+      statusStartedGeneration = gen
       // Tests call applyStatusResult(gen, stdout, stderr, code)
       return
     }
@@ -624,15 +664,21 @@ Item {
     var helper = resolvedHelperPath()
     if (!helper.length)
       return
+    settingsBootstrapGeneration++
+    activeSettingsBootstrapGeneration = settingsBootstrapGeneration
     settingsBootstrapBusy = true
     settingsBootstrapTimeout.restart()
-    if (testMode)
+    if (testMode) {
+      settingsBootstrapStartedGeneration = activeSettingsBootstrapGeneration
       return
+    }
     settingsBootstrapProcess.command = Settings.settingsArgvShow(helper)
     settingsBootstrapProcess.running = true
   }
 
-  function applySettingsBootstrapResult(stdout, exitCode, fromTimeout) {
+  function applySettingsBootstrapResult(generation, stdout, exitCode, fromTimeout) {
+    if (!Core.shouldApplyGeneration(activeSettingsBootstrapGeneration, generation))
+      return
     settingsBootstrapTimeout.stop()
     settingsBootstrapBusy = false
     recordCompletedCallback(!!fromTimeout)
@@ -648,8 +694,10 @@ Item {
       return
     settingsReadBusy = true
     settingsReadTimeout.restart()
-    if (testMode)
+    if (testMode) {
+      settingsReadStartedGeneration = activeSettingsReadGeneration
       return
+    }
     settingsReadProcess.command = Settings.settingsArgvShow(helper)
     settingsReadProcess.running = true
   }
@@ -696,8 +744,10 @@ Item {
       return
     settingsWriteBusy = true
     settingsWriteTimeout.restart()
-    if (testMode)
+    if (testMode) {
+      settingsWriteStartedGeneration = activeSettingsWriteGeneration
       return
+    }
     // Re-arm stdin: each save closes it after writing (EOF delivery below).
     settingsWriteProcess.stdinEnabled = true
     settingsWriteProcess.command = Settings.settingsArgvApplyStdin(helper)
@@ -710,7 +760,10 @@ Item {
     settingsWriteTimeout.stop()
     settingsWriteBusy = false
     recordCompletedCallback(!!fromTimeout)
-    pendingSettingsPayload = ""
+    if (pendingSettingsPayloadGeneration === generation) {
+      pendingSettingsPayload = ""
+      pendingSettingsPayloadGeneration = 0
+    }
     settingsState = Settings.settingsFinishSave(settingsState, generation, ok, canonical)
     settingsDraft = settingsState ? settingsState.draft : null
     if (ok && canonical)
@@ -734,6 +787,8 @@ Item {
       return
     if (!Core.canStartLane(maintenanceHandoffBusy))
       return
+    maintenanceHandoffGeneration++
+    activeMaintenanceHandoffGeneration = maintenanceHandoffGeneration
     maintenanceHandoffBusy = true
     maintenanceHandoffTimeout.restart()
     var helper = resolvedHelperPath()
@@ -746,8 +801,10 @@ Item {
     else
       argv = helper && helper.length ? [helper, "doctor", "scan"] : null
 
-    if (testMode)
+    if (testMode) {
+      maintenanceHandoffStartedGeneration = activeMaintenanceHandoffGeneration
       return
+    }
     if (!argv) {
       maintenanceHandoffBusy = false
       return
@@ -762,7 +819,9 @@ Item {
     maintenanceHandoffProcess.running = true
   }
 
-  function applyMaintenanceHandoffDone(exitCode, fromTimeout) {
+  function applyMaintenanceHandoffDone(generation, exitCode, fromTimeout) {
+    if (!Core.shouldApplyGeneration(activeMaintenanceHandoffGeneration, generation))
+      return
     maintenanceHandoffTimeout.stop()
     maintenanceHandoffBusy = false
     recordCompletedCallback(!!fromTimeout)
@@ -794,6 +853,83 @@ Item {
     }
   }
 
+  function versionProbeExited(exitCode, generation, stdout, stderr) {
+    var gen = generation === undefined ? versionProbeStartedGeneration : generation
+    if (!shouldApplyProcessExit("versionProbe", gen, activeVersionProbeGeneration))
+      return
+    applyVersionProbeResult(gen,
+                            stdout === undefined ? versionOut.text || "" : stdout,
+                            stderr === undefined ? versionErr.text || "" : stderr,
+                            exitCode)
+  }
+
+  function statusExited(exitCode, generation, stdout, stderr) {
+    var gen = generation === undefined ? statusStartedGeneration : generation
+    if (!shouldApplyProcessExit("status", gen, activeStatusGeneration))
+      return
+    applyStatusResult(gen,
+                      stdout === undefined ? statusOut.text || "" : stdout,
+                      stderr === undefined ? statusErr.text || "" : stderr,
+                      exitCode)
+  }
+
+  function settingsReadExited(exitCode, generation, stdout) {
+    var gen = generation === undefined ? settingsReadStartedGeneration : generation
+    if (!shouldApplyProcessExit("settingsRead", gen, activeSettingsReadGeneration))
+      return
+    applySettingsReadResult(gen,
+                            stdout === undefined ? settingsReadOut.text || "" : stdout,
+                            exitCode)
+  }
+
+  function settingsBootstrapExited(exitCode, generation, stdout) {
+    var gen = generation === undefined ? settingsBootstrapStartedGeneration : generation
+    if (!shouldApplyProcessExit("settingsBootstrap", gen, activeSettingsBootstrapGeneration))
+      return
+    applySettingsBootstrapResult(
+      gen,
+      stdout === undefined ? settingsBootstrapOut.text || "" : stdout,
+      exitCode
+    )
+  }
+
+  function settingsWriteExited(exitCode, generation, stdout) {
+    var gen = generation === undefined ? settingsWriteStartedGeneration : generation
+    if (!shouldApplyProcessExit("settingsWrite", gen, activeSettingsWriteGeneration))
+      return
+    var ok = exitCode === 0
+    var canonical = null
+    if (ok) {
+      try {
+        var output = stdout === undefined ? settingsWriteOut.text || "" : stdout
+        canonical = JSON.parse(String(output).trim())
+        if (!Settings.validateSettingsDraft(canonical).ok)
+          ok = false
+      } catch (e) {
+        ok = false
+      }
+    }
+    applySettingsWriteResult(gen, ok, canonical)
+  }
+
+  function maintenanceCheckExited(exitCode, generation, stdout) {
+    var gen = generation === undefined ? maintenanceCheckStartedGeneration : generation
+    if (!shouldApplyProcessExit("maintenanceCheck", gen, activeMaintenanceCheckGeneration))
+      return
+    applyUpdateCheckResult(
+      gen,
+      stdout === undefined ? maintenanceCheckOut.text || "" : stdout,
+      exitCode
+    )
+  }
+
+  function maintenanceHandoffExited(exitCode, generation) {
+    var gen = generation === undefined ? maintenanceHandoffStartedGeneration : generation
+    if (!shouldApplyProcessExit("maintenanceHandoff", gen, activeMaintenanceHandoffGeneration))
+      return
+    applyMaintenanceHandoffDone(gen, exitCode)
+  }
+
   // -------------------------------------------------------------------------
   // Processes (isolated lanes)
   // -------------------------------------------------------------------------
@@ -802,42 +938,32 @@ Item {
     id: versionProbe
     stdout: StdioCollector { id: versionOut; waitForEnd: true }
     stderr: StdioCollector { id: versionErr; waitForEnd: true }
-    onExited: function (exitCode) {
-      if (!root.versionProbeRunning)
-        return
-      root.applyVersionProbeResult(versionOut.text || "", versionErr.text || "", exitCode)
-    }
+    onStarted: root.versionProbeStartedGeneration = root.activeVersionProbeGeneration
+    onExited: function (exitCode) { root.versionProbeExited(exitCode) }
   }
 
   Process {
     id: statusProcess
     stdout: StdioCollector { id: statusOut; waitForEnd: true }
     stderr: StdioCollector { id: statusErr; waitForEnd: true }
-    onExited: function (exitCode) {
-      root.applyStatusResult(root.activeStatusGeneration, statusOut.text || "", statusErr.text || "", exitCode)
-    }
+    onStarted: root.statusStartedGeneration = root.activeStatusGeneration
+    onExited: function (exitCode) { root.statusExited(exitCode) }
   }
 
   Process {
     id: settingsReadProcess
     stdout: StdioCollector { id: settingsReadOut; waitForEnd: true }
     stderr: StdioCollector { id: settingsReadErr; waitForEnd: true }
-    onExited: function (exitCode) {
-      root.applySettingsReadResult(
-        root.activeSettingsReadGeneration,
-        settingsReadOut.text || "",
-        exitCode
-      )
-    }
+    onStarted: root.settingsReadStartedGeneration = root.activeSettingsReadGeneration
+    onExited: function (exitCode) { root.settingsReadExited(exitCode) }
   }
 
   Process {
     id: settingsBootstrapProcess
     stdout: StdioCollector { id: settingsBootstrapOut; waitForEnd: true }
     stderr: StdioCollector { id: settingsBootstrapErr; waitForEnd: true }
-    onExited: function (exitCode) {
-      root.applySettingsBootstrapResult(settingsBootstrapOut.text || "", exitCode)
-    }
+    onStarted: root.settingsBootstrapStartedGeneration = root.activeSettingsBootstrapGeneration
+    onExited: function (exitCode) { root.settingsBootstrapExited(exitCode) }
   }
 
   Process {
@@ -846,37 +972,25 @@ Item {
     stdout: StdioCollector { id: settingsWriteOut; waitForEnd: true }
     stderr: StdioCollector { id: settingsWriteErr; waitForEnd: true }
     onStarted: {
+      root.settingsWriteStartedGeneration = root.activeSettingsWriteGeneration
       // Write the immutable captured payload; never re-read live draft (SET-018).
       // config apply stdin reads until EOF — write() alone does not deliver it;
       // stdinEnabled=false closes the write channel (same as maintenance handoff).
-      if (root.pendingSettingsPayload && root.pendingSettingsPayload.length) {
+      if (root.pendingSettingsPayloadGeneration === root.settingsWriteStartedGeneration
+          && root.pendingSettingsPayload && root.pendingSettingsPayload.length) {
         write(root.pendingSettingsPayload + "\n")
         settingsWriteProcess.stdinEnabled = false
       }
     }
-    onExited: function (exitCode) {
-      var ok = exitCode === 0
-      var canonical = null
-      if (ok) {
-        try {
-          canonical = JSON.parse(String(settingsWriteOut.text || "").trim())
-          if (!Settings.validateSettingsDraft(canonical).ok)
-            ok = false
-        } catch (e) {
-          ok = false
-        }
-      }
-      root.applySettingsWriteResult(root.activeSettingsWriteGeneration, ok, canonical)
-    }
+    onExited: function (exitCode) { root.settingsWriteExited(exitCode) }
   }
 
   Process {
     id: maintenanceCheckProcess
     stdout: StdioCollector { id: maintenanceCheckOut; waitForEnd: true }
     stderr: StdioCollector { id: maintenanceCheckErr; waitForEnd: true }
-    onExited: function (exitCode) {
-      root.applyUpdateCheckResult(maintenanceCheckOut.text || "", exitCode)
-    }
+    onStarted: root.maintenanceCheckStartedGeneration = root.activeMaintenanceCheckGeneration
+    onExited: function (exitCode) { root.maintenanceCheckExited(exitCode) }
   }
 
   Process {
@@ -885,6 +999,7 @@ Item {
     stdout: StdioCollector { id: maintenanceHandoffOut; waitForEnd: true }
     stderr: StdioCollector { id: maintenanceHandoffErr; waitForEnd: true }
     onStarted: {
+      root.maintenanceHandoffStartedGeneration = root.activeMaintenanceHandoffGeneration
       // BUNDLE-036 / UX-048: non-TTY uninstall confirmation uses read_to_end.
       // write() alone does not deliver EOF; stdinEnabled=false closes the write channel.
       if (root.pendingMaintenancePayload && root.pendingMaintenancePayload.length
@@ -893,9 +1008,7 @@ Item {
         maintenanceHandoffProcess.stdinEnabled = false
       }
     }
-    onExited: function (exitCode) {
-      root.applyMaintenanceHandoffDone(exitCode)
-    }
+    onExited: function (exitCode) { root.maintenanceHandoffExited(exitCode) }
   }
 
   // Single completed handler — QML rejects duplicate assignments of this
@@ -910,7 +1023,8 @@ Item {
         return
       if (versionProbe.running)
         versionProbe.running = false
-      root.finishVersionProbeFailure()
+      root.recordLaneTimeout("versionProbe", root.activeVersionProbeGeneration)
+      root.applyVersionProbeResult(root.activeVersionProbeGeneration, "", "timeout", 1, true)
     }
   }
 
@@ -923,7 +1037,7 @@ Item {
         return
       if (statusProcess.running)
         statusProcess.running = false
-      root.recordLaneTimeout("status")
+      root.recordLaneTimeout("status", root.activeStatusGeneration)
       root.applyStatusResult(root.activeStatusGeneration, "", "timeout", 1, true)
     }
   }
@@ -937,7 +1051,7 @@ Item {
         return
       if (settingsReadProcess.running)
         settingsReadProcess.running = false
-      root.recordLaneTimeout("settingsRead")
+      root.recordLaneTimeout("settingsRead", root.activeSettingsReadGeneration)
       root.applySettingsReadResult(root.activeSettingsReadGeneration, "", 1, true)
     }
   }
@@ -951,8 +1065,8 @@ Item {
         return
       if (settingsBootstrapProcess.running)
         settingsBootstrapProcess.running = false
-      root.recordLaneTimeout("settingsBootstrap")
-      root.applySettingsBootstrapResult("", 1, true)
+      root.recordLaneTimeout("settingsBootstrap", root.activeSettingsBootstrapGeneration)
+      root.applySettingsBootstrapResult(root.activeSettingsBootstrapGeneration, "", 1, true)
     }
   }
 
@@ -965,7 +1079,7 @@ Item {
         return
       if (settingsWriteProcess.running)
         settingsWriteProcess.running = false
-      root.recordLaneTimeout("settingsWrite")
+      root.recordLaneTimeout("settingsWrite", root.activeSettingsWriteGeneration)
       root.applySettingsWriteResult(root.activeSettingsWriteGeneration, false, null, true)
     }
   }
@@ -979,8 +1093,8 @@ Item {
         return
       if (maintenanceCheckProcess.running)
         maintenanceCheckProcess.running = false
-      root.recordLaneTimeout("maintenanceCheck")
-      root.applyUpdateCheckResult("", 1, true)
+      root.recordLaneTimeout("maintenanceCheck", root.activeMaintenanceCheckGeneration)
+      root.applyUpdateCheckResult(root.activeMaintenanceCheckGeneration, "", 1, true)
     }
   }
 
@@ -993,8 +1107,8 @@ Item {
         return
       if (maintenanceHandoffProcess.running)
         maintenanceHandoffProcess.running = false
-      root.recordLaneTimeout("maintenanceHandoff")
-      root.applyMaintenanceHandoffDone(1, true)
+      root.recordLaneTimeout("maintenanceHandoff", root.activeMaintenanceHandoffGeneration)
+      root.applyMaintenanceHandoffDone(root.activeMaintenanceHandoffGeneration, 1, true)
     }
   }
 

--- a/Service.qml
+++ b/Service.qml
@@ -49,6 +49,8 @@ Item {
   property int loginRequestCount: 0
   property string lastLoginProviderId: ""
   property var lastLoginArgv: null
+  property var lastRestartShellArgv: null
+  property int restartShellRequestCount: 0
   property string lastViewInstallationUrl: ""
   // Pending maintenance intention after confirm (update apply / uninstall).
   property var pendingMaintenanceIntention: null
@@ -356,6 +358,15 @@ Item {
     if (testMode)
       return
     // Exact argv array — never shell-string construction (UX-048).
+    Quickshell.execDetached(argv)
+  }
+
+  function restartShell() {
+    var argv = Maintenance.restartShellArgv()
+    lastRestartShellArgv = argv.slice()
+    restartShellRequestCount++
+    if (testMode)
+      return
     Quickshell.execDetached(argv)
   }
 

--- a/SettingsView.qml
+++ b/SettingsView.qml
@@ -129,9 +129,6 @@ Item {
         if (root.agentService)
           root.agentService.restartShell()
       }
-      Keys.onReturnPressed: focusActivate()
-      Keys.onEnterPressed: focusActivate()
-      Keys.onSpacePressed: focusActivate()
       Accessible.onPressAction: focusActivate()
       onClicked: focusActivate()
     }

--- a/SettingsView.qml
+++ b/SettingsView.qml
@@ -72,6 +72,10 @@ Item {
     return String(root.iconBase) + name
   }
 
+  function collectFocusTargets() {
+    return root.loadFailed ? [restartShellButton] : []
+  }
+
   Column {
     id: col
     width: parent.width
@@ -110,6 +114,26 @@ Item {
       textFormat: Text.PlainText
       Accessible.role: Accessible.StaticText
       Accessible.name: text
+    }
+
+    Button {
+      id: restartShellButton
+      visible: root.loadFailed
+      text: "Restart shell"
+      bordered: true
+      focusable: true
+      foreground: root.foreground
+      fontFamily: root.fontFamily
+      Accessible.name: "Restart shell"
+      function focusActivate() {
+        if (root.agentService)
+          root.agentService.restartShell()
+      }
+      Keys.onReturnPressed: focusActivate()
+      Keys.onEnterPressed: focusActivate()
+      Keys.onSpacePressed: focusActivate()
+      Accessible.onPressAction: focusActivate()
+      onClicked: focusActivate()
     }
 
     Text {

--- a/components/FocusController.qml
+++ b/components/FocusController.qml
@@ -13,6 +13,7 @@ Item {
   property int index: -1
   property var flickable: null
   property int lineHeight: 18
+  property bool focusBlocked: false
 
   readonly property int count: targets && targets.length ? targets.length : 0
   readonly property var current: {
@@ -45,14 +46,28 @@ Item {
   }
 
   function setTargets(list) {
+    var previousCurrent = current
     targets = list || []
     if (count === 0) {
       index = -1
       return
     }
-    if (index < 0 || index >= count)
+
+    var preservedIndex = -1
+    if (previousCurrent) {
+      for (var i = 0; i < count; i++) {
+        if (targets[i] === previousCurrent) {
+          preservedIndex = i
+          break
+        }
+      }
+    }
+    if (preservedIndex >= 0)
+      index = preservedIndex
+    else if (index < 0 || index >= count)
       index = 0
-    focusCurrent()
+    if (!focusBlocked)
+      focusCurrent()
   }
 
   function move(direction) {

--- a/components/StateMessage.qml
+++ b/components/StateMessage.qml
@@ -114,14 +114,8 @@ Column {
               modelData ? modelData.target : null
             )
           }
-          Keys.onReturnPressed: focusActivate()
-          Keys.onEnterPressed: focusActivate()
-          Keys.onSpacePressed: focusActivate()
           Accessible.onPressAction: focusActivate()
-          onClicked: root.actionActivated(
-            modelData && modelData.kind ? String(modelData.kind) : "",
-            modelData ? modelData.target : null
-          )
+          onClicked: focusActivate()
         }
       }
     }

--- a/components/StateMessage.qml
+++ b/components/StateMessage.qml
@@ -18,6 +18,18 @@ Column {
   width: parent ? parent.width : implicitWidth
   spacing: Style.space(10)
 
+  function collectFocusTargets() {
+    var targets = []
+    if (!root.visible || root.skeleton)
+      return targets
+    for (var i = 0; i < actionRepeater.count; i++) {
+      var item = actionRepeater.itemAt(i)
+      if (item)
+        targets.push(item)
+    }
+    return targets
+  }
+
   // UX-026 skeleton placeholders (no plugin-authored motion).
   Column {
     visible: root.skeleton
@@ -83,6 +95,7 @@ Column {
       spacing: Style.space(8)
 
       Repeater {
+        id: actionRepeater
         model: root.actions
 
         Button {
@@ -95,6 +108,16 @@ Column {
           // Keep action labels fully inside content (no left clip).
           leftAlign: true
           Accessible.name: text
+          function focusActivate() {
+            root.actionActivated(
+              modelData && modelData.kind ? String(modelData.kind) : "",
+              modelData ? modelData.target : null
+            )
+          }
+          Keys.onReturnPressed: focusActivate()
+          Keys.onEnterPressed: focusActivate()
+          Keys.onSpacePressed: focusActivate()
+          Accessible.onPressAction: focusActivate()
           onClicked: root.actionActivated(
             modelData && modelData.kind ? String(modelData.kind) : "",
             modelData ? modelData.target : null

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -113,9 +113,10 @@ provider network collection. Independent QML process lanes prevent status,
 settings, version, and maintenance requests from cancelling each other.
 Each lane has its own deadline. Timeouts finish through the lane's typed state
 transition instead of leaving a busy flag set forever. Timeouts in two distinct
-lanes set `runtimeHealth` to `stalled`; the next accepted helper callback clears
-the signal. While stalled, the popup offers `omarchy-restart-shell` through an
-exact argv array. Settings offers the same recovery action after a failed load.
+lanes before any accepted helper callback set `runtimeHealth` to `stalled`.
+The next accepted helper callback clears the signal. While stalled, the popup
+offers `omarchy-restart-shell` through an exact argv array. Settings offers the
+same recovery action after a failed load.
 
 ## Settings
 

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -111,6 +111,11 @@ refreshes cannot become accidental all-provider refreshes or disappear.
 A dedicated two-second private-helper `version` probe establishes health before
 provider network collection. Independent QML process lanes prevent status,
 settings, version, and maintenance requests from cancelling each other.
+Each lane has its own deadline. Timeouts finish through the lane's typed state
+transition instead of leaving a busy flag set forever. Timeouts in two distinct
+lanes set `runtimeHealth` to `stalled`; the next accepted helper callback clears
+the signal. While stalled, the popup offers `omarchy-restart-shell` through an
+exact argv array. Settings offers the same recovery action after a failed load.
 
 ## Settings
 

--- a/docs/dev/omarchy-shell.md
+++ b/docs/dev/omarchy-shell.md
@@ -81,8 +81,10 @@ for successful interactive login. The target architecture fixes the exact
 return values and validation.
 
 Service startup verifies the private helper with a dedicated two-second
-`version` process before provider polling. Health therefore depends on
-manifest/helper equality, not provider network latency.
+`version` process before provider polling. Health normally depends on
+manifest/helper equality, not provider network latency. It returns `stalled`
+when two distinct process lanes exceed their deadlines before an accepted
+helper callback completes.
 
 Each chip registers with `bar.registerClickTarget()`, implements
 `triggerPress(button)`, and unregisters on destruction.

--- a/docs/guide/runtime.md
+++ b/docs/guide/runtime.md
@@ -103,6 +103,14 @@ provider's TTL instead.
 
 Collection discovery is separate from interactive login-CLI discovery.
 
+## Stalled service recovery
+
+The shared QML service gives each helper process lane a deadline. If two
+different lanes time out before any helper callback completes, the popup shows
+that Agent Bar has lost contact with its helper. Select `Restart shell` to run
+`omarchy-restart-shell`. A failed Settings load keeps its existing error text
+and offers the same action.
+
 ## Privacy
 
 Logs, screenshots, checkpoints, cache, and doctor reports redact tokens,

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -87,6 +87,10 @@ Then inspect:
 Do not run `omarchy bar plugin add` over an existing entry; it can reset
 placement.
 
+If the popup reports that Agent Bar lost contact with its helper, use its
+`Restart shell` button. The banner appears after helper calls stall in two
+process lanes.
+
 ## Settings stay on "Loading" or report "could not be loaded" after an update
 
 `omarchy plugin update` replaces the plugin tree and the helper on disk, but
@@ -94,6 +98,8 @@ the QML already running keeps the old code until the shell restarts. When the
 new helper lists a provider the old QML does not know, Settings cannot finish
 its load; a release before 10.3.13 stayed on "Loading" forever, current
 releases show "Settings could not be loaded". Either way:
+
+Use the `Restart shell` button in Settings, or run the command directly:
 
 ```bash
 omarchy-restart-shell

--- a/docs/specs/v10/02-target-architecture.md
+++ b/docs/specs/v10/02-target-architecture.md
@@ -262,15 +262,18 @@ The table is product data, not an example:
 - `ARCH-020`: `Service.qml` owns one `IpcHandler` target named
   `othavi0.agent-bar` with only `health(expectedVersion)` and
   `refresh(providerId)` methods.
-- `ARCH-021`: `health` returns `ok` only when the loaded manifest version and
-  last verified helper version both equal `expectedVersion`. `refresh`
+- `ARCH-021`: `health` returns `stalled` when two distinct process lanes exceed
+  their deadlines before an accepted helper callback completes. Otherwise, it
+  returns `ok` only when the loaded manifest version and last verified helper
+  version both equal `expectedVersion`. `refresh`
   validates the closed provider ID, queues one cache-bypass provider refresh,
   and returns `ok`; invalid IDs return `unknown`.
 - `ARCH-022`: The locked source order, window IDs, limits, TTL, timeout, and
   retry policy above are literal contract tests.
-- `ARCH-023`: `Service.qml` owns distinct process lanes for `status`,
-  `versionProbe`, `settingsRead`, `settingsWrite`, `maintenanceCheck`, and
-  `maintenanceHandoff`. No lane calls `exec()` while its process is running.
+- `ARCH-023`: `Service.qml` owns seven distinct process lanes: `status`,
+  `versionProbe`, `settingsRead`, `settingsBootstrap`, `settingsWrite`,
+  `maintenanceCheck`, and `maintenanceHandoff`. No lane calls `exec()` while
+  its process is running.
 - `ARCH-024`: Status requests coalesce through the target-aware rules. Settings
   writes serialize. Maintenance handoff blocks new settings writes and polling;
   an already-running status or settings write drains before detached handoff,

--- a/tests/qml/tst_Keyboard.qml
+++ b/tests/qml/tst_Keyboard.qml
@@ -1,6 +1,7 @@
 import QtQuick
 import QtTest
 import "../../CoreScroll.js" as Core
+import "../../components"
 
 TestCase {
   id: testCase
@@ -22,6 +23,19 @@ TestCase {
     xhr.open("GET", "file://" + repoRoot + "/" + rel, false)
     xhr.send()
     return String(xhr.responseText || "")
+  }
+
+  Component {
+    id: focusControllerComponent
+    FocusController { }
+  }
+
+  Component {
+    id: focusTargetComponent
+    Item {
+      width: 20
+      height: 20
+    }
   }
 
   function test_provider_jk_and_arrows_delta() {
@@ -93,5 +107,35 @@ TestCase {
     verify(src.indexOf("scrollPage") >= 0)
     verify(src.indexOf("Behavior") < 0)
     verify(src.indexOf("Transition") < 0)
+  }
+
+  function test_focus_controller_preserves_current_target_identity() {
+    var controller = createTemporaryObject(focusControllerComponent, testCase)
+    var first = createTemporaryObject(focusTargetComponent, testCase)
+    var current = createTemporaryObject(focusTargetComponent, testCase)
+    var inserted = createTemporaryObject(focusTargetComponent, testCase)
+    verify(controller && first && current && inserted)
+
+    controller.setTargets([first, current])
+    controller.index = 1
+    controller.setTargets([inserted, first, current])
+
+    compare(controller.index, 2)
+    compare(controller.current, current)
+  }
+
+  function test_focus_controller_does_not_refocus_while_editor_active() {
+    var controller = createTemporaryObject(focusControllerComponent, testCase)
+    var editor = createTemporaryObject(focusTargetComponent, testCase)
+    var action = createTemporaryObject(focusTargetComponent, testCase)
+    verify(controller && editor && action)
+
+    editor.forceActiveFocus()
+    verify(editor.activeFocus)
+    controller.focusBlocked = true
+    controller.setTargets([action])
+
+    verify(editor.activeFocus)
+    verify(!action.activeFocus)
   }
 }

--- a/tests/qml/tst_Maintenance.qml
+++ b/tests/qml/tst_Maintenance.qml
@@ -36,6 +36,12 @@ TestCase {
     compare(Core.loginDetachedArgv("", "claude"), null)
   }
 
+  function test_restart_shell_argv_exact() {
+    var argv = Core.restartShellArgv()
+    compare(argv.length, 1)
+    compare(argv[0], "omarchy-restart-shell")
+  }
+
   function test_terminal_helper_xdg_argv_exact() {
     var argv = Core.terminalHelperXdgArgv("/plugin", "amp")
     compare(argv[0], "xdg-terminal-exec")
@@ -203,6 +209,21 @@ TestCase {
     verify(src.indexOf("loginDetachedArgv") >= 0)
     verify(src.indexOf("bash -lc") < 0)
     verify(src.indexOf("sh -c") < 0)
+  }
+
+  function test_service_restart_shell_uses_exec_detached() {
+    var src = read("Service.qml")
+    var start = src.indexOf("function restartShell()")
+    verify(start >= 0)
+    var end = src.indexOf("function ", start + 10)
+    verify(end > start)
+    var body = src.substring(start, end)
+    verify(body.indexOf("Maintenance.restartShellArgv()") >= 0)
+    verify(body.indexOf("lastRestartShellArgv = argv.slice()") >= 0)
+    verify(body.indexOf("restartShellRequestCount++") >= 0)
+    verify(body.indexOf("if (testMode)") >= 0)
+    verify(body.indexOf("Quickshell.execDetached(argv)") >= 0)
+    verify(body.indexOf("sh -c") < 0)
   }
 
   // BUNDLE-036 / UX-048: after writing uninstall confirmation, close stdin so the

--- a/tests/qml/tst_Popup.qml
+++ b/tests/qml/tst_Popup.qml
@@ -25,6 +25,62 @@ TestCase {
     return String(xhr.responseText || "")
   }
 
+  function test_state_message_restart_action_emits_typed_signal() {
+    var source = read("components/StateMessage.qml")
+    source = source.replace("import qs.Commons\n", "")
+    source = source.replace("import qs.Ui\n", "")
+    source = source.replace("  id: root\n",
+                            "  id: root\n  property alias actionRepeaterForTest: actionRepeater\n")
+    source = source.replace(/Style\.space\((\d+)\)/g, "$1")
+    source = source.replace(/Style\.cornerRadius/g, "4")
+    source = source.replace(/Style\.selectedFill/g, '"#333333"')
+    source = source.replace(/Style\.hoverFill/g, '"#444444"')
+    source = source.replace(/Style\.font\.body/g, "14")
+    source = source.replace(/Style\.font\.caption/g, "12")
+    source = source.replace(/Color\.foreground/g, '"#ffffff"')
+    source = source.replace(/Style\.font\.family/g, '"sans"')
+    source = source.replace(/Util\.alpha\(root\.foreground, 0\.72\)/g,
+                            "root.foreground")
+    source = source.replace(/          text: modelData[^\n]*\n/, "")
+    source = source.replace(/          foreground: root\.foreground\n/, "")
+    source = source.replace(/          fontFamily: root\.fontFamily\n/, "")
+    source = source.replace(/          bordered: true\n/, "")
+    source = source.replace(/          focusable: true\n/, "")
+    source = source.replace(/          leftAlign: true\n/, "")
+    source = source.replace(
+      "        Button {",
+      "        Rectangle {\n"
+        + "          property string text: modelData && modelData.label"
+        + " ? String(modelData.label) : \"\"\n"
+        + "          property color foreground: root.foreground\n"
+        + "          property string fontFamily: root.fontFamily\n"
+        + "          property bool bordered: true\n"
+        + "          property bool focusable: true\n"
+        + "          property bool leftAlign: true\n"
+        + "          signal clicked()"
+    )
+    var message = Qt.createQmlObject(source, testCase,
+                                     "StateMessageHarness.qml")
+    verify(message !== null)
+    message.width = 320
+    message.title = "Agent Bar lost contact with its helper"
+    message.body = "Restart the shell to recover."
+    message.actions = [{
+      kind: "restart_shell",
+      label: "Restart shell",
+      target: null
+    }]
+    wait(1)
+    var receivedKind = ""
+    message.actionActivated.connect(function (kind, target) {
+      receivedKind = kind
+    })
+    compare(message.actionRepeaterForTest.count, 1)
+    message.actionRepeaterForTest.itemAt(0).focusActivate()
+    compare(receivedKind, "restart_shell")
+    message.destroy()
+  }
+
   function test_popup_uses_keyboard_panel_and_rail() {
     var src = read("Popup.qml")
     verify(src.indexOf("KeyboardPanel") >= 0)
@@ -32,6 +88,21 @@ TestCase {
     verify(src.indexOf("ProviderView") >= 0)
     verify(src.indexOf("PanelKeyCatcher") >= 0)
     verify(src.indexOf("fittedContent") >= 0 || src.indexOf("maxContentWidth") >= 0)
+  }
+
+  function test_stalled_banner_is_conditional_and_actionable() {
+    var src = read("Popup.qml")
+    var banner = src.indexOf("id: stalledMessage")
+    verify(banner >= 0)
+    var loader = src.indexOf("id: contentLoader")
+    verify(loader > banner, "the stalled banner must render above the active view")
+    var body = src.substring(banner, loader)
+    verify(body.indexOf('runtimeHealth === "stalled"') >= 0)
+    verify(body.indexOf('title: "Agent Bar lost contact with its helper"') >= 0)
+    verify(body.indexOf('body: "Restart the shell to recover."') >= 0)
+    verify(body.indexOf('label: "Restart shell"') >= 0)
+    verify(body.indexOf("root.agentService.restartShell()") >= 0)
+    verify(src.indexOf("stalledMessage.collectFocusTargets()") >= 0)
   }
 
   function test_rail_is_icon_only_settings_at_bottom() {

--- a/tests/qml/tst_Popup.qml
+++ b/tests/qml/tst_Popup.qml
@@ -27,6 +27,8 @@ TestCase {
 
   function test_state_message_restart_action_emits_typed_signal() {
     var source = read("components/StateMessage.qml")
+    verify(source.indexOf("Keys.onReturnPressed") < 0,
+           "StateMessage must rely on the host Button key mapping")
     source = source.replace("import qs.Commons\n", "")
     source = source.replace("import qs.Ui\n", "")
     source = source.replace("  id: root\n",
@@ -72,12 +74,24 @@ TestCase {
     }]
     wait(1)
     var receivedKind = ""
+    var activationCount = 0
     message.actionActivated.connect(function (kind, target) {
       receivedKind = kind
+      activationCount += 1
     })
     compare(message.actionRepeaterForTest.count, 1)
-    message.actionRepeaterForTest.itemAt(0).focusActivate()
+    var action = message.actionRepeaterForTest.itemAt(0)
+    action.clicked()
     compare(receivedKind, "restart_shell")
+    compare(activationCount, 1)
+    action.focusActivate()
+    compare(activationCount, 2)
+
+    message.visible = false
+    compare(message.collectFocusTargets().length, 0)
+    message.visible = true
+    message.skeleton = true
+    compare(message.collectFocusTargets().length, 0)
     message.destroy()
   }
 

--- a/tests/qml/tst_Service.qml
+++ b/tests/qml/tst_Service.qml
@@ -51,7 +51,7 @@ TestCase {
     readonly property string manifestVersion: "10.0.0"
 
     function health(v) {
-      return Core.health(versionReady, versionFailed, helperVersion, manifestVersion, v)
+      return Core.health(versionReady, versionFailed, helperVersion, manifestVersion, v, "ok")
     }
     function applyVersion(stdout) {
       var v = Core.parseVersionStdout(stdout, "", 0)
@@ -391,7 +391,7 @@ TestCase {
     compare(Core.canStartLane(true), false)
   }
 
-  function test_service_qml_declares_six_process_lanes() {
+  function test_service_qml_declares_seven_process_lanes() {
     var xhr = new XMLHttpRequest()
     xhr.open("GET", serviceUrl, false)
     xhr.send()
@@ -399,11 +399,35 @@ TestCase {
     verify(src.indexOf("id: versionProbe") >= 0)
     verify(src.indexOf("id: statusProcess") >= 0)
     verify(src.indexOf("id: settingsReadProcess") >= 0)
+    verify(src.indexOf("id: settingsBootstrapProcess") >= 0)
     verify(src.indexOf("id: settingsWriteProcess") >= 0)
     verify(src.indexOf("id: maintenanceCheckProcess") >= 0)
     verify(src.indexOf("id: maintenanceHandoffProcess") >= 0)
     verify(src.indexOf("id: pollTimer") >= 0)
     verify(src.indexOf('target: "othavi0.agent-bar"') >= 0)
+  }
+
+  function test_service_qml_declares_lane_timeouts_and_destruction() {
+    var xhr = new XMLHttpRequest()
+    xhr.open("GET", serviceUrl, false)
+    xhr.send()
+    var src = String(xhr.responseText)
+    verify(src.indexOf("id: settingsReadTimeout") >= 0)
+    verify(src.indexOf("id: settingsBootstrapTimeout") >= 0)
+    verify(src.indexOf("id: settingsWriteTimeout") >= 0)
+    verify(src.indexOf("id: maintenanceCheckTimeout") >= 0)
+    verify(src.indexOf("id: maintenanceHandoffTimeout") >= 0)
+    verify(src.indexOf("Component.onDestruction") >= 0)
+  }
+
+  function test_runtime_health() {
+    compare(Core.runtimeHealth({}), "ok")
+    compare(Core.runtimeHealth({ settingsRead: true }), "ok")
+    compare(Core.runtimeHealth({ settingsRead: true, status: true }), "stalled")
+    var original = { status: true }
+    var next = Core.recordLaneTimeout(original, "settingsRead")
+    compare(Core.runtimeHealth(next), "stalled")
+    verify(original.settingsRead === undefined)
   }
 
   // Live Quattro: duplicate Component.onCompleted → "Property value set multiple times"

--- a/tests/qml/tst_Service.qml
+++ b/tests/qml/tst_Service.qml
@@ -441,6 +441,47 @@ TestCase {
     compare(cleared.status, 3)
   }
 
+  function test_lane_timeout_clear_is_immutable() {
+    var original = { status: true, settingsRead: true }
+    var cleared = Core.clearLaneTimeout(original, "status")
+    verify(original.status)
+    verify(!cleared.status)
+    verify(cleared.settingsRead)
+  }
+
+  function test_real_apply_clears_older_settled_generation() {
+    var s = Qt.createQmlObject([
+      "import QtQuick",
+      "import '../../CoreService.js' as Core",
+      "Item {",
+      "  property var settled: ({ status: 3, settingsRead: 8 })",
+      "  function applyStatus() { settled = Core.clearSettledLane(settled, 'status') }",
+      "}"
+    ].join("\n"), testCase)
+    verify(s !== null)
+    s.applyStatus()
+    verify(!Core.isLaneSettled(s.settled, "status", 3))
+    verify(Core.isLaneSettled(s.settled, "settingsRead", 8))
+    s.destroy()
+  }
+
+  function test_service_pins_started_generation_in_kick() {
+    var xhr = new XMLHttpRequest()
+    xhr.open("GET", serviceUrl, false)
+    xhr.send()
+    var src = String(xhr.responseText)
+    verify(src.indexOf("onStarted: root.versionProbeStartedGeneration") < 0)
+    verify(src.indexOf("onStarted: root.statusStartedGeneration") < 0)
+    verify(src.indexOf("onStarted: root.settingsReadStartedGeneration") < 0)
+    verify(src.indexOf("onStarted: root.settingsBootstrapStartedGeneration") < 0)
+    verify(src.indexOf("root.settingsWriteStartedGeneration = root.activeSettingsWriteGeneration\n      // Write") < 0)
+    verify(src.indexOf("onStarted: root.maintenanceCheckStartedGeneration") < 0)
+    verify(src.indexOf("root.maintenanceHandoffStartedGeneration = root.activeMaintenanceHandoffGeneration\n      // BUNDLE") < 0)
+    var pin = src.indexOf("statusStartedGeneration = gen")
+    var start = src.indexOf("statusProcess.running = true", pin)
+    verify(pin >= 0 && start > pin)
+  }
+
   // Live Quattro: duplicate Component.onCompleted → "Property value set multiple times"
   // and the service never loads (bar chips disappear).
   function test_service_qml_has_single_component_on_completed() {

--- a/tests/qml/tst_Service.qml
+++ b/tests/qml/tst_Service.qml
@@ -430,6 +430,17 @@ TestCase {
     verify(original.settingsRead === undefined)
   }
 
+  function test_settled_lane_generation_is_immutable() {
+    var original = { status: 3 }
+    var settled = Core.settleLane(original, "settingsWrite", 7)
+    verify(Core.isLaneSettled(settled, "settingsWrite", 7))
+    verify(!Core.isLaneSettled(settled, "settingsWrite", 8))
+    compare(original.settingsWrite, undefined)
+    var cleared = Core.clearSettledLane(settled, "settingsWrite", 7)
+    verify(!Core.isLaneSettled(cleared, "settingsWrite", 7))
+    compare(cleared.status, 3)
+  }
+
   // Live Quattro: duplicate Component.onCompleted → "Property value set multiple times"
   // and the service never loads (bar chips disappear).
   function test_service_qml_has_single_component_on_completed() {

--- a/tests/qml/tst_ServiceTimeouts.qml
+++ b/tests/qml/tst_ServiceTimeouts.qml
@@ -338,4 +338,16 @@ TestCase {
     tryCompare(s, "runtimeHealth", "stalled", 500)
     compare(s.health("10.3.17"), "stalled")
   }
+
+  function test_restart_shell_records_exact_argv_without_execution_in_test_mode() {
+    var s = createService()
+    compare(s.restartShellRequestCount, 0)
+    compare(s.lastRestartShellArgv, null)
+
+    s.restartShell()
+
+    compare(s.restartShellRequestCount, 1)
+    compare(s.lastRestartShellArgv.length, 1)
+    compare(s.lastRestartShellArgv[0], "omarchy-restart-shell")
+  }
 }

--- a/tests/qml/tst_ServiceTimeouts.qml
+++ b/tests/qml/tst_ServiceTimeouts.qml
@@ -59,7 +59,7 @@ TestCase {
     service.maintenanceCheckTimeoutMs = 50
     service.maintenanceHandoffTimeoutMs = 50
     service.collectionDelayMs = 10000
-    service.applyVersionProbeResult("10.3.17\n", "", 0)
+    service.applyVersionProbeResult(service.activeVersionProbeGeneration, "10.3.17\n", "", 0)
     return service
   }
 
@@ -111,7 +111,7 @@ TestCase {
 
   function test_settings_write_timeout_returns_dirty() {
     var s = createService()
-    s.applySettingsBootstrapResult("", 1)
+    s.applySettingsBootstrapResult(s.activeSettingsBootstrapGeneration, "", 1)
     s.openSettings("monitor-a")
     var generation = s.activeSettingsReadGeneration
     s.applySettingsReadResult(generation, JSON.stringify(validSettings()), 0)
@@ -120,6 +120,39 @@ TestCase {
     compare(s.settingsState.phase, "saving")
     tryVerify(function () { return s.settingsState.phase === "dirty" }, 500)
     compare(s.settingsWriteBusy, false)
+  }
+
+  function test_late_timed_out_write_cannot_adopt_old_canonical() {
+    var s = createService()
+    s.applySettingsBootstrapResult(s.activeSettingsBootstrapGeneration, "", 1)
+    s.openSettings("monitor-a")
+    s.applySettingsReadResult(
+      s.activeSettingsReadGeneration,
+      JSON.stringify(validSettings()),
+      0
+    )
+    s.setDisplayMetric("used")
+    verify(s.saveSettings())
+    var generationA = s.activeSettingsWriteGeneration
+    var canonicalA = JSON.parse(JSON.stringify(s.settingsDraft))
+    tryVerify(function () { return s.settingsState.phase === "dirty" }, 500)
+
+    s.setDisplayMetric("remaining")
+    verify(s.saveSettings())
+    var generationB = s.activeSettingsWriteGeneration
+    verify(generationB !== generationA)
+    compare(s.settingsState.phase, "saving")
+    compare(s.settingsDraft.display.metric, "remaining")
+    verify(s.pendingSettingsPayload.indexOf('"metric":"remaining"') >= 0)
+
+    s.settingsWriteExited(0, generationA, JSON.stringify(canonicalA))
+
+    compare(s.settingsState.phase, "saving")
+    compare(s.settingsDraft.display.metric, "remaining")
+    compare(s.settingsState.snapshot.display.metric, "remaining")
+    compare(s.appliedSettings.display.metric, "remaining")
+    verify(s.pendingSettingsPayload.indexOf('"metric":"remaining"') >= 0)
+    compare(Object.keys(s.timedOutLanes).length, 0)
   }
 
   function test_update_check_timeout_enters_error() {
@@ -145,9 +178,61 @@ TestCase {
     tryCompare(s, "statusBusy", false, 500)
   }
 
+  function test_late_timed_out_status_cannot_replace_new_request() {
+    var s = createService()
+    s.beginCollection()
+    var generationA = s.activeStatusGeneration
+    tryCompare(s, "statusBusy", false, 500)
+    s.kickStatus()
+    var generationB = s.activeStatusGeneration
+    verify(generationB !== generationA)
+
+    s.statusExited(0, generationA, validEnvelope(), "")
+
+    compare(s.activeStatusGeneration, generationB)
+    compare(s.statusBusy, true)
+    compare(s.snapshot, null)
+    compare(Object.keys(s.timedOutLanes).length, 0)
+  }
+
+  function test_late_timed_out_bootstrap_cannot_replace_new_request() {
+    var s = createService()
+    var generationA = s.activeSettingsBootstrapGeneration
+    tryCompare(s, "settingsBootstrapBusy", false, 500)
+    s.kickSettingsBootstrap()
+    var generationB = s.activeSettingsBootstrapGeneration
+    verify(generationB !== generationA)
+
+    s.settingsBootstrapExited(0, generationA, JSON.stringify(validSettings()))
+
+    compare(s.activeSettingsBootstrapGeneration, generationB)
+    compare(s.settingsBootstrapBusy, true)
+    compare(s.appliedSettings, null)
+    compare(Object.keys(s.timedOutLanes).length, 0)
+  }
+
+  function test_stale_non_timeout_exit_is_ignored_completely() {
+    var s = createService()
+    s.beginCollection()
+    var generationA = s.activeStatusGeneration
+    s.statusBusy = false
+    s.kickStatus()
+    var generationB = s.activeStatusGeneration
+    var completedBefore = s.completedCallbackCount
+    s.recordLaneTimeout("settingsRead")
+
+    s.statusExited(0, generationA, validEnvelope(), "")
+
+    compare(s.activeStatusGeneration, generationB)
+    compare(s.statusBusy, true)
+    compare(s.snapshot, null)
+    compare(s.completedCallbackCount, completedBefore)
+    verify(s.timedOutLanes.settingsRead)
+  }
+
   function test_runtime_health_accumulates_and_real_callback_resets() {
     var s = createService()
-    s.applySettingsBootstrapResult("", 1)
+    s.applySettingsBootstrapResult(s.activeSettingsBootstrapGeneration, "", 1)
     s.openSettings("monitor-a")
     tryVerify(function () { return s.settingsState.phase === "load_failed" }, 500)
     compare(s.runtimeHealth, "ok")
@@ -164,7 +249,7 @@ TestCase {
 
   function test_health_reports_stalled_first() {
     var s = createService()
-    s.applySettingsBootstrapResult("", 1)
+    s.applySettingsBootstrapResult(s.activeSettingsBootstrapGeneration, "", 1)
     s.openSettings("monitor-a")
     tryVerify(function () { return s.settingsState.phase === "load_failed" }, 500)
     s.checkForUpdates()

--- a/tests/qml/tst_ServiceTimeouts.qml
+++ b/tests/qml/tst_ServiceTimeouts.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import QtTest
+import "../../CoreService.js" as Core
 
 TestCase {
   id: testCase
@@ -155,6 +156,40 @@ TestCase {
     compare(Object.keys(s.timedOutLanes).length, 0)
   }
 
+  function test_native_write_exit_keeps_new_save_intact() {
+    var s = createService()
+    s.applySettingsBootstrapResult(s.activeSettingsBootstrapGeneration, "", 1)
+    s.openSettings("monitor-a")
+    s.applySettingsReadResult(
+      s.activeSettingsReadGeneration,
+      JSON.stringify(validSettings()),
+      0
+    )
+    s.setDisplayMetric("used")
+    verify(s.saveSettings())
+    var generationA = s.activeSettingsWriteGeneration
+    tryVerify(function () { return s.settingsState.phase === "dirty" }, 500)
+
+    s.setDisplayMetric("remaining")
+    verify(s.saveSettings())
+    var generationB = s.activeSettingsWriteGeneration
+    verify(generationB !== generationA)
+    s.settingsWriteStartedGeneration = generationA
+    var completedBefore = s.completedCallbackCount
+
+    s.settingsWriteExited(0)
+
+    compare(s.activeSettingsWriteGeneration, generationB)
+    compare(s.settingsWriteBusy, true)
+    compare(s.settingsState.phase, "saving")
+    compare(s.settingsDraft.display.metric, "remaining")
+    compare(s.settingsState.snapshot.display.metric, "remaining")
+    verify(s.pendingSettingsPayload.indexOf('"metric":"remaining"') >= 0)
+    compare(s.pendingSettingsPayloadGeneration, generationB)
+    compare(s.completedCallbackCount, completedBefore)
+    verify(!s.timedOutLanes.settingsWrite)
+  }
+
   function test_update_check_timeout_enters_error() {
     var s = createService()
     s.checkForUpdates()
@@ -180,6 +215,7 @@ TestCase {
 
   function test_late_timed_out_status_cannot_replace_new_request() {
     var s = createService()
+    s.applySettingsBootstrapResult(s.activeSettingsBootstrapGeneration, "", 1)
     s.beginCollection()
     var generationA = s.activeStatusGeneration
     tryCompare(s, "statusBusy", false, 500)
@@ -193,6 +229,27 @@ TestCase {
     compare(s.statusBusy, true)
     compare(s.snapshot, null)
     compare(Object.keys(s.timedOutLanes).length, 0)
+  }
+
+  function test_native_status_exit_keeps_new_request_intact() {
+    var s = createService()
+    s.beginCollection()
+    var generationA = s.activeStatusGeneration
+    tryCompare(s, "statusBusy", false, 500)
+    s.kickStatus()
+    var generationB = s.activeStatusGeneration
+    verify(generationB !== generationA)
+    s.statusStartedGeneration = generationA
+    var completedBefore = s.completedCallbackCount
+
+    s.statusExited(0)
+
+    compare(s.activeStatusGeneration, generationB)
+    compare(s.statusBusy, true)
+    compare(s.refreshing, true)
+    compare(s.snapshot, null)
+    compare(s.completedCallbackCount, completedBefore)
+    verify(!s.timedOutLanes.status)
   }
 
   function test_late_timed_out_bootstrap_cannot_replace_new_request() {
@@ -211,7 +268,7 @@ TestCase {
     compare(Object.keys(s.timedOutLanes).length, 0)
   }
 
-  function test_stale_non_timeout_exit_is_ignored_completely() {
+  function test_settled_exit_is_ignored_completely() {
     var s = createService()
     s.beginCollection()
     var generationA = s.activeStatusGeneration
@@ -220,6 +277,7 @@ TestCase {
     var generationB = s.activeStatusGeneration
     var completedBefore = s.completedCallbackCount
     s.recordLaneTimeout("settingsRead")
+    s.recordLaneTimeout("status", generationA)
 
     s.statusExited(0, generationA, validEnvelope(), "")
 
@@ -228,6 +286,30 @@ TestCase {
     compare(s.snapshot, null)
     compare(s.completedCallbackCount, completedBefore)
     verify(s.timedOutLanes.settingsRead)
+    verify(!s.timedOutLanes.status)
+  }
+
+  function test_reap_clears_only_its_own_timed_out_lane() {
+    var s = createService()
+    s.recordLaneTimeout("status", 4)
+    s.recordLaneTimeout("settingsRead", 9)
+    s.recordLaneTimeout("maintenanceCheck", 12)
+    compare(s.runtimeHealth, "stalled")
+    var completedBefore = s.completedCallbackCount
+
+    s.statusExited(0, 4, validEnvelope(), "")
+
+    verify(!s.timedOutLanes.status)
+    verify(s.timedOutLanes.settingsRead)
+    compare(s.runtimeHealth, "stalled")
+    compare(s.completedCallbackCount, completedBefore)
+    verify(!Core.isLaneSettled(s.settledLanes, "status", 4))
+    verify(Core.isLaneSettled(s.settledLanes, "settingsRead", 9))
+    verify(Core.isLaneSettled(s.settledLanes, "maintenanceCheck", 12))
+
+    s.applySettingsReadResult(s.activeSettingsReadGeneration, "", 1)
+    compare(Object.keys(s.timedOutLanes).length, 0)
+    verify(!Core.isLaneSettled(s.settledLanes, "settingsRead", 9))
   }
 
   function test_runtime_health_accumulates_and_real_callback_resets() {

--- a/tests/qml/tst_ServiceTimeouts.qml
+++ b/tests/qml/tst_ServiceTimeouts.qml
@@ -1,0 +1,174 @@
+import QtQuick
+import QtTest
+
+TestCase {
+  id: testCase
+  name: "AgentBarServiceTimeouts"
+  when: windowShown
+
+  property string repoRoot: {
+    var path = String(Qt.resolvedUrl(".")).replace("file://", "")
+    if (path.endsWith("/"))
+      path = path.slice(0, -1)
+    var parts = path.split("/")
+    parts.pop(); parts.pop()
+    return parts.join("/")
+  }
+  property string serviceUrl: "file://" + repoRoot + "/Service.qml"
+  property var service: null
+
+  function createService() {
+    var component = Qt.createComponent(serviceUrl)
+    if (component.status === Component.Ready) {
+      service = component.createObject(testCase)
+    } else {
+      // Arch packages Quickshell's QML plugins into the quickshell executable,
+      // so qmltestrunner cannot load Process/IpcHandler. Keep Service.qml's
+      // production logic intact and replace only those native test seams.
+      var xhr = new XMLHttpRequest()
+      xhr.open("GET", serviceUrl, false)
+      xhr.send()
+      var source = String(xhr.responseText)
+      source = source.replace("import Quickshell\n", "")
+      source = source.replace("import Quickshell.Io\n", "")
+      var processStart = source.indexOf("  // Processes (isolated lanes)")
+      var processEnd = source.indexOf("  // Single completed handler", processStart)
+      verify(processStart >= 0 && processEnd > processStart)
+      var processMocks = [
+        "  QtObject { id: versionProbe; property bool running: false; property var command: [] }",
+        "  QtObject { id: statusProcess; property bool running: false; property var command: [] }",
+        "  QtObject { id: settingsReadProcess; property bool running: false; property var command: [] }",
+        "  QtObject { id: settingsBootstrapProcess; property bool running: false; property var command: [] }",
+        "  QtObject { id: settingsWriteProcess; property bool running: false; property bool stdinEnabled: true; property var command: [] }",
+        "  QtObject { id: maintenanceCheckProcess; property bool running: false; property var command: [] }",
+        "  QtObject { id: maintenanceHandoffProcess; property bool running: false; property bool stdinEnabled: false; property var command: [] }",
+        ""
+      ].join("\n")
+      source = source.slice(0, processStart) + processMocks + source.slice(processEnd)
+      source = source.replace(/  IpcHandler \{[\s\S]*?\n  \}\n\n  onHelperPathChanged:/,
+                              "  QtObject { }\n\n  onHelperPathChanged:")
+      service = Qt.createQmlObject(source, testCase, serviceUrl)
+    }
+    verify(service !== null, component.errorString())
+    service.testMode = true
+    service.helperPath = "/nonexistent"
+    service.manifest = ({ version: "10.3.17", __sourceDir: "/nonexistent" })
+    service.versionProbeTimeoutMs = 50
+    service.statusTimeoutMs = 50
+    service.settingsTimeoutMs = 50
+    service.maintenanceCheckTimeoutMs = 50
+    service.maintenanceHandoffTimeoutMs = 50
+    service.collectionDelayMs = 10000
+    service.applyVersionProbeResult("10.3.17\n", "", 0)
+    return service
+  }
+
+  function cleanup() {
+    if (service) {
+      service.destroy()
+      service = null
+    }
+  }
+
+  function validEnvelope() {
+    return JSON.stringify({
+      schemaVersion: 2,
+      helperVersion: "10.3.17",
+      generatedAt: "2026-08-26T12:00:00Z",
+      request: { provider: null, cache: "use" },
+      providers: []
+    })
+  }
+
+  function validSettings() {
+    return {
+      schemaVersion: 1,
+      providers: [
+        { id: "claude", enabled: true },
+        { id: "codex", enabled: true },
+        { id: "amp", enabled: false },
+        { id: "grok", enabled: false },
+        { id: "antigravity", enabled: false }
+      ],
+      display: { metric: "remaining" },
+      refreshIntervalSeconds: 60,
+      notifications: { enabled: true, reminderMinutes: 120 }
+    }
+  }
+
+  function test_settings_read_timeout_fails_load() {
+    var s = createService()
+    s.openSettings("monitor-a")
+    tryVerify(function () { return s.settingsState.phase === "load_failed" }, 500)
+    compare(s.settingsReadBusy, false)
+  }
+
+  function test_settings_bootstrap_timeout_keeps_defaults() {
+    var s = createService()
+    tryCompare(s, "settingsBootstrapBusy", false, 500)
+    compare(s.appliedSettings, null)
+  }
+
+  function test_settings_write_timeout_returns_dirty() {
+    var s = createService()
+    s.applySettingsBootstrapResult("", 1)
+    s.openSettings("monitor-a")
+    var generation = s.activeSettingsReadGeneration
+    s.applySettingsReadResult(generation, JSON.stringify(validSettings()), 0)
+    s.setDisplayMetric("used")
+    verify(s.saveSettings())
+    compare(s.settingsState.phase, "saving")
+    tryVerify(function () { return s.settingsState.phase === "dirty" }, 500)
+    compare(s.settingsWriteBusy, false)
+  }
+
+  function test_update_check_timeout_enters_error() {
+    var s = createService()
+    s.checkForUpdates()
+    tryVerify(function () { return s.maintenanceUi.phase === "error" }, 500)
+    compare(s.maintenanceCheckBusy, false)
+  }
+
+  function test_maintenance_handoff_timeout_unblocks() {
+    var s = createService()
+    s.pendingMaintenanceIntention = ({ kind: "update_apply", version: "10.3.18" })
+    s.beginMaintenanceHandoff()
+    compare(s.maintenanceState.blocked, true)
+    tryVerify(function () { return !s.maintenanceState.blocked }, 500)
+    compare(s.maintenanceHandoffBusy, false)
+  }
+
+  function test_status_timeout_runs_in_test_mode() {
+    var s = createService()
+    s.beginCollection()
+    compare(s.statusBusy, true)
+    tryCompare(s, "statusBusy", false, 500)
+  }
+
+  function test_runtime_health_accumulates_and_real_callback_resets() {
+    var s = createService()
+    s.applySettingsBootstrapResult("", 1)
+    s.openSettings("monitor-a")
+    tryVerify(function () { return s.settingsState.phase === "load_failed" }, 500)
+    compare(s.runtimeHealth, "ok")
+    s.checkForUpdates()
+    tryCompare(s, "runtimeHealth", "stalled", 500)
+    var generation = s.activeStatusGeneration
+    if (!s.statusBusy) {
+      s.kickStatus()
+      generation = s.activeStatusGeneration
+    }
+    s.applyStatusResult(generation, validEnvelope(), "", 0)
+    compare(s.runtimeHealth, "ok")
+  }
+
+  function test_health_reports_stalled_first() {
+    var s = createService()
+    s.applySettingsBootstrapResult("", 1)
+    s.openSettings("monitor-a")
+    tryVerify(function () { return s.settingsState.phase === "load_failed" }, 500)
+    s.checkForUpdates()
+    tryCompare(s, "runtimeHealth", "stalled", 500)
+    compare(s.health("10.3.17"), "stalled")
+  }
+}

--- a/tests/qml/tst_Settings.qml
+++ b/tests/qml/tst_Settings.qml
@@ -196,9 +196,13 @@ TestCase {
     verify(src.indexOf("Settings could not be loaded") >= 0)
     verify(src.indexOf("load_failed") >= 0)
     verify(src.indexOf('text: "Restart shell"') >= 0)
+    verify(src.indexOf("visible: root.loadFailed") >= 0)
     verify(src.indexOf('Accessible.name: "Restart shell"') >= 0)
     verify(src.indexOf("root.agentService.restartShell()") >= 0)
     verify(src.indexOf("function collectFocusTargets()") >= 0)
+    verify(src.indexOf("return root.loadFailed ? [restartShellButton] : []") >= 0)
+    verify(src.indexOf("Keys.onReturnPressed") < 0,
+           "Settings must rely on the host Button key mapping")
     // No credentials / money / theme / cache editor
     verify(src.indexOf("credential") < 0 || src.toLowerCase().indexOf("no credential") >= 0)
     verify(src.indexOf("password") < 0)

--- a/tests/qml/tst_Settings.qml
+++ b/tests/qml/tst_Settings.qml
@@ -195,6 +195,10 @@ TestCase {
     // SET-026: the failed-load copy is rendered by the view itself.
     verify(src.indexOf("Settings could not be loaded") >= 0)
     verify(src.indexOf("load_failed") >= 0)
+    verify(src.indexOf('text: "Restart shell"') >= 0)
+    verify(src.indexOf('Accessible.name: "Restart shell"') >= 0)
+    verify(src.indexOf("root.agentService.restartShell()") >= 0)
+    verify(src.indexOf("function collectFocusTargets()") >= 0)
     // No credentials / money / theme / cache editor
     verify(src.indexOf("credential") < 0 || src.toLowerCase().indexOf("no credential") >= 0)
     verify(src.indexOf("password") < 0)


### PR DESCRIPTION
Closes #73

## Problem

A fresh `omarchy plugin add` / `omarchy plugin remove` races the shell's 150 ms inotify plugin reload. The half-reloaded service instance kept helper processes that never returned, so every lane stayed `busy` forever: Settings stuck at "Loading…", chips frozen on their error/default state, until the user restarted the shell by hand.

## Changes

- **Every service lane has a deadline.** `Service.qml` arms a `Timer` per process lane (version probe, status, settings read/bootstrap/write, update check, maintenance handoff). A timeout finishes through the lane's typed state transition instead of leaving a busy flag set.
- **Callbacks are pinned to their start generation.** Each lane records the generation it started with; a late `onExited` from a timed-out process only reaps the zombie marker and never applies its result to a newer request (SET-017/018/021). The reap clears only its own lane's timeout entry.
- **`runtimeHealth === "stalled"`** when two distinct lanes time out before any accepted helper callback. The IPC `health` handler returns `stalled` ahead of the version check (ARCH-021).
- **Recovery UI.** The popup shows a plain-text banner with a `Restart shell` action (`omarchy-restart-shell` via exact argv `execDetached`, single-fire, keyboard-focusable). Settings offers the same action after a failed load. The focus ring keeps the current target across rebuilds and does not steal focus from an active editor.
- Docs: architecture, runtime guide, omarchy-shell contract, troubleshooting, ARCH-021/ARCH-023, CHANGELOG.

## Verification

- `cargo fmt --check`, `cargo test` (367 passed), `cargo clippy --all-targets -- -D warnings`, `git diff --check`: clean.
- Qt6 `qmltestrunner`: 290 passed, 0 failed (18 new service-timeout/generation cases exercise timeout → new request → late exit, per lane).
- `omarchy plugin validate .`: ok. `cargo test --test active_language`: ok.
- Not verified: live rendering of the stalled banner and the Settings button. `qmltestrunner` cannot instantiate `KeyboardPanel`/`qs.Ui`, so that needs a live-shell QA pass before release.

## Follow-up

The root cause (plugin add/remove/update racing the inotify reload) lives in Omarchy itself; an upstream issue will be filed separately and linked from #73.
