### PR TITLE
fix: resolve plugin source dir from QML, not manifest.__sourceDir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- fix: resolve the plugin's own install directory via the QML engine's
+  file resolution instead of `manifest.__sourceDir` — Quattro's
+  `publicPluginManifest()` strips that field for every third-party plugin
+  before injection, so the helper path was always empty, the version
+  probe never ran, and every provider chip was stuck on the loading
+  placeholder (`···`) forever.
 - fix: Grok no longer flips to "Sign in" after hours idle. The CLI's access
   token lives six hours and nothing renews it while the CLI is idle; sending
   it expired earned a 401 that read as a real rejection and discarded the

--- a/CoreService.js
+++ b/CoreService.js
@@ -97,6 +97,34 @@ function isClosedProvider(providerId) {
   return !!CLOSED_PROVIDERS[String(providerId || "")]
 }
 
+// Quattro strips manifest.__sourceDir for every third-party plugin
+// (shell.publicPluginManifest deletes it before injection — only
+// manifest.__isFirstParty keeps the field). A third-party service must
+// therefore learn its own install directory from the QML engine's own
+// file-resolution instead of from the host-provided manifest: `file://`
+// is the only scheme a local plugin file resolves to, so anything else
+// (a qrc:/http(s):/relative fallback the engine could return) is not a
+// usable local path.
+function urlToLocalPath(fileUrl) {
+  var s = String(fileUrl || "")
+  if (s.indexOf("file://") !== 0)
+    return ""
+  var path = decodeURIComponent(s.slice("file://".length))
+  if (path.length > 1 && path.charAt(path.length - 1) === "/")
+    path = path.slice(0, -1)
+  return path
+}
+
+// manifest.__sourceDir (present only for first-party plugins) wins when
+// available; selfDirUrl (Qt.resolvedUrl(".") on Service.qml, always
+// available, independent of Quattro's manifest injection timing) is the
+// third-party fallback.
+function resolvePluginRoot(manifest, selfDirUrl) {
+  if (manifest && manifest.__sourceDir)
+    return String(manifest.__sourceDir)
+  return urlToLocalPath(selfDirUrl)
+}
+
 // QML property-var interop: nested arrays become array-like QVariantList where
 // Array.isArray is false but .length and numeric keys still work.
 function isArrayLike(value) {

--- a/Service.qml
+++ b/Service.qml
@@ -17,9 +17,11 @@ Item {
   property var barWidgetRegistry: null
   property var pluginRegistry: null
 
-  readonly property string pluginRoot: manifest && manifest.__sourceDir
-      ? String(manifest.__sourceDir)
-      : ""
+  // manifest.__sourceDir only survives injection for first-party plugins;
+  // Quattro's publicPluginManifest() strips it for every third-party one
+  // (this plugin included), so the QML engine's own resolution of "." is
+  // the fallback that makes pluginRoot independent of that host contract.
+  readonly property string pluginRoot: Core.resolvePluginRoot(manifest, String(Qt.resolvedUrl(".")))
 
   // Test harness: absolute helper path. Production uses pluginRoot/bin/agent-bar.
   property string helperPath: ""
@@ -118,16 +120,11 @@ Item {
   function resolvedHelperPath() {
     if (helperPath && helperPath.length > 0)
       return helperPath
-    // Prefer live manifest.__sourceDir over pluginRoot: Quattro sets `manifest`
-    // after createObject, and onManifestChanged can run before the pluginRoot
-    // binding re-evaluates (nested JS field access is not a QML property).
-    var root = ""
-    if (manifest && manifest.__sourceDir)
-      root = String(manifest.__sourceDir)
-    else if (pluginRoot && pluginRoot.length > 0)
-      root = pluginRoot
-    if (root && root.length > 0)
-      return root + "/bin/agent-bar"
+    // pluginRoot binds directly on the `manifest` property (not a nested
+    // field captured once), so it is already current by the time
+    // onManifestChanged fires — no need to re-derive it here.
+    if (pluginRoot && pluginRoot.length > 0)
+      return pluginRoot + "/bin/agent-bar"
     return ""
   }
 

--- a/tests/qml/tst_Service.qml
+++ b/tests/qml/tst_Service.qml
@@ -225,6 +225,42 @@ TestCase {
     compare(h.collectionStarted, true)
   }
 
+  // Quattro's shell.publicPluginManifest() deletes manifest.__sourceDir
+  // for every third-party plugin before injection (only
+  // manifest.__isFirstParty keeps it) — reproduced with the exact live
+  // shape Quattro hands this service (bundle.json / manifest.json fields,
+  // no __sourceDir). Without a fallback, pluginRoot goes permanently
+  // empty and the bar never leaves the loading placeholder for any
+  // provider (PROD-live-stuck-loading, 2026-09-08).
+  function test_resolve_plugin_root_falls_back_when_sourceDir_stripped() {
+    var thirdPartyManifest = {
+      schemaVersion: 1, id: "othavi0.agent-bar", name: "Agent Bar",
+      version: "10.3.11", kinds: ["service", "bar-widget"],
+      entryPoints: { service: "Service.qml", barWidget: "BarWidget.qml" }
+    }
+    compare(Core.resolvePluginRoot(thirdPartyManifest, "file:///home/u/.config/omarchy/plugins/othavi0.agent-bar/"),
+        "/home/u/.config/omarchy/plugins/othavi0.agent-bar")
+  }
+
+  function test_resolve_plugin_root_prefers_sourceDir_when_present() {
+    var firstPartyManifest = { id: "omarchy.example", __sourceDir: "/usr/share/omarchy/plugins/omarchy.example", __isFirstParty: true }
+    compare(Core.resolvePluginRoot(firstPartyManifest, "file:///should/not/be/used"),
+        "/usr/share/omarchy/plugins/omarchy.example")
+  }
+
+  function test_resolve_plugin_root_empty_without_local_file_url() {
+    compare(Core.resolvePluginRoot(null, "file:///a/b"), "/a/b")
+    compare(Core.resolvePluginRoot({}, ""), "")
+    compare(Core.resolvePluginRoot({}, "https://example.com/x"), "")
+  }
+
+  function test_url_to_local_path_decodes_and_trims_trailing_slash() {
+    compare(Core.urlToLocalPath("file:///home/a%20b/plugins/x/"), "/home/a b/plugins/x")
+    compare(Core.urlToLocalPath("file:///a/b"), "/a/b")
+    compare(Core.urlToLocalPath("not-a-url"), "")
+    compare(Core.urlToLocalPath(""), "")
+  }
+
   function test_refresh_closed_providers() {
     reset()
     h.applyVersion("10.0.0\n")
@@ -523,7 +559,11 @@ TestCase {
     verify(src.indexOf("onManifestChanged") >= 0)
     verify(src.indexOf("onHelperPathChanged") >= 0)
     verify(src.indexOf("tryStartProduction()") >= 0)
-    verify(src.indexOf("manifest.__sourceDir") >= 0)
+    // pluginRoot must resolve from the QML engine's own file location
+    // (Core.resolvePluginRoot / Qt.resolvedUrl), not solely from
+    // manifest.__sourceDir — Quattro strips that field for every
+    // third-party plugin, this one included.
+    verify(src.indexOf("Core.resolvePluginRoot(manifest, String(Qt.resolvedUrl(\".\")))") >= 0)
     // Empty helper path must wait, not finishVersionProbeFailure.
     var emptyBranch = src.indexOf("if (!helper.length)")
     verify(emptyBranch >= 0)


### PR DESCRIPTION
## Summary

- Quattro's `shell.publicPluginManifest()` deletes `manifest.__sourceDir` before injecting the manifest into any third-party plugin instance — only `manifest.__isFirstParty` plugins keep the field. `Service.qml` relied entirely on `manifest.__sourceDir` to build the bundled helper's path, so for every third-party install `pluginRoot`/`resolvedHelperPath()` were permanently empty, the version probe never ran, `beginCollection()` never fired, and every provider chip stayed on the loading placeholder (`···`) forever — regardless of provider, and it does not clear on a shell restart since it's structural, not a race.
- `pluginRoot` now falls back to the QML engine's own file resolution (`Qt.resolvedUrl(".")` on `Service.qml`, converted to a local path via a new `Core.urlToLocalPath`/`Core.resolvePluginRoot` pair in `CoreService.js`), which is available immediately and independent of what Quattro chooses to inject. `manifest.__sourceDir` still wins when present (first-party plugins), so behavior there is unchanged.
- Simplified `resolvedHelperPath()`: the old direct re-read of `manifest.__sourceDir` was working around a possible staleness in the `pluginRoot` binding at the exact moment `onManifestChanged` fires; since `pluginRoot` now binds on `manifest` directly rather than a nested field, that workaround is no longer needed.

Verified live: confirmed via a temporary diagnostic IPC method (since removed) that the running shell had `manifestPresent: true` but `pluginRoot: ""` before this fix, and `health()` returning `"ok"` with the service performing its own live poll cycle after.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo test` (full suite, 308 unit tests + integration suites)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `git diff --check`
- [x] `qmllint` — no new warnings introduced
- [x] `omarchy plugin validate .`
- [x] `qmltestrunner` — 297 passed, 0 failed, including 4 new tests for `Core.resolvePluginRoot`/`Core.urlToLocalPath` and an updated regression test for the deferred-probe contract
- [x] Deployed to a live install and confirmed the bar's version probe succeeds (`health()` → `"ok"`) and the service's own poll cycle produces live provider data, where before the fix every provider was stuck on the loading placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011qch16jYnU4rF5HtFYZ1du