### PR TITLE
feat: release a deliberately set version (10.4.0)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,8 +94,9 @@ superseded wherever a numbered spec file or the code says otherwise.
 
 ## Release
 
-Merging to `master` triggers an automatic patch release: version bump, Rust
-gates, and a single `release: v{version}` commit that stamps
+Merging to `master` triggers an automatic release: a patch bump (or a minor
+or major version set by hand in the pull request, see
+`docs/dev/releasing.md`), Rust gates, and a single `release: v{version}` commit that stamps
 `bin/agent-bar`, `bundle.json`, and the manifest version straight into the
 repository root — the root IS the plugin tree, per
 [ADR 0006](docs/adr/0006-single-repository-distribution.md) — followed by

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-bar"
-version = "10.3.27"
+version = "10.4.0"
 dependencies = [
  "assert_cmd",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-bar"
-version = "10.3.27"
+version = "10.4.0"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT"

--- a/docs/dev/releasing.md
+++ b/docs/dev/releasing.md
@@ -3,7 +3,8 @@
 Releases are automatic. Every push to `master` that touches a product path
 (`src/**`, `scripts/**`, `Cargo.toml`, `Cargo.lock`, `*.qml`, `Core*.js`,
 `components/**`, `icons/**`, `manifest.json`) triggers
-`.github/workflows/auto-release.yml`, which cuts a patch release, stamps
+`.github/workflows/auto-release.yml`, which cuts a release (a patch bump,
+or a minor or major set by hand; see [Manual boundary](#manual-boundary)), stamps
 the release artifacts into the repository root, and publishes the product
 release in a single run. Docs-only merges cut nothing. See
 [ADR 0006](../adr/0006-single-repository-distribution.md), which
@@ -236,8 +237,11 @@ and `manifest.json` in a pull request. That version has no tag yet, so the
 release run its merge triggers publishes it as set instead of bumping the
 patch; `workflow_dispatch` runs the same pipeline without a merge. Until
 that run lands, `master` carries the new version in `manifest.json` next to
-the previous `bundle.json` and helper; the update check reads `bundle.json`,
-so installs are not offered the half-stamped tree. Merging to `master` is
+the previous `bundle.json` and helper. `update check` reads `bundle.json`,
+so neither the Settings button nor automatic updates offer that tree; a
+manual `omarchy plugin update` in the window pulls it, the health IPC
+answers `unknown` until the next update, and a failed release run keeps the
+window open until a fixed run lands. Merging to `master` is
 the release decision; there is no separate per-release authorization step.
 
 ## Local reproduction

--- a/docs/dev/releasing.md
+++ b/docs/dev/releasing.md
@@ -20,9 +20,13 @@ installation.
 
 ## Automatic pipeline
 
-1. `scripts/agent-bar-cut-release` bumps the patch version in `Cargo.toml`,
-   the lockfile, and `manifest.json`, writes `docs/releases/{version}.md`
-   from the Conventional Commit subjects since the last tag, and prepends
+1. `scripts/agent-bar-cut-release` picks the version: when the
+   `Cargo.toml` version already has a `v{version}` tag it bumps the patch
+   in `Cargo.toml`, the lockfile, and `manifest.json`; when it has no tag
+   yet (a minor or major set by hand, see [Manual boundary](#manual-boundary))
+   it releases that version as set, and refuses one that is not above the
+   last release tag. It writes `docs/releases/{version}.md` from the
+   Conventional Commit subjects since the last release tag, and prepends
    a matching CHANGELOG section below `[Unreleased]`. Preview locally:
 
    ```bash
@@ -226,10 +230,15 @@ in one call; the release workflow runs it as part of the stamp step.
 
 ## Manual boundary
 
-Automatic cuts are always patch bumps. Minor and major releases remain
-human-driven: set the version deliberately, then run the same pipeline via
-`workflow_dispatch`. Merging to `master` is the release decision for patch
-versions; there is no separate per-release authorization step.
+Automatic cuts are patch bumps. Minor and major releases remain
+human-driven: set the version deliberately in `Cargo.toml`, `Cargo.lock`,
+and `manifest.json` in a pull request. That version has no tag yet, so the
+release run its merge triggers publishes it as set instead of bumping the
+patch; `workflow_dispatch` runs the same pipeline without a merge. Until
+that run lands, `master` carries the new version in `manifest.json` next to
+the previous `bundle.json` and helper; the update check reads `bundle.json`,
+so installs are not offered the half-stamped tree. Merging to `master` is
+the release decision; there is no separate per-release authorization step.
 
 ## Local reproduction
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "id": "othavi0.agent-bar",
   "name": "Agent Bar",
-  "version": "10.3.27",
+  "version": "10.4.0",
   "author": "othavi0",
   "license": "MIT",
   "description": "LLM quota monitor for Claude, Codex, Amp, Grok, and Antigravity.",

--- a/scripts/agent-bar-cut-release
+++ b/scripts/agent-bar-cut-release
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-# Bump the patch version and materialize release notes for an auto-release.
+# Pick the release version and materialize release notes for an auto-release.
+# A Cargo.toml version that already carries a tag bumps the patch; a version
+# set deliberately and not yet tagged (a minor or major) is released as set.
 # Mutates: Cargo.toml, Cargo.lock, docs/releases/{next}.md, CHANGELOG.md.
 # Git commit/tag/push stay in the workflow, so this stays testable locally.
 # Usage: scripts/agent-bar-cut-release [--dry-run]
@@ -31,11 +33,25 @@ case "$MAJOR$MINOR$PATCH" in
     exit 1
     ;;
 esac
-NEXT="${MAJOR}.${MINOR}.$((PATCH + 1))"
+# Notes cover everything since the last release tag, which for a deliberate
+# version is not v${CUR}.
+PREV="$(git describe --tags --abbrev=0 --match 'v[0-9]*' 2>/dev/null || true)"
+
+if git rev-parse -q --verify "refs/tags/v${CUR}" >/dev/null; then
+  NEXT="${MAJOR}.${MINOR}.$((PATCH + 1))"
+else
+  NEXT="$CUR"
+  LAST="${PREV#v}"
+  if [ -n "$LAST" ] &&
+    [ "$(printf '%s\n%s\n' "$LAST" "$NEXT" | sort -V | tail -n 1)" != "$NEXT" ]; then
+    echo "Cargo.toml version $NEXT is not above the last release $LAST" >&2
+    exit 1
+  fi
+fi
 
 RANGE=""
-if git rev-parse -q --verify "refs/tags/v${CUR}" >/dev/null; then
-  RANGE="v${CUR}..HEAD"
+if [ -n "$PREV" ]; then
+  RANGE="${PREV}..HEAD"
 fi
 if [ -n "$RANGE" ]; then
   SUBJECTS="$(git log --no-merges --pretty='- %s' "$RANGE")"
@@ -49,7 +65,7 @@ fi
 TODAY="$(date -u +%F)"
 NOTES_PATH="docs/releases/${NEXT}.md"
 NOTES="$(printf '# Agent Bar %s\n\nAutomated release cut from main. Changes since %s:\n\n%s\n' \
-  "$NEXT" "$CUR" "$SUBJECTS")"
+  "$NEXT" "${PREV#v}" "$SUBJECTS")"
 
 if [ "$DRY_RUN" -eq 1 ]; then
   echo "next-version: $NEXT"
@@ -67,7 +83,7 @@ if [ -f "$NOTES_PATH" ]; then
   exit 1
 fi
 
-# Bump only the first (package) version line.
+# Bump only the first (package) version line; a no-op for a deliberate one.
 sed -i "0,/^version = \"${CUR}\"/s//version = \"${NEXT}\"/" Cargo.toml
 cargo update --workspace --offline --quiet
 

--- a/tests/cut_release.rs
+++ b/tests/cut_release.rs
@@ -33,12 +33,16 @@ fn git(repo: &Path, args: &[&str]) {
     assert!(status.success(), "git {args:?}");
 }
 
-fn write_version(repo: &Path, version: &str) {
+fn write_cargo_version(repo: &Path, version: &str) {
     fs::write(
         repo.join("Cargo.toml"),
-        format!("[package]\nname = \"fixture\"\nversion = \"{version}\"\n"),
+        format!("[package]\nname = \"fixture\"\nversion = \"{version}\"\nedition = \"2021\"\n"),
     )
     .unwrap();
+}
+
+fn write_version(repo: &Path, version: &str) {
+    write_cargo_version(repo, version);
     fs::write(
         repo.join("manifest.json"),
         format!("{{\n  \"version\": \"{version}\"\n}}\n"),
@@ -50,6 +54,9 @@ fn write_version(repo: &Path, version: &str) {
 fn released_repo(tmp: &Path) -> PathBuf {
     let repo = tmp.join("repo");
     fs::create_dir_all(repo.join("docs/releases")).unwrap();
+    // A buildable crate so the real run's `cargo update --offline` works.
+    fs::create_dir_all(repo.join("src")).unwrap();
+    fs::write(repo.join("src/lib.rs"), "").unwrap();
     fs::write(
         repo.join("CHANGELOG.md"),
         "# Changelog\n\n## [Unreleased]\n",
@@ -121,6 +128,69 @@ fn untagged_version_below_the_last_release_is_refused() {
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(
         stderr.contains("10.3.9 is not above the last release 10.3.27"),
+        "{stderr}"
+    );
+}
+
+fn cut(repo: &Path) -> std::process::Output {
+    Command::new("bash")
+        .arg(cut_release_script())
+        .current_dir(repo)
+        .output()
+        .expect("run cut-release")
+}
+
+fn read(repo: &Path, rel: &str) -> String {
+    fs::read_to_string(repo.join(rel)).unwrap()
+}
+
+#[test]
+fn real_run_stamps_a_deliberate_version_as_set() {
+    let tmp = tempfile::tempdir().unwrap();
+    let repo = released_repo(tmp.path());
+    write_version(&repo, "10.4.0");
+    git(&repo, &["commit", "-q", "-am", "chore: set version 10.4.0"]);
+    let out = cut(&repo);
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(read(&repo, "Cargo.toml").contains("version = \"10.4.0\""));
+    assert!(read(&repo, "manifest.json").contains("\"version\": \"10.4.0\""));
+    assert!(read(&repo, "docs/releases/10.4.0.md").contains("Changes since 10.3.27:"));
+    assert!(read(&repo, "CHANGELOG.md").contains("## [10.4.0] - "));
+}
+
+#[test]
+fn real_run_bumps_a_tagged_version() {
+    let tmp = tempfile::tempdir().unwrap();
+    let repo = released_repo(tmp.path());
+    let out = cut(&repo);
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(read(&repo, "Cargo.toml").contains("version = \"10.3.28\""));
+    assert!(read(&repo, "manifest.json").contains("\"version\": \"10.3.28\""));
+    assert!(repo.join("docs/releases/10.3.28.md").is_file());
+}
+
+#[test]
+fn deliberate_version_missing_from_the_manifest_is_refused() {
+    let tmp = tempfile::tempdir().unwrap();
+    let repo = released_repo(tmp.path());
+    write_cargo_version(&repo, "10.4.0");
+    git(
+        &repo,
+        &["commit", "-q", "-am", "chore: half a version bump"],
+    );
+    let out = cut(&repo);
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("manifest.json version stamp failed"),
         "{stderr}"
     );
 }

--- a/tests/cut_release.rs
+++ b/tests/cut_release.rs
@@ -1,0 +1,126 @@
+//! `scripts/agent-bar-cut-release` version contract (docs/dev/releasing.md,
+//! "Manual boundary"): a version already carrying a tag bumps the patch; a
+//! version set deliberately and not yet tagged is released as set.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn cut_release_script() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("scripts/agent-bar-cut-release")
+}
+
+fn git(repo: &Path, args: &[&str]) {
+    let status = Command::new("git")
+        .args([
+            "-c",
+            "user.name=t",
+            "-c",
+            "user.email=t@t",
+            "-c",
+            "tag.gpgSign=false",
+        ])
+        .args([
+            "-c",
+            "commit.gpgSign=false",
+            "-c",
+            "core.hooksPath=/dev/null",
+        ])
+        .args(args)
+        .current_dir(repo)
+        .status()
+        .expect("run git");
+    assert!(status.success(), "git {args:?}");
+}
+
+fn write_version(repo: &Path, version: &str) {
+    fs::write(
+        repo.join("Cargo.toml"),
+        format!("[package]\nname = \"fixture\"\nversion = \"{version}\"\n"),
+    )
+    .unwrap();
+    fs::write(
+        repo.join("manifest.json"),
+        format!("{{\n  \"version\": \"{version}\"\n}}\n"),
+    )
+    .unwrap();
+}
+
+/// A repository whose last release is `v10.3.27`, then one feature commit.
+fn released_repo(tmp: &Path) -> PathBuf {
+    let repo = tmp.join("repo");
+    fs::create_dir_all(repo.join("docs/releases")).unwrap();
+    fs::write(
+        repo.join("CHANGELOG.md"),
+        "# Changelog\n\n## [Unreleased]\n",
+    )
+    .unwrap();
+    write_version(&repo, "10.3.27");
+    git(&repo, &["init", "-q"]);
+    git(&repo, &["add", "-A"]);
+    git(&repo, &["commit", "-q", "-m", "release: v10.3.27"]);
+    git(&repo, &["tag", "v10.3.27"]);
+    fs::write(repo.join("feature.txt"), "x\n").unwrap();
+    git(&repo, &["add", "-A"]);
+    git(&repo, &["commit", "-q", "-m", "feat: something new"]);
+    repo
+}
+
+fn dry_run(repo: &Path) -> String {
+    let out = Command::new("bash")
+        .arg(cut_release_script())
+        .arg("--dry-run")
+        .current_dir(repo)
+        .output()
+        .expect("run cut-release");
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8(out.stdout).unwrap()
+}
+
+#[test]
+fn tagged_version_bumps_the_patch() {
+    let tmp = tempfile::tempdir().unwrap();
+    let repo = released_repo(tmp.path());
+    let out = dry_run(&repo);
+    assert!(out.contains("next-version: 10.3.28\n"), "{out}");
+    assert!(out.contains("Changes since 10.3.27:"), "{out}");
+    assert!(out.contains("- feat: something new"), "{out}");
+}
+
+#[test]
+fn untagged_version_is_released_as_set() {
+    let tmp = tempfile::tempdir().unwrap();
+    let repo = released_repo(tmp.path());
+    write_version(&repo, "10.4.0");
+    git(&repo, &["commit", "-q", "-am", "chore: set version 10.4.0"]);
+    let out = dry_run(&repo);
+    assert!(out.contains("next-version: 10.4.0\n"), "{out}");
+    // Notes still cover everything since the last release tag.
+    assert!(out.contains("Changes since 10.3.27:"), "{out}");
+    assert!(out.contains("- feat: something new"), "{out}");
+    assert!(out.contains("- chore: set version 10.4.0"), "{out}");
+}
+
+#[test]
+fn untagged_version_below_the_last_release_is_refused() {
+    let tmp = tempfile::tempdir().unwrap();
+    let repo = released_repo(tmp.path());
+    write_version(&repo, "10.3.9");
+    git(&repo, &["commit", "-q", "-am", "chore: typo"]);
+    let out = Command::new("bash")
+        .arg(cut_release_script())
+        .arg("--dry-run")
+        .current_dir(&repo)
+        .output()
+        .expect("run cut-release");
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("10.3.9 is not above the last release 10.3.27"),
+        "{stderr}"
+    );
+}


### PR DESCRIPTION
Cuts 10.4.0 for the Antigravity Claude/GPT quota work (#91, already out as 10.3.27).

`agent-bar-cut-release` always bumped the patch, so the minor and major releases `docs/dev/releasing.md` describes could not be cut: no starting version patch-bumps into 10.4.0. The script now picks the version like this.

- A `Cargo.toml` version that already has a `v{version}` tag bumps the patch, as before.
- A version without a tag was set by hand, and the script releases it as set. It refuses a version that is not above the last release tag.
- Notes run from the last release tag in both cases.

The second commit sets 10.4.0 in `Cargo.toml`, `Cargo.lock` and `manifest.json`, so merging this PR cuts v10.4.0 through the normal auto-release run. After that, ordinary merges go back to 10.4.1, 10.4.2 and so on.

Between the merge and the release commit, `master` has `manifest.json` at 10.4.0 next to the 10.3.27 `bundle.json` and helper. `update check` reads `bundle.json`, so Settings and automatic updates don't offer that tree. `docs/dev/releasing.md` spells out the manual `omarchy plugin update` case.

## Verification

- `tests/cut_release.rs`, 6 tests. Dry run: a tagged version bumps, a deliberate one is released as set, and a version below the last tag is refused. Real run: stamps a deliberate version, bumps a tagged one, and refuses a deliberate version missing from `manifest.json`. Before the script change, the deliberate-version test got 10.4.1.
- `cargo test`: 402 passed, 0 failed.
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `git diff --check` and ShellCheck 0.11.0 on the script are clean.
- `scripts/agent-bar-cut-release --dry-run` on this branch prints `next-version: 10.4.0`, with changes since 10.3.27.
