### PR TITLE
fix: guard deferred rebuildFocusTargets calls

### DIFF
--- a/Popup.qml
+++ b/Popup.qml
@@ -197,7 +197,8 @@ KeyboardPanel {
       root.rebuildFocusTargets()
   })
   onAgentServiceChanged: Qt.callLater(function () {
-    root.rebuildFocusTargets()
+    if (typeof root.rebuildFocusTargets === "function")
+      root.rebuildFocusTargets()
   })
 
   PanelKeyCatcher {
@@ -333,7 +334,10 @@ KeyboardPanel {
                 if (kind === "restart_shell" && root.agentService)
                   root.agentService.restartShell()
               }
-              onVisibleChanged: Qt.callLater(root.rebuildFocusTargets)
+              onVisibleChanged: Qt.callLater(function () {
+                if (typeof root.rebuildFocusTargets === "function")
+                  root.rebuildFocusTargets()
+              })
             }
 
             Loader {


### PR DESCRIPTION
Fixes #83.

## What

Two of `Popup.qml`'s four `Qt.callLater(...rebuildFocusTargets...)` call
sites (`onAgentServiceChanged`, and the settings-row `onVisibleChanged`)
called `root.rebuildFocusTargets()` without checking it still existed —
unlike the other two (`onViewChanged`, `onSelectedIdChanged`), which already
guard with `typeof root.rebuildFocusTargets === "function"`.

Both unguarded sites fire during popup teardown, so the deferred call
frequently ran after the popup's `root` component was already destroyed,
throwing on every open/close cycle:

```
TypeError: Property 'rebuildFocusTargets' of object Popup_QMLTYPE_404(...) is not a function (exception occurred during delayed function evaluation)
```

This guards them the same way the other two already are — no behavior
change on the happy path, just a no-op instead of a throw once the object
is gone.

## Verification

Run from a clean worktree off `origin/master` (`0e1bd58`, v10.3.22):

```
$ cargo fmt --check
(clean)

$ cargo test
test result: ok. 308 passed; 0 failed ... (agent_bar lib)
... 0 failed across every other test binary (integration + doc tests)

$ cargo clippy --all-targets -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 5.62s
(clean)

$ /usr/lib/qt6/bin/qmllint -I /usr/share/omarchy/shell ./*.qml components/*.qml
1515 warnings both before and after this change (identical count via
git stash/pop) — all pre-existing qs.Ui/qs.Commons import-resolution
noise from linting outside the full shell context, none on the changed
lines.

$ omarchy plugin validate .
exit 0

$ QT_QPA_PLATFORM=offscreen QML_XHR_ALLOW_FILE_READ=1 QT_LOGGING_TO_CONSOLE=1 \
  /usr/lib/qt6/bin/qmltestrunner -input tests/qml -import /usr/share/omarchy/shell -import . -o -,txt
Totals: 293 passed, 0 failed, 0 skipped, 0 blacklisted
```

No new test added: this is a defensive guard around an object-lifetime
race (`Qt.callLater` outliving the popup's destruction) that's awkward to
provoke deterministically in the existing QML test harness, and the fix
is a direct, minimal mirror of the pattern the other two call sites
already use and are presumably already covered by.

## Deviations

None from CONTRIBUTING.md's standard verification. Developed and tested
in an isolated `git worktree` off `origin/master`, per "Safe development"
— the live desktop install was only used beforehand to observe and
diagnose the bug (`quickshell log`, `agent-bar status`/`health`/`refresh`
IPC calls), never to develop the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XAuCno1GwiTk5RmtMRrAfi
