### PR TITLE
docs: tell stuck installs how to update

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,21 @@ provider, a popup with every usage window, and a countdown to the next
 reset. A fresh install shows Claude and Codex; Amp, Grok, and Antigravity
 are one toggle away in Settings.
 
+> [!IMPORTANT]
+> **Agent Bar older than 10.3.25 can't update itself on Omarchy 4.0.3.**
+> Version 10.3.22 and older never loads there: the chips show `···`, the
+> popup stays on its loading placeholder, and Settings says "Update check
+> failed". Version 10.3.24 loads but can stop refreshing a couple of minutes
+> after the shell starts. Run this once in a terminal to move to the fixed
+> release:
+>
+> ```bash
+> omarchy plugin update othavi0.agent-bar --yes && omarchy-restart-shell
+> ```
+>
+> If you're already current, it only restarts the shell. From 10.3.25 on,
+> Agent Bar installs new releases by itself.
+
 ![Agent Bar preview](preview.png)
 
 ## What you see


### PR DESCRIPTION
Adds a notice at the top of the README for installs that can't update themselves on Omarchy 4.0.3.

- 10.3.22 and older read their helper path from `manifest.__sourceDir`, which Omarchy 4.0.3 strips from third-party plugins (upstream omacom/omarchy#10863). They never load and their own update button fails. Every v10 tag through v10.3.22 references `__sourceDir` in `Service.qml`.
- 10.3.24 can freeze a couple of minutes after the shell starts now that a newer release exists (fixed in 10.3.25, #88).

Both need one terminal run of `omarchy plugin update othavi0.agent-bar --yes && omarchy-restart-shell`. On a current install the update reports "up to date" and only the shell restarts.

Checks: `active_language`, `active_docs`, `active_legacy_scan` and `git diff --check` pass.
