### PR TITLE
fix: session window leads chip and popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- fix: the chip and popup lead with the session window whenever the provider
+  delivers one (`session` for Claude and Codex, `gemini-5h` for Antigravity).
+  Once the five-hour reset elapsed overnight the old election handed the
+  chip to the weekly percentage every morning; a weekly window near its
+  limit still tints the numeral and shows `!`, it no longer takes the number
+  (UX-020D amended, see
+  `docs/specs/v10/amendments/2026-09-04-session-window-leads-design.md`).
 - feat: a first run now enables Claude and Codex only. Amp, Grok, and
   Antigravity are opt-in from Settings, so a provider whose CLI is absent no
   longer renders as a chip nobody asked for. This is not limited to brand-new

--- a/CoreView.js
+++ b/CoreView.js
@@ -92,10 +92,11 @@ function visibleProviders(snapshot, settings) {
   return out
 }
 
-// UX-002 / UX-032A (amended 2026-08-07): the chip renders the elected lead
-// window's used|remaining percent — the same election the popup runs — or an
-// em-dash when there is no window. Chip and popup can never disagree on
-// which window a number belongs to.
+// UX-002 / UX-032A (amended 2026-08-07, 2026-09-04): the chip renders the
+// elected lead window's used|remaining percent — the same election the popup
+// runs, which pins a session window first — or an em-dash when there is no
+// window. Chip and popup can never disagree on which window a number
+// belongs to.
 function chipPercentText(provider, metric, nowMs) {
   var lines = windowDisplayLines(provider, metric, nowMs)
   var lead = electLeadIndex(lines)
@@ -643,10 +644,20 @@ function remainingRank(line) {
   return line.remainingPercent === null ? Infinity : line.remainingPercent
 }
 
-// §8: deterministic four-step lead election: critical, plan, nearest future
-// reset, then first delivered. This replaces the old id allowlist that silently
-// demoted any window id it did not know. Returns an index into `lines`, or -1
-// when there is nothing to lead.
+// UX-020D (amended 2026-09-04): the window ids the Rust mappers emit for a
+// provider's short rolling window (Claude/Codex `session`, Antigravity
+// `gemini-5h`). Typed schema data, like the `plan-` prefix below — this list
+// only promotes known ids; an id it does not know is never demoted.
+var SESSION_WINDOW_IDS = ["session", "gemini-5h"]
+
+function isSessionWindowId(id) {
+  return SESSION_WINDOW_IDS.indexOf(String(id)) >= 0
+}
+
+// §8: deterministic five-step lead election: session, critical, plan, nearest
+// future reset, then first delivered. This replaces the old id allowlist that
+// silently demoted any window id it did not know. Returns an index into
+// `lines`, or -1 when there is nothing to lead.
 //
 // Delivered order is unique per line, so `<` on the index is already a total
 // tiebreak; the spec's further "then by window id" step is unreachable and is
@@ -657,6 +668,17 @@ function electLeadIndex(lines) {
 
   var i
   var best = -1
+
+  // 0. UX-020D (amended 2026-09-04): a session window leads whenever one is
+  //    delivered, even after its reset elapsed and even when a weekly window
+  //    is critical — the weekly still tints the chip and shows the "!" cue
+  //    through providerSeverity, it just never takes the number. Without
+  //    this, every morning the elapsed session reset handed the chip to the
+  //    weekly percentage.
+  for (i = 0; i < lines.length; i++) {
+    if (isSessionWindowId(lines[i].id))
+      return i
+  }
 
   // 1. Any critical window leads; among criticals, the lowest remaining.
   for (i = 0; i < lines.length; i++) {

--- a/docs/specs/v10/04-quickshell-ux-and-accessibility.md
+++ b/docs/specs/v10/04-quickshell-ux-and-accessibility.md
@@ -79,15 +79,19 @@ not literal UI.
   critical lead window renders its numeral and track in the urgent theme
   colour, and a ready provider with a critical window shows the `!` cue on its
   bar chip. Every level carries a word; no level is colour-only.
-- `UX-020D`: The popup renders exactly one lead window, elected
-  deterministically: a critical window wins, and among criticals the one with
-  the lowest remaining percentage; otherwise a plan window (window id
+- `UX-020D` (amended 2026-09-04): The popup renders exactly one lead
+  window, elected deterministically: a session window (window id `session`
+  or `gemini-5h`) leads whenever present, the first delivered one if
+  several; otherwise a critical window wins, and among criticals the one
+  with the lowest remaining percentage; otherwise a plan window (window id
   starting `plan-`) wins, and among plan windows the one with the lowest
   remaining percentage; otherwise the window whose reset comes soonest; ties
   keep the delivered order; when no window has a future reset the first
   delivered window leads. Every other window renders as a compact row in
   delivered order. Reset times render as a countdown, in hours below 24
-  hours.
+  hours. A critical non-lead window still drives severity (`UX-020C`); it
+  never takes the number. See
+  `docs/specs/v10/amendments/2026-09-04-session-window-leads-design.md`.
 - `UX-020B`: The selected rail icon uses a neutral soft plate only for the
   provider that owns the open content; no accent edge tick; Settings has no
   idle selected-looking border.

--- a/docs/specs/v10/04-quickshell-ux-and-accessibility.md
+++ b/docs/specs/v10/04-quickshell-ux-and-accessibility.md
@@ -72,13 +72,16 @@ not literal UI.
 - `UX-020A`: Every percentage window row shows a horizontal usage track
   filled by the displayed metric (used or remaining), in both the lead window
   and the compact rows, so secondary windows stay comparable.
-- `UX-020C`: Severity is computed from `usedPercent`, independent of the
-  displayed metric, using the notification thresholds: at or above 95 the
-  window is Critical, at or above 90 it is Warning. The popup header shows a
-  severity tag reading `Critical` or `Low` when the provider has one, the
-  critical lead window renders its numeral and track in the urgent theme
-  colour, and a ready provider with a critical window shows the `!` cue on its
-  bar chip. Every level carries a word; no level is colour-only.
+- `UX-020C` (amended 2026-09-04): Severity is computed from `usedPercent`,
+  independent of the displayed metric, using the notification thresholds: at
+  or above 95 the window is Critical, at or above 90 it is Warning. The popup
+  header shows a severity tag reading `Critical` or `Low` when the provider
+  has one, a critical window renders its numeral and track in the urgent
+  theme colour whether it is the lead or a compact row, and a ready provider
+  with a critical window shows the `!` cue on its bar chip, whose accessible
+  name carries the word `critical` even when the chip numeral belongs to a
+  non-critical session window. Every level carries a word; no level is
+  colour-only.
 - `UX-020D` (amended 2026-09-04): The popup renders exactly one lead
   window, elected deterministically: a session window (window id `session`
   or `gemini-5h`) leads whenever present, the first delivered one if

--- a/docs/specs/v10/04-quickshell-ux-and-accessibility.md
+++ b/docs/specs/v10/04-quickshell-ux-and-accessibility.md
@@ -78,9 +78,9 @@ not literal UI.
   header shows a severity tag reading `Critical` or `Low` when the provider
   has one, a critical window renders its numeral and track in the urgent
   theme colour whether it is the lead or a compact row, and a ready provider
-  with a critical window shows the `!` cue on its bar chip, whose accessible
-  name carries the word `critical` even when the chip numeral belongs to a
-  non-critical session window. Every level carries a word; no level is
+  with a critical window shows the `!` cue on its bar chip; the cue's
+  accessible name carries the word `critical` even when the chip numeral
+  belongs to a non-critical session window. Every level carries a word; no level is
   colour-only.
 - `UX-020D` (amended 2026-09-04): The popup renders exactly one lead
   window, elected deterministically: a session window (window id `session`

--- a/docs/specs/v10/README.md
+++ b/docs/specs/v10/README.md
@@ -25,6 +25,9 @@ The login-state visibility design, approved 2026-08-25, refines `JSON-004`,
 `UX-030`, `CACHE-004`, `CACHE-006`, and `ARCH-021`:
 [docs/specs/v10/amendments/2026-08-25-login-state-visibility-design.md](amendments/2026-08-25-login-state-visibility-design.md).
 
+The session-window-leads design, approved 2026-09-04, amends `UX-020D`:
+[docs/specs/v10/amendments/2026-09-04-session-window-leads-design.md](amendments/2026-09-04-session-window-leads-design.md).
+
 ## Product statement
 
 Agent Bar v10 is an Omarchy Quattro Quickshell plugin. Its only graphical
@@ -52,7 +55,8 @@ application, an AUR product, or a cargo-binstall product.
    [2026-08-06 plugin ID rename](amendments/2026-08-06-plugin-id-rename-design.md),
    [2026-08-06 remove chip tooltip](amendments/2026-08-06-remove-chip-tooltip-design.md),
    [2026-08-11 monorepo migration](amendments/2026-08-11-monorepo-migration-design.md),
-   [2026-08-25 login-state visibility](amendments/2026-08-25-login-state-visibility-design.md).
+   [2026-08-25 login-state visibility](amendments/2026-08-25-login-state-visibility-design.md),
+   [2026-09-04 session window leads](amendments/2026-09-04-session-window-leads-design.md).
 
 When two statements conflict, the earlier contract in this reading order wins
 unless a later file explicitly identifies the requirement ID it refines.

--- a/docs/specs/v10/README.md
+++ b/docs/specs/v10/README.md
@@ -25,7 +25,8 @@ The login-state visibility design, approved 2026-08-25, refines `JSON-004`,
 `UX-030`, `CACHE-004`, `CACHE-006`, and `ARCH-021`:
 [docs/specs/v10/amendments/2026-08-25-login-state-visibility-design.md](amendments/2026-08-25-login-state-visibility-design.md).
 
-The session-window-leads design, approved 2026-09-04, amends `UX-020D`:
+The session-window-leads design, approved 2026-09-04, amends `UX-020C` and
+`UX-020D`:
 [docs/specs/v10/amendments/2026-09-04-session-window-leads-design.md](amendments/2026-09-04-session-window-leads-design.md).
 
 ## Product statement

--- a/docs/specs/v10/amendments/2026-09-04-session-window-leads-design.md
+++ b/docs/specs/v10/amendments/2026-09-04-session-window-leads-design.md
@@ -38,6 +38,8 @@ and the `!` cue, and in the popup, never by taking the chip number.
 A session window leads whenever one is delivered. The existing election
 applies only when no session window exists.
 
+This document is the change-control record for `UX-020C` and `UX-020D`.
+
 Session windows are identified by id. The Rust mappers author these ids as
 typed schema data: `session` for Claude and Codex, `gemini-5h` for
 Antigravity. This is the same contract the `plan-` prefix already relies on
@@ -55,8 +57,11 @@ does not know, which is the defect the pre-2026-08-07 allowlist had.
   above the critical threshold still paints the numeral urgent and shows
   `!` while the numeral itself stays the session percentage.
 - Per provider: Claude, Codex, and Antigravity now lead with their session
-  window. Grok delivers only `weekly` and Amp leads with `plan-` windows, so
-  neither changes.
+  window. Grok delivers at most one window and Amp delivers `daily` and
+  `plan-` windows, so neither changes.
+- Codex maps a primary window with an unlisted duration to
+  `other:<minutes>:<ordinal>`; such an account keeps the previous election.
+  Only the two ids above are promoted.
 
 ## Not changing
 
@@ -75,12 +80,21 @@ does not know, which is the defect the pre-2026-08-07 allowlist had.
   per-model window keeps the urgent tint and the `!` cue without taking the
   number.
 - `test_gemini_5h_window_leads_like_session` covers the Antigravity id.
-- `test_lead_election_critical_beats_nearest_reset` and
+- `test_lead_election_critical_beats_nearest_reset`,
+  `test_lead_election_nearest_future_reset_when_healthy`, and
   `test_unknown_window_id_can_lead` previously used `session` as the losing
-  window; they now use non-session ids so they keep proving the steps they
-  are named after.
+  or winning window; they now use non-session ids so they keep proving the
+  steps they are named after.
 
 ## Spec amendment
+
+`UX-020C` gains two clauses: a critical window renders its numeral and track
+in the urgent theme colour whether it is the lead or a compact row, and the
+chip's accessible name carries the word `critical` even when the numeral
+belongs to a non-critical session window. Both already hold in
+`components/UsageWindow.qml` and `components/ProviderChip.qml`; the text now
+requires them, because after this change the critical window is usually a
+compact row.
 
 `UX-002` reads: the chip shows the used or remaining percentage of the
 elected lead window (per `UX-020D`), so chip and popup always name the same

--- a/docs/specs/v10/amendments/2026-09-04-session-window-leads-design.md
+++ b/docs/specs/v10/amendments/2026-09-04-session-window-leads-design.md
@@ -1,0 +1,97 @@
+# Session window leads the chip and popup
+
+Date: 2026-09-04
+Status: approved
+
+## Context
+
+The bar chip and the popup show one number: the percentage of the elected
+lead window (`UX-002`). `UX-020D` elected that window in four steps: a
+critical window first, then a plan window, then the window whose reset comes
+soonest, then the first delivered window. A window whose reset already
+elapsed, or that has no reset, did not compete in the third step.
+
+On a Claude account this produced a wrong chip every morning. Cached status
+from 2026-09-03 20:42 BRT carried three windows: `session` at 21 % used
+resetting `2026-09-04T03:10Z`, `weekly` at 64 % resetting
+`2026-09-04T12:00Z`, and `weekly-model:fable` at 79 % resetting at the same
+instant. Replaying that document through `CoreView.js` at two clocks gave:
+
+```
+2026-09-03T23:45Z  lead=session  chip=21%
+2026-09-04T10:00Z  lead=weekly   chip=64%
+```
+
+Overnight the session reset elapsed, the third step skipped the session, and
+the weekly window took the number. Two more paths reach the same outcome:
+a session opened after ~07:00Z on this account resets after the 12:00Z
+weekly reset and loses the "soonest reset" comparison while active; and a
+weekly or per-model window at or above 95 % used wins the first step
+outright.
+
+The owner decided on 2026-09-04: the chip always shows the five-hour window
+when there is one. A weekly window running out is reported through colour
+and the `!` cue, and in the popup, never by taking the chip number.
+
+## Decision
+
+A session window leads whenever one is delivered. The existing election
+applies only when no session window exists.
+
+Session windows are identified by id. The Rust mappers author these ids as
+typed schema data: `session` for Claude and Codex, `gemini-5h` for
+Antigravity. This is the same contract the `plan-` prefix already relies on
+in `UX-020D`. The rule only promotes ids it knows; it never demotes an id it
+does not know, which is the defect the pre-2026-08-07 allowlist had.
+
+## Design
+
+- `CoreView.js` `electLeadIndex` gains a step 0 before the critical step:
+  the first delivered line whose id is in `SESSION_WINDOW_IDS`
+  (`["session", "gemini-5h"]`) leads. Steps 1 to 4 are unchanged.
+- Chip and popup share the election, so both change together (`UX-002`).
+- `chipSeverityUrgent` and `chipStateCue` are unchanged. They derive from
+  `providerSeverity`, which scans every window, so a weekly window at or
+  above the critical threshold still paints the numeral urgent and shows
+  `!` while the numeral itself stays the session percentage.
+- Per provider: Claude, Codex, and Antigravity now lead with their session
+  window. Grok delivers only `weekly` and Amp leads with `plan-` windows, so
+  neither changes.
+
+## Not changing
+
+- Severity thresholds, notification levels, and their parity test.
+- Stale retention: a retained session window leads exactly like a fresh one,
+  which is the "last known value" the owner asked for after hours idle.
+- The status JSON schema and the Rust mappers.
+
+## Tests
+
+`tests/qml/tst_ProviderStates.qml`:
+
+- `test_session_window_leads_over_sooner_weekly_reset` replays the
+  2026-09-03 data at 10:00Z and the active-session-after-weekly-reset case.
+- `test_session_window_leads_over_critical_weekly` proves a critical
+  per-model window keeps the urgent tint and the `!` cue without taking the
+  number.
+- `test_gemini_5h_window_leads_like_session` covers the Antigravity id.
+- `test_lead_election_critical_beats_nearest_reset` and
+  `test_unknown_window_id_can_lead` previously used `session` as the losing
+  window; they now use non-session ids so they keep proving the steps they
+  are named after.
+
+## Spec amendment
+
+`UX-002` reads: the chip shows the used or remaining percentage of the
+elected lead window (per `UX-020D`), so chip and popup always name the same
+number.
+
+`UX-020D` reads: the popup renders exactly one lead window, elected
+deterministically. A session window (id `session` or `gemini-5h`) leads
+whenever present, the first delivered one if several. Otherwise a critical
+window wins, and among criticals the one with the lowest remaining
+percentage; otherwise a plan window (id starting `plan-`) wins, and among
+plan windows the one with the lowest remaining percentage; otherwise the
+window whose reset comes soonest; ties keep the delivered order; when no
+window has a future reset the first delivered window leads. Every other
+window renders as a compact row in delivered order.

--- a/tests/qml/tst_ProviderStates.qml
+++ b/tests/qml/tst_ProviderStates.qml
@@ -322,14 +322,16 @@ TestCase {
     compare(layout.lead.severity, "critical")
   }
 
+  // Non-session ids on purpose: a session window would be pinned before this
+  // step ever ran (see the 2026-09-04 tests).
   function test_lead_election_nearest_future_reset_when_healthy() {
     var layout = layoutOf([
       { id: "weekly", label: "Weekly (7d)", usedPercent: 40, remainingPercent: 60,
         resetsAt: "2026-07-31T11:59:59Z" },
-      { id: "session", label: "Session (5h)", usedPercent: 4, remainingPercent: 96,
+      { id: "daily", label: "Daily (1d)", usedPercent: 4, remainingPercent: 96,
         resetsAt: "2026-07-28T18:00:00Z" }
     ], "2026-07-28T15:00:00Z")
-    compare(layout.lead.id, "session")
+    compare(layout.lead.id, "daily")
     // The rest keeps delivered order, not election order.
     compare(layout.rest.length, 1)
     compare(layout.rest[0].id, "weekly")
@@ -405,7 +407,7 @@ TestCase {
       { id: "weekly-model:opus", label: "Opus", usedPercent: 97, remainingPercent: 3,
         resetsAt: "2026-07-31T11:59:59Z" },
       { id: "weekly", label: "Weekly (7d)", usedPercent: 10, remainingPercent: 90,
-        resetsAt: "2026-07-31T11:59:59Z" }
+        resetsAt: "2026-07-28T15:30:00Z" }
     ], "2026-07-28T15:00:00Z")
     compare(layout.lead.id, "weekly-model:opus")
   }
@@ -452,6 +454,9 @@ TestCase {
     compare(Core.chipPercentText(provider, "remaining", now), "90%")
     compare(Core.chipSeverityUrgent(provider), true)
     compare(Core.chipStateCue(provider), "!")
+    // The urgent numeral is not the critical number, so the word carried by
+    // the cue is what keeps this from being a colour-only signal (UX-020C).
+    compare(Core.chipCueLabel(provider), "critical")
   }
 
   // Antigravity's five-hour bucket is the same kind of window under its own id.

--- a/tests/qml/tst_ProviderStates.qml
+++ b/tests/qml/tst_ProviderStates.qml
@@ -230,9 +230,11 @@ TestCase {
     compare(Core.windowLayout(provider, "used", now).lead.severity, "critical")
   }
 
+  // Among non-session windows severity still outranks the nearest reset
+  // (a session window would pin the lead first; see the 2026-09-04 tests).
   function test_lead_election_critical_beats_nearest_reset() {
     var layout = layoutOf([
-      { id: "session", label: "Session (5h)", usedPercent: 10, remainingPercent: 90,
+      { id: "daily", label: "Daily (1d)", usedPercent: 10, remainingPercent: 90,
         resetsAt: "2026-07-28T15:30:00Z" },
       { id: "weekly", label: "Weekly (7d)", usedPercent: 96, remainingPercent: 4,
         resetsAt: "2026-07-31T11:59:59Z" }
@@ -240,7 +242,7 @@ TestCase {
     compare(layout.lead.id, "weekly")
     compare(layout.lead.severity, "critical")
     compare(layout.rest.length, 1)
-    compare(layout.rest[0].id, "session")
+    compare(layout.rest[0].id, "daily")
   }
 
   function test_lead_election_lowest_remaining_among_criticals() {
@@ -402,10 +404,65 @@ TestCase {
     var layout = layoutOf([
       { id: "weekly-model:opus", label: "Opus", usedPercent: 97, remainingPercent: 3,
         resetsAt: "2026-07-31T11:59:59Z" },
-      { id: "session", label: "Session (5h)", usedPercent: 10, remainingPercent: 90,
-        resetsAt: "2026-07-28T15:30:00Z" }
+      { id: "weekly", label: "Weekly (7d)", usedPercent: 10, remainingPercent: 90,
+        resetsAt: "2026-07-31T11:59:59Z" }
     ], "2026-07-28T15:00:00Z")
     compare(layout.lead.id, "weekly-model:opus")
+  }
+
+  // UX-020D (amended 2026-09-04): a session window leads whenever present.
+  // Live data from 2026-09-03: overnight the session reset elapsed, so the
+  // old election handed the chip to the weekly window every morning.
+  function test_session_window_leads_over_sooner_weekly_reset() {
+    var windows = [
+      { id: "session", label: "Session (5h)", usedPercent: 21, remainingPercent: 79,
+        resetsAt: "2026-09-04T03:10:00Z" },
+      { id: "weekly", label: "Weekly (7d)", usedPercent: 64, remainingPercent: 36,
+        resetsAt: "2026-09-04T12:00:00Z" },
+      { id: "weekly-model:fable", label: "Fable", usedPercent: 79, remainingPercent: 21,
+        resetsAt: "2026-09-04T12:00:00Z" }
+    ]
+    var morning = Date.parse("2026-09-04T10:00:00Z")
+    compare(Core.windowLayout(readyWith(windows), "remaining", morning).lead.id, "session")
+    compare(Core.chipPercentText(readyWith(windows), "used", morning), "21%")
+
+    // An active session whose reset comes after the weekly reset still leads.
+    var active = layoutOf([
+      { id: "session", label: "Session (5h)", usedPercent: 3, remainingPercent: 97,
+        resetsAt: "2026-09-04T16:00:00Z" },
+      { id: "weekly", label: "Weekly (7d)", usedPercent: 64, remainingPercent: 36,
+        resetsAt: "2026-09-04T12:00:00Z" }
+    ], "2026-09-04T11:00:00Z")
+    compare(active.lead.id, "session")
+    compare(active.rest.length, 1)
+    compare(active.rest[0].id, "weekly")
+  }
+
+  // A critical weekly window keeps the urgent tint and the "!" cue but never
+  // takes the chip number away from the session.
+  function test_session_window_leads_over_critical_weekly() {
+    var provider = readyWith([
+      { id: "session", label: "Session (5h)", usedPercent: 10, remainingPercent: 90,
+        resetsAt: "2026-09-04T16:00:00Z" },
+      { id: "weekly-model:fable", label: "Fable", usedPercent: 96, remainingPercent: 4,
+        resetsAt: "2026-09-11T12:00:00Z" }
+    ])
+    var now = Date.parse("2026-09-04T11:00:00Z")
+    compare(Core.windowLayout(provider, "remaining", now).lead.id, "session")
+    compare(Core.chipPercentText(provider, "remaining", now), "90%")
+    compare(Core.chipSeverityUrgent(provider), true)
+    compare(Core.chipStateCue(provider), "!")
+  }
+
+  // Antigravity's five-hour bucket is the same kind of window under its own id.
+  function test_gemini_5h_window_leads_like_session() {
+    var layout = layoutOf([
+      { id: "gemini-weekly", label: "Weekly (7d)", usedPercent: 40, remainingPercent: 60,
+        resetsAt: "2026-09-05T12:00:00Z" },
+      { id: "gemini-5h", label: "Session (5h)", usedPercent: 12, remainingPercent: 88,
+        resetsAt: null }
+    ], "2026-09-04T11:00:00Z")
+    compare(layout.lead.id, "gemini-5h")
   }
 
   function test_lines_carry_raw_percentages_and_countdown() {


### PR DESCRIPTION
## Symptom

Every morning the Claude chip showed the weekly percentage instead of the five-hour one. Cached status from 2026-09-03 20:42 BRT carried `session` 21 % (reset 03:10Z), `weekly` 64 % (reset 12:00Z) and `weekly-model:fable` 79 % (reset 12:00Z). Replayed through `CoreView.js`:

```
2026-09-03T23:45Z  lead=session  chip=21%
2026-09-04T10:00Z  lead=weekly   chip=64%
```

## Cause

`electLeadIndex` elected the nearest future reset, and a window whose reset already elapsed did not compete. Overnight the session reset passed, so the weekly window took the number. Two more paths gave the same result: a session opened after ~07:00Z resets after the 12:00Z weekly reset and loses the comparison while active, and a weekly or per-model window at or above 95 % wins the critical step outright.

## Change

A session window (`session` for Claude and Codex, `gemini-5h` for Antigravity) leads whenever the provider delivers one. The existing election applies only when there is none. Severity is untouched. A critical weekly window still paints the numeral urgent and shows `!`, it just never takes the number. Grok (weekly only) and Amp (`plan-`) do not change.

Owner decision from 2026-09-04: the chip always shows the five-hour window; a weekly window running out is reported through colour, the `!` cue, and the popup.

- `CoreView.js`: step 0 in `electLeadIndex`, `SESSION_WINDOW_IDS`.
- `tests/qml/tst_ProviderStates.qml`: three new tests (live data replay, critical weekly with the `critical` accessible word, `gemini-5h`); three existing tests that used `session` as the losing or winning window now use non-session ids so they keep proving their own step.
- `docs/specs/v10/amendments/2026-09-04-session-window-leads-design.md`, UX-020D and UX-020C in `04-quickshell-ux-and-accessibility.md` (the urgent tint on a compact row and the word carried by the cue become required, since the critical window is now usually a compact row), spec README, CHANGELOG.

One consequence worth knowing: with a session at 10 % and a weekly at 96 %, the chip reads `90%` in the urgent colour with `!`. The number is the session, the colour is the weekly. The cue's accessible name says `critical`, and the popup names the critical row. Codex accounts whose primary window has an unlisted duration (`other:<minutes>:<ordinal>`) keep the previous election.

## Verification

```
cargo fmt --check                               ok
cargo test                                      303 passed
cargo clippy --all-targets -- -D warnings       ok
git diff --check                                ok
qmllint (Qt6 path)                              only the known qs.* unresolved-import warnings
omarchy plugin validate .                       exit 0
qmltestrunner (Qt6 path)                        293 passed, 0 failed
```

The three new QML tests failed against `master` before the change (lead `weekly`, `weekly-model:fable`, `gemini-weekly` respectively).

I did not verify the bar itself. That needs the release path (`Auto release` then `omarchy plugin update othavi0.agent-bar`) and a morning look at the chip.
