### PR TITLE
fix: retry a waiting handoff when status ends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- fix: an automatic update no longer freezes the bar. On 10.3.24 the
+  two-minute update check lands on the second 60 s poll; the handoff then
+  waited for that status run and nothing retried it, so polling stopped,
+  the gear no longer opened Settings, and the update never applied. The
+  finished status run now retries the waiting handoff. A 10.3.24 install
+  that already stopped refreshing needs
+  `omarchy plugin update othavi0.agent-bar --yes && omarchy-restart-shell`
+  once.
 - fix: the bar loads again on Omarchy 4.0.3. The host now hands third-party
   plugins a public manifest copy without `__sourceDir`, which the service used
   to locate `bin/agent-bar`; the helper path came out empty, no process ever

--- a/Service.qml
+++ b/Service.qml
@@ -702,6 +702,9 @@ Item {
     statusBusy = false
     refreshing = false
     recordCompletedCallback(!!fromTimeout, "status")
+    // A handoff that began while this run was in flight waits for the free
+    // lane; without this retry it waits forever with polling stopped.
+    tryMaintenanceDetach()
 
     if (exitCode !== 0) {
       // Keep last snapshot (CACHE-021 / malformed retention).

--- a/tests/qml/tst_ServiceTimeouts.qml
+++ b/tests/qml/tst_ServiceTimeouts.qml
@@ -404,6 +404,38 @@ TestCase {
     compare(s.maintenanceUi.message, "Update started. The shell reloads when it finishes.")
   }
 
+  // Live 10.3.24: the two-minute tick lands on the second 60 s poll, the
+  // check returns before the status run, and the handoff waited for a status
+  // completion that never retried it: polling stopped and Settings stayed
+  // blocked for good.
+  function test_handoff_waiting_on_status_starts_when_status_finishes() {
+    var s = createService()
+    bootstrapSettings(s)
+    verify(s.automaticUpdateTick())
+    s.kickStatus()
+    compare(s.statusBusy, true)
+    var statusGeneration = s.activeStatusGeneration
+
+    s.applyUpdateCheckResult(s.activeMaintenanceCheckGeneration, availableCheck(), 0)
+    compare(s.maintenanceState.blocked, true)
+    compare(s.maintenanceHandoffBusy, false)
+
+    s.applyStatusResult(statusGeneration, validEnvelope(), "", 0)
+    compare(s.maintenanceHandoffBusy, true)
+  }
+
+  function test_handoff_waiting_on_a_failed_status_still_starts() {
+    var s = createService()
+    bootstrapSettings(s)
+    s.kickStatus()
+    var statusGeneration = s.activeStatusGeneration
+    s.pendingMaintenanceIntention = ({ kind: "update_apply", version: "10.3.18" })
+    s.beginMaintenanceHandoff()
+    compare(s.maintenanceHandoffBusy, false)
+    s.applyStatusResult(statusGeneration, "", "boom", 1)
+    compare(s.maintenanceHandoffBusy, true)
+  }
+
   function test_automatic_update_checks_then_applies_without_a_click() {
     var s = createService()
     bootstrapSettings(s)


### PR DESCRIPTION
## Symptom

On 10.3.24, with a newer release out, the bar stops refreshing about two minutes after the shell starts, and the gear in the popup no longer opens Settings. The update never gets applied. It stays that way until the shell restarts, and then the same thing happens two minutes later.

Seen live on this machine: the status cache was last written at 09:54:46, right after the automatic check fired, and no update unit ever started.

## Cause

`applyStatusResult` frees the status lane but never retries a handoff that was waiting for it. `beginMaintenanceHandoff` stops polling and calls `tryMaintenanceDetach`, which waits while `statusBusy` is true. Only the settings-write path called `tryMaintenanceDetach` again.

With the default 60 s refresh, the automatic update tick fires two minutes after start, together with the second poll. The check answers before the status run finishes, the handoff starts while `statusBusy` is true, and nothing retries it. `maintenanceState.blocked` stays on, which stops polling, makes `openSettings` return, and never runs `update apply`.

## Fix

`applyStatusResult` calls `tryMaintenanceDetach()` once the lane is free, on every exit path including a failed status and a timeout. `kickStatus` already refuses to start while maintenance is blocked, so the follow-up poll can't race the handoff.

## Verification

```
cargo fmt --check                               ok
cargo test                                      ok
cargo clippy --all-targets -- -D warnings       ok
git diff --check                                ok
qmltestrunner, Qt6 offscreen                    312 passed, 0 failed
omarchy plugin validate .                       ok
```

I wrote two tests first, and both failed on `master` (`maintenanceHandoffBusy` stayed `false`):

- `test_handoff_waiting_on_status_starts_when_status_finishes`: an automatic check applies while a status run is in flight, and the handoff starts once that run returns.
- `test_handoff_waiting_on_a_failed_status_still_starts`: the same wait ended by a failed status run.

Live, after copying the fixed `Service.qml` into the installed plugin and restarting the shell at 09:59:33:

- at 10:01:39 the automatic update unit started, which the unfixed code never reached;
- the unit ended `updateFailed` because I had modified files in that checkout, so the fast-forward refused;
- polling kept going, with the status cache written again at 10:03:44.

## Installs already on 10.3.24

This release is the "newer version" that triggers the stall on 10.3.24, and 10.3.24 code can't be fixed from outside. On a 10.3.24 install where the bar stops refreshing, one terminal run gets it onto this fix:

```
omarchy plugin update othavi0.agent-bar --yes && omarchy-restart-shell
```
