### PR TITLE
fix: guard every deferred focus rebuild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- fix: closing the popup no longer logs
+  `TypeError: Property 'rebuildFocusTargets' ... is not a function`. Two of
+  the deferred focus rebuilds ran unguarded after the popup was destroyed;
+  every deferred rebuild now goes through one guarded helper
+  ([#83](https://github.com/othavi0/omarchy-agent-bar/issues/83), reported
+  and first fixed in #84 by @alinuxfan).
 - fix: an automatic update no longer freezes the bar. On 10.3.24 the
   two-minute update check lands on the second 60 s poll; the handoff then
   waited for that status run and nothing retried it, so polling stopped,

--- a/Popup.qml
+++ b/Popup.qml
@@ -181,13 +181,20 @@ KeyboardPanel {
     focusController.setTargets(list)
   }
 
-  onViewChanged: {
-    if (contentFlick)
-      contentFlick.contentY = 0
+  // Deferred so the rail and the Loader finish building first. The popup
+  // can be destroyed before the call runs (#83), so check the method is
+  // still there instead of throwing from a dead object.
+  function scheduleFocusRebuild() {
     Qt.callLater(function () {
       if (typeof root.rebuildFocusTargets === "function")
         root.rebuildFocusTargets()
     })
+  }
+
+  onViewChanged: {
+    if (contentFlick)
+      contentFlick.contentY = 0
+    scheduleFocusRebuild()
   }
   onSelectedIdChanged: Qt.callLater(function () {
     // FocusController may not be ready on the first selectedId emission.
@@ -196,9 +203,7 @@ KeyboardPanel {
     if (typeof root.rebuildFocusTargets === "function")
       root.rebuildFocusTargets()
   })
-  onAgentServiceChanged: Qt.callLater(function () {
-    root.rebuildFocusTargets()
-  })
+  onAgentServiceChanged: scheduleFocusRebuild()
 
   PanelKeyCatcher {
     id: keyCatcher
@@ -333,17 +338,14 @@ KeyboardPanel {
                 if (kind === "restart_shell" && root.agentService)
                   root.agentService.restartShell()
               }
-              onVisibleChanged: Qt.callLater(root.rebuildFocusTargets)
+              onVisibleChanged: root.scheduleFocusRebuild()
             }
 
             Loader {
               id: contentLoader
               width: parent.width
               sourceComponent: root.view === "settings" ? settingsContent : providerContent
-              onLoaded: Qt.callLater(function () {
-                if (typeof root.rebuildFocusTargets === "function")
-                  root.rebuildFocusTargets()
-              })
+              onLoaded: root.scheduleFocusRebuild()
             }
           }
         }

--- a/tests/qml/tst_Popup.qml
+++ b/tests/qml/tst_Popup.qml
@@ -482,4 +482,22 @@ TestCase {
     var win = read("components/UsageWindow.qml")
     verify(win.indexOf("property string resetClock") >= 0)
   }
+
+  // #83: a deferred rebuild can run after the popup was destroyed, where an
+  // unguarded root.rebuildFocusTargets() throws on every open/close cycle.
+  function test_deferred_focus_rebuild_survives_popup_destruction() {
+    var src = read("Popup.qml")
+    verify(src.indexOf("Qt.callLater(root.rebuildFocusTargets)") < 0)
+    var re = /root\.rebuildFocusTargets\(\)/g
+    var m
+    while ((m = re.exec(src)) !== null) {
+      var before = src.slice(Math.max(0, m.index - 80), m.index)
+      verify(before.indexOf('typeof root.rebuildFocusTargets === "function"') >= 0,
+             "unguarded rebuildFocusTargets() at offset " + m.index)
+    }
+    // One deferral helper instead of a guarded closure per call site.
+    verify(src.indexOf("function scheduleFocusRebuild()") >= 0)
+    compare(src.split("Qt.callLater(").length - 1, 2,
+            "only scheduleFocusRebuild and onSelectedIdChanged defer")
+  }
 }


### PR DESCRIPTION
Fixes #83. Supersedes #84, which found the bug and proposed the right guard; @alinuxfan is credited as co-author.

## Symptom

Closing the popup logs, once per open/close cycle:

```
Popup.qml[200:-1]: TypeError: Property 'rebuildFocusTargets' of object Popup_QMLTYPE_…(…) is not a function (exception occurred during delayed function evaluation)
```

I saw the same line in the journal on this machine while the plugin reloaded. It's log noise, but it reads like the widget broke.

## Cause

`Popup.qml` defers its focus-target rebuild with `Qt.callLater` from five places. Three of those deferred closures checked that `root.rebuildFocusTargets` still existed. `onAgentServiceChanged` and the stall message's `onVisibleChanged` did not, and both fire during teardown, so their deferred call ran after the popup was destroyed.

## Change

- One helper, `scheduleFocusRebuild()`, holds the guarded deferral. `onViewChanged`, `onAgentServiceChanged`, the stall message's `onVisibleChanged` and the content `Loader`'s `onLoaded` call it. The synchronous call is safe because handlers run while the object is alive, and only the deferred part needs the guard.
- `onSelectedIdChanged` keeps its own guarded deferral because it also runs `clampScroll()`.
- The file goes from five copies of the closure to one helper plus that one site. This is #84's fix, minus the duplication it left in place.

## Verification

```
cargo fmt --check                               ok
cargo test                                      ok
cargo clippy --all-targets -- -D warnings       ok
git diff --check                                ok
qmltestrunner, Qt6 offscreen                    313 passed, 0 failed
omarchy plugin validate .                       ok
qmllint Popup.qml                               45 warnings before and after
```

The new `test_deferred_focus_rebuild_survives_popup_destruction` in `tests/qml/tst_Popup.qml` failed on `master`. It requires every `root.rebuildFocusTargets()` call to sit behind its `typeof` guard, bans passing the method straight to `Qt.callLater`, and allows only two deferral sites. No test covered these call sites before. I didn't reproduce the teardown timing live; the source contract is what the test proves.
