### PR TITLE
feat: automatic updates that reload the shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- feat: automatic updates. The service checks for a new release two
+  minutes after start and every six hours, and installs it while the popup
+  is closed. After a successful update the helper's update unit shows a
+  toast and restarts the shell, so the new version actually loads; before,
+  `omarchy plugin update` only rescanned plugins and the old QML kept
+  running until the next restart, whether the update came from the terminal
+  or the Settings button. A failed or rolled-back update never restarts the
+  shell. Turn it off with the new "Update automatically" toggle
+  (`updates.automatic` in `settings.json`, default on and assumed when
+  absent).
+
 - feat: Antigravity usage and quota support via
   `agy --print /usage --output-format json`, reading the `gemini-weekly` and
   `gemini-5h` buckets by id into percentage windows. Disabled by default —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - feat: automatic updates. The service checks for a new release two
   minutes after start and every six hours, and installs it while the popup
-  is closed. After a successful update the helper's update unit shows a
-  toast and restarts the shell, so the new version actually loads; before,
-  `omarchy plugin update` only rescanned plugins and the old QML kept
-  running until the next restart, whether the update came from the terminal
-  or the Settings button. A failed or rolled-back update never restarts the
-  shell. Turn it off with the new "Update automatically" toggle
-  (`updates.automatic` in `settings.json`, default on and assumed when
-  absent).
+  is closed. The update unit now runs the helper's new `update run`, which
+  restarts the shell after the fast-forward so the new version actually
+  loads; before, `omarchy plugin update` only rescanned plugins and the old
+  QML kept running until the next restart, whether the update came from the
+  terminal or the Settings button. The restart happens only when the plugin
+  commit moved, waits for a locked session to unlock, and never follows a
+  failed or rolled-back update. Turn it off with the new "Update
+  automatically" toggle (`updates.automatic` in `settings.json`, default on
+  and assumed when absent; ignored until the settings file was read).
 
 - feat: Antigravity usage and quota support via
   `agy --print /usage --output-format json`, reading the `gemini-weekly` and

--- a/CoreMaintenance.js
+++ b/CoreMaintenance.js
@@ -229,6 +229,26 @@ function maintenanceUiArmOrConfirmUninstall(ui) {
   return { ui: next, confirmed: true }
 }
 
+// Automatic update check gate: the setting is on, the helper answered, no
+// maintenance or check is in flight, and the popup is closed so the shell
+// restart that follows an update never lands under the user's pointer.
+function automaticUpdateCheckAllowed(context) {
+  if (!context)
+    return false
+  return context.automatic === true
+      && context.versionReady === true
+      && context.blocked !== true
+      && context.checkBusy !== true
+      && context.popupOpen !== true
+}
+
+// Only a plain available update is applied without a click; reinstall and
+// failures stay for the user to see in Settings.
+function shouldAutoApplyUpdate(ui) {
+  return !!ui && ui.phase === "update_available"
+      && !!ui.targetVersion && String(ui.targetVersion).length > 0
+}
+
 function maintenanceUiApplying(ui) {
   var next = cloneMaintenanceUi(ui)
   next.phase = "applying"

--- a/CoreMaintenance.js
+++ b/CoreMaintenance.js
@@ -229,13 +229,15 @@ function maintenanceUiArmOrConfirmUninstall(ui) {
   return { ui: next, confirmed: true }
 }
 
-// Automatic update check gate: the setting is on, the helper answered, no
-// maintenance or check is in flight, and the popup is closed so the shell
-// restart that follows an update never lands under the user's pointer.
+// Automatic update check gate: settings loaded and the setting is on (the
+// default is on, so an unread settings file must not count as consent), the
+// helper answered, no maintenance or check is in flight, and the popup is
+// closed when the update starts.
 function automaticUpdateCheckAllowed(context) {
   if (!context)
     return false
   return context.automatic === true
+      && context.settingsLoaded === true
       && context.versionReady === true
       && context.blocked !== true
       && context.checkBusy !== true

--- a/CoreService.js
+++ b/CoreService.js
@@ -383,6 +383,16 @@ function defaultSettings() {
     ],
     display: { metric: "remaining" },
     refreshIntervalSeconds: 60,
-    notifications: { enabled: true, reminderMinutes: 120 }
+    notifications: { enabled: true, reminderMinutes: 120 },
+    updates: { automatic: true }
   }
+}
+
+// Automatic updates are on unless the applied settings say otherwise. No
+// settings yet, or a document from a helper that predates the block, means
+// the product default.
+function automaticUpdatesEnabled(settings) {
+  if (!settings || !settings.updates || typeof settings.updates.automatic !== "boolean")
+    return true
+  return settings.updates.automatic
 }

--- a/CoreSettings.js
+++ b/CoreSettings.js
@@ -252,6 +252,12 @@ function setReminderMinutes(draft, minutes) {
   return next
 }
 
+function setAutomaticUpdates(draft, enabled) {
+  var next = cloneDraft(draft)
+  next.updates = { automatic: !!enabled }
+  return next
+}
+
 function validateSettingsDraft(draft) {
   if (!draft || typeof draft !== "object")
     return { ok: false, reason: "not an object" }
@@ -268,6 +274,10 @@ function validateSettingsDraft(draft) {
   if (!isFinite(reminder) || reminder !== Math.floor(reminder)
       || reminder < 15 || reminder > 1440)
     return { ok: false, reason: "notifications.reminderMinutes" }
+  // Optional: a helper older than the block omits it (SET-025 skew).
+  if (draft.updates !== undefined
+      && (!draft.updates || typeof draft.updates.automatic !== "boolean"))
+    return { ok: false, reason: "updates.automatic" }
   if (!Array.isArray(draft.providers))
     return { ok: false, reason: "providers length" }
   // SET-025: every provider this QML knows must be present exactly once. A

--- a/Service.qml
+++ b/Service.qml
@@ -32,6 +32,14 @@ Item {
   property int maintenanceHandoffTimeoutMs: 120000
   property int pollIntervalMs: Core.pollIntervalMs(appliedSettings)
   property int collectionDelayMs: 0
+  // Automatic updates: first check shortly after the helper answers, then
+  // every six hours while the shell runs.
+  property int autoUpdateFirstDelayMs: 120000
+  property int autoUpdateIntervalMs: 21600000
+  readonly property bool autoUpdateScheduled: autoUpdateTimer.running
+  readonly property int autoUpdateDelayMs: autoUpdateTimer.interval
+  // True while the in-flight update check was started by the timer.
+  property bool automaticCheck: false
 
   // --- Public service surface (Task 9 / Task 10) ---
   property var snapshot: null
@@ -285,6 +293,12 @@ Item {
     })
   }
 
+  function setAutomaticUpdates(enabled) {
+    mutateSettingsDraft(function (d) {
+      return Settings.setAutomaticUpdates(d, enabled)
+    })
+  }
+
   function restoreSettingsDefaults() {
     if (settingsLocked())
       return
@@ -378,28 +392,55 @@ Item {
   }
 
   function checkForUpdates() {
+    startUpdateCheck(false)
+  }
+
+  // Timer entry point. Reschedules itself, then checks when the gate allows;
+  // returns whether a check started.
+  function automaticUpdateTick() {
+    autoUpdateTimer.interval = autoUpdateIntervalMs
+    autoUpdateTimer.restart()
+    if (!Maintenance.automaticUpdateCheckAllowed({
+          automatic: Core.automaticUpdatesEnabled(appliedSettings),
+          versionReady: versionReady,
+          blocked: maintenanceState.blocked,
+          checkBusy: maintenanceCheckBusy,
+          popupOpen: popupOwner !== null
+        }))
+      return false
+    return startUpdateCheck(true)
+  }
+
+  function startUpdateCheck(automatic) {
     if (maintenanceState.blocked)
-      return
+      return false
     if (!Core.canStartLane(maintenanceCheckBusy))
-      return
+      return false
     syncMaintenanceVersion()
     maintenanceCheckGeneration++
     activeMaintenanceCheckGeneration = maintenanceCheckGeneration
-    maintenanceUi = Maintenance.maintenanceUiChecking(maintenanceUi)
+    automaticCheck = !!automatic
+    // An automatic check stays invisible until it has something to show.
+    if (!automaticCheck)
+      maintenanceUi = Maintenance.maintenanceUiChecking(maintenanceUi)
     maintenanceCheckBusy = true
     maintenanceCheckTimeout.restart()
     var helper = resolvedHelperPath()
     if (!helper.length) {
+      maintenanceCheckTimeout.stop()
       maintenanceCheckBusy = false
-      maintenanceUi = Maintenance.maintenanceUiFromCheck(maintenanceUi, "", 1, helperVersion)
-      return
+      if (!automaticCheck)
+        maintenanceUi = Maintenance.maintenanceUiFromCheck(maintenanceUi, "", 1, helperVersion)
+      automaticCheck = false
+      return false
     }
     maintenanceCheckProcess.command = Maintenance.updateCheckArgv(helper)
     maintenanceCheckStartedGeneration = activeMaintenanceCheckGeneration
     if (testMode) {
-      return
+      return true
     }
     maintenanceCheckProcess.running = true
+    return true
   }
 
   function applyUpdateCheckResult(generation, stdout, exitCode, fromTimeout) {
@@ -408,12 +449,29 @@ Item {
     maintenanceCheckTimeout.stop()
     maintenanceCheckBusy = false
     recordCompletedCallback(!!fromTimeout, "maintenanceCheck")
-    maintenanceUi = Maintenance.maintenanceUiFromCheck(
+    var automatic = automaticCheck
+    automaticCheck = false
+    var next = Maintenance.maintenanceUiFromCheck(
       maintenanceUi,
       stdout,
       exitCode,
       helperVersion || manifestVersion
     )
+    if (!automatic) {
+      maintenanceUi = next
+      return
+    }
+    // A failed automatic check retries on the next tick without painting an
+    // error nobody asked for.
+    if (next.phase === "error")
+      return
+    maintenanceUi = next
+    // Re-check the gate: the popup may have opened while the check ran.
+    if (Maintenance.shouldAutoApplyUpdate(next)
+        && Core.automaticUpdatesEnabled(appliedSettings)
+        && popupOwner === null
+        && !maintenanceState.blocked)
+      confirmUpdateApply()
   }
 
   function openUpdateConfirm() {
@@ -562,6 +620,10 @@ Item {
     versionFailed = false
     syncMaintenanceVersion()
     kickSettingsBootstrap()
+    if (!autoUpdateTimer.running) {
+      autoUpdateTimer.interval = autoUpdateFirstDelayMs
+      autoUpdateTimer.start()
+    }
     if (collectionDelayMs > 0) {
       collectionDelay.interval = collectionDelayMs
       collectionDelay.start()
@@ -1130,6 +1192,14 @@ Item {
     }
   }
 
+  Timer {
+    id: autoUpdateTimer
+    interval: root.autoUpdateFirstDelayMs
+    repeat: false
+    running: false
+    onTriggered: root.automaticUpdateTick()
+  }
+
   IpcHandler {
     target: "othavi0.agent-bar"
     function health(expectedVersion: string): string { return root.health(expectedVersion) }
@@ -1158,6 +1228,7 @@ Item {
     maintenanceHandoffTimeout.stop()
     collectionDelay.stop()
     pollTimer.stop()
+    autoUpdateTimer.stop()
     if (versionProbe.running)
       versionProbe.running = false
     if (statusProcess.running)

--- a/Service.qml
+++ b/Service.qml
@@ -402,6 +402,7 @@ Item {
     autoUpdateTimer.restart()
     if (!Maintenance.automaticUpdateCheckAllowed({
           automatic: Core.automaticUpdatesEnabled(appliedSettings),
+          settingsLoaded: appliedSettings !== null,
           versionReady: versionReady,
           blocked: maintenanceState.blocked,
           checkBusy: maintenanceCheckBusy,
@@ -414,6 +415,13 @@ Item {
   function startUpdateCheck(automatic) {
     if (maintenanceState.blocked)
       return false
+    // A click during a silent automatic check adopts it: the result will be
+    // painted like any manual check, and never applied without a click.
+    if (!automatic && maintenanceCheckBusy && automaticCheck) {
+      automaticCheck = false
+      maintenanceUi = Maintenance.maintenanceUiChecking(maintenanceUi)
+      return true
+    }
     if (!Core.canStartLane(maintenanceCheckBusy))
       return false
     syncMaintenanceVersion()
@@ -462,8 +470,8 @@ Item {
       return
     }
     // A failed automatic check retries on the next tick without painting an
-    // error nobody asked for.
-    if (next.phase === "error")
+    // error nobody asked for, and never repaints an update already handed off.
+    if (next.phase === "error" || maintenanceState.blocked)
       return
     maintenanceUi = next
     // Re-check the gate: the popup may have opened while the check ran.
@@ -903,7 +911,9 @@ Item {
     if (intention && intention.kind === "update_apply") {
       if (exitCode === 0) {
         maintenanceUi = Maintenance.maintenanceUiIdle(helperVersion || intention.version)
-        maintenanceUi.message = "Update applied."
+        // `update apply` returns once the unit is queued; the unit restarts
+        // the shell when the new tree is in place.
+        maintenanceUi.message = "Update started. The shell reloads when it finishes."
       } else {
         maintenanceUi = Maintenance.cloneMaintenanceUi(maintenanceUi)
         maintenanceUi.phase = "error"

--- a/SettingsView.qml
+++ b/SettingsView.qml
@@ -55,6 +55,12 @@ Item {
     return true
   }
 
+  readonly property bool automaticUpdatesOn: {
+    if (draft && draft.updates && typeof draft.updates.automatic === "boolean")
+      return draft.updates.automatic
+    return true
+  }
+
   readonly property int reminderMinutes: {
     if (draft && draft.notifications
         && isFinite(Number(draft.notifications.reminderMinutes)))
@@ -340,6 +346,21 @@ Item {
           textFormat: Text.PlainText
           Accessible.ignored: true
         }
+      }
+    }
+
+    // Updates
+    Toggle {
+      opacity: root.locked ? 0.55 : 1.0
+      enabled: !root.locked
+      label: "Update automatically"
+      description: "Install new versions and reload the shell."
+      checked: root.automaticUpdatesOn
+      foreground: root.foreground
+      fontFamily: root.fontFamily
+      onClicked: {
+        if (root.agentService)
+          root.agentService.setAutomaticUpdates(!root.automaticUpdatesOn)
       }
     }
 

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -133,24 +133,27 @@ payload. Generation IDs prevent stale callbacks.
 CLI rather than staging, exchanging, or rolling back the plugin directory
 themselves:
 
-1. resolve `omarchy` and `systemd-run` to absolute executable paths
-   (fails closed before anything destructive if either is missing);
+1. resolve `omarchy` and `systemd-run` (and, for update,
+   `omarchy-restart-shell`) to absolute executable paths, failing closed
+   before anything destructive if one is missing;
 2. `uninstall purge` removes Agent Bar's own XDG state here, before the
    handoff;
-3. run `omarchy plugin update othavi0.agent-bar --yes` or
-   `omarchy plugin remove othavi0.agent-bar --yes` as a detached transient
-   `systemd-run --user` unit; the update unit is `oneshot` and restarts the
-   shell (after an optional `notify-send` toast) in `ExecStartPost=`, which
-   runs only when the update succeeded;
-4. return once systemd has accepted and started the unit.
+3. start a detached transient `systemd-run --user` unit: `omarchy plugin
+   remove othavi0.agent-bar --yes` for uninstall, or `--no-block` with the
+   helper's own `update run` for update;
+4. return once systemd has accepted the unit.
 
-`omarchy plugin update` owns the git fetch, fast-forward, re-validation, and
-`git reset --hard ORIG_HEAD` rollback on a failed validation. `omarchy
-plugin remove` owns disabling the bar entry, deleting (or, for a non-git
-directory, backing up) the plugin directory, and rescanning. Detaching the
-unit lets the operation survive destruction of the initiating QML service
-during rescan; there is no permanent daemon and no verified worker copy of
-the helper.
+`update run` wraps `omarchy plugin update othavi0.agent-bar --yes`, which
+owns the git fetch, fast-forward, re-validation, and `git reset --hard
+ORIG_HEAD` rollback on a failed validation. The rescan it triggers does not
+reload a running `Service.qml`, so `update run` compares the plugin `HEAD`
+before and after and, only when it moved, shows a toast and runs
+`omarchy-restart-shell`, retrying while a locked session refuses it.
+`omarchy plugin remove` owns disabling the bar entry, deleting (or, for a
+non-git directory, backing up) the plugin directory, and rescanning.
+Detaching the unit lets the operation outlive the shell process that
+started it; there is no permanent daemon and no verified worker copy of the
+helper.
 
 `update check` fetches this repository's `bundle.json` receipt directly
 from `master` over HTTPS (the repository root is the plugin tree; see

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -139,7 +139,9 @@ themselves:
    handoff;
 3. run `omarchy plugin update othavi0.agent-bar --yes` or
    `omarchy plugin remove othavi0.agent-bar --yes` as a detached transient
-   `systemd-run --user` unit;
+   `systemd-run --user` unit; the update unit is `oneshot` and restarts the
+   shell (after an optional `notify-send` toast) in `ExecStartPost=`, which
+   runs only when the update succeeded;
 4. return once systemd has accepted and started the unit.
 
 `omarchy plugin update` owns the git fetch, fast-forward, re-validation, and

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -134,8 +134,8 @@ CLI rather than staging, exchanging, or rolling back the plugin directory
 themselves:
 
 1. resolve `omarchy` and `systemd-run` (and, for update,
-   `omarchy-restart-shell`) to absolute executable paths, failing closed
-   before anything destructive if one is missing;
+   `omarchy-restart-shell`, `git`, and `timeout`) to absolute executable
+   paths, failing closed before anything destructive if one is missing;
 2. `uninstall purge` removes Agent Bar's own XDG state here, before the
    handoff;
 3. start a detached transient `systemd-run --user` unit: `omarchy plugin

--- a/docs/dev/releasing.md
+++ b/docs/dev/releasing.md
@@ -169,9 +169,10 @@ After merging:
    `omarchy plugin update` triggers does not reload a running
    `Service.qml`, so after this manual command run `omarchy-restart-shell`
    before judging the release. The Settings button and the automatic update
-   run `update apply`, whose unit restarts the shell by itself; to prove that
-   path, click `Update to <version>` on an install one release behind and
-   confirm the shell reloads on its own.
+   run `update apply`, whose `update run` unit restarts the shell by itself;
+   to prove that path, click `Update to <version>` on an install one release
+   behind and confirm the shell reloads on its own
+   (`journalctl --user -u 'agent-bar-update-*'` shows `"outcome":"updated"`).
 
 `omarchy update` (the system-wide update) does not update plugins by
 design; installs that want it hook `omarchy-plugin-update --yes` into

--- a/docs/dev/releasing.md
+++ b/docs/dev/releasing.md
@@ -165,10 +165,13 @@ After merging:
    ~/.config/omarchy/plugins/othavi0.agent-bar/bin/agent-bar update check
    ```
 
-   Then glance at the bar: chips must render with live data after the
-   automatic shell rescan. Open Settings too: if it stays on "Loading" or
-   reports "could not be loaded", the rescan did not replace the running
-   QML — run `omarchy-restart-shell` and reopen before judging the release.
+   Then glance at the bar: chips must render with live data. The rescan
+   `omarchy plugin update` triggers does not reload a running
+   `Service.qml`, so after this manual command run `omarchy-restart-shell`
+   before judging the release. The Settings button and the automatic update
+   run `update apply`, whose unit restarts the shell by itself; to prove that
+   path, click `Update to <version>` on an install one release behind and
+   confirm the shell reloads on its own.
 
 `omarchy update` (the system-wide update) does not update plugins by
 design; installs that want it hook `omarchy-plugin-update --yes` into

--- a/docs/guide/commands.md
+++ b/docs/guide/commands.md
@@ -94,13 +94,15 @@ confirmed owned legacy artifacts.
 - `update check` returns machine-readable compatibility metadata read from
   this repository's own `bundle.json` git receipt (the repository root is
   the plugin tree; see [ADR 0006](../adr/0006-single-repository-distribution.md)).
-- `update apply` takes no argument. It delegates unconditionally to
-  `omarchy plugin update othavi0.agent-bar --yes` as a detached transient unit
-  and returns as soon as the handoff is accepted; that command owns the
+- `update apply` takes no argument. It queues `update run` as a detached
+  transient unit and returns as soon as systemd accepts it.
+- `update run` is that unit's body; QML never calls it. It runs
+  `omarchy plugin update othavi0.agent-bar --yes`, which owns the
   fast-forward, re-validation, and automatic rollback on a failed
-  validation. After a successful update the unit shows a `notify-send`
-  toast, when available, and runs `omarchy-restart-shell` so the new QML
-  loads.
+  validation. When the plugin `HEAD` moved, it shows a `notify-send` toast
+  (when available) and runs `omarchy-restart-shell` so the new QML loads,
+  retrying every minute while the session is locked. It prints
+  `{"schemaVersion":1,"operation":"updateRun","outcome":"..."}`.
 
 Normal users use the Maintenance UI.
 

--- a/docs/guide/commands.md
+++ b/docs/guide/commands.md
@@ -62,7 +62,7 @@ argv, so `"$PLUGIN" login antigravity` never launches a CLI and fails with
 "$PLUGIN" config show
 "$PLUGIN" config apply stdin
 "$PLUGIN" config apply file /path/to/settings.json
-"$PLUGIN" config apply json '{"schemaVersion":1,"providers":[{"id":"claude","enabled":true},{"id":"codex","enabled":true},{"id":"amp","enabled":false},{"id":"grok","enabled":false},{"id":"antigravity","enabled":false}],"display":{"metric":"remaining"},"refreshIntervalSeconds":60,"notifications":{"enabled":true,"reminderMinutes":120}}'
+"$PLUGIN" config apply json '{"schemaVersion":1,"providers":[{"id":"claude","enabled":true},{"id":"codex","enabled":true},{"id":"amp","enabled":false},{"id":"grok","enabled":false},{"id":"antigravity","enabled":false}],"display":{"metric":"remaining"},"refreshIntervalSeconds":60,"notifications":{"enabled":true,"reminderMinutes":120},"updates":{"automatic":true}}'
 ```
 
 `show` is read-only. `apply` requires one complete valid settings document and
@@ -98,7 +98,9 @@ confirmed owned legacy artifacts.
   `omarchy plugin update othavi0.agent-bar --yes` as a detached transient unit
   and returns as soon as the handoff is accepted; that command owns the
   fast-forward, re-validation, and automatic rollback on a failed
-  validation.
+  validation. After a successful update the unit shows a `notify-send`
+  toast, when available, and runs `omarchy-restart-shell` so the new QML
+  loads.
 
 Normal users use the Maintenance UI.
 

--- a/docs/guide/integration.md
+++ b/docs/guide/integration.md
@@ -84,6 +84,9 @@ as a detached transient unit:
 
 ```text
 systemd-run --user --collect --unit=agent-bar-update-<txid>.service \
+  --service-type=oneshot \
+  '--property=ExecStartPost=<notify-send> --app-name="Agent Bar" "Agent Bar updated" "..."' \
+  --property=ExecStartPost=<omarchy-restart-shell> \
   -- <omarchy> plugin update othavi0.agent-bar --yes
 
 systemd-run --user --collect --unit=agent-bar-remove-<txid>.service \
@@ -98,6 +101,13 @@ disabling the bar entry, deleting (or backing up) the plugin directory, and
 rescanning. Both commands hold the shared exclusive maintenance lock only
 for the purge/preflight/handoff step, not for the delegated mutation
 itself.
+
+A rescan does not reload a running `Service.qml`, so the update unit is
+`oneshot` and restarts the shell in `ExecStartPost=` once
+`omarchy plugin update` exits 0. A failed or rolled-back update leaves the
+shell alone. With `updates.automatic` on, the service runs this same path by
+itself: a check two minutes after start and every six hours, applied only
+while the popup is closed.
 
 ## Ownership
 

--- a/docs/guide/integration.md
+++ b/docs/guide/integration.md
@@ -83,31 +83,30 @@ absolute executable paths, then hands its live mutation to the Omarchy CLI
 as a detached transient unit:
 
 ```text
-systemd-run --user --collect --unit=agent-bar-update-<txid>.service \
-  --service-type=oneshot \
-  '--property=ExecStartPost=<notify-send> --app-name="Agent Bar" "Agent Bar updated" "..."' \
-  --property=ExecStartPost=<omarchy-restart-shell> \
-  -- <omarchy> plugin update othavi0.agent-bar --yes
+systemd-run --user --collect --no-block --unit=agent-bar-update-<txid>.service \
+  --property=RuntimeMaxSec=25h -- <plugin>/bin/agent-bar update run
 
 systemd-run --user --collect --unit=agent-bar-remove-<txid>.service \
   -- <omarchy> plugin remove othavi0.agent-bar --yes
 ```
 
 Detachment lets the helper return as soon as systemd accepts the unit,
-without depending on the QML service that may be torn down by the rescan
-the update or removal triggers. `omarchy plugin update` owns the git
-fast-forward and its own validation rollback; `omarchy plugin remove` owns
-disabling the bar entry, deleting (or backing up) the plugin directory, and
-rescanning. Both commands hold the shared exclusive maintenance lock only
-for the purge/preflight/handoff step, not for the delegated mutation
-itself.
+without depending on the shell process that started it. `update run` wraps
+`omarchy plugin update othavi0.agent-bar --yes` (ten-minute timeout), which
+owns the git fast-forward and its own validation rollback; `omarchy plugin
+remove` owns disabling the bar entry, deleting (or backing up) the plugin
+directory, and rescanning. Both commands hold the shared exclusive
+maintenance lock only for the purge/preflight/handoff step, not for the
+delegated mutation itself; `update run` uses its own lock so two runs never
+overlap.
 
-A rescan does not reload a running `Service.qml`, so the update unit is
-`oneshot` and restarts the shell in `ExecStartPost=` once
-`omarchy plugin update` exits 0. A failed or rolled-back update leaves the
-shell alone. With `updates.automatic` on, the service runs this same path by
-itself: a check two minutes after start and every six hours, applied only
-while the popup is closed.
+The rescan `omarchy plugin update` triggers does not reload a running
+`Service.qml`. `update run` therefore compares the plugin `HEAD` before and
+after: when it moved, it shows a toast and runs `omarchy-restart-shell`,
+retrying every minute while a locked session refuses it; when it did not,
+or the update failed, the shell is left alone. With `updates.automatic` on,
+the service starts this same path by itself: a check two minutes after start
+and every six hours, applied only while the popup is closed.
 
 ## Ownership
 

--- a/docs/guide/runtime.md
+++ b/docs/guide/runtime.md
@@ -57,9 +57,17 @@ exists.
   "refreshIntervalSeconds": 60,
   "notifications": {
     "enabled": true
+  },
+  "updates": {
+    "automatic": true
   }
 }
 ```
+
+`updates.automatic` (default `true`, and assumed when the block is absent)
+lets the service check for a new release two minutes after start and every
+six hours, then install it and reload the shell while the popup is closed.
+Turn it off with the "Update automatically" toggle in Settings.
 
 Unknown keys and invalid/duplicate/missing providers are rejected. Reads never
 rewrite. Applies validate before lock and atomic replacement. File mode is

--- a/docs/specs/v10/03-cli-and-json-contract.md
+++ b/docs/specs/v10/03-cli-and-json-contract.md
@@ -308,7 +308,9 @@ Amended by git-plugin-distribution (2026-08-05):
 plugin directory in-process; each resolves `omarchy` and `systemd-run` to
 absolute paths, then detaches unconditionally to the Omarchy CLI as a
 transient `systemd-run --user` unit and returns once the handoff is
-accepted.
+accepted. The update unit is `oneshot` and also resolves
+`omarchy-restart-shell` (required) and `notify-send` (optional), which run
+as `ExecStartPost=` steps after a successful update (`MIG-020`).
 
 - `CLI-024`: `doctor scan` is read-only.
 - `CLI-025`: `doctor clean` removes only confirmed owned legacy artifacts after

--- a/docs/specs/v10/03-cli-and-json-contract.md
+++ b/docs/specs/v10/03-cli-and-json-contract.md
@@ -30,6 +30,7 @@ agent-bar setup
 agent-bar update
 agent-bar update check
 agent-bar update apply
+agent-bar update run
 agent-bar uninstall
 agent-bar uninstall purge
 
@@ -308,9 +309,11 @@ Amended by git-plugin-distribution (2026-08-05):
 plugin directory in-process; each resolves `omarchy` and `systemd-run` to
 absolute paths, then detaches unconditionally to the Omarchy CLI as a
 transient `systemd-run --user` unit and returns once the handoff is
-accepted. The update unit is `oneshot` and also resolves
-`omarchy-restart-shell` (required) and `notify-send` (optional), which run
-as `ExecStartPost=` steps after a successful update (`MIG-020`).
+accepted. `update apply` also requires `omarchy-restart-shell`, and its
+unit runs `update run`: the fast-forward, then a toast and a shell restart
+only when the plugin `HEAD` moved (`MIG-020`). `update run` prints one line,
+`{"schemaVersion":1,"operation":"updateRun","outcome":"<upToDate|updated|updateFailed|restartGaveUp>"}`,
+and exits non-zero for the last two.
 
 - `CLI-024`: `doctor scan` is read-only.
 - `CLI-025`: `doctor clean` removes only confirmed owned legacy artifacts after
@@ -321,10 +324,16 @@ as `ExecStartPost=` steps after a successful update (`MIG-020`).
   detached `omarchy plugin remove` handoff.
 - `CLI-028`: QML passes structured intentions; it never concatenates command
   strings.
-- `CLI-029`: `update apply` takes no version argument. It delegates
-  unconditionally to `omarchy plugin update othavi0.agent-bar --yes`, which
-  owns the git fetch, fast-forward, re-validation, and automatic
+- `CLI-029`: `update apply` takes no version argument. It queues `update run`,
+  which delegates unconditionally to
+  `omarchy plugin update othavi0.agent-bar --yes`; that command owns the git
+  fetch, fast-forward, re-validation, and automatic
   `git reset --hard ORIG_HEAD` rollback on a failed validation.
+- `CLI-029A`: `update run` takes no argument and is only the update unit's
+  body. It restarts the shell only when the plugin `HEAD` moved, retries a
+  refused restart every minute for up to a day, and exits at once when
+  another run holds its lock
+  (`docs/specs/v10/amendments/2026-09-10-automatic-updates-design.md`).
 - `CLI-030`: Setup, update, doctor, and uninstall never touch unrelated Omarchy
   plugins or layout entries.
 - `CLI-031`: Notification dispatch failure is reported on stderr, does not

--- a/docs/specs/v10/03-cli-and-json-contract.md
+++ b/docs/specs/v10/03-cli-and-json-contract.md
@@ -309,11 +309,12 @@ Amended by git-plugin-distribution (2026-08-05):
 plugin directory in-process; each resolves `omarchy` and `systemd-run` to
 absolute paths, then detaches unconditionally to the Omarchy CLI as a
 transient `systemd-run --user` unit and returns once the handoff is
-accepted. `update apply` also requires `omarchy-restart-shell`, and its
-unit runs `update run`: the fast-forward, then a toast and a shell restart
-only when the plugin `HEAD` moved (`MIG-020`). `update run` prints one line,
-`{"schemaVersion":1,"operation":"updateRun","outcome":"<upToDate|updated|updateFailed|restartGaveUp>"}`,
-and exits non-zero for the last two.
+accepted. `update apply` also requires `omarchy-restart-shell`, `git`, and
+`timeout`, and its unit runs `update run`: the fast-forward, then a toast
+and a shell restart only when the plugin `HEAD` moved (`MIG-020`).
+`update run` prints one line,
+`{"schemaVersion":1,"operation":"updateRun","outcome":"<upToDate|updated|updateFailed|restartGaveUp|alreadyRunning>"}`,
+and exits non-zero for `updateFailed` and `restartGaveUp`.
 
 - `CLI-024`: `doctor scan` is read-only.
 - `CLI-025`: `doctor clean` removes only confirmed owned legacy artifacts after

--- a/docs/specs/v10/04-quickshell-ux-and-accessibility.md
+++ b/docs/specs/v10/04-quickshell-ux-and-accessibility.md
@@ -168,9 +168,10 @@ Requirements:
 - `UX-041A`: With `updates.automatic` on (`SET-028`), the service also
   checks two minutes after the helper answers and every six hours after
   that, and applies a plain available update through the same handoff as
-  the button. It skips a tick while the popup is open or maintenance is in
-  flight, never applies `reinstall_required`, and a failed automatic check
-  paints nothing. Amended by
+  the button. It skips a tick until the boot settings read succeeded, while
+  the popup is open, or while maintenance is in flight, never applies
+  `reinstall_required`, and a failed automatic check paints nothing. A click
+  on `Check for updates` during a silent check adopts it. Amended by
   `docs/specs/v10/amendments/2026-09-10-automatic-updates-design.md`.
 - `UX-042`: When available, show `Update to <version>` and a release-notes
   link.

--- a/docs/specs/v10/04-quickshell-ux-and-accessibility.md
+++ b/docs/specs/v10/04-quickshell-ux-and-accessibility.md
@@ -165,6 +165,13 @@ Requirements:
 
 - `UX-040`: Show the installed version.
 - `UX-041`: `Check for updates` performs an explicit network request.
+- `UX-041A`: With `updates.automatic` on (`SET-028`), the service also
+  checks two minutes after the helper answers and every six hours after
+  that, and applies a plain available update through the same handoff as
+  the button. It skips a tick while the popup is open or maintenance is in
+  flight, never applies `reinstall_required`, and a failed automatic check
+  paints nothing. Amended by
+  `docs/specs/v10/amendments/2026-09-10-automatic-updates-design.md`.
 - `UX-042`: When available, show `Update to <version>` and a release-notes
   link.
 - `UX-043`: Update confirmation names current version, target version,

--- a/docs/specs/v10/05-settings-cache-and-notifications.md
+++ b/docs/specs/v10/05-settings-cache-and-notifications.md
@@ -19,6 +19,9 @@
   "notifications": {
     "enabled": true,
     "reminderMinutes": 120
+  },
+  "updates": {
+    "automatic": true
   }
 }
 ```
@@ -102,6 +105,11 @@ closed
   until its default is chosen. Existing documents are untouched, because a
   read never rewrites a row it already has (`SET-007`), and a migrated v9
   choice outranks this default (`MIG-009`, `PROD-024`).
+- `SET-028`: `updates.automatic` is a boolean. The `updates` block is
+  optional on read and defaults to `{ "automatic": true }`, so a document
+  written before it keeps parsing without a rewrite (`SET-007`); any other
+  key inside it is rejected under `SET-006`. It gates `UX-041A` only: the
+  explicit `Check for updates` button works either way.
 
 ## Cache files
 

--- a/docs/specs/v10/06-migration-and-legacy-removal.md
+++ b/docs/specs/v10/06-migration-and-legacy-removal.md
@@ -226,7 +226,11 @@ service it may be running under.
 - `MIG-020`: `update apply` takes no version argument and detaches
   unconditionally to `omarchy plugin update othavi0.agent-bar --yes`, which
   owns the git fetch, fast-forward, re-validation, and
-  `git reset --hard ORIG_HEAD` rollback on a failed validation.
+  `git reset --hard ORIG_HEAD` rollback on a failed validation. The unit is
+  `oneshot` with `ExecStartPost=` steps that toast through `notify-send`
+  (when present) and run `omarchy-restart-shell`, so a successful update
+  also reloads the running QML and a failed one leaves the shell alone
+  (`docs/specs/v10/amendments/2026-09-10-automatic-updates-design.md`).
 - `MIG-021`: `update check` reads the distribution repository's
   `bundle.json` receipt over HTTPS and reports `reinstallRequired: true`,
   forcing `available`/`latestCompatible` null, whenever the live plugin root

--- a/docs/specs/v10/06-migration-and-legacy-removal.md
+++ b/docs/specs/v10/06-migration-and-legacy-removal.md
@@ -226,10 +226,11 @@ service it may be running under.
 - `MIG-020`: `update apply` takes no version argument and detaches
   unconditionally to `omarchy plugin update othavi0.agent-bar --yes`, which
   owns the git fetch, fast-forward, re-validation, and
-  `git reset --hard ORIG_HEAD` rollback on a failed validation. The unit is
-  `oneshot` with `ExecStartPost=` steps that toast through `notify-send`
-  (when present) and run `omarchy-restart-shell`, so a successful update
-  also reloads the running QML and a failed one leaves the shell alone
+  `git reset --hard ORIG_HEAD` rollback on a failed validation. The queued
+  unit runs the helper's `update run`, which wraps that command, and when it
+  moved the plugin `HEAD` toasts through `notify-send` (when present) and
+  runs `omarchy-restart-shell`, retrying while the session is locked. A
+  failed or no-op update leaves the shell alone
   (`docs/specs/v10/amendments/2026-09-10-automatic-updates-design.md`).
 - `MIG-021`: `update check` reads the distribution repository's
   `bundle.json` receipt over HTTPS and reports `reinstallRequired: true`,

--- a/docs/specs/v10/08-plugin-bundle-and-release.md
+++ b/docs/specs/v10/08-plugin-bundle-and-release.md
@@ -373,8 +373,9 @@ What replaces it:
   --unit=agent-bar-<update|remove>-<32-lowercase-hex-txid>.service -- <omarchy>
   plugin <update|remove> othavi0.agent-bar --yes` and return once systemd has
   accepted it, so the operation survives the initiating QML service being
-  torn down by the rescan it triggers. `MIG-020`–`MIG-026` are the current
-  contract.
+  torn down by the rescan it triggers. The update unit adds
+  `--service-type=oneshot` and `ExecStartPost=` steps for a toast and
+  `omarchy-restart-shell`. `MIG-020`–`MIG-026` are the current contract.
 
 ## UI uninstall
 

--- a/docs/specs/v10/08-plugin-bundle-and-release.md
+++ b/docs/specs/v10/08-plugin-bundle-and-release.md
@@ -372,10 +372,11 @@ What replaces it:
   each start one `systemd-run --user --collect
   --unit=agent-bar-<update|remove>-<32-lowercase-hex-txid>.service -- <omarchy>
   plugin <update|remove> othavi0.agent-bar --yes` and return once systemd has
-  accepted it, so the operation survives the initiating QML service being
-  torn down by the rescan it triggers. The update unit adds
-  `--service-type=oneshot` and `ExecStartPost=` steps for a toast and
-  `omarchy-restart-shell`. `MIG-020`–`MIG-026` are the current contract.
+  accepted it, so the operation outlives the shell process that started it.
+  The update unit is `--no-block` and runs the helper's `update run`, which
+  restarts the shell only when the fast-forward moved `HEAD`: the rescan
+  `omarchy plugin update` triggers does not reload a running `Service.qml`.
+  `MIG-020`–`MIG-026` are the current contract.
 
 ## UI uninstall
 

--- a/docs/specs/v10/08-plugin-bundle-and-release.md
+++ b/docs/specs/v10/08-plugin-bundle-and-release.md
@@ -368,14 +368,17 @@ What replaces it:
   argv0 dispatch, health-IPC polling, `listPlugins` absence verification,
   monotonic deadline budget, and post-commit garbage collection they
   described are gone with the worker chain. What survives of the
-  "detached transient unit" idea is simpler: `update apply` and `uninstall`
-  each start one `systemd-run --user --collect
-  --unit=agent-bar-<update|remove>-<32-lowercase-hex-txid>.service -- <omarchy>
-  plugin <update|remove> othavi0.agent-bar --yes` and return once systemd has
-  accepted it, so the operation outlives the shell process that started it.
-  The update unit is `--no-block` and runs the helper's `update run`, which
-  restarts the shell only when the fast-forward moved `HEAD`: the rescan
-  `omarchy plugin update` triggers does not reload a running `Service.qml`.
+  "detached transient unit" idea is simpler: `uninstall` starts one
+  `systemd-run --user --collect
+  --unit=agent-bar-remove-<32-lowercase-hex-txid>.service -- <omarchy>
+  plugin remove othavi0.agent-bar --yes`, and `update apply` starts one
+  `systemd-run --user --collect --no-block
+  --unit=agent-bar-update-<32-lowercase-hex-txid>.service
+  --property=RuntimeMaxSec=25h -- <helper> update run`. Both return once
+  systemd has accepted the unit, so the operation outlives the shell process
+  that started it. `update run` wraps `omarchy plugin update othavi0.agent-bar
+  --yes` and restarts the shell only when the fast-forward moved `HEAD`: the
+  rescan that command triggers does not reload a running `Service.qml`.
   `MIG-020`–`MIG-026` are the current contract.
 
 ## UI uninstall

--- a/docs/specs/v10/README.md
+++ b/docs/specs/v10/README.md
@@ -34,6 +34,10 @@ contract in `02-target-architecture.md` and Omarchy contract `1` in
 `08-plugin-bundle-and-release.md`:
 [docs/specs/v10/amendments/2026-09-10-plugin-root-from-service-url-design.md](amendments/2026-09-10-plugin-root-from-service-url-design.md).
 
+The automatic-updates design, approved 2026-09-10, adds `UX-041A` and
+`SET-028` and amends `MIG-020`:
+[docs/specs/v10/amendments/2026-09-10-automatic-updates-design.md](amendments/2026-09-10-automatic-updates-design.md).
+
 ## Product statement
 
 Agent Bar v10 is an Omarchy Quattro Quickshell plugin. Its only graphical
@@ -63,7 +67,8 @@ application, an AUR product, or a cargo-binstall product.
    [2026-08-11 monorepo migration](amendments/2026-08-11-monorepo-migration-design.md),
    [2026-08-25 login-state visibility](amendments/2026-08-25-login-state-visibility-design.md),
    [2026-09-04 session window leads](amendments/2026-09-04-session-window-leads-design.md),
-   [2026-09-10 plugin root from Service URL](amendments/2026-09-10-plugin-root-from-service-url-design.md).
+   [2026-09-10 plugin root from Service URL](amendments/2026-09-10-plugin-root-from-service-url-design.md),
+   [2026-09-10 automatic updates](amendments/2026-09-10-automatic-updates-design.md).
 
 When two statements conflict, the earlier contract in this reading order wins
 unless a later file explicitly identifies the requirement ID it refines.

--- a/docs/specs/v10/README.md
+++ b/docs/specs/v10/README.md
@@ -34,8 +34,8 @@ contract in `02-target-architecture.md` and Omarchy contract `1` in
 `08-plugin-bundle-and-release.md`:
 [docs/specs/v10/amendments/2026-09-10-plugin-root-from-service-url-design.md](amendments/2026-09-10-plugin-root-from-service-url-design.md).
 
-The automatic-updates design, approved 2026-09-10, adds `UX-041A` and
-`SET-028` and amends `MIG-020`:
+The automatic-updates design, approved 2026-09-10, adds `UX-041A`,
+`SET-028`, and `CLI-029A` and amends `CLI-029` and `MIG-020`:
 [docs/specs/v10/amendments/2026-09-10-automatic-updates-design.md](amendments/2026-09-10-automatic-updates-design.md).
 
 ## Product statement

--- a/docs/specs/v10/amendments/2026-09-10-automatic-updates-design.md
+++ b/docs/specs/v10/amendments/2026-09-10-automatic-updates-design.md
@@ -25,32 +25,41 @@ Settings switch to turn them off.
 
 ## Decision
 
-1. `update apply` starts its transient unit as `--service-type=oneshot` with
-   two `ExecStartPost=` steps: a `notify-send` toast, then
-   `omarchy-restart-shell`. Oneshot runs `ExecStartPost=` only after
-   `omarchy plugin update` exits 0, so a failed or rolled-back update never
-   restarts the shell. A missing `notify-send` drops the toast; a missing
-   `omarchy-restart-shell` fails closed like `omarchy` and `systemd-run`.
-   Both paths are embedded in unit command lines, so any path with
-   whitespace, quotes, `%`, `$`, or `\` fails closed.
-2. `Service.qml` checks for updates two minutes after the helper answers and
+1. `update apply` queues a transient unit with `systemd-run --user --collect
+   --no-block --property=RuntimeMaxSec=25h` whose command is the helper's
+   own `update run`, and returns at once. It still fails closed, before any
+   unit starts, when `omarchy`, `omarchy-restart-shell`, or `systemd-run` is
+   missing.
+2. `update run` is the unit's body. It reads the plugin `HEAD`, runs
+   `omarchy plugin update othavi0.agent-bar --yes` under a ten-minute
+   `timeout`, and reads `HEAD` again. An unchanged `HEAD` ends the run with
+   no toast and no restart, which covers "is up to date" exits and installs
+   whose `origin` lags the official release. A moved `HEAD` sends a
+   `notify-send` toast when available (its failure is ignored) and then runs
+   `omarchy-restart-shell`. That command refuses while the session is
+   locked, so the restart is retried every minute for up to a day. A second
+   `update run` while one holds `$XDG_STATE_HOME/agent-bar/update-run.lock`
+   exits at once. The run never takes the maintenance lock, so status and
+   settings keep working during a long fetch.
+3. `Service.qml` checks for updates two minutes after the helper answers and
    every six hours after that. When the check reports a plain available
    update, it applies it through the same handoff the Settings button uses.
-   It does not check or apply while the popup is open, while maintenance is
-   in flight, or when the setting is off. It never applies
-   `reinstall_required`. A failed automatic check paints nothing and waits
-   for the next tick.
-3. `settings.json` gains an optional `updates.automatic` boolean. Absent
+   It does not check or apply until the boot settings read succeeded, while
+   the popup is open, while maintenance is in flight, or when the setting is
+   off. It never applies `reinstall_required`. A failed automatic check
+   paints nothing and waits for the next tick. A click on `Check for
+   updates` during a silent automatic check adopts it as a manual check.
+4. `settings.json` gains an optional `updates.automatic` boolean. Absent
    means `true`, so every existing document keeps parsing and gets automatic
    updates. Settings shows it as the "Update automatically" toggle.
 
 ## Contract changes
 
-- `UX-041` becomes: `Check for updates` performs an explicit network request;
-  `UX-041A` adds the automatic check and apply above.
+- `UX-041A` adds the automatic check and apply; `UX-041` is unchanged.
 - `SET-028` defines `updates.automatic`.
-- `MIG-020` and the unit description in `03`, `06`, and `08` gain the
-  oneshot `ExecStartPost=` steps.
+- `MIG-020` and the unit description in `03`, `06`, and `08` describe the
+  `update run` unit.
+- `CLI` grammar gains `update run`.
 
 ## Consequences
 

--- a/docs/specs/v10/amendments/2026-09-10-automatic-updates-design.md
+++ b/docs/specs/v10/amendments/2026-09-10-automatic-updates-design.md
@@ -1,0 +1,61 @@
+# Automatic updates that reload the shell
+
+Date: 2026-09-10
+Status: approved
+
+## Context
+
+Omarchy 4.0.3 stopped handing third-party plugins `manifest.__sourceDir`.
+Agent Bar 10.3.22 read its helper path from that field, so on every updated
+machine no process lane started, including the update check. Release 10.3.23
+fixed the path, but it could reach those machines only through a terminal
+command, because nothing in Omarchy updates plugins on its own: the
+`omarchy update` flow runs user hooks only, and the plugin menu offers no
+update entry.
+
+A second gap showed up in the same verification. `omarchy plugin update`
+fast-forwards the tree and asks the shell to rescan plugins, and the rescan
+does not reload a running `Service.qml`. After an update, on 10.3.23 as on
+earlier versions, the old QML kept running against the new tree until the
+next shell restart, whether the update came from the terminal or from the
+Settings button.
+
+The owner asked for updates that reach users without a terminal, with a
+Settings switch to turn them off.
+
+## Decision
+
+1. `update apply` starts its transient unit as `--service-type=oneshot` with
+   two `ExecStartPost=` steps: a `notify-send` toast, then
+   `omarchy-restart-shell`. Oneshot runs `ExecStartPost=` only after
+   `omarchy plugin update` exits 0, so a failed or rolled-back update never
+   restarts the shell. A missing `notify-send` drops the toast; a missing
+   `omarchy-restart-shell` fails closed like `omarchy` and `systemd-run`.
+   Both paths are embedded in unit command lines, so any path with
+   whitespace, quotes, `%`, `$`, or `\` fails closed.
+2. `Service.qml` checks for updates two minutes after the helper answers and
+   every six hours after that. When the check reports a plain available
+   update, it applies it through the same handoff the Settings button uses.
+   It does not check or apply while the popup is open, while maintenance is
+   in flight, or when the setting is off. It never applies
+   `reinstall_required`. A failed automatic check paints nothing and waits
+   for the next tick.
+3. `settings.json` gains an optional `updates.automatic` boolean. Absent
+   means `true`, so every existing document keeps parsing and gets automatic
+   updates. Settings shows it as the "Update automatically" toggle.
+
+## Contract changes
+
+- `UX-041` becomes: `Check for updates` performs an explicit network request;
+  `UX-041A` adds the automatic check and apply above.
+- `SET-028` defines `updates.automatic`.
+- `MIG-020` and the unit description in `03`, `06`, and `08` gain the
+  oneshot `ExecStartPost=` steps.
+
+## Consequences
+
+Installs still on 10.3.22 cannot receive this release on their own. Their
+running code never reaches the helper, so each needs
+`omarchy plugin update othavi0.agent-bar --yes && omarchy-restart-shell`
+once. Installs on 10.3.23 receive it after one Settings update and one shell
+restart. From this release on, updates arrive and reload without either step.

--- a/schemas/settings-v1.schema.json
+++ b/schemas/settings-v1.schema.json
@@ -55,6 +55,16 @@
           "maximum": 1440
         }
       }
+    },
+    "updates": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["automatic"],
+      "properties": {
+        "automatic": {
+          "type": "boolean"
+        }
+      }
     }
   },
   "$defs": {

--- a/src/cli/command.rs
+++ b/src/cli/command.rs
@@ -108,15 +108,17 @@ pub enum ConfigInput {
     Json(String),
 }
 
-/// Update subcommands. `Apply` takes no argument: `update apply` is an
-/// unconditional detached delegation to `omarchy plugin update
-/// othavi0.agent-bar --yes` (git-plugin-distribution Task 2), not a
-/// version-gated apply of a specific release.
+/// Update subcommands. `Apply` takes no argument: `update apply` starts a
+/// detached unit and returns (git-plugin-distribution Task 2), not a
+/// version-gated apply of a specific release. `Run` is that unit's body: it
+/// delegates to `omarchy plugin update othavi0.agent-bar --yes` and restarts
+/// the shell when the tree changed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UpdateCommand {
     Interactive,
     Check,
     Apply,
+    Run,
 }
 
 /// Doctor subcommands.

--- a/src/cli/grammar.rs
+++ b/src/cli/grammar.rs
@@ -235,6 +235,10 @@ fn parse_update(tokens: &[String]) -> Result<Command, CliFailure> {
         [word, ..] if word == "apply" => Err(CliFailure::grammar(
             "unexpected argument after update apply",
         )),
+        [word] if word == "run" => Ok(Command::Update(UpdateCommand::Run)),
+        [word, ..] if word == "run" => {
+            Err(CliFailure::grammar("unexpected argument after update run"))
+        }
         [other, ..] => Err(CliFailure::grammar(format!(
             "unknown argument '{other}' for update"
         ))),

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -520,22 +520,51 @@ fn dispatch_update_apply() -> Result<(), CliFailure> {
     let systemd_run = resolve_absolute_executable("systemd-run")
         .map_err(|e| CliFailure::plugin(e.to_string()))?;
 
+    // `omarchy plugin update` only rescans plugins, and a rescan does not
+    // reload a running Service.qml: without a shell restart the old QML keeps
+    // running against the new tree. The restart runs from the unit, outside
+    // the shell process it replaces. A missing notifier never blocks it.
+    let restart_shell = unit_command_path(
+        resolve_absolute_executable("omarchy-restart-shell")
+            .map_err(|e| CliFailure::plugin(e.to_string()))?,
+    )?;
+    let notify = match resolve_absolute_executable("notify-send") {
+        Ok(path) => Some(unit_command_path(path)?),
+        Err(_) => None,
+    };
+
     let clock = SystemClock;
     let txid = txid_from_bytes(format!("update-apply:{}", Clock::now_utc(&clock)).as_bytes());
     let unit = format!("agent-bar-update-{txid}.service");
     let unit_flag = format!("--unit={unit}");
 
-    let argv: [&str; 9] = [
-        "--user",
-        "--collect",
-        unit_flag.as_str(),
-        "--",
-        omarchy_bin.as_str(),
-        "plugin",
-        "update",
-        "othavi0.agent-bar",
-        "--yes",
+    // Oneshot: ExecStartPost runs only after `omarchy plugin update` exits 0,
+    // so a failed or rolled-back update never restarts the shell.
+    let mut argv: Vec<String> = vec![
+        "--user".to_string(),
+        "--collect".to_string(),
+        unit_flag,
+        "--service-type=oneshot".to_string(),
     ];
+    if let Some(notify) = notify {
+        argv.push(format!(
+            "--property=ExecStartPost={notify} --app-name=\"Agent Bar\" \
+             \"Agent Bar updated\" \"The shell is reloading to finish the update.\""
+        ));
+    }
+    argv.push(format!("--property=ExecStartPost={restart_shell}"));
+    argv.extend(
+        [
+            "--",
+            omarchy_bin.as_str(),
+            "plugin",
+            "update",
+            "othavi0.agent-bar",
+            "--yes",
+        ]
+        .map(str::to_string),
+    );
+    let argv: Vec<&str> = argv.iter().map(String::as_str).collect();
 
     let runner = ProcessCommandRunner;
     let out = runner
@@ -557,6 +586,23 @@ fn dispatch_update_apply() -> Result<(), CliFailure> {
     let json = serde_json::to_string(&doc).map_err(|e| CliFailure::plugin(e.to_string()))?;
     println!("{json}");
     Ok(())
+}
+
+/// An absolute executable path that is safe to embed in a systemd unit
+/// command line. systemd splits `ExecStartPost=` on whitespace and expands
+/// `%` specifiers and `$` variables, so any other character fails closed.
+fn unit_command_path(path: String) -> Result<String, CliFailure> {
+    let safe = path.starts_with('/')
+        && path
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '/' | '.' | '_' | '-' | '+'));
+    if safe {
+        Ok(path)
+    } else {
+        Err(CliFailure::plugin(format!(
+            "executable path cannot be used in a unit command line: {path}"
+        )))
+    }
 }
 
 /// `update` (no subcommand): the old TTY confirmation flow required a
@@ -788,5 +834,26 @@ mod tests {
         );
         let err = confirm_uninstall(false, false, &mut stdin, &mut stderr).unwrap_err();
         assert_eq!(err.exit_code, VALIDATION);
+    }
+
+    #[test]
+    fn unit_command_path_rejects_what_systemd_would_split_or_expand() {
+        assert_eq!(
+            unit_command_path("/usr/bin/omarchy-restart-shell".to_string()).unwrap(),
+            "/usr/bin/omarchy-restart-shell"
+        );
+        for unsafe_path in [
+            "omarchy-restart-shell",
+            "/home/a b/bin/notify-send",
+            "/opt/%h/notify-send",
+            "/opt/$HOME/notify-send",
+            "/opt/\"q\"/notify-send",
+            "/opt/a\\b/notify-send",
+        ] {
+            assert!(
+                unit_command_path(unsafe_path.to_string()).is_err(),
+                "{unsafe_path}"
+            );
+        }
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -518,10 +518,10 @@ fn dispatch_update_apply() -> Result<(), CliFailure> {
         .map_err(|e| CliFailure::plugin(format!("exclusive maintenance lock: {e}")))?;
 
     // Fail closed here, where QML sees the error, rather than inside the
-    // detached unit where nobody would.
-    resolve_absolute_executable("omarchy").map_err(|e| CliFailure::plugin(e.to_string()))?;
-    resolve_absolute_executable("omarchy-restart-shell")
-        .map_err(|e| CliFailure::plugin(e.to_string()))?;
+    // detached unit where nobody would: every tool `update run` requires.
+    for tool in ["omarchy", "omarchy-restart-shell", "git", "timeout"] {
+        resolve_absolute_executable(tool).map_err(|e| CliFailure::plugin(e.to_string()))?;
+    }
     let systemd_run = resolve_absolute_executable("systemd-run")
         .map_err(|e| CliFailure::plugin(e.to_string()))?;
     let helper = std::env::current_exe()
@@ -580,6 +580,17 @@ struct UpdateRunReport {
     outcome: &'static str,
 }
 
+fn print_update_run_report(outcome: &'static str) -> Result<(), CliFailure> {
+    let doc = UpdateRunReport {
+        schema_version: 1,
+        operation: "updateRun",
+        outcome,
+    };
+    let json = serde_json::to_string(&doc).map_err(|e| CliFailure::plugin(e.to_string()))?;
+    println!("{json}");
+    Ok(())
+}
+
 /// `update run`: the detached unit's body (see `plugin::update_run`).
 ///
 /// A second run while one is still retrying a restart exits 0 at once: the
@@ -606,7 +617,7 @@ fn dispatch_update_run() -> Result<(), CliFailure> {
         .map_err(|e| CliFailure::plugin(format!("update run lock: {e}")))?
     else {
         eprintln!("agent-bar: another update run is in progress");
-        return Ok(());
+        return print_update_run_report("alreadyRunning");
     };
 
     let resolve = |name: &str| {
@@ -635,13 +646,7 @@ fn dispatch_update_run() -> Result<(), CliFailure> {
         UpdateRunOutcome::UpdateFailed(_) => "updateFailed",
         UpdateRunOutcome::RestartGaveUp => "restartGaveUp",
     };
-    let doc = UpdateRunReport {
-        schema_version: 1,
-        operation: "updateRun",
-        outcome: label,
-    };
-    let json = serde_json::to_string(&doc).map_err(|e| CliFailure::plugin(e.to_string()))?;
-    println!("{json}");
+    print_update_run_report(label)?;
     match outcome {
         UpdateRunOutcome::UpToDate | UpdateRunOutcome::Updated => Ok(()),
         UpdateRunOutcome::UpdateFailed(code) => Err(CliFailure::plugin(format!(

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -89,7 +89,8 @@ pub fn help_text(topic: Option<HelpTopic>) -> String {
         }
         Some(HelpTopic::Update) => "update — print usage; no interactive flow\n\
              update check — report whether a newer release exists\n\
-             update apply — delegate to 'omarchy plugin update othavi0.agent-bar'\n"
+             update apply — start 'update run' in a detached unit and return\n\
+             update run — 'omarchy plugin update othavi0.agent-bar', then restart the shell if it changed\n"
             .to_owned(),
         Some(HelpTopic::Uninstall) => {
             "uninstall — remove the plugin (keeps settings and backups)\n\
@@ -124,6 +125,7 @@ pub fn dispatch(command: Command) -> Result<(), CliFailure> {
         Command::Update(UpdateCommand::Interactive) => dispatch_update_interactive(),
         Command::Update(UpdateCommand::Check) => dispatch_update_check(),
         Command::Update(UpdateCommand::Apply) => dispatch_update_apply(),
+        Command::Update(UpdateCommand::Run) => dispatch_update_run(),
         Command::Config(config) => dispatch_config(config),
         Command::Login(provider) => dispatch_login(provider),
         Command::Status(opts) => dispatch_status(opts),
@@ -515,56 +517,37 @@ fn dispatch_update_apply() -> Result<(), CliFailure> {
         .lock_exclusive()
         .map_err(|e| CliFailure::plugin(format!("exclusive maintenance lock: {e}")))?;
 
-    let omarchy_bin =
-        resolve_absolute_executable("omarchy").map_err(|e| CliFailure::plugin(e.to_string()))?;
+    // Fail closed here, where QML sees the error, rather than inside the
+    // detached unit where nobody would.
+    resolve_absolute_executable("omarchy").map_err(|e| CliFailure::plugin(e.to_string()))?;
+    resolve_absolute_executable("omarchy-restart-shell")
+        .map_err(|e| CliFailure::plugin(e.to_string()))?;
     let systemd_run = resolve_absolute_executable("systemd-run")
         .map_err(|e| CliFailure::plugin(e.to_string()))?;
-
-    // `omarchy plugin update` only rescans plugins, and a rescan does not
-    // reload a running Service.qml: without a shell restart the old QML keeps
-    // running against the new tree. The restart runs from the unit, outside
-    // the shell process it replaces. A missing notifier never blocks it.
-    let restart_shell = unit_command_path(
-        resolve_absolute_executable("omarchy-restart-shell")
-            .map_err(|e| CliFailure::plugin(e.to_string()))?,
-    )?;
-    let notify = match resolve_absolute_executable("notify-send") {
-        Ok(path) => Some(unit_command_path(path)?),
-        Err(_) => None,
-    };
+    let helper = std::env::current_exe()
+        .map_err(|e| CliFailure::plugin(format!("cannot locate the helper: {e}")))?;
+    let helper = unit_argv_path(helper.to_string_lossy().into_owned())?;
 
     let clock = SystemClock;
     let txid = txid_from_bytes(format!("update-apply:{}", Clock::now_utc(&clock)).as_bytes());
     let unit = format!("agent-bar-update-{txid}.service");
     let unit_flag = format!("--unit={unit}");
 
-    // Oneshot: ExecStartPost runs only after `omarchy plugin update` exits 0,
-    // so a failed or rolled-back update never restarts the shell.
-    let mut argv: Vec<String> = vec![
-        "--user".to_string(),
-        "--collect".to_string(),
-        unit_flag,
-        "--service-type=oneshot".to_string(),
+    // The unit runs `update run`, which owns the fast-forward and the shell
+    // restart. `--no-block` returns once systemd queued it, so this process
+    // and its maintenance lock never wait on a `git fetch`; RuntimeMaxSec
+    // bounds the unit, including a day of retries behind a locked session.
+    let argv: [&str; 9] = [
+        "--user",
+        "--collect",
+        "--no-block",
+        unit_flag.as_str(),
+        "--property=RuntimeMaxSec=25h",
+        "--",
+        helper.as_str(),
+        "update",
+        "run",
     ];
-    if let Some(notify) = notify {
-        argv.push(format!(
-            "--property=ExecStartPost={notify} --app-name=\"Agent Bar\" \
-             \"Agent Bar updated\" \"The shell is reloading to finish the update.\""
-        ));
-    }
-    argv.push(format!("--property=ExecStartPost={restart_shell}"));
-    argv.extend(
-        [
-            "--",
-            omarchy_bin.as_str(),
-            "plugin",
-            "update",
-            "othavi0.agent-bar",
-            "--yes",
-        ]
-        .map(str::to_string),
-    );
-    let argv: Vec<&str> = argv.iter().map(String::as_str).collect();
 
     let runner = ProcessCommandRunner;
     let out = runner
@@ -588,19 +571,97 @@ fn dispatch_update_apply() -> Result<(), CliFailure> {
     Ok(())
 }
 
-/// An absolute executable path that is safe to embed in a systemd unit
-/// command line. systemd splits `ExecStartPost=` on whitespace and expands
-/// `%` specifiers and `$` variables, so any other character fails closed.
-fn unit_command_path(path: String) -> Result<String, CliFailure> {
-    let safe = path.starts_with('/')
-        && path
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '/' | '.' | '_' | '-' | '+'));
-    if safe {
+/// `update run` stdout document: one line for the unit's journal.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct UpdateRunReport {
+    schema_version: u32,
+    operation: &'static str,
+    outcome: &'static str,
+}
+
+/// `update run`: the detached unit's body (see `plugin::update_run`).
+///
+/// A second run while one is still retrying a restart exits 0 at once: the
+/// run lock, separate from the maintenance lock, is never waited on, so
+/// status and settings keep working during a long fetch or a locked session.
+fn dispatch_update_run() -> Result<(), CliFailure> {
+    use crate::plugin::update_run::{
+        run_update, UpdateRunLimits, UpdateRunOutcome, UpdateRunTools,
+    };
+    use crate::plugin::{resolve_absolute_executable, PluginPaths, ProcessCommandRunner};
+    use crate::support::maintenance_gate::MaintenanceGate;
+
+    let home = std::env::var_os("HOME")
+        .ok_or_else(|| CliFailure::plugin("HOME is required for update run".to_string()))?;
+    let xdg_state = std::env::var_os("XDG_STATE_HOME").map(PathBuf::from);
+    let paths = PluginPaths::production(PathBuf::from(home), xdg_state);
+
+    std::fs::create_dir_all(&paths.xdg_state)
+        .map_err(|e| CliFailure::plugin(format!("create state directory: {e}")))?;
+    let gate = MaintenanceGate::open(paths.xdg_state.join("update-run.lock"))
+        .map_err(|e| CliFailure::plugin(format!("open update run lock: {e}")))?;
+    let Some(_run) = gate
+        .try_lock_exclusive()
+        .map_err(|e| CliFailure::plugin(format!("update run lock: {e}")))?
+    else {
+        eprintln!("agent-bar: another update run is in progress");
+        return Ok(());
+    };
+
+    let resolve = |name: &str| {
+        resolve_absolute_executable(name).map_err(|e| CliFailure::plugin(e.to_string()))
+    };
+    let tools = UpdateRunTools {
+        git: resolve("git")?,
+        timeout: resolve("timeout")?,
+        omarchy: resolve("omarchy")?,
+        restart_shell: resolve("omarchy-restart-shell")?,
+        notify: resolve_absolute_executable("notify-send").ok(),
+    };
+
+    let outcome = run_update(
+        &ProcessCommandRunner,
+        &std::thread::sleep,
+        &tools,
+        &paths.plugin_root,
+        &UpdateRunLimits::default(),
+    )
+    .map_err(|e| CliFailure::plugin(e.to_string()))?;
+
+    let label = match outcome {
+        UpdateRunOutcome::UpToDate => "upToDate",
+        UpdateRunOutcome::Updated => "updated",
+        UpdateRunOutcome::UpdateFailed(_) => "updateFailed",
+        UpdateRunOutcome::RestartGaveUp => "restartGaveUp",
+    };
+    let doc = UpdateRunReport {
+        schema_version: 1,
+        operation: "updateRun",
+        outcome: label,
+    };
+    let json = serde_json::to_string(&doc).map_err(|e| CliFailure::plugin(e.to_string()))?;
+    println!("{json}");
+    match outcome {
+        UpdateRunOutcome::UpToDate | UpdateRunOutcome::Updated => Ok(()),
+        UpdateRunOutcome::UpdateFailed(code) => Err(CliFailure::plugin(format!(
+            "omarchy plugin update exited {code}"
+        ))),
+        UpdateRunOutcome::RestartGaveUp => Err(CliFailure::plugin(
+            "the shell refused every restart; restart it to load the update".to_string(),
+        )),
+    }
+}
+
+/// An absolute path that systemd-run passes to the unit unchanged. The argv
+/// travels over D-Bus without word splitting, but systemd-run expands `$`
+/// variables and `%` specifiers, so a path carrying either fails closed.
+fn unit_argv_path(path: String) -> Result<String, CliFailure> {
+    if path.starts_with('/') && !path.contains(['$', '%']) {
         Ok(path)
     } else {
         Err(CliFailure::plugin(format!(
-            "executable path cannot be used in a unit command line: {path}"
+            "helper path cannot be passed to systemd-run: {path}"
         )))
     }
 }
@@ -837,21 +898,16 @@ mod tests {
     }
 
     #[test]
-    fn unit_command_path_rejects_what_systemd_would_split_or_expand() {
-        assert_eq!(
-            unit_command_path("/usr/bin/omarchy-restart-shell".to_string()).unwrap(),
-            "/usr/bin/omarchy-restart-shell"
-        );
-        for unsafe_path in [
-            "omarchy-restart-shell",
-            "/home/a b/bin/notify-send",
-            "/opt/%h/notify-send",
-            "/opt/$HOME/notify-send",
-            "/opt/\"q\"/notify-send",
-            "/opt/a\\b/notify-send",
+    fn unit_argv_path_rejects_what_systemd_run_would_expand() {
+        for safe in [
+            "/home/u/.config/omarchy/plugins/othavi0.agent-bar/bin/agent-bar",
+            "/home/a b/plugins/othavi0.agent-bar/bin/agent-bar",
         ] {
+            assert_eq!(unit_argv_path(safe.to_string()).unwrap(), safe);
+        }
+        for unsafe_path in ["bin/agent-bar", "/opt/%h/agent-bar", "/opt/$HOME/agent-bar"] {
             assert!(
-                unit_command_path(unsafe_path.to_string()).is_err(),
+                unit_argv_path(unsafe_path.to_string()).is_err(),
                 "{unsafe_path}"
             );
         }

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -6,6 +6,7 @@ pub mod maintenance;
 pub mod omarchy;
 pub mod ownership;
 pub mod paths;
+pub mod update_run;
 
 pub use bundle::{
     BundleBuilder, BundleError, BundleFileEntry, BundleReceipt, BundleValidator,

--- a/src/plugin/update_run.rs
+++ b/src/plugin/update_run.rs
@@ -1,0 +1,348 @@
+//! `update run`: the body of the detached update unit.
+//!
+//! `omarchy plugin update` fast-forwards the tree and rescans plugins, and a
+//! rescan does not reload a running `Service.qml`. This step decides whether
+//! the shell must restart: only when the fast-forward actually moved `HEAD`.
+//! A locked session refuses `omarchy-restart-shell`, so the restart is
+//! retried on a fixed cadence until the session unlocks or the budget ends.
+
+use std::path::Path;
+use std::time::Duration;
+
+use crate::plugin::{CommandRunner, OmarchyError, PLUGIN_ID};
+
+/// Absolute executables the run needs. `notify` is optional: a toast is a
+/// courtesy and never gates the restart.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UpdateRunTools {
+    pub git: String,
+    pub timeout: String,
+    pub omarchy: String,
+    pub restart_shell: String,
+    pub notify: Option<String>,
+}
+
+/// Time budget for one run.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UpdateRunLimits {
+    /// Hard ceiling for `omarchy plugin update` (a stalled `git fetch`).
+    pub update_timeout_secs: u64,
+    /// Wait between refused restart attempts.
+    pub restart_retry: Duration,
+    /// Restart attempts before giving up.
+    pub max_restart_attempts: u32,
+}
+
+impl Default for UpdateRunLimits {
+    /// Ten minutes for the update; a restart attempt every minute for a day.
+    fn default() -> Self {
+        Self {
+            update_timeout_secs: 600,
+            restart_retry: Duration::from_secs(60),
+            max_restart_attempts: 1440,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UpdateRunOutcome {
+    /// The fast-forward found nothing new: no toast, no restart.
+    UpToDate,
+    /// `HEAD` moved and the shell restarted onto the new tree.
+    Updated,
+    /// `omarchy plugin update` failed or timed out (its exit code); it owns
+    /// the rollback, and the shell is left alone.
+    UpdateFailed(i32),
+    /// `HEAD` moved but every restart attempt was refused.
+    RestartGaveUp,
+}
+
+fn head(runner: &dyn CommandRunner, git: &str, plugin_root: &Path) -> Result<String, OmarchyError> {
+    let root = plugin_root.to_string_lossy();
+    let out = runner.run(git, &["-C", root.as_ref(), "rev-parse", "HEAD"])?;
+    let sha = out.stdout.trim().to_string();
+    if out.code != 0 || sha.is_empty() {
+        return Err(OmarchyError::Message(format!(
+            "cannot read the plugin commit: {}",
+            out.stderr.trim()
+        )));
+    }
+    Ok(sha)
+}
+
+/// Update the plugin, then restart the shell only if the tree changed.
+pub fn run_update(
+    runner: &dyn CommandRunner,
+    sleep: &dyn Fn(Duration),
+    tools: &UpdateRunTools,
+    plugin_root: &Path,
+    limits: &UpdateRunLimits,
+) -> Result<UpdateRunOutcome, OmarchyError> {
+    let before = head(runner, &tools.git, plugin_root)?;
+
+    let timeout_secs = limits.update_timeout_secs.to_string();
+    let update = runner.run(
+        &tools.timeout,
+        &[
+            "--kill-after=10",
+            timeout_secs.as_str(),
+            tools.omarchy.as_str(),
+            "plugin",
+            "update",
+            PLUGIN_ID,
+            "--yes",
+        ],
+    )?;
+    if update.code != 0 {
+        return Ok(UpdateRunOutcome::UpdateFailed(update.code));
+    }
+
+    if head(runner, &tools.git, plugin_root)? == before {
+        return Ok(UpdateRunOutcome::UpToDate);
+    }
+
+    // Toasts persist across the shell restart below, so notify first.
+    if let Some(notify) = &tools.notify {
+        let _ = runner.run(
+            &tools.timeout,
+            &[
+                "10",
+                notify.as_str(),
+                "--app-name=Agent Bar",
+                "Agent Bar updated",
+                "The shell is reloading to finish the update.",
+            ],
+        );
+    }
+
+    for attempt in 0..limits.max_restart_attempts {
+        if attempt > 0 {
+            sleep(limits.restart_retry);
+        }
+        if let Ok(out) = runner.run(&tools.restart_shell, &[]) {
+            if out.code == 0 {
+                return Ok(UpdateRunOutcome::Updated);
+            }
+        }
+    }
+    Ok(UpdateRunOutcome::RestartGaveUp)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::plugin::{CommandOutput, CommandRunner, OmarchyError};
+    use std::cell::RefCell;
+    use std::path::Path;
+    use std::time::Duration;
+
+    /// Scripted runner: answers by program name, records every call.
+    struct FakeRunner {
+        heads: RefCell<Vec<&'static str>>,
+        update_code: i32,
+        restart_codes: RefCell<Vec<i32>>,
+        notify_fails: bool,
+        calls: RefCell<Vec<Vec<String>>>,
+    }
+
+    impl FakeRunner {
+        fn new(heads: &[&'static str], update_code: i32, restart_codes: &[i32]) -> Self {
+            Self {
+                heads: RefCell::new(heads.to_vec()),
+                update_code,
+                restart_codes: RefCell::new(restart_codes.to_vec()),
+                notify_fails: false,
+                calls: RefCell::new(Vec::new()),
+            }
+        }
+
+        fn programs(&self) -> Vec<String> {
+            self.calls
+                .borrow()
+                .iter()
+                .map(|c| {
+                    // `timeout` wraps the real program: report what it runs.
+                    if c[0] == "/usr/bin/timeout" {
+                        c.iter()
+                            .skip(1)
+                            .find(|a| a.starts_with('/'))
+                            .cloned()
+                            .unwrap_or_default()
+                    } else {
+                        c[0].clone()
+                    }
+                })
+                .collect()
+        }
+    }
+
+    fn ok(code: i32, stdout: &str) -> Result<CommandOutput, OmarchyError> {
+        Ok(CommandOutput {
+            code,
+            stdout: stdout.to_string(),
+            stderr: String::new(),
+        })
+    }
+
+    impl CommandRunner for FakeRunner {
+        fn run(&self, program: &str, args: &[&str]) -> Result<CommandOutput, OmarchyError> {
+            let mut call = vec![program.to_string()];
+            call.extend(args.iter().map(|a| a.to_string()));
+            self.calls.borrow_mut().push(call);
+            let target = if program == "/usr/bin/timeout" {
+                args.iter()
+                    .find(|a| a.starts_with('/'))
+                    .copied()
+                    .unwrap_or("")
+            } else {
+                program
+            };
+            match target {
+                "/usr/bin/git" => {
+                    let head = self.heads.borrow_mut().remove(0);
+                    ok(0, &format!("{head}\n"))
+                }
+                "/usr/bin/omarchy" => ok(self.update_code, ""),
+                "/usr/bin/notify-send" if self.notify_fails => {
+                    Err(OmarchyError::Message("no notification server".to_string()))
+                }
+                "/usr/bin/notify-send" => ok(0, ""),
+                "/usr/bin/omarchy-restart-shell" => {
+                    let code = self.restart_codes.borrow_mut().remove(0);
+                    ok(code, "")
+                }
+                other => panic!("unexpected program {other}"),
+            }
+        }
+    }
+
+    fn tools(notify: bool) -> UpdateRunTools {
+        UpdateRunTools {
+            git: "/usr/bin/git".to_string(),
+            timeout: "/usr/bin/timeout".to_string(),
+            omarchy: "/usr/bin/omarchy".to_string(),
+            restart_shell: "/usr/bin/omarchy-restart-shell".to_string(),
+            notify: notify.then(|| "/usr/bin/notify-send".to_string()),
+        }
+    }
+
+    fn limits(max_restart_attempts: u32) -> UpdateRunLimits {
+        UpdateRunLimits {
+            update_timeout_secs: 600,
+            restart_retry: Duration::from_secs(60),
+            max_restart_attempts,
+        }
+    }
+
+    fn run(runner: &FakeRunner, notify: bool, attempts: u32) -> (UpdateRunOutcome, u32) {
+        let sleeps = RefCell::new(0u32);
+        let outcome = run_update(
+            runner,
+            &|d: Duration| {
+                assert_eq!(d, Duration::from_secs(60));
+                *sleeps.borrow_mut() += 1;
+            },
+            &tools(notify),
+            Path::new("/plugins/othavi0.agent-bar"),
+            &limits(attempts),
+        )
+        .unwrap();
+        let count = *sleeps.borrow();
+        (outcome, count)
+    }
+
+    #[test]
+    fn up_to_date_neither_notifies_nor_restarts() {
+        let runner = FakeRunner::new(&["aaa", "aaa"], 0, &[]);
+        let (outcome, sleeps) = run(&runner, true, 3);
+        assert_eq!(outcome, UpdateRunOutcome::UpToDate);
+        assert_eq!(sleeps, 0);
+        assert_eq!(
+            runner.programs(),
+            ["/usr/bin/git", "/usr/bin/omarchy", "/usr/bin/git"]
+        );
+    }
+
+    #[test]
+    fn a_moved_head_notifies_then_restarts_the_shell() {
+        let runner = FakeRunner::new(&["aaa", "bbb"], 0, &[0]);
+        let (outcome, sleeps) = run(&runner, true, 3);
+        assert_eq!(outcome, UpdateRunOutcome::Updated);
+        assert_eq!(sleeps, 0);
+        assert_eq!(
+            runner.programs(),
+            [
+                "/usr/bin/git",
+                "/usr/bin/omarchy",
+                "/usr/bin/git",
+                "/usr/bin/notify-send",
+                "/usr/bin/omarchy-restart-shell"
+            ]
+        );
+        let calls = runner.calls.borrow();
+        assert_eq!(
+            calls[1],
+            [
+                "/usr/bin/timeout",
+                "--kill-after=10",
+                "600",
+                "/usr/bin/omarchy",
+                "plugin",
+                "update",
+                "othavi0.agent-bar",
+                "--yes"
+            ]
+        );
+        assert_eq!(
+            calls[0],
+            [
+                "/usr/bin/git",
+                "-C",
+                "/plugins/othavi0.agent-bar",
+                "rev-parse",
+                "HEAD"
+            ]
+        );
+    }
+
+    #[test]
+    fn a_failed_update_never_restarts() {
+        let runner = FakeRunner::new(&["aaa"], 1, &[]);
+        let (outcome, _) = run(&runner, true, 3);
+        assert_eq!(outcome, UpdateRunOutcome::UpdateFailed(1));
+        assert_eq!(runner.programs(), ["/usr/bin/git", "/usr/bin/omarchy"]);
+    }
+
+    #[test]
+    fn a_refused_restart_is_retried_until_the_session_unlocks() {
+        // omarchy-restart-shell exits 1 while the session is locked.
+        let runner = FakeRunner::new(&["aaa", "bbb"], 0, &[1, 1, 0]);
+        let (outcome, sleeps) = run(&runner, false, 5);
+        assert_eq!(outcome, UpdateRunOutcome::Updated);
+        assert_eq!(sleeps, 2);
+    }
+
+    #[test]
+    fn the_restart_budget_ends_without_a_restart() {
+        let runner = FakeRunner::new(&["aaa", "bbb"], 0, &[1, 1, 1]);
+        let (outcome, sleeps) = run(&runner, false, 3);
+        assert_eq!(outcome, UpdateRunOutcome::RestartGaveUp);
+        assert_eq!(sleeps, 2);
+    }
+
+    #[test]
+    fn a_failing_or_missing_notifier_never_blocks_the_restart() {
+        let mut runner = FakeRunner::new(&["aaa", "bbb"], 0, &[0]);
+        runner.notify_fails = true;
+        let (outcome, _) = run(&runner, true, 3);
+        assert_eq!(outcome, UpdateRunOutcome::Updated);
+
+        let runner = FakeRunner::new(&["aaa", "bbb"], 0, &[0]);
+        let (outcome, _) = run(&runner, false, 3);
+        assert_eq!(outcome, UpdateRunOutcome::Updated);
+        assert!(!runner
+            .programs()
+            .iter()
+            .any(|p| p == "/usr/bin/notify-send"));
+    }
+}

--- a/src/settings/migration.rs
+++ b/src/settings/migration.rs
@@ -537,6 +537,7 @@ fn migrate_v9_settings(raw: &[u8]) -> Result<(Settings, Vec<String>, bool), Migr
             enabled: notify_enabled,
             reminder_minutes: crate::settings::schema::default_reminder_minutes(),
         },
+        updates: crate::settings::schema::UpdateSettings::default(),
     };
     settings
         .validate()

--- a/src/settings/schema.rs
+++ b/src/settings/schema.rs
@@ -80,6 +80,20 @@ pub struct NotificationSettings {
     pub reminder_minutes: u32,
 }
 
+/// Updates block. The whole block is optional on read so documents written
+/// before it stay valid and take the default (automatic updates on).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct UpdateSettings {
+    pub automatic: bool,
+}
+
+impl Default for UpdateSettings {
+    fn default() -> Self {
+        Self { automatic: true }
+    }
+}
+
 /// Canonical settings document (schema v1).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -89,6 +103,8 @@ pub struct Settings {
     pub display: DisplaySettings,
     pub refresh_interval_seconds: u32,
     pub notifications: NotificationSettings,
+    #[serde(default)]
+    pub updates: UpdateSettings,
 }
 
 /// Settings validation / parse error (maps to helper exit code 3).
@@ -187,6 +203,7 @@ impl Settings {
                 enabled: true,
                 reminder_minutes: DEFAULT_REMINDER_MINUTES,
             },
+            updates: UpdateSettings::default(),
         }
     }
 
@@ -304,6 +321,7 @@ fn reject_unknown_top_level(value: &Value) -> Result<(), SettingsError> {
         "display",
         "refreshIntervalSeconds",
         "notifications",
+        "updates",
     ];
     for key in obj.keys() {
         if !ALLOWED.contains(&key.as_str()) {
@@ -329,6 +347,16 @@ fn reject_unknown_top_level(value: &Value) -> Result<(), SettingsError> {
                 return Err(SettingsError::new(format!(
                     "unknown notifications key '{key}'"
                 )));
+            }
+        }
+    }
+    if let Some(updates) = obj.get("updates") {
+        let updates = updates
+            .as_object()
+            .ok_or_else(|| SettingsError::new("updates must be an object"))?;
+        for key in updates.keys() {
+            if key != "automatic" {
+                return Err(SettingsError::new(format!("unknown updates key '{key}'")));
             }
         }
     }
@@ -522,5 +550,28 @@ mod tests {
         let doc = br#"{"schemaVersion":1,"providers":[{"id":"claude","enabled":true},{"id":"codex","enabled":true},{"id":"amp","enabled":true},{"id":"grok","enabled":true},{"id":"antigravity","enabled":false}],"display":{"metric":"remaining"},"refreshIntervalSeconds":60,"notifications":{"enabled":true,"reminderMinutes":240}}"#;
         let parsed = Settings::parse_strict(doc).unwrap();
         assert_eq!(parsed.notifications.reminder_minutes, 240);
+    }
+
+    #[test]
+    fn automatic_updates_default_on_when_absent() {
+        // Every settings.json written before this block must keep parsing
+        // (SET-007), and it takes the product default: updates are automatic.
+        let doc = br#"{"schemaVersion":1,"providers":[{"id":"claude","enabled":true},{"id":"codex","enabled":true},{"id":"amp","enabled":true},{"id":"grok","enabled":true},{"id":"antigravity","enabled":false}],"display":{"metric":"remaining"},"refreshIntervalSeconds":60,"notifications":{"enabled":true}}"#;
+        let parsed = Settings::parse_strict(doc).unwrap();
+        assert!(parsed.updates.automatic);
+        assert!(Settings::defaults().updates.automatic);
+    }
+
+    #[test]
+    fn automatic_updates_round_trip_and_reject_unknown_keys() {
+        let doc = br#"{"schemaVersion":1,"providers":[{"id":"claude","enabled":true},{"id":"codex","enabled":true},{"id":"amp","enabled":true},{"id":"grok","enabled":true},{"id":"antigravity","enabled":false}],"display":{"metric":"remaining"},"refreshIntervalSeconds":60,"notifications":{"enabled":true},"updates":{"automatic":false}}"#;
+        let parsed = Settings::parse_strict(doc).unwrap();
+        assert!(!parsed.updates.automatic);
+        let line = parsed.to_canonical_json_line().unwrap();
+        assert!(line.contains(r#""updates":{"automatic":false}"#));
+
+        let unknown = br#"{"schemaVersion":1,"providers":[{"id":"claude","enabled":true},{"id":"codex","enabled":true},{"id":"amp","enabled":true},{"id":"grok","enabled":true},{"id":"antigravity","enabled":false}],"display":{"metric":"remaining"},"refreshIntervalSeconds":60,"notifications":{"enabled":true},"updates":{"automatic":true,"channel":"beta"}}"#;
+        let err = Settings::parse_strict(unknown).unwrap_err();
+        assert!(err.message().contains("unknown updates key 'channel'"));
     }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -671,6 +671,102 @@ fn update_apply_emits_delegation_document() {
     assert!(argv.contains(&"--".to_string()));
 }
 
+/// Runs `update apply` with PATH limited to `path_dir` (plus a `bash` link
+/// for the shims) and returns the recorded systemd-run argv.
+fn update_apply_argv_with_path_dir(root: &Path, path_dir: &Path) -> Vec<String> {
+    let home = root.join("home");
+    std::fs::create_dir_all(&home).unwrap();
+    write_executable(&path_dir.join("omarchy"), "#!/usr/bin/env bash\nexit 0\n");
+    write_executable(
+        &path_dir.join("omarchy-restart-shell"),
+        "#!/usr/bin/env bash\nexit 0\n",
+    );
+    #[cfg(unix)]
+    std::os::unix::fs::symlink("/bin/bash", path_dir.join("bash")).unwrap();
+    let systemd_run_argv = root.join("systemd-run-argv.bin");
+    write_executable(
+        &path_dir.join("systemd-run"),
+        &recording_shim_body(&systemd_run_argv),
+    );
+
+    let bin = assert_cmd::cargo::cargo_bin("agent-bar");
+    let output = StdCommand::new(&bin)
+        .args(["update", "apply"])
+        .env("HOME", &home)
+        .env("XDG_STATE_HOME", home.join("state"))
+        .env("XDG_CACHE_HOME", home.join("cache"))
+        .env("XDG_CONFIG_HOME", home.join("config"))
+        .env("PATH", path_dir)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr={} stdout={}",
+        String::from_utf8_lossy(&output.stderr),
+        String::from_utf8_lossy(&output.stdout)
+    );
+    read_nul_argv(&systemd_run_argv)
+}
+
+#[test]
+fn update_apply_restarts_shell_after_a_successful_update() {
+    // `omarchy plugin update` only rescans plugins, which does not reload a
+    // running Service.qml. The unit is oneshot so ExecStartPost runs only
+    // after the fast-forward succeeded: notify first, then restart the shell.
+    let dir = tempdir().unwrap();
+    let path_dir = dir.path().join("pathbin");
+    write_executable(
+        &path_dir.join("notify-send"),
+        "#!/usr/bin/env bash\nexit 0\n",
+    );
+    let argv = update_apply_argv_with_path_dir(dir.path(), &path_dir);
+
+    let separator = argv.iter().position(|a| a == "--").expect("argv has --");
+    let oneshot = argv
+        .iter()
+        .position(|a| a == "--service-type=oneshot")
+        .expect("unit is oneshot");
+    let notify_prefix = format!(
+        "--property=ExecStartPost={}/notify-send ",
+        path_dir.display()
+    );
+    let notify = argv
+        .iter()
+        .position(|a| a.starts_with(&notify_prefix))
+        .unwrap_or_else(|| panic!("notify step missing: {argv:?}"));
+    let restart = argv
+        .iter()
+        .position(|a| {
+            a == &format!(
+                "--property=ExecStartPost={}/omarchy-restart-shell",
+                path_dir.display()
+            )
+        })
+        .unwrap_or_else(|| panic!("restart step missing: {argv:?}"));
+    assert!(oneshot < separator && notify < restart && restart < separator);
+    assert!(argv.ends_with(&[
+        "plugin".to_string(),
+        "update".to_string(),
+        "othavi0.agent-bar".to_string(),
+        "--yes".to_string(),
+    ]));
+}
+
+#[test]
+fn update_apply_without_notify_send_still_restarts_the_shell() {
+    let dir = tempdir().unwrap();
+    let path_dir = dir.path().join("pathbin");
+    let argv = update_apply_argv_with_path_dir(dir.path(), &path_dir);
+    assert!(
+        !argv.iter().any(|a| a.contains("notify-send")),
+        "argv={argv:?}"
+    );
+    assert!(argv.contains(&format!(
+        "--property=ExecStartPost={}/omarchy-restart-shell",
+        path_dir.display()
+    )));
+}
+
 /// Fixture for the two `uninstall` delegation tests: isolated XDG roots with
 /// owned content, plus a fake `$HOME/.config/omarchy/shell.json` the helper
 /// must never touch (git-plugin-distribution Task 3: shell.json is

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -215,6 +215,18 @@ fn setup_rejects_any_argument() {
 }
 
 #[test]
+fn update_run_parses_and_takes_no_argument() {
+    // `update run` is what the detached update unit executes; QML never
+    // calls it directly.
+    assert_eq!(
+        parse(words(&["update", "run"])).unwrap(),
+        Command::Update(UpdateCommand::Run)
+    );
+    let err = parse(words(&["update", "run", "now"])).unwrap_err();
+    assert_eq!(err.exit_code, GRAMMAR);
+}
+
+#[test]
 fn update_apply_rejects_trailing_arguments() {
     // `update apply` takes no argument (git-plugin-distribution Task 2): it
     // delegates unconditionally instead of applying a specific version.
@@ -601,17 +613,21 @@ fn read_nul_argv(path: &Path) -> Vec<String> {
 
 #[test]
 fn update_apply_emits_delegation_document() {
-    // omarchy and systemd-run resolved via fake PATH shims in a tempdir that
-    // record argv (git-plugin-distribution Task 2): `update apply` never
-    // downloads/stages/exchanges anymore, it hands off to
-    // `systemd-run --user --collect --unit=... -- <omarchy> plugin update
-    // othavi0.agent-bar --yes` and prints the delegation document.
+    // omarchy, omarchy-restart-shell and systemd-run resolved via fake PATH
+    // shims in a tempdir that record argv (git-plugin-distribution Task 2):
+    // `update apply` never downloads/stages/exchanges anymore, it queues
+    // `systemd-run --user --collect --no-block --unit=... -- <helper> update
+    // run` and prints the delegation document.
     let dir = tempdir().unwrap();
     let home = dir.path().join("home");
     std::fs::create_dir_all(&home).unwrap();
 
     let path_dir = dir.path().join("pathbin");
     write_executable(&path_dir.join("omarchy"), "#!/usr/bin/env bash\nexit 0\n");
+    write_executable(
+        &path_dir.join("omarchy-restart-shell"),
+        "#!/usr/bin/env bash\nexit 0\n",
+    );
 
     let systemd_run_argv = dir.path().join("systemd-run-argv.bin");
     write_executable(
@@ -656,115 +672,118 @@ fn update_apply_emits_delegation_document() {
     );
 
     let argv = read_nul_argv(&systemd_run_argv);
+    // The unit runs this very helper: `update run` owns the fast-forward and
+    // the shell restart, so a rescan that keeps the old QML is not the end.
+    let helper = std::fs::canonicalize(&bin).unwrap();
     assert!(
         argv.ends_with(&[
-            "plugin".to_string(),
+            helper.display().to_string(),
             "update".to_string(),
-            "othavi0.agent-bar".to_string(),
-            "--yes".to_string(),
+            "run".to_string(),
         ]),
         "argv={argv:?}"
     );
     assert_eq!(argv.first().map(String::as_str), Some("--user"));
     assert!(argv.contains(&"--collect".to_string()));
+    // Queued, not awaited: the helper and its maintenance lock never wait on
+    // a git fetch or a locked session.
+    assert!(argv.contains(&"--no-block".to_string()));
+    assert!(argv.contains(&"--property=RuntimeMaxSec=25h".to_string()));
     assert!(argv.iter().any(|a| a == &format!("--unit={unit}")));
     assert!(argv.contains(&"--".to_string()));
+    assert!(!argv.iter().any(|a| a.contains("ExecStartPost")));
 }
 
-/// Runs `update apply` with PATH limited to `path_dir` (plus a `bash` link
-/// for the shims) and returns the recorded systemd-run argv.
-fn update_apply_argv_with_path_dir(root: &Path, path_dir: &Path) -> Vec<String> {
-    let home = root.join("home");
+#[test]
+fn update_apply_fails_closed_without_omarchy_restart_shell() {
+    let dir = tempdir().unwrap();
+    let home = dir.path().join("home");
     std::fs::create_dir_all(&home).unwrap();
+    let path_dir = dir.path().join("pathbin");
     write_executable(&path_dir.join("omarchy"), "#!/usr/bin/env bash\nexit 0\n");
-    write_executable(
-        &path_dir.join("omarchy-restart-shell"),
-        "#!/usr/bin/env bash\nexit 0\n",
-    );
-    #[cfg(unix)]
-    std::os::unix::fs::symlink("/bin/bash", path_dir.join("bash")).unwrap();
-    let systemd_run_argv = root.join("systemd-run-argv.bin");
+    let systemd_run_argv = dir.path().join("systemd-run-argv.bin");
     write_executable(
         &path_dir.join("systemd-run"),
         &recording_shim_body(&systemd_run_argv),
     );
+    #[cfg(unix)]
+    std::os::unix::fs::symlink("/bin/bash", path_dir.join("bash")).unwrap();
 
-    let bin = assert_cmd::cargo::cargo_bin("agent-bar");
-    let output = StdCommand::new(&bin)
+    let output = StdCommand::new(assert_cmd::cargo::cargo_bin("agent-bar"))
         .args(["update", "apply"])
         .env("HOME", &home)
         .env("XDG_STATE_HOME", home.join("state"))
-        .env("XDG_CACHE_HOME", home.join("cache"))
-        .env("XDG_CONFIG_HOME", home.join("config"))
-        .env("PATH", path_dir)
+        .env("PATH", &path_dir)
         .output()
         .unwrap();
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("omarchy-restart-shell"));
+    assert!(!systemd_run_argv.exists(), "no unit may start");
+}
+
+/// Shims for `update run`: a git that answers `before` then `after` for
+/// `rev-parse HEAD`, an omarchy that succeeds, and a restart that records it
+/// ran. PATH is limited to the shim directory plus `bash` and `timeout`.
+fn update_run_in(root: &Path, before: &str, after: &str) -> (std::process::Output, PathBuf) {
+    let home = root.join("home");
+    std::fs::create_dir_all(&home).unwrap();
+    let path_dir = root.join("pathbin");
+    let counter = root.join("git-calls");
+    write_executable(
+        &path_dir.join("git"),
+        &format!(
+            "#!/usr/bin/env bash\nn=0\n[ -f \"{c}\" ] && n=$(<\"{c}\")\necho $((n+1)) > \"{c}\"\n\
+             if [ \"$n\" = 0 ]; then echo {before}; else echo {after}; fi\n",
+            c = counter.display()
+        ),
+    );
+    write_executable(&path_dir.join("omarchy"), "#!/usr/bin/env bash\nexit 0\n");
+    let restarted = root.join("restarted");
+    write_executable(
+        &path_dir.join("omarchy-restart-shell"),
+        &format!("#!/usr/bin/env bash\n: > \"{}\"\n", restarted.display()),
+    );
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink("/bin/bash", path_dir.join("bash")).unwrap();
+        let timeout = ["/usr/bin/timeout", "/bin/timeout"]
+            .into_iter()
+            .find(|p| Path::new(p).exists())
+            .expect("coreutils timeout");
+        std::os::unix::fs::symlink(timeout, path_dir.join("timeout")).unwrap();
+    }
+    let output = StdCommand::new(assert_cmd::cargo::cargo_bin("agent-bar"))
+        .args(["update", "run"])
+        .env("HOME", &home)
+        .env("XDG_STATE_HOME", home.join("state"))
+        .env("PATH", &path_dir)
+        .output()
+        .unwrap();
+    (output, restarted)
+}
+
+#[test]
+fn update_run_restarts_the_shell_only_when_the_tree_moved() {
+    let dir = tempdir().unwrap();
+    let (output, restarted) = update_run_in(dir.path(), "aaa", "bbb");
     assert!(
         output.status.success(),
-        "stderr={} stdout={}",
-        String::from_utf8_lossy(&output.stderr),
-        String::from_utf8_lossy(&output.stdout)
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
     );
-    read_nul_argv(&systemd_run_argv)
-}
+    let doc: serde_json::Value =
+        serde_json::from_str(String::from_utf8_lossy(&output.stdout).trim()).unwrap();
+    assert_eq!(doc["operation"], "updateRun");
+    assert_eq!(doc["outcome"], "updated");
+    assert!(restarted.exists());
 
-#[test]
-fn update_apply_restarts_shell_after_a_successful_update() {
-    // `omarchy plugin update` only rescans plugins, which does not reload a
-    // running Service.qml. The unit is oneshot so ExecStartPost runs only
-    // after the fast-forward succeeded: notify first, then restart the shell.
     let dir = tempdir().unwrap();
-    let path_dir = dir.path().join("pathbin");
-    write_executable(
-        &path_dir.join("notify-send"),
-        "#!/usr/bin/env bash\nexit 0\n",
-    );
-    let argv = update_apply_argv_with_path_dir(dir.path(), &path_dir);
-
-    let separator = argv.iter().position(|a| a == "--").expect("argv has --");
-    let oneshot = argv
-        .iter()
-        .position(|a| a == "--service-type=oneshot")
-        .expect("unit is oneshot");
-    let notify_prefix = format!(
-        "--property=ExecStartPost={}/notify-send ",
-        path_dir.display()
-    );
-    let notify = argv
-        .iter()
-        .position(|a| a.starts_with(&notify_prefix))
-        .unwrap_or_else(|| panic!("notify step missing: {argv:?}"));
-    let restart = argv
-        .iter()
-        .position(|a| {
-            a == &format!(
-                "--property=ExecStartPost={}/omarchy-restart-shell",
-                path_dir.display()
-            )
-        })
-        .unwrap_or_else(|| panic!("restart step missing: {argv:?}"));
-    assert!(oneshot < separator && notify < restart && restart < separator);
-    assert!(argv.ends_with(&[
-        "plugin".to_string(),
-        "update".to_string(),
-        "othavi0.agent-bar".to_string(),
-        "--yes".to_string(),
-    ]));
-}
-
-#[test]
-fn update_apply_without_notify_send_still_restarts_the_shell() {
-    let dir = tempdir().unwrap();
-    let path_dir = dir.path().join("pathbin");
-    let argv = update_apply_argv_with_path_dir(dir.path(), &path_dir);
-    assert!(
-        !argv.iter().any(|a| a.contains("notify-send")),
-        "argv={argv:?}"
-    );
-    assert!(argv.contains(&format!(
-        "--property=ExecStartPost={}/omarchy-restart-shell",
-        path_dir.display()
-    )));
+    let (output, restarted) = update_run_in(dir.path(), "aaa", "aaa");
+    assert!(output.status.success());
+    let doc: serde_json::Value =
+        serde_json::from_str(String::from_utf8_lossy(&output.stdout).trim()).unwrap();
+    assert_eq!(doc["outcome"], "upToDate");
+    assert!(!restarted.exists(), "an up-to-date tree must not restart");
 }
 
 /// Fixture for the two `uninstall` delegation tests: isolated XDG roots with

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -763,6 +763,25 @@ fn update_run_in(root: &Path, before: &str, after: &str) -> (std::process::Outpu
 }
 
 #[test]
+fn update_run_reports_and_skips_while_another_run_holds_the_lock() {
+    let dir = tempdir().unwrap();
+    let state = dir.path().join("home/state/agent-bar");
+    std::fs::create_dir_all(&state).unwrap();
+    let gate =
+        agent_bar::support::maintenance_gate::MaintenanceGate::open(state.join("update-run.lock"))
+            .unwrap();
+    let _held = gate.try_lock_exclusive().unwrap().expect("lock is free");
+
+    let (output, restarted) = update_run_in(dir.path(), "aaa", "bbb");
+    assert!(output.status.success());
+    let doc: serde_json::Value =
+        serde_json::from_str(String::from_utf8_lossy(&output.stdout).trim()).unwrap();
+    assert_eq!(doc["outcome"], "alreadyRunning");
+    assert!(!restarted.exists());
+    assert!(!dir.path().join("git-calls").exists(), "nothing may run");
+}
+
+#[test]
 fn update_run_restarts_the_shell_only_when_the_tree_moved() {
     let dir = tempdir().unwrap();
     let (output, restarted) = update_run_in(dir.path(), "aaa", "bbb");

--- a/tests/fixtures/settings-v1/invalid-updates-key.json
+++ b/tests/fixtures/settings-v1/invalid-updates-key.json
@@ -1,0 +1,21 @@
+{
+  "schemaVersion": 1,
+  "providers": [
+    { "id": "claude", "enabled": true },
+    { "id": "codex", "enabled": true },
+    { "id": "amp", "enabled": false },
+    { "id": "grok", "enabled": false },
+    { "id": "antigravity", "enabled": false }
+  ],
+  "display": {
+    "metric": "remaining"
+  },
+  "refreshIntervalSeconds": 60,
+  "notifications": {
+    "enabled": true
+  },
+  "updates": {
+    "automatic": true,
+    "channel": "beta"
+  }
+}

--- a/tests/fixtures/settings-v1/valid-manual-updates.json
+++ b/tests/fixtures/settings-v1/valid-manual-updates.json
@@ -1,0 +1,21 @@
+{
+  "schemaVersion": 1,
+  "providers": [
+    { "id": "claude", "enabled": true },
+    { "id": "codex", "enabled": true },
+    { "id": "amp", "enabled": false },
+    { "id": "grok", "enabled": false },
+    { "id": "antigravity", "enabled": false }
+  ],
+  "display": {
+    "metric": "remaining"
+  },
+  "refreshIntervalSeconds": 60,
+  "notifications": {
+    "enabled": true,
+    "reminderMinutes": 120
+  },
+  "updates": {
+    "automatic": false
+  }
+}

--- a/tests/qml/tst_Maintenance.qml
+++ b/tests/qml/tst_Maintenance.qml
@@ -279,9 +279,12 @@ TestCase {
   }
 
   function test_automatic_update_check_gate() {
-    var ok = { automatic: true, versionReady: true, blocked: false, checkBusy: false, popupOpen: false }
+    var ok = { automatic: true, settingsLoaded: true, versionReady: true,
+               blocked: false, checkBusy: false, popupOpen: false }
     compare(Core.automaticUpdateCheckAllowed(ok), true)
-    var keys = ["automatic", "versionReady"]
+    // settingsLoaded: a failed boot read must not turn an opt-out into an
+    // update (the default is "on", so unknown settings fail closed here).
+    var keys = ["automatic", "settingsLoaded", "versionReady"]
     for (var i = 0; i < keys.length; i++) {
       var off = JSON.parse(JSON.stringify(ok))
       off[keys[i]] = false

--- a/tests/qml/tst_Maintenance.qml
+++ b/tests/qml/tst_Maintenance.qml
@@ -278,6 +278,44 @@ TestCase {
     verify(src.indexOf("land in the next task") < 0)
   }
 
+  function test_automatic_update_check_gate() {
+    var ok = { automatic: true, versionReady: true, blocked: false, checkBusy: false, popupOpen: false }
+    compare(Core.automaticUpdateCheckAllowed(ok), true)
+    var keys = ["automatic", "versionReady"]
+    for (var i = 0; i < keys.length; i++) {
+      var off = JSON.parse(JSON.stringify(ok))
+      off[keys[i]] = false
+      compare(Core.automaticUpdateCheckAllowed(off), false, keys[i])
+    }
+    var busy = ["blocked", "checkBusy", "popupOpen"]
+    for (var j = 0; j < busy.length; j++) {
+      var on = JSON.parse(JSON.stringify(ok))
+      on[busy[j]] = true
+      compare(Core.automaticUpdateCheckAllowed(on), false, busy[j])
+    }
+  }
+
+  function test_automatic_update_applies_only_an_available_update() {
+    var idle = Core.maintenanceUiIdle("10.3.23")
+    var available = Core.maintenanceUiFromCheck(idle, JSON.stringify({
+      schemaVersion: 1,
+      current: { version: "10.3.23" },
+      available: true,
+      reinstallRequired: false,
+      latestCompatible: { version: "10.3.24", releaseNotesUrl: "" }
+    }), 0, "10.3.23")
+    compare(Core.shouldAutoApplyUpdate(available), true)
+    compare(Core.shouldAutoApplyUpdate(Core.maintenanceUiFromCheck(idle, "", 1, "10.3.23")), false)
+    compare(Core.shouldAutoApplyUpdate(Core.maintenanceUiFromCheck(idle, JSON.stringify({
+      schemaVersion: 1, current: { version: "10.3.23" }, available: false,
+      reinstallRequired: false, latestCompatible: null
+    }), 0, "10.3.23")), false)
+    compare(Core.shouldAutoApplyUpdate(Core.maintenanceUiFromCheck(idle, JSON.stringify({
+      schemaVersion: 1, current: { version: "10.3.23" }, available: true,
+      reinstallRequired: true, latestCompatible: { version: "10.3.24" }
+    }), 0, "10.3.23")), false)
+  }
+
   function test_helper_script_source_contract() {
     var src = read("scripts/agent-bar-open-terminal")
     verify(src.indexOf("xdg-terminal-exec") >= 0)

--- a/tests/qml/tst_ServiceTimeouts.qml
+++ b/tests/qml/tst_ServiceTimeouts.qml
@@ -342,6 +342,100 @@ TestCase {
     compare(s.health("10.3.17"), "stalled")
   }
 
+  function availableCheck() {
+    return JSON.stringify({
+      schemaVersion: 1,
+      current: { version: "10.3.17" },
+      available: true,
+      reinstallRequired: false,
+      latestCompatible: { version: "10.3.18", releaseNotesUrl: "" }
+    })
+  }
+
+  function test_version_ready_schedules_the_first_automatic_check() {
+    var s = createService()
+    verify(s.autoUpdateScheduled)
+    compare(s.autoUpdateDelayMs, s.autoUpdateFirstDelayMs)
+    compare(s.autoUpdateFirstDelayMs, 120000)
+    compare(s.autoUpdateIntervalMs, 21600000)
+  }
+
+  function test_automatic_update_checks_then_applies_without_a_click() {
+    var s = createService()
+    s.applySettingsBootstrapResult(s.activeSettingsBootstrapGeneration, "", 1)
+    compare(s.automaticUpdateTick(), true)
+    compare(s.maintenanceCheckBusy, true)
+    compare(s.maintenanceUi.phase, "idle")
+    compare(s.autoUpdateDelayMs, s.autoUpdateIntervalMs)
+    verify(s.autoUpdateScheduled)
+
+    s.applyUpdateCheckResult(s.activeMaintenanceCheckGeneration, availableCheck(), 0)
+
+    compare(s.pendingMaintenanceIntention.kind, "update_apply")
+    compare(s.pendingMaintenanceIntention.version, "10.3.18")
+    compare(s.maintenanceState.blocked, true)
+    compare(s.maintenanceUi.phase, "applying")
+    compare(s.maintenanceHandoffBusy, true)
+  }
+
+  function test_automatic_update_respects_the_setting() {
+    var s = createService()
+    var settings = validSettings()
+    settings.updates = { automatic: false }
+    s.applySettingsBootstrapResult(s.activeSettingsBootstrapGeneration, JSON.stringify(settings), 0)
+    compare(s.automaticUpdateTick(), false)
+    compare(s.maintenanceCheckBusy, false)
+    verify(s.autoUpdateScheduled)
+  }
+
+  function test_automatic_update_waits_while_the_popup_is_open() {
+    var s = createService()
+    s.applySettingsBootstrapResult(s.activeSettingsBootstrapGeneration, "", 1)
+    s.popupOwner = ({ owner: "monitor-a", providerId: "", view: "provider" })
+    compare(s.automaticUpdateTick(), false)
+    compare(s.maintenanceCheckBusy, false)
+  }
+
+  function test_automatic_check_failure_stays_silent() {
+    var s = createService()
+    s.applySettingsBootstrapResult(s.activeSettingsBootstrapGeneration, "", 1)
+    verify(s.automaticUpdateTick())
+    s.applyUpdateCheckResult(s.activeMaintenanceCheckGeneration, "", 1)
+    compare(s.maintenanceUi.phase, "idle")
+    compare(s.pendingMaintenanceIntention, null)
+    compare(s.maintenanceState.blocked, false)
+  }
+
+  function test_automatic_updates_toggle_saves_with_the_draft() {
+    var s = createService()
+    s.applySettingsBootstrapResult(s.activeSettingsBootstrapGeneration, "", 1)
+    s.openSettings("monitor-a")
+    s.applySettingsReadResult(s.activeSettingsReadGeneration, JSON.stringify(validSettings()), 0)
+    s.setAutomaticUpdates(false)
+    compare(s.settingsDraft.updates.automatic, false)
+    compare(s.settingsState.phase, "dirty")
+    verify(s.saveSettings())
+    verify(s.pendingSettingsPayload.indexOf('"updates":{"automatic":false}') >= 0)
+  }
+
+  function test_settings_view_offers_the_automatic_updates_toggle() {
+    var xhr = new XMLHttpRequest()
+    xhr.open("GET", "file://" + repoRoot + "/SettingsView.qml", false)
+    xhr.send()
+    var src = String(xhr.responseText)
+    verify(src.indexOf("label: \"Update automatically\"") >= 0)
+    verify(src.indexOf("setAutomaticUpdates(!root.automaticUpdatesOn)") >= 0)
+  }
+
+  function test_manual_check_still_waits_for_a_click() {
+    var s = createService()
+    s.applySettingsBootstrapResult(s.activeSettingsBootstrapGeneration, "", 1)
+    s.checkForUpdates()
+    s.applyUpdateCheckResult(s.activeMaintenanceCheckGeneration, availableCheck(), 0)
+    compare(s.maintenanceUi.phase, "update_available")
+    compare(s.pendingMaintenanceIntention, null)
+  }
+
   // Omarchy 4.0.3 (basecamp/omarchy#9618) injects a public manifest copy
   // without the host-only __sourceDir; the plugin tree must still resolve.
   function test_helper_and_login_resolve_from_public_manifest() {

--- a/tests/qml/tst_ServiceTimeouts.qml
+++ b/tests/qml/tst_ServiceTimeouts.qml
@@ -360,9 +360,53 @@ TestCase {
     compare(s.autoUpdateIntervalMs, 21600000)
   }
 
-  function test_automatic_update_checks_then_applies_without_a_click() {
+  function bootstrapSettings(s) {
+    s.applySettingsBootstrapResult(s.activeSettingsBootstrapGeneration, JSON.stringify(validSettings()), 0)
+    verify(s.appliedSettings !== null)
+  }
+
+  function test_automatic_update_skips_until_settings_load() {
     var s = createService()
     s.applySettingsBootstrapResult(s.activeSettingsBootstrapGeneration, "", 1)
+    compare(s.appliedSettings, null)
+    compare(s.automaticUpdateTick(), false)
+    compare(s.maintenanceCheckBusy, false)
+  }
+
+  function test_manual_click_takes_over_an_automatic_check() {
+    var s = createService()
+    bootstrapSettings(s)
+    verify(s.automaticUpdateTick())
+    s.checkForUpdates()
+    compare(s.maintenanceUi.phase, "checking")
+    s.applyUpdateCheckResult(s.activeMaintenanceCheckGeneration, "", 1)
+    compare(s.maintenanceUi.phase, "error")
+  }
+
+  function test_automatic_result_never_overwrites_a_handoff() {
+    var s = createService()
+    bootstrapSettings(s)
+    verify(s.automaticUpdateTick())
+    s.pendingMaintenanceIntention = ({ kind: "update_apply", version: "10.3.18" })
+    s.beginMaintenanceHandoff()
+    var before = s.maintenanceUi.phase
+    s.applyUpdateCheckResult(s.activeMaintenanceCheckGeneration, availableCheck(), 0)
+    compare(s.maintenanceUi.phase, before)
+  }
+
+  function test_started_update_says_the_shell_reloads_later() {
+    var s = createService()
+    bootstrapSettings(s)
+    s.checkForUpdates()
+    s.applyUpdateCheckResult(s.activeMaintenanceCheckGeneration, availableCheck(), 0)
+    verify(s.confirmUpdateApply())
+    s.applyMaintenanceHandoffDone(s.activeMaintenanceHandoffGeneration, 0)
+    compare(s.maintenanceUi.message, "Update started. The shell reloads when it finishes.")
+  }
+
+  function test_automatic_update_checks_then_applies_without_a_click() {
+    var s = createService()
+    bootstrapSettings(s)
     compare(s.automaticUpdateTick(), true)
     compare(s.maintenanceCheckBusy, true)
     compare(s.maintenanceUi.phase, "idle")
@@ -390,7 +434,7 @@ TestCase {
 
   function test_automatic_update_waits_while_the_popup_is_open() {
     var s = createService()
-    s.applySettingsBootstrapResult(s.activeSettingsBootstrapGeneration, "", 1)
+    bootstrapSettings(s)
     s.popupOwner = ({ owner: "monitor-a", providerId: "", view: "provider" })
     compare(s.automaticUpdateTick(), false)
     compare(s.maintenanceCheckBusy, false)
@@ -398,7 +442,7 @@ TestCase {
 
   function test_automatic_check_failure_stays_silent() {
     var s = createService()
-    s.applySettingsBootstrapResult(s.activeSettingsBootstrapGeneration, "", 1)
+    bootstrapSettings(s)
     verify(s.automaticUpdateTick())
     s.applyUpdateCheckResult(s.activeMaintenanceCheckGeneration, "", 1)
     compare(s.maintenanceUi.phase, "idle")

--- a/tests/qml/tst_Settings.qml
+++ b/tests/qml/tst_Settings.qml
@@ -105,6 +105,29 @@ TestCase {
     compare(Core.validateSettingsDraft(bad).ok, false)
   }
 
+  function test_automatic_updates_setting() {
+    var d = Service.defaultSettings()
+    compare(d.updates.automatic, true)
+    compare(Service.automaticUpdatesEnabled(d), true)
+
+    d = Core.setAutomaticUpdates(d, false)
+    compare(d.updates.automatic, false)
+    compare(Service.automaticUpdatesEnabled(d), false)
+    compare(Core.validateSettingsDraft(d).ok, true)
+
+    // A document from a helper that predates the block, or no settings at
+    // all yet, means the product default: automatic.
+    var legacy = Service.defaultSettings()
+    delete legacy.updates
+    compare(Core.validateSettingsDraft(legacy).ok, true)
+    compare(Service.automaticUpdatesEnabled(legacy), true)
+    compare(Service.automaticUpdatesEnabled(null), true)
+
+    var bad = Service.defaultSettings()
+    bad.updates = { automatic: "yes" }
+    compare(Core.validateSettingsDraft(bad).ok, false)
+  }
+
   function test_notifications_toggle() {
     var d = Service.defaultSettings()
     d = Core.setNotificationsEnabled(d, false)


### PR DESCRIPTION
## Why

After #86 fixed Agent Bar on Omarchy 4.0.3, the fix still had no way to reach users. Nothing in Omarchy updates plugins on its own. `omarchy update` runs user hooks only, the plugin menu has enable, disable, clone and remove but no update, and 10.3.22 cannot run its own update check. Every affected machine needed a terminal.

Checking the update path turned up a second problem. `omarchy plugin update` fast-forwards the tree and then only asks the shell to rescan plugins. The rescan does not reload a running `Service.qml`. I ran it on this machine: after updating from 10.3.22 to 10.3.23, `qs -p /usr/share/omarchy/shell ipc call othavi0.agent-bar health 10.3.23` kept answering `unknown`, and switched to `ok` only after `omarchy-restart-shell`. That applies to the terminal command and to the Settings "Update" button alike.

## What changes

- New `agent-bar update run`, the body of the update unit (`src/plugin/update_run.rs`). It reads the plugin `HEAD`, runs `omarchy plugin update othavi0.agent-bar --yes` under `timeout --kill-after=10 600`, and reads `HEAD` again.
  - Unchanged `HEAD` means no toast and no restart. That covers the "is up to date" exit 0 and installs whose `origin` lags the official repo, which would otherwise restart in a loop.
  - Moved `HEAD` sends a `notify-send` toast when available, ignoring its failure, then runs `omarchy-restart-shell`. The script refuses while the session is locked, so the run retries every 60 s, 1440 times.
  - A second run while `$XDG_STATE_HOME/agent-bar/update-run.lock` is held exits at once with `alreadyRunning`.
  - It prints one line: `{"schemaVersion":1,"operation":"updateRun","outcome":"..."}`.
- `update apply` now queues `systemd-run --user --collect --no-block --property=RuntimeMaxSec=25h -- <helper> update run` and returns right away, so its maintenance lock never waits on a fetch. Before queuing the unit, it fails closed if `omarchy`, `omarchy-restart-shell`, `git`, `timeout` or `systemd-run` is missing.
- `Service.qml` checks for updates 2 minutes after the helper answers and every 6 hours after that. When it finds a plain available update, it applies it through the same handoff the button uses. It skips a tick until the boot settings read has succeeded, while the popup is open, and while maintenance is in flight. It never applies `reinstall_required`, and a failed automatic check shows nothing. Clicking "Check for updates" during a silent check turns it into a manual one. The message after a started update now reads "Update started. The shell reloads when it finishes."
- `settings.json` gets an optional `updates.automatic` block. If it's missing, the value defaults to `true`. Rust schema, allowlist, JSON Schema and QML validation all accept a missing block. Settings has an "Update automatically" toggle.
- Spec: amendment `docs/specs/v10/amendments/2026-09-10-automatic-updates-design.md` (`UX-041A`, `SET-028`, `CLI-029A`; amends `CLI-029`, `MIG-020`), plus guides, architecture, releasing and CHANGELOG.

Installs still on 10.3.22 can't pick this up on their own, because their running code never reaches the helper. They need `omarchy plugin update othavi0.agent-bar --yes && omarchy-restart-shell` once. 10.3.23 needs one "Update" click plus one shell restart. After that, updates arrive and reload by themselves.

## Review

An adversarial pass over the first version found one blocker and five important issues. The first version used a `oneshot` unit with `ExecStartPost=` steps. Its old CLI test needed a real `omarchy-restart-shell`, which the Ubuntu release runner doesn't have. It also restarted on "up to date" exits, gave up for good on a locked session, let a failed toast cancel the restart, turned `update apply` into a blocking call, and let a failed boot settings read override the opt-out. Moving the logic into `update run` fixes all of these. A scoped re-review confirmed that, plus two smaller gaps (preflight for `git`/`timeout`, a report for the lock-held skip), both fixed in the last commit.

## Verification

```
cargo fmt --check                               ok
cargo test                                      ok (all suites)
cargo clippy --all-targets -- -D warnings       ok
git diff --check                                ok
qmltestrunner, Qt6 offscreen                    310 passed, 0 failed
omarchy plugin validate .                       ok
cli suite with no omarchy* on PATH              25 passed, 0 failed
```

I wrote the tests first and saw each one fail. In Rust:
- settings `updates` default and allowlist;
- `update run` grammar;
- six `run_update` cases with a scripted runner: up to date, moved `HEAD`, failed update, restart refused then accepted, restart budget spent, notifier failing or missing;
- `update apply` argv;
- `update apply` failing closed without `omarchy-restart-shell`;
- an end-to-end `update run` with PATH shims (moved and unchanged `HEAD`);
- the lock-held skip.

In QML: the gate (including `settingsLoaded`), apply-without-click, the setting, popup open, a silent failure, a manual click adopting an automatic check, an automatic result never overwriting a handoff, the toggle saving with the draft, and the new message.

Live on Omarchy 4.0.3:
- `update run` in a real `systemd-run --user` unit, with `HOME` pointed at a throwaway clone checked out at 10.3.22, fast-forwarded to 10.3.23, printed `"outcome":"updated"`, and the real shell restarted (old process exited on IPC at 09:24:29.008, new one launched at 09:24:29.410).
- Running it again printed `"outcome":"upToDate"` and the shell PID stayed the same.
- On the owner's machine, the Settings view built from this branch rendered the "Update automatically" toggle.
- The installed plugin went back to a clean 10.3.23 afterwards.

Not tested live: the six-hour tick and the locked-session retry. Both are covered only by tests.
