### PR TITLE
fix: resolve plugin root from Service.qml URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,8 +57,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   plugins a public manifest copy without `__sourceDir`, which the service used
   to locate `bin/agent-bar`; the helper path came out empty, no process ever
   started, and the popup stayed on its loading skeleton with "Update check
-  failed". The service now derives the plugin root from its own file URL, so
-  status, login, and update checks work on every Omarchy version.
+  failed". The service now derives the plugin root from its own file URL and
+  reads no host-only manifest field, so status, login, and update checks start
+  again.
 - fix: Grok no longer flips to "Sign in" after hours idle. The CLI's access
   token lives six hours and nothing renews it while the CLI is idle; sending
   it expired earned a 401 that read as a real rejection and discarded the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- fix: the bar loads again on Omarchy 4.0.3. The host now hands third-party
+  plugins a public manifest copy without `__sourceDir`, which the service used
+  to locate `bin/agent-bar`; the helper path came out empty, no process ever
+  started, and the popup stayed on its loading skeleton with "Update check
+  failed". The service now derives the plugin root from its own file URL, so
+  status, login, and update checks work on every Omarchy version.
 - fix: Grok no longer flips to "Sign in" after hours idle. The CLI's access
   token lives six hours and nothing renews it while the CLI is idle; sending
   it expired earned a 401 that read as a real rejection and discarded the

--- a/CoreService.js
+++ b/CoreService.js
@@ -26,6 +26,21 @@ var PROVIDER_STATES = {
 }
 
 // ---------------------------------------------------------------------------
+// Plugin tree
+// ---------------------------------------------------------------------------
+
+// Filesystem path of a file:// directory URL (Qt.resolvedUrl(".")); "" otherwise.
+function pluginRootFromUrl(url) {
+  var text = String(url || "")
+  if (text.indexOf("file://") !== 0)
+    return ""
+  var path = decodeURIComponent(text.slice("file://".length))
+  while (path.length > 1 && path.charAt(path.length - 1) === "/")
+    path = path.slice(0, -1)
+  return path
+}
+
+// ---------------------------------------------------------------------------
 // Version / health / IPC refresh
 // ---------------------------------------------------------------------------
 

--- a/Service.qml
+++ b/Service.qml
@@ -17,9 +17,9 @@ Item {
   property var barWidgetRegistry: null
   property var pluginRegistry: null
 
-  readonly property string pluginRoot: manifest && manifest.__sourceDir
-      ? String(manifest.__sourceDir)
-      : ""
+  // The plugin tree is this file's directory. The host's manifest copy carries
+  // no source path for third-party plugins (Omarchy 4.0.3).
+  readonly property string pluginRoot: Core.pluginRootFromUrl(Qt.resolvedUrl("."))
 
   // Test harness: absolute helper path. Production uses pluginRoot/bin/agent-bar.
   property string helperPath: ""
@@ -118,16 +118,8 @@ Item {
   function resolvedHelperPath() {
     if (helperPath && helperPath.length > 0)
       return helperPath
-    // Prefer live manifest.__sourceDir over pluginRoot: Quattro sets `manifest`
-    // after createObject, and onManifestChanged can run before the pluginRoot
-    // binding re-evaluates (nested JS field access is not a QML property).
-    var root = ""
-    if (manifest && manifest.__sourceDir)
-      root = String(manifest.__sourceDir)
-    else if (pluginRoot && pluginRoot.length > 0)
-      root = pluginRoot
-    if (root && root.length > 0)
-      return root + "/bin/agent-bar"
+    if (pluginRoot.length > 0)
+      return pluginRoot + "/bin/agent-bar"
     return ""
   }
 
@@ -524,9 +516,9 @@ Item {
       finishVersionProbeFailure()
   }
 
-  // Quattro injects `manifest` (and thus pluginRoot) after createObject returns.
-  // The completed handler therefore often runs with an empty helper path; do not
-  // treat that as a permanent probe failure — retry when the path appears.
+  // pluginRoot resolves at construction; an empty helper path only means a test
+  // harness has not set helperPath yet. Do not treat that as a permanent probe
+  // failure — retry when the path appears.
   function tryStartProduction() {
     if (testMode)
       return
@@ -546,8 +538,7 @@ Item {
       return
     var helper = resolvedHelperPath()
     if (!helper.length) {
-      // Empty path is expected before Quattro property injection; wait for
-      // onManifestChanged / onHelperPathChanged rather than locking out.
+      // Wait for onManifestChanged / onHelperPathChanged rather than locking out.
       return
     }
     versionProbeRunning = true

--- a/Service.qml
+++ b/Service.qml
@@ -516,16 +516,18 @@ Item {
       finishVersionProbeFailure()
   }
 
-  // pluginRoot resolves at construction; an empty helper path only means a test
-  // harness has not set helperPath yet. Do not treat that as a permanent probe
-  // failure — retry when the path appears.
+  // pluginRoot resolves at construction. It is empty only when Service.qml was
+  // loaded from a non-file URL; say so instead of idling silently, and keep
+  // retrying if a helperPath arrives later.
   function tryStartProduction() {
     if (testMode)
       return
     if (versionReady || versionProbeRunning)
       return
-    if (!resolvedHelperPath().length)
+    if (!resolvedHelperPath().length) {
+      console.warn("Agent Bar: cannot resolve plugin root from " + Qt.resolvedUrl("."))
       return
+    }
     startVersionProbe()
   }
 
@@ -538,7 +540,7 @@ Item {
       return
     var helper = resolvedHelperPath()
     if (!helper.length) {
-      // Wait for onManifestChanged / onHelperPathChanged rather than locking out.
+      // Wait for onHelperPathChanged rather than locking out.
       return
     }
     versionProbeRunning = true

--- a/docs/dev/omarchy-shell.md
+++ b/docs/dev/omarchy-shell.md
@@ -63,7 +63,10 @@ property var barWidgetRegistry: null
 property var pluginRegistry: null
 ```
 
-The absolute discovered plugin root is `manifest.__sourceDir`.
+The absolute plugin root is the directory of `Service.qml` itself,
+`Qt.resolvedUrl(".")` converted to a path. The injected `manifest` is a public
+copy: since Omarchy 4.0.3 the host strips `__sourceDir` and other host-only
+fields from third-party manifests, so the plugin never reads them.
 
 ## Widget injection
 
@@ -132,7 +135,7 @@ it can reset placement.
 ## Interactive login
 
 QML invokes the bundled Bash launcher with an argv array. The launcher resolves
-the private helper from `manifest.__sourceDir`, delegates the configured
+the private helper from its own location in the plugin tree, delegates the configured
 terminal choice to `xdg-terminal-exec`, and runs the helper by bundle path. It
 does not assume a global executable, construct a shell string, or maintain its
 own terminal-emulator fallback list.

--- a/docs/dev/omarchy-shell.md
+++ b/docs/dev/omarchy-shell.md
@@ -135,8 +135,9 @@ it can reset placement.
 ## Interactive login
 
 QML invokes the bundled Bash launcher with an argv array. The launcher resolves
-the private helper from its own location in the plugin tree, delegates the configured
-terminal choice to `xdg-terminal-exec`, and runs the helper by bundle path. It
+the private helper from its own location in the plugin tree, delegates the
+configured terminal choice to `xdg-terminal-exec`, and runs the helper by
+bundle path. It
 does not assume a global executable, construct a shell string, or maintain its
 own terminal-emulator fallback list.
 

--- a/docs/specs/v10/02-target-architecture.md
+++ b/docs/specs/v10/02-target-architecture.md
@@ -336,8 +336,8 @@ property var manifest: null
 property var barWidgetRegistry: null
 property var pluginRegistry: null
 
-readonly property string pluginRoot:
-    manifest && manifest.__sourceDir ? String(manifest.__sourceDir) : ""
+// This file's directory; the host's public manifest carries no source path.
+readonly property string pluginRoot: Core.pluginRootFromUrl(Qt.resolvedUrl("."))
 ```
 
 `BarWidget.qml` receives `bar`, `moduleName`, and `settings`. It resolves the

--- a/docs/specs/v10/08-plugin-bundle-and-release.md
+++ b/docs/specs/v10/08-plugin-bundle-and-release.md
@@ -319,7 +319,8 @@ delegates to always fast-forwards to whatever the distribution repository's
 Omarchy contract `1` means all of these are required:
 
 - Quattro manifest service and bar-widget entry points;
-- `manifest.__sourceDir` service injection;
+- service injection of a public `manifest` copy (the plugin root comes from
+  `Service.qml`'s own URL, never from host-only manifest fields);
 - `bar.shell.serviceFor(moduleName)`;
 - `KeyboardPanel`, `PanelKeyCatcher`, and `BarWidget`;
 - `IpcHandler` reached through `omarchy-shell`;

--- a/docs/specs/v10/README.md
+++ b/docs/specs/v10/README.md
@@ -29,6 +29,11 @@ The session-window-leads design, approved 2026-09-04, amends `UX-020C` and
 `UX-020D`:
 [docs/specs/v10/amendments/2026-09-04-session-window-leads-design.md](amendments/2026-09-04-session-window-leads-design.md).
 
+The plugin-root design, approved 2026-09-10, amends the Quattro injection
+contract in `02-target-architecture.md` and Omarchy contract `1` in
+`08-plugin-bundle-and-release.md`:
+[docs/specs/v10/amendments/2026-09-10-plugin-root-from-service-url-design.md](amendments/2026-09-10-plugin-root-from-service-url-design.md).
+
 ## Product statement
 
 Agent Bar v10 is an Omarchy Quattro Quickshell plugin. Its only graphical
@@ -57,7 +62,8 @@ application, an AUR product, or a cargo-binstall product.
    [2026-08-06 remove chip tooltip](amendments/2026-08-06-remove-chip-tooltip-design.md),
    [2026-08-11 monorepo migration](amendments/2026-08-11-monorepo-migration-design.md),
    [2026-08-25 login-state visibility](amendments/2026-08-25-login-state-visibility-design.md),
-   [2026-09-04 session window leads](amendments/2026-09-04-session-window-leads-design.md).
+   [2026-09-04 session window leads](amendments/2026-09-04-session-window-leads-design.md),
+   [2026-09-10 plugin root from Service URL](amendments/2026-09-10-plugin-root-from-service-url-design.md).
 
 When two statements conflict, the earlier contract in this reading order wins
 unless a later file explicitly identifies the requirement ID it refines.

--- a/docs/specs/v10/amendments/2026-09-10-plugin-root-from-service-url-design.md
+++ b/docs/specs/v10/amendments/2026-09-10-plugin-root-from-service-url-design.md
@@ -1,0 +1,37 @@
+# Plugin root comes from Service.qml's own URL
+
+Date: 2026-09-10
+Status: approved
+
+## Context
+
+Omarchy 4.0.3 ships basecamp/omarchy#9618, merged 2026-09-07, which narrows
+what third-party plugins receive from the shell. Service instances now get
+`shell.publicPluginManifest(manifest)`, a JSON copy without the host-only
+fields `__sourceDir`, `__isFirstParty`, and `__hostCapabilities`.
+
+`Service.qml` built `pluginRoot`, and from it the helper path and the login
+launcher path, out of `manifest.__sourceDir`. On 4.0.3 that field is gone, so
+the helper path was empty, no process lane ever started, and the bar stayed on
+its loading state on every updated machine.
+
+## Decision
+
+`pluginRoot` is the directory of `Service.qml` itself:
+`Core.pluginRootFromUrl(Qt.resolvedUrl("."))`. The host loads `Service.qml`
+from `__sourceDir + "/Service.qml"`, so this value equals the old one by
+construction, and it exists at object construction instead of after manifest
+injection.
+
+The plugin reads no host-only manifest field. `manifest` stays injected and
+is used only for public fields such as `version`.
+
+## Contract changes
+
+- `02-target-architecture.md`, "Target QML boundaries": the injection snippet
+  derives `pluginRoot` from the service URL.
+- `08-plugin-bundle-and-release.md`, "Update check": Omarchy contract `1`
+  requires service injection of a public `manifest` copy instead of
+  `manifest.__sourceDir` service injection.
+- `Service.qml` must stay at the plugin root, which the manifest entry point
+  already requires.

--- a/tests/qml/tst_Service.qml
+++ b/tests/qml/tst_Service.qml
@@ -217,6 +217,14 @@ TestCase {
     verify(!("activation" in m))
   }
 
+  function test_plugin_root_from_url() {
+    compare(Core.pluginRootFromUrl("file:///home/u/.config/omarchy/plugins/othavi0.agent-bar/"),
+            "/home/u/.config/omarchy/plugins/othavi0.agent-bar")
+    compare(Core.pluginRootFromUrl("file:///home/a%20b/%C3%A7/plugin/"), "/home/a b/" + String.fromCharCode(0xE7) + "/plugin")
+    compare(Core.pluginRootFromUrl("qrc:/plugin/"), "")
+    compare(Core.pluginRootFromUrl(""), "")
+  }
+
   function test_version_and_health() {
     reset()
     h.applyVersion("10.0.0\n")
@@ -523,7 +531,8 @@ TestCase {
     verify(src.indexOf("onManifestChanged") >= 0)
     verify(src.indexOf("onHelperPathChanged") >= 0)
     verify(src.indexOf("tryStartProduction()") >= 0)
-    verify(src.indexOf("manifest.__sourceDir") >= 0)
+    // The host strips __sourceDir from third-party manifests (Omarchy 4.0.3).
+    verify(src.indexOf("__sourceDir") < 0)
     // Empty helper path must wait, not finishVersionProbeFailure.
     var emptyBranch = src.indexOf("if (!helper.length)")
     verify(emptyBranch >= 0)

--- a/tests/qml/tst_ServiceTimeouts.qml
+++ b/tests/qml/tst_ServiceTimeouts.qml
@@ -53,7 +53,7 @@ TestCase {
     verify(service !== null, component.errorString())
     service.testMode = true
     service.helperPath = "/nonexistent"
-    service.manifest = ({ version: "10.3.17", __sourceDir: "/nonexistent" })
+    service.manifest = ({ version: "10.3.17" })
     service.versionProbeTimeoutMs = 50
     service.statusTimeoutMs = 50
     service.settingsTimeoutMs = 50
@@ -337,6 +337,18 @@ TestCase {
     s.checkForUpdates()
     tryCompare(s, "runtimeHealth", "stalled", 500)
     compare(s.health("10.3.17"), "stalled")
+  }
+
+  // Omarchy 4.0.3 (basecamp/omarchy#9618) injects a public manifest copy
+  // without the host-only __sourceDir; the plugin tree must still resolve.
+  function test_helper_and_login_resolve_from_public_manifest() {
+    var s = createService()
+    s.helperPath = ""
+    s.manifest = ({ id: "othavi0.agent-bar", version: "10.3.22" })
+    compare(s.pluginRoot, repoRoot)
+    compare(s.resolvedHelperPath(), repoRoot + "/bin/agent-bar")
+    s.loginProvider("claude")
+    compare(s.lastLoginArgv[0], repoRoot + "/scripts/agent-bar-open-terminal")
   }
 
   function test_restart_shell_records_exact_argv_without_execution_in_test_mode() {

--- a/tests/qml/tst_ServiceTimeouts.qml
+++ b/tests/qml/tst_ServiceTimeouts.qml
@@ -21,7 +21,9 @@ TestCase {
   function createService() {
     var component = Qt.createComponent(serviceUrl)
     if (component.status === Component.Ready) {
-      service = component.createObject(testCase)
+      // testMode must hold before Component.onCompleted: pluginRoot resolves
+      // at construction and would otherwise start the bundled helper.
+      service = component.createObject(testCase, { testMode: true, helperPath: "/nonexistent" })
     } else {
       // Arch packages Quickshell's QML plugins into the quickshell executable,
       // so qmltestrunner cannot load Process/IpcHandler. Keep Service.qml's
@@ -48,6 +50,7 @@ TestCase {
       source = source.slice(0, processStart) + processMocks + source.slice(processEnd)
       source = source.replace(/  IpcHandler \{[\s\S]*?\n  \}\n\n  onHelperPathChanged:/,
                               "  QtObject { }\n\n  onHelperPathChanged:")
+      source = source.replace("property bool testMode: false", "property bool testMode: true")
       service = Qt.createQmlObject(source, testCase, serviceUrl)
     }
     verify(service !== null, component.errorString())


### PR DESCRIPTION
## Symptom

After updating Omarchy from 4.0.2 to 4.0.3, the Agent Bar chips show `···` and never fill in. The popup stays on its loading skeleton, and Settings shows "Update check failed". Other machines hit the same thing after the same update. The helper itself is fine. Run by hand, `bin/agent-bar` prints live Claude, Codex and Grok windows.

## Cause

Omarchy 4.0.3 ships basecamp/omarchy#9618, "Restrict third-party plugin access to authentication services", merged on 2026-09-07. The shell now injects third-party plugins with `shell.publicPluginManifest(manifest)`. That function returns a JSON copy without `__sourceDir`, `__isFirstParty` and `__hostCapabilities`. It lives at `/usr/share/omarchy/shell/shell.qml:316`, and line 930 uses it for service instances.

`Service.qml` built the helper path from `manifest.__sourceDir`. With that field gone, `resolvedHelperPath()` returned `""`. `tryStartProduction()` read the empty path as "manifest not injected yet" and returned without logging anything. So the version probe, status polling, settings bootstrap and update check never started. Login broke too, because `loginProvider()` needs `pluginRoot`. The Quickshell log from `qs log` has no Agent Bar error, which fits that silent return.

Nothing else the plugin uses went away. `bar.shell.serviceFor(moduleName)` still exists on the new `PluginShellApi` facade.

## Change

- `Service.qml` now takes `pluginRoot` from its own file URL, `Core.pluginRootFromUrl(Qt.resolvedUrl("."))`, and no code reads `__sourceDir` anymore. The value exists at construction, so the manifest-injection ordering the old comments worked around no longer matters. This also works on 4.0.2.
- `CoreService.js` gains a pure `pluginRootFromUrl(url)`. It strips `file://`, percent-decodes the path so spaces and non-ASCII characters survive, drops the trailing slash, and returns `""` for any URL that isn't `file://`.
- `tryStartProduction()` now logs `Agent Bar: cannot resolve plugin root from <url>` when the helper path comes out empty. The original bug stayed invisible because this path returned silently.
- `tst_ServiceTimeouts.qml` builds the service with `testMode: true` before `Component.onCompleted`. Now that `pluginRoot` exists at construction, a harness that can load Quickshell would otherwise start the bundled `bin/agent-bar`.
- Spec amendment `docs/specs/v10/amendments/2026-09-10-plugin-root-from-service-url-design.md`, indexed in `docs/specs/v10/README.md`.
- Docs. `docs/dev/omarchy-shell.md` now says where the plugin root comes from and that the injected manifest is a public copy. It also claimed the Bash launcher read `__sourceDir`, which was wrong before this change too, since the launcher finds the helper from its own location. I also updated the injection snippet in `docs/specs/v10/02-target-architecture.md`, the contract list in `docs/specs/v10/08-plugin-bundle-and-release.md`, and CHANGELOG under Fixed.

## Verification

```
cargo fmt --check                               ok
cargo test                                      ok, all suites incl. root_tree_validate
cargo clippy --all-targets -- -D warnings       ok
git diff --check                                ok
qmltestrunner, Qt6 offscreen                    295 passed, 0 failed
omarchy plugin validate .                       ok
qmllint Service.qml                             same 7 signal-handler-parameters warnings as master
```

I wrote the tests first, and three of them failed against `master`.

- `AgentBarServiceTimeouts::test_helper_and_login_resolve_from_public_manifest` loads the real `Service.qml` with a manifest shaped like the 4.0.3 public copy, with no `__sourceDir`. It checks `pluginRoot`, `resolvedHelperPath()` and the login argv. On `master`, `pluginRoot` came back `""`, which is the production bug.
- `AgentBarService::test_plugin_root_from_url` covers the URL conversion, including percent-encoded spaces and `ç`.
- `AgentBarService::test_service_qml_defers_probe_until_helper_path` used to require `manifest.__sourceDir` in the source. Now it requires that `__sourceDir` never appears.

With the fix, all 295 pass. The existing timeout tests stopped injecting `__sourceDir` as well.

Live smoke on Omarchy 4.0.3, run on the first commit: I copied the two changed files into the installed plugin and ran `omarchy-restart-shell`. `qs -p /usr/share/omarchy/shell ipc call othavi0.agent-bar health 10.3.22` answered `ok`, and the bar showed percentages for Claude, Codex and Antigravity plus `—` for Grok, where it had shown `···` before. Then I reverted both files with `git checkout`, so the install is back on a clean `master` for the update path.

After merge, the release still needs its update-path check through `omarchy plugin update othavi0.agent-bar`. On the old version the in-plugin "Check for updates" button goes through the same broken path, so each affected machine has to run that command once from a terminal.
