### PR TITLE
feat: report Antigravity Claude/GPT quota

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   failed or rolled-back update. Turn it off with the new "Update
   automatically" toggle (`updates.automatic` in `settings.json`, default on
   and assumed when absent; ignored until the settings file was read).
+- feat: Antigravity also reports the Claude/GPT quota (`3p-weekly`,
+  `3p-5h`) next to Gemini. The two families have separate quotas (requested
+  in #82, first proposed in #85 by @alinuxfan).
 
 - feat: Antigravity usage and quota support via
   `agy --print /usage --output-format json`, reading the `gemini-weekly` and
@@ -46,6 +49,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- feat: Antigravity windows name their family and duration (`Gemini · 7d`,
+  `Gemini · 5h`, `Claude/GPT · 7d`, `Claude/GPT · 5h`) instead of
+  `Weekly (7d)` and `Session (5h)`. With both session windows delivered,
+  the lower one leads the chip. A full bucket shows no reset: its window
+  only starts on first use, and until then `agy` reports a reset that moves
+  with the clock.
 - fix: the chip and popup lead with the session window whenever the provider
   delivers one (`session` for Claude and Codex, `gemini-5h` for Antigravity).
   Once the five-hour reset elapsed overnight the old election handed the

--- a/CoreView.js
+++ b/CoreView.js
@@ -644,11 +644,12 @@ function remainingRank(line) {
   return line.remainingPercent === null ? Infinity : line.remainingPercent
 }
 
-// UX-020D (amended 2026-09-04): the window ids the Rust mappers emit for a
-// provider's short rolling window (Claude/Codex `session`, Antigravity
-// `gemini-5h`). Typed schema data, like the `plan-` prefix below — this list
-// only promotes known ids; an id it does not know is never demoted.
-var SESSION_WINDOW_IDS = ["session", "gemini-5h"]
+// UX-020D (amended 2026-09-04, 2026-09-10): the window ids the Rust mappers
+// emit for a provider's short rolling window (Claude/Codex `session`,
+// Antigravity `gemini-5h` and `3p-5h`). Typed schema data, like the `plan-`
+// prefix below — this list only promotes known ids; an id it does not know is
+// never demoted.
+var SESSION_WINDOW_IDS = ["session", "gemini-5h", "3p-5h"]
 
 function isSessionWindowId(id) {
   return SESSION_WINDOW_IDS.indexOf(String(id)) >= 0
@@ -675,10 +676,17 @@ function electLeadIndex(lines) {
   //    through providerSeverity, it just never takes the number. Without
   //    this, every morning the elapsed session reset handed the chip to the
   //    weekly percentage.
+  //    (amended 2026-09-10) Antigravity delivers one session per model
+  //    family; the family in use drains its own, so the lowest remaining
+  //    leads and a tie keeps the delivered order.
   for (i = 0; i < lines.length; i++) {
-    if (isSessionWindowId(lines[i].id))
-      return i
+    if (!isSessionWindowId(lines[i].id))
+      continue
+    if (best < 0 || remainingRank(lines[i]) < remainingRank(lines[best]))
+      best = i
   }
+  if (best >= 0)
+    return best
 
   // 1. Any critical window leads; among criticals, the lowest remaining.
   for (i = 0; i < lines.length; i++) {

--- a/docs/guide/runtime.md
+++ b/docs/guide/runtime.md
@@ -110,8 +110,11 @@ provider's TTL instead.
   previous reading, when the cache holds one, stays on the bar as `stale`;
   a first collection with an expired token reports the session expired.
 - Antigravity uses its official `agy --print /usage --output-format json`
-  command, reads the `gemini-weekly` and `gemini-5h` buckets by id, and reads
-  no credential files. It requires `agy` 1.1.11 or newer; older builds send
+  command, reads the Gemini (`gemini-weekly`, `gemini-5h`) and Claude/GPT
+  (`3p-weekly`, `3p-5h`) buckets by id, and reads no credential files. The
+  two families have separate quotas; the lower of the two session windows
+  leads the chip. A full bucket shows no reset, because its window
+  only starts on first use. It requires `agy` 1.1.11 or newer; older builds send
   `/usage` to the model as a prompt instead of printing usage data.
 
 Collection discovery is separate from interactive login-CLI discovery.

--- a/docs/specs/v10/02-target-architecture.md
+++ b/docs/specs/v10/02-target-architecture.md
@@ -212,7 +212,7 @@ Locked collection policy:
 | `codex` | resolved `codex app-server` JSON-RPC `rateLimits/read`, then newest valid rate-limit event below `$HOME/.codex/sessions` | `session`, `weekly`, then `other:<duration-minutes>:<ordinal>` | 90 s | 10 s | one app-server timeout retry before filesystem fallback |
 | `amp` | resolved `amp usage` with `NO_COLOR=1`, `TERM=dumb` | `daily`, or no windows when the account exposes no percentage | 90 s | 10 s | one timeout/process-I/O retry |
 | `grok` | `$GROK_HOME/auth.json` (when its `expires_at` is at most 60 s in the future and the `grok` executable was discovered, one argv-only `grok models` run with the catalog timeout, `NO_COLOR=1`, `TERM=dumb`, output ignored, then `auth.json` re-read; a token still expired is a retryable `unauthenticated` so the prior reading is retained as `stale`; a file the CLI cleared is a non-retryable `unauthenticated`; a torn document is retryable; a file that cannot be read is a non-retryable `provider_error`), then authenticated GET `https://cli-chat-proxy.grok.com/v1/billing?format=credits` (literal; headers Authorization Bearer + x-grok-client-mode); when that payload has no `creditUsagePercent`, one GET `https://cli-chat-proxy.grok.com/v1/billing` (same headers) whose `used / monthlyLimit` ratio becomes `monthly` (amounts discarded); its HTTP failures are the same typed results as the first request so stale retention applies, and a 2xx body without a ratio keeps the credits reading | `weekly` (credits) or `monthly` (limit ratio), or no windows when the plan publishes neither | 90 s | 10 s | one network/timeout retry per request |
-| `antigravity` | resolved `agy --version` (requires 1.1.11 or newer, because older builds send `/usage` to the model as a prompt) then `agy --print /usage --output-format json` with `NO_COLOR=1`, `TERM=dumb`; windows come from the `gemini-weekly` and `gemini-5h` bucket ids, the `Claude and GPT models` group is ignored | `gemini-weekly`, `gemini-5h` | 90 s | 10 s | none |
+| `antigravity` | resolved `agy --version` (requires 1.1.11 or newer, because older builds send `/usage` to the model as a prompt) then `agy --print /usage --output-format json` with `NO_COLOR=1`, `TERM=dumb`; windows come from the `gemini-weekly`, `gemini-5h`, `3p-weekly`, and `3p-5h` bucket ids in that order, labelled with their family and duration (`Gemini · 7d`, `Claude/GPT · 5h`); a bucket with a remaining fraction of 1 or more carries no reset, because no window is running | `gemini-weekly`, `gemini-5h`, `3p-weekly`, `3p-5h` | 90 s | 10 s | none |
 
 Antigravity was removed once (see `CHANGELOG.md`) when it read credentials and
 plan data out of a `~/.gemini` layout that no longer matches current installs.
@@ -242,7 +242,8 @@ not counted as a retry.
 
 Provider labels are fixed English copy: Claude `Session`/`Weekly`, Codex
 `Session`/`Weekly`, Amp `Daily`, Grok `Weekly (7d)`/`Monthly`, and Antigravity
-`Session (5h)`/`Weekly (7d)`. Dynamic model labels are
+`Gemini · 7d`/`Gemini · 5h`/`Claude/GPT · 7d`/`Claude/GPT · 5h`. Dynamic model
+labels are
 sanitized plain text. A dynamic Claude model ID is lowercased, limited to
 ASCII letters/digits/hyphens, and prefixed with `weekly-model:`; collisions
 receive the deterministic source-order suffix `:2`, `:3`, and so on. Monetary

--- a/docs/specs/v10/04-quickshell-ux-and-accessibility.md
+++ b/docs/specs/v10/04-quickshell-ux-and-accessibility.md
@@ -82,10 +82,11 @@ not literal UI.
   accessible name carries the word `critical` even when the chip numeral
   belongs to a non-critical session window. Every level carries a word; no level is
   colour-only.
-- `UX-020D` (amended 2026-09-04): The popup renders exactly one lead
-  window, elected deterministically: a session window (window id `session`
-  or `gemini-5h`) leads whenever present, the first delivered one if
-  several; otherwise a critical window wins, and among criticals the one
+- `UX-020D` (amended 2026-09-04, 2026-09-10): The popup renders exactly one
+  lead window, elected deterministically: a session window (window id
+  `session`, `gemini-5h`, or `3p-5h`) leads whenever present, and among
+  several the one with the lowest remaining percentage, ties keeping the
+  delivered order; otherwise a critical window wins, and among criticals the one
   with the lowest remaining percentage; otherwise a plan window (window id
   starting `plan-`) wins, and among plan windows the one with the lowest
   remaining percentage; otherwise the window whose reset comes soonest; ties

--- a/docs/specs/v10/README.md
+++ b/docs/specs/v10/README.md
@@ -68,7 +68,8 @@ application, an AUR product, or a cargo-binstall product.
    [2026-08-25 login-state visibility](amendments/2026-08-25-login-state-visibility-design.md),
    [2026-09-04 session window leads](amendments/2026-09-04-session-window-leads-design.md),
    [2026-09-10 plugin root from Service URL](amendments/2026-09-10-plugin-root-from-service-url-design.md),
-   [2026-09-10 automatic updates](amendments/2026-09-10-automatic-updates-design.md).
+   [2026-09-10 automatic updates](amendments/2026-09-10-automatic-updates-design.md),
+   [2026-09-10 Antigravity third-party windows](amendments/2026-09-10-antigravity-third-party-windows-design.md).
 
 When two statements conflict, the earlier contract in this reading order wins
 unless a later file explicitly identifies the requirement ID it refines.

--- a/docs/specs/v10/amendments/2026-09-10-antigravity-third-party-windows-design.md
+++ b/docs/specs/v10/amendments/2026-09-10-antigravity-third-party-windows-design.md
@@ -1,0 +1,83 @@
+# Antigravity reports its Claude/GPT quota
+
+Date: 2026-09-10
+Status: approved
+
+## Context
+
+`agy --print /usage --output-format json` reports two model families, each
+on its own weekly and five-hour quota:
+
+| Group | Bucket ids | Models (`agy` 1.2.0) |
+|---|---|---|
+| Gemini Models | `gemini-weekly`, `gemini-5h` | Gemini Flash, Gemini Pro |
+| Claude and GPT models | `3p-weekly`, `3p-5h` | Claude Opus, Claude Sonnet, GPT-OSS |
+
+The CLI describes them itself: "Within each group, models share a weekly
+limit and a 5-hour limit. Quota is consumed proportionally to the cost of
+the tokens." Agent Bar mapped only the Gemini pair, so an account working
+through Claude or GPT in Antigravity saw nothing drain until the quota ran
+out (issue #82).
+
+A live probe on 2026-09-10 against `agy` 1.2.0 established how the buckets
+behave:
+
+- A bucket that no one has used reports `remaining_fraction` exactly `1`
+  and `reset_time` equal to the request time plus the whole window. Two
+  requests three seconds apart each got a reset about five hours (or
+  seven days) after themselves, so the reset moves with the clock.
+- The first prompt on a family starts both of its windows. From then on
+  the reset is fixed at first use plus five hours (or seven days): a
+  second Gemini prompt fifteen minutes later left it unchanged, and the
+  Claude/GPT reset, read fifteen minutes apart, did not move either.
+- A prompt debits both windows of its own family and nothing of the other.
+
+## Decision
+
+- The mapper reads all four bucket ids, in a fixed order: Gemini weekly,
+  Gemini five-hour, Claude/GPT weekly, Claude/GPT five-hour. Any other id,
+  including guessed aliases such as `claude-5h`, is ignored.
+- Every Antigravity window names its family and duration: `Gemini · 7d`,
+  `Gemini · 5h`, `Claude/GPT · 7d`, `Claude/GPT · 5h`. The longer
+  `Claude/GPT · Session (5h)` measures 165 px in the 11 px popup font and
+  the compact row gives its label about 118 px, so it would elide to
+  `Claude/GPT · Ses…`; the short form is at most 99 px. Window ids do not
+  change, so notification state keyed by window survives; notification
+  titles gain the family.
+- A bucket with a remaining fraction of `1` or more carries no reset. No
+  window is running and the reset `agy` reports never arrives.
+- `3p-5h` joins `SESSION_WINDOW_IDS`. When several session windows are
+  delivered, the one with the lowest remaining percentage leads, and a tie
+  keeps the delivered order. The rule is written for any provider; only
+  Antigravity delivers more than one session id today, and the schema
+  rejects duplicate window ids within a provider.
+
+The lead is the tighter session, not a detected "current" family. With one
+family in use, that is the family in use: an idle family sits at 100 % and
+only wins a tie, where the chip number is identical anyway. With both in
+use, the lower session leads even if the other family is the one being
+used right now. On an account whose plan reports no five-hour buckets, a
+full weekly bucket has no reset and does not compete in the nearest-reset
+step; with both weeklies in use, the sooner reset leads.
+
+Severity is unchanged (`UX-020C`): a critical window of either family still
+tints the chip and shows `!`, even when the numeral belongs to the other
+family's session.
+
+## Contract changes
+
+- `UX-020D`: session window ids are `session`, `gemini-5h`, and `3p-5h`;
+  among several, the lowest remaining percentage leads, ties keep the
+  delivered order. This supersedes "the first delivered one if several"
+  from the 2026-09-04 amendment.
+- `02-target-architecture.md`, locked collection policy: the Antigravity row
+  lists all four bucket ids and the full-bucket reset rule, and the
+  provider labels paragraph lists the four Antigravity labels.
+
+## Tests
+
+- `src/providers/v2_map.rs`: the fixture maps to four labelled windows;
+  `claude-*` ids are ignored; a full bucket carries no reset while a used
+  one keeps it; the order is fixed however the CLI orders groups.
+- `tests/qml/tst_ProviderStates.qml`: the Claude/GPT session leads when it
+  is lower, the Gemini session when it is lower, and a tie keeps Gemini.

--- a/src/providers/adapters.rs
+++ b/src/providers/adapters.rs
@@ -2589,9 +2589,8 @@ done
         assert_no_money(&result);
         match result {
             ProviderResult::Ready { windows, .. } => {
-                assert_eq!(windows.len(), 2);
-                assert_eq!(windows[0].id(), "gemini-weekly");
-                assert_eq!(windows[1].id(), "gemini-5h");
+                let ids: Vec<&str> = windows.iter().map(|w| w.id()).collect();
+                assert_eq!(ids, ["gemini-weekly", "gemini-5h", "3p-weekly", "3p-5h"]);
             }
             other => panic!("expected ready, got {other:?}"),
         }
@@ -2762,7 +2761,7 @@ done
             antigravity_collect_at_version(antigravity_output(0, "v1.2.0\n")).await;
         assert_eq!(calls, 2, "a supported version proceeds to the usage call");
         match result {
-            ProviderResult::Ready { windows, .. } => assert_eq!(windows.len(), 2),
+            ProviderResult::Ready { windows, .. } => assert_eq!(windows.len(), 4),
             other => panic!("expected ready, got {other:?}"),
         }
     }

--- a/src/providers/v2_map.rs
+++ b/src/providers/v2_map.rs
@@ -23,6 +23,13 @@ const LABEL_SESSION: &str = "Session (5h)";
 const LABEL_DAILY: &str = "Daily (1d)";
 const LABEL_WEEKLY: &str = "Weekly (7d)";
 
+// Antigravity meters two model families on separate quotas, so each window
+// names its family.
+const LABEL_GEMINI_WEEKLY: &str = "Gemini · 7d";
+const LABEL_GEMINI_SESSION: &str = "Gemini · 5h";
+const LABEL_THIRD_PARTY_WEEKLY: &str = "Claude/GPT · 7d";
+const LABEL_THIRD_PARTY_SESSION: &str = "Claude/GPT · 5h";
+
 // ---------------------------------------------------------------------------
 // Amp
 // ---------------------------------------------------------------------------
@@ -928,10 +935,15 @@ fn antigravity_error(message: &str) -> ProviderResult {
 
 /// Parse `agy --print /usage --output-format json` into a domain result.
 ///
-/// Only the Gemini family carries a percentage window Agent Bar reports; the
-/// shared Claude/GPT buckets (`3p-*`) are ignored. A run without any window is
-/// `Ready` with an empty list — a connected provider without a percentage
-/// window is valid, exactly as for Amp.
+/// `agy` meters two model families, Gemini (`gemini-*`) and Claude/GPT
+/// (`3p-*`), each on its own weekly and five-hour quota. All four buckets map
+/// to windows in a fixed order; any other bucket id is ignored. A run without
+/// any window is `Ready` with an empty list — a connected provider without a
+/// percentage window is valid, exactly as for Amp.
+///
+/// A window starts on first use. A full bucket has none running, and `agy`
+/// reports its `reset_time` as now plus the whole window, a moving target, so
+/// a full bucket carries no reset.
 ///
 /// The logged-out banner is not handled here: `Unauthenticated` needs to know
 /// whether login is available, which is discovery state the adapter owns, so
@@ -946,10 +958,13 @@ pub fn antigravity_from_usage_json(stdout: &str, now: OffsetDateTime) -> Provide
         return antigravity_error("Antigravity usage command failed.");
     }
 
-    // Two named slots rather than a push list: they give the fixed weekly ->
-    // 5h order and the per-id dedupe (first bucket wins) in one move.
-    let mut weekly: Option<UsageWindow> = None;
-    let mut session: Option<UsageWindow> = None;
+    // Named slots rather than a push list: they give the fixed family, then
+    // weekly -> 5h, order and the per-id dedupe (first bucket wins) in one
+    // move.
+    let mut gemini_weekly: Option<UsageWindow> = None;
+    let mut gemini_session: Option<UsageWindow> = None;
+    let mut third_party_weekly: Option<UsageWindow> = None;
+    let mut third_party_session: Option<UsageWindow> = None;
 
     for bucket in usage
         .command
@@ -959,8 +974,10 @@ pub fn antigravity_from_usage_json(stdout: &str, now: OffsetDateTime) -> Provide
         .flat_map(|group| group.buckets.iter())
     {
         let (label, slot) = match bucket.id.as_str() {
-            "gemini-weekly" => (LABEL_WEEKLY, &mut weekly),
-            "gemini-5h" => (LABEL_SESSION, &mut session),
+            "gemini-weekly" => (LABEL_GEMINI_WEEKLY, &mut gemini_weekly),
+            "gemini-5h" => (LABEL_GEMINI_SESSION, &mut gemini_session),
+            "3p-weekly" => (LABEL_THIRD_PARTY_WEEKLY, &mut third_party_weekly),
+            "3p-5h" => (LABEL_THIRD_PARTY_SESSION, &mut third_party_session),
             _ => continue,
         };
         if slot.is_some() {
@@ -975,6 +992,7 @@ pub fn antigravity_from_usage_json(stdout: &str, now: OffsetDateTime) -> Provide
         let resets_at = bucket
             .reset_time
             .as_deref()
+            .filter(|_| fraction < 1.0)
             .and_then(|ts| OffsetDateTime::parse(ts, &Rfc3339).ok())
             .map(|ts| ts.to_offset(UtcOffset::UTC));
 
@@ -995,7 +1013,12 @@ pub fn antigravity_from_usage_json(stdout: &str, now: OffsetDateTime) -> Provide
         source: DataSource::Live,
         plan: None,
         account: None,
-        windows: weekly.into_iter().chain(session).collect(),
+        windows: gemini_weekly
+            .into_iter()
+            .chain(gemini_session)
+            .chain(third_party_weekly)
+            .chain(third_party_session)
+            .collect(),
         last_success_at: now,
         rate_limit_resets_available: None,
     }
@@ -1644,10 +1667,10 @@ mod tests {
                 account,
                 ..
             } => {
-                assert_eq!(windows.len(), 2);
+                assert_eq!(windows.len(), 4);
 
                 assert_eq!(windows[0].id(), "gemini-weekly");
-                assert_eq!(windows[0].label(), LABEL_WEEKLY);
+                assert_eq!(windows[0].label(), "Gemini · 7d");
                 assert!((windows[0].remaining_percent() - 86.0).abs() < 0.01);
                 assert!((windows[0].used_percent() - 14.0).abs() < 0.01);
                 assert_eq!(
@@ -1656,13 +1679,25 @@ mod tests {
                 );
 
                 assert_eq!(windows[1].id(), "gemini-5h");
-                assert_eq!(windows[1].label(), LABEL_SESSION);
+                assert_eq!(windows[1].label(), "Gemini · 5h");
                 assert!((windows[1].remaining_percent() - 92.0).abs() < 0.01);
                 assert!((windows[1].used_percent() - 8.0).abs() < 0.01);
                 assert_eq!(
                     windows[1].resets_at(),
                     Some(datetime!(2026-08-23 04:25:14 UTC))
                 );
+
+                // The Claude/GPT pair is untouched in this capture: full, so
+                // no window is running and its reset is dropped.
+                assert_eq!(windows[2].id(), "3p-weekly");
+                assert_eq!(windows[2].label(), "Claude/GPT · 7d");
+                assert!((windows[2].remaining_percent() - 100.0).abs() < 0.01);
+                assert_eq!(windows[2].resets_at(), None);
+
+                assert_eq!(windows[3].id(), "3p-5h");
+                assert_eq!(windows[3].label(), "Claude/GPT · 5h");
+                assert!((windows[3].remaining_percent() - 100.0).abs() < 0.01);
+                assert_eq!(windows[3].resets_at(), None);
 
                 assert!(plan.is_none());
                 assert!(account.is_none());
@@ -1672,16 +1707,42 @@ mod tests {
     }
 
     #[test]
-    fn antigravity_ignores_the_shared_third_party_buckets() {
-        // The fixture carries `3p-weekly` and `3p-5h` next to the Gemini pair;
-        // only the Gemini family has a window Agent Bar reports, so the ready
-        // result above must contain exactly two windows and neither of these.
-        let fixture = include_str!("../../tests/fixtures/antigravity/usage.json");
-        match antigravity_from_usage_json(fixture, datetime!(2026-08-21 12:00:00 UTC)) {
+    fn antigravity_ignores_unknown_bucket_ids() {
+        // Only the four ids `agy` 1.2.0 reports are mapped. Guessed aliases
+        // such as `claude-5h` stay unknown and never become a window.
+        let payload = r#"{"status":"SUCCESS","command":{"name":"usage","data":{"groups":[
+            {"name":"Claude and GPT models","buckets":[
+              {"id":"claude-weekly","window":"weekly","remaining_fraction":0.5},
+              {"id":"claude-5h","window":"5h","remaining_fraction":0.5}]}]}}}"#;
+        match antigravity_from_usage_json(payload, datetime!(2026-08-21 12:00:00 UTC)) {
+            ProviderResult::Ready { windows, .. } => assert!(windows.is_empty(), "{windows:?}"),
+            other => panic!("expected ready, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn antigravity_full_bucket_carries_no_reset() {
+        // A window starts on first use. Until then `agy` reports the bucket
+        // full with `reset_time` = now + the whole window, a moving target
+        // that never arrives, so a full bucket carries no reset. A bucket
+        // with any use keeps the fixed reset `agy` reports.
+        let payload = r#"{"status":"SUCCESS","command":{"name":"usage","data":{"groups":[
+            {"name":"Gemini Models","buckets":[
+              {"id":"gemini-weekly","window":"weekly","remaining_fraction":1.4,
+               "reset_time":"2026-08-28T12:00:03Z"},
+              {"id":"gemini-5h","window":"5h","remaining_fraction":1,
+               "reset_time":"2026-08-21T17:00:03Z"}]},
+            {"name":"Claude and GPT models","buckets":[
+              {"id":"3p-5h","window":"5h","remaining_fraction":0.99,
+               "reset_time":"2026-08-21T16:10:00Z"}]}]}}}"#;
+        match antigravity_from_usage_json(payload, datetime!(2026-08-21 12:00:00 UTC)) {
             ProviderResult::Ready { windows, .. } => {
-                assert!(
-                    windows.iter().all(|w| !w.id().starts_with("3p-")),
-                    "{windows:?}"
+                assert_eq!(windows.len(), 3);
+                assert_eq!(windows[0].resets_at(), None);
+                assert_eq!(windows[1].resets_at(), None);
+                assert_eq!(
+                    windows[2].resets_at(),
+                    Some(datetime!(2026-08-21 16:10:00 UTC))
                 );
             }
             other => panic!("expected ready, got {other:?}"),
@@ -1692,10 +1753,10 @@ mod tests {
     fn antigravity_zero_windows_is_ready_not_an_error() {
         // Same rule as Amp: a connected provider without a percentage window
         // is valid and renders "—" (CLAUDE.md, provider rules). An account
-        // with only the shared Claude/GPT group is exactly this case.
+        // whose buckets carry no id Agent Bar maps is exactly this case.
         let payload = r#"{"status":"SUCCESS","command":{"name":"usage","data":{"groups":[
-            {"name":"Claude and GPT models","buckets":[
-              {"id":"3p-weekly","window":"weekly","remaining_fraction":1,
+            {"name":"Other models","buckets":[
+              {"id":"other-weekly","window":"weekly","remaining_fraction":1,
                "reset_time":"2026-08-29T23:25:14Z"}]}]}}}"#;
         let result = antigravity_from_usage_json(payload, datetime!(2026-08-21 12:00:00 UTC));
         assert_no_money(&result);
@@ -1778,17 +1839,20 @@ mod tests {
     }
 
     #[test]
-    fn antigravity_orders_weekly_before_the_five_hour_window() {
-        // The CLI is free to reorder its buckets; the rendered order is not.
+    fn antigravity_orders_windows_by_family_then_weekly_first() {
+        // The CLI is free to reorder groups and buckets; the rendered order
+        // is not: Gemini weekly, Gemini 5h, Claude/GPT weekly, Claude/GPT 5h.
         let payload = r#"{"status":"SUCCESS","command":{"name":"usage","data":{"groups":[
+            {"name":"Claude and GPT models","buckets":[
+              {"id":"3p-5h","window":"5h","remaining_fraction":1},
+              {"id":"3p-weekly","window":"weekly","remaining_fraction":1}]},
             {"name":"Gemini Models","buckets":[
               {"id":"gemini-5h","window":"5h","remaining_fraction":1},
               {"id":"gemini-weekly","window":"weekly","remaining_fraction":1}]}]}}}"#;
         match antigravity_from_usage_json(payload, datetime!(2026-08-21 12:00:00 UTC)) {
             ProviderResult::Ready { windows, .. } => {
-                assert_eq!(windows.len(), 2);
-                assert_eq!(windows[0].id(), "gemini-weekly");
-                assert_eq!(windows[1].id(), "gemini-5h");
+                let ids: Vec<&str> = windows.iter().map(|w| w.id()).collect();
+                assert_eq!(ids, ["gemini-weekly", "gemini-5h", "3p-weekly", "3p-5h"]);
                 // A bucket without `reset_time` is still a window.
                 assert_eq!(windows[0].resets_at(), None);
             }

--- a/tests/fixtures/status-v2/valid-antigravity-ready.json
+++ b/tests/fixtures/status-v2/valid-antigravity-ready.json
@@ -17,17 +17,31 @@
       "windows": [
         {
           "id": "gemini-weekly",
-          "label": "Weekly (7d)",
+          "label": "Gemini · 7d",
           "usedPercent": 14.0,
           "remainingPercent": 86.0,
           "resetsAt": "2026-08-27T16:18:13Z"
         },
         {
           "id": "gemini-5h",
-          "label": "Session (5h)",
+          "label": "Gemini · 5h",
           "usedPercent": 8.0,
           "remainingPercent": 92.0,
           "resetsAt": "2026-08-21T22:09:26Z"
+        },
+        {
+          "id": "3p-weekly",
+          "label": "Claude/GPT · 7d",
+          "usedPercent": 0.0,
+          "remainingPercent": 100.0,
+          "resetsAt": null
+        },
+        {
+          "id": "3p-5h",
+          "label": "Claude/GPT · 5h",
+          "usedPercent": 0.0,
+          "remainingPercent": 100.0,
+          "resetsAt": null
         }
       ],
       "lastSuccessAt": "2026-08-21T12:00:00Z",

--- a/tests/qml/tst_ProviderStates.qml
+++ b/tests/qml/tst_ProviderStates.qml
@@ -462,12 +462,49 @@ TestCase {
   // Antigravity's five-hour bucket is the same kind of window under its own id.
   function test_gemini_5h_window_leads_like_session() {
     var layout = layoutOf([
-      { id: "gemini-weekly", label: "Weekly (7d)", usedPercent: 40, remainingPercent: 60,
-        resetsAt: "2026-09-05T12:00:00Z" },
-      { id: "gemini-5h", label: "Session (5h)", usedPercent: 12, remainingPercent: 88,
-        resetsAt: null }
+      { id: "gemini-weekly", label: "Gemini · 7d", usedPercent: 40,
+        remainingPercent: 60, resetsAt: "2026-09-05T12:00:00Z" },
+      { id: "gemini-5h", label: "Gemini · 5h", usedPercent: 12,
+        remainingPercent: 88, resetsAt: null }
     ], "2026-09-04T11:00:00Z")
     compare(layout.lead.id, "gemini-5h")
+  }
+
+  // Antigravity meters Gemini and Claude/GPT on separate quotas. The family in
+  // use is the one draining its five-hour window, so the lowest remaining
+  // session leads; an idle family sits at 100 % and only wins a tie.
+  function antigravityWindows(geminiSession, thirdPartySession) {
+    return [
+      { id: "gemini-weekly", label: "Gemini · 7d", usedPercent: 20,
+        remainingPercent: 80, resetsAt: "2026-09-10T12:00:00Z" },
+      { id: "gemini-5h", label: "Gemini · 5h",
+        usedPercent: 100 - geminiSession, remainingPercent: geminiSession,
+        resetsAt: geminiSession < 100 ? "2026-09-04T16:00:00Z" : null },
+      { id: "3p-weekly", label: "Claude/GPT · 7d", usedPercent: 30,
+        remainingPercent: 70, resetsAt: "2026-09-10T12:00:00Z" },
+      { id: "3p-5h", label: "Claude/GPT · 5h",
+        usedPercent: 100 - thirdPartySession, remainingPercent: thirdPartySession,
+        resetsAt: thirdPartySession < 100 ? "2026-09-04T15:00:00Z" : null }
+    ]
+  }
+
+  function test_antigravity_third_party_session_leads_when_in_use() {
+    var layout = layoutOf(antigravityWindows(100, 40), "2026-09-04T11:00:00Z")
+    compare(layout.lead.id, "3p-5h")
+    compare(Core.chipPercentText(readyWith(antigravityWindows(100, 40)), "remaining",
+                                 Date.parse("2026-09-04T11:00:00Z")), "40%")
+  }
+
+  function test_antigravity_gemini_session_leads_when_lower() {
+    compare(layoutOf(antigravityWindows(35, 60), "2026-09-04T11:00:00Z").lead.id,
+            "gemini-5h")
+  }
+
+  function test_antigravity_session_tie_keeps_delivered_order() {
+    compare(layoutOf(antigravityWindows(100, 100), "2026-09-04T11:00:00Z").lead.id,
+            "gemini-5h")
+    compare(layoutOf(antigravityWindows(75, 75), "2026-09-04T11:00:00Z").lead.id,
+            "gemini-5h")
   }
 
   function test_lines_carry_raw_percentages_and_countdown() {


### PR DESCRIPTION
Antigravity meters Gemini and Claude/GPT on separate quotas, two buckets each. We only mapped the Gemini pair, so anyone working through Claude or GPT in Antigravity saw Gemini sit at 100% while their real quota drained.

Closes #82. Supersedes #85, credited with `Co-authored-by`.

## What changes

- The mapper reads `gemini-weekly`, `gemini-5h`, `3p-weekly` and `3p-5h`, always in that order. It ignores every other id, including the `claude-*` aliases from #85, which `agy` 1.2.0 never emits.
- Labels name the family and duration: `Gemini · 7d`, `Gemini · 5h`, `Claude/GPT · 7d`, `Claude/GPT · 5h`. The longer `Claude/GPT · Session (5h)` elides in the compact row. Window ids stay the same, so notification state carries over.
- `3p-5h` counts as a session window. With two sessions delivered, the lower one leads the chip. A tie keeps Gemini.
- A full bucket carries no reset. Until you use a family, `agy` reports its reset as now plus the whole window, so the old "resets in 5h 0m" never arrived.

The spec change lives in a dated amendment, `docs/specs/v10/amendments/2026-09-10-antigravity-third-party-windows-design.md`. The v10 README indexes it, and `UX-020D` and the architecture table match it.

## How the buckets behave

I probed `agy` 1.2.0 on a live account.

- An unused bucket reports `remaining_fraction` 1 and a reset that moves with the clock.
- The first prompt on a family pins both of its resets at first use plus the window. A second Gemini prompt 15 minutes later left the reset where it was.
- A prompt debits both buckets of its own family and leaves the other family alone.

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` and `git diff --check` are clean.
- `cargo test`: 396 passed, 0 failed.
- Qt6 `qmltestrunner`: 316 passed, 0 failed.
- `omarchy plugin validate .` exits 0.
- `qmllint` shows no new warnings against `master`.
- Live smoke. I copied the new helper and `CoreView.js` into the installed plugin and restarted the shell. Health came back `ok`, and the helper reported the four labelled windows from a real account.

The tests failed before the code. The Rust mapper returned 2 windows where the tests expected 4, and `master`'s `CoreView.js` elected `gemini-5h` in `test_antigravity_third_party_session_leads_when_in_use`.
