### PR TITLE
refactor: drop comments that restate the code

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,11 +1,5 @@
 name: Auto release
 
-# Every product merge to master cuts an official release. The release
-# commit itself carries the stamped plugin artifacts (bin/agent-bar,
-# bundle.json, manifest version), so the repository root is always the
-# complete installable plugin tree and `omarchy plugin update` receives
-# exactly one fast-forward commit per release.
-
 on:
   push:
     branches: [master]

--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -7,8 +7,6 @@ import "CoreView.js" as Core
 import "CoreService.js" as Service
 import "components"
 
-// Monitor-local provider chips. Resolves the shared service via shell.serviceFor.
-// Presentation only — Service owns I/O and polling (ARCH-023).
 BarWidget {
   id: root
   moduleName: "othavi0.agent-bar"
@@ -42,7 +40,6 @@ BarWidget {
     onTriggered: root.nowMs = Date.now()
   }
 
-  // Popup is open on another monitor → this instance hosts dismiss-only overlay.
   readonly property bool foreignDismissActive: Service.foreignPopupOpen(
     agentService ? agentService.popupOwner : null,
     root
@@ -119,8 +116,6 @@ BarWidget {
     }
   }
 
-  // Monitor-local popup; only the owning bar instance opens (UX-021/022).
-  // Direct child + property initializers (model-usage / media pattern).
   // Do not wrap in Loader+Component: under Quattro that path leaves
   // KeyboardPanel required anchorItem/bar unset (Loader Error, no panel).
   Popup {
@@ -130,10 +125,6 @@ BarWidget {
     agentService: root.agentService
   }
 
-  // Cross-monitor outside-click: KeyboardPanel only maps on the owner
-  // monitor. Non-owner bars host a transparent full-screen dismiss layer so
-  // a click on the other desktop always closes (design D1). Bar strip
-  // forwards to clickTargets so chips can still transfer (D2/D3).
   PanelWindow {
     id: foreignDismiss
     property var anchorWindow: root.QsWindow ? root.QsWindow.window : null

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,41 +16,25 @@ name = "agent-bar-bundle"
 path = "src/bin/agent-bar-bundle.rs"
 
 [dependencies]
-# status/settings/cache/plugin JSON contracts
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-# typed domain errors across modules
 thiserror = "2"
-# clock, status timestamps, provider windows
 time = { version = "0.3", features = ["serde", "serde-well-known", "local-offset", "formatting", "parsing", "macros"] }
-# atomic writes and isolated tests
 tempfile = "3"
-# stderr diagnostics for cache/notifications
 log = "0.4"
-# helper binary stderr logger init
 env_logger = "0.11"
-# async process/HTTP collection runtime
 tokio = { version = "1", features = ["rt", "macros", "time", "process", "io-util", "io-std", "sync"] }
-# Claude HTTP collector and update check
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "stream"] }
-# HTTP body streaming in providers/http
 futures = "0.3"
-# provider stdout/session parsers
 regex = "1"
-# update version comparison
 semver = "1.0.28"
-# exclusive maintenance gate lock
 fs2 = "0.4.3"
-# bundle and ownership hashes
 sha2 = "0.11.0"
 
 [dev-dependencies]
-# CLI integration tests
 assert_cmd = "2"
 predicates = "3"
-# test-util runtime in tests
 tokio = { version = "1", features = ["test-util", "macros", "rt"] }
-# schema_contract fixture gate
 jsonschema = { version = "0.33", default-features = false }
 
 [profile.release]

--- a/CoreMaintenance.js
+++ b/CoreMaintenance.js
@@ -1,10 +1,5 @@
-// Maintenance state: handoff/lane guard, login, update, uninstall UI.
 .pragma library
 .import "CoreService.js" as Kernel
-
-// ---------------------------------------------------------------------------
-// Maintenance state
-// ---------------------------------------------------------------------------
 
 function maintenanceIdle() {
   return { phase: "idle", blocked: false }
@@ -18,16 +13,11 @@ function maintenanceCanStartWrite(maint) {
   return !maint || !maint.blocked
 }
 
-// Drain rule: handoff waits while status or settingsWrite busy.
 function maintenanceCanDetach(maint, statusBusy, settingsWriteBusy) {
   if (!maint || maint.phase !== "handoff")
     return false
   return !statusBusy && !settingsWriteBusy
 }
-
-// ---------------------------------------------------------------------------
-// Login / maintenance UI (Task 13 — UX-040..048)
-// ---------------------------------------------------------------------------
 
 function loginDetachedArgv(pluginRoot, providerId) {
   if (!pluginRoot || !String(pluginRoot).length)
@@ -74,7 +64,6 @@ function uninstallArgv(helperPath, purge) {
   return [String(helperPath), "uninstall"]
 }
 
-// Non-TTY uninstall confirmation document (CLI contract).
 function uninstallConfirmation(purge) {
   return {
     schemaVersion: 1,
@@ -120,12 +109,6 @@ function cloneMaintenanceUi(ui) {
   }
 }
 
-// Parse `update check` stdout: the BUNDLE-021 document
-// { schemaVersion, checkedAt, current, available, latestCompatible }.
-// A successful check always writes exactly that JSON, so exit 0 with
-// anything else is a failed check, not an implied answer. The fixtures in
-// tests/fixtures/update-check/ are pinned byte-exactly to the Rust
-// serializer by tests/update_check_parity.rs.
 function maintenanceUiFromCheck(ui, stdout, exitCode, fallbackVersion) {
   var next = cloneMaintenanceUi(ui)
   next.updateConfirmOpen = false
@@ -153,9 +136,6 @@ function maintenanceUiFromCheck(ui, stdout, exitCode, fallbackVersion) {
           next.message = "Update to " + next.targetVersion + " is available."
           return next
         }
-        // latestCompatible may be null (nothing fits this target/contract)
-        // or describe the installed version; either way there is nothing
-        // to offer.
         if (doc.available === false) {
           next.phase = "up_to_date"
           next.targetVersion = ""
@@ -165,7 +145,6 @@ function maintenanceUiFromCheck(ui, stdout, exitCode, fallbackVersion) {
         }
       }
     } catch (e) {
-      // unusable stdout falls through to the single failure exit
     }
   }
   next.phase = "error"
@@ -212,12 +191,10 @@ function maintenanceUiCloseUninstallConfirm(ui) {
 function maintenanceUiSetPurge(ui, purge) {
   var next = cloneMaintenanceUi(ui)
   next.purgeSettings = !!purge
-  // Changing purge resets the second destructive arm (UX-047 safety).
   next.uninstallArmed = false
   return next
 }
 
-// First destructive click arms; second confirms (UX-047).
 function maintenanceUiArmOrConfirmUninstall(ui) {
   var next = cloneMaintenanceUi(ui)
   if (!next.uninstallConfirmOpen)
@@ -229,10 +206,6 @@ function maintenanceUiArmOrConfirmUninstall(ui) {
   return { ui: next, confirmed: true }
 }
 
-// Automatic update check gate: settings loaded and the setting is on (the
-// default is on, so an unread settings file must not count as consent), the
-// helper answered, no maintenance or check is in flight, and the popup is
-// closed when the update starts.
 function automaticUpdateCheckAllowed(context) {
   if (!context)
     return false
@@ -244,8 +217,6 @@ function automaticUpdateCheckAllowed(context) {
       && context.popupOpen !== true
 }
 
-// Only a plain available update is applied without a click; reinstall and
-// failures stay for the user to see in Settings.
 function shouldAutoApplyUpdate(ui) {
   return !!ui && ui.phase === "update_available"
       && !!ui.targetVersion && String(ui.targetVersion).length > 0

--- a/CoreScroll.js
+++ b/CoreScroll.js
@@ -1,4 +1,3 @@
-// A11y / scroll: focus, viewport math, keyboard routing.
 .pragma library
 
 function focusNextIndex(current, direction, count) {
@@ -20,13 +19,10 @@ function maxContentY(contentHeight, viewportHeight) {
   return Math.max(0, ch - vh)
 }
 
-// A11Y short-content: Flickable must not accept wheel/drag when no overflow.
 function flickableInteractive(contentHeight, viewportHeight) {
   return maxContentY(contentHeight, viewportHeight) > 0
 }
 
-// Card height from real body (not a large empty floor). minCompact is a
-// small floor for header+one row; maxCap is maxContentHeight.
 function fittedPopupContentHeight(bodyHeight, minCompact, maxCap) {
   var body = Number(bodyHeight)
   var minH = Number(minCompact)
@@ -50,7 +46,6 @@ function clampContentY(y, contentHeight, viewportHeight) {
   return n
 }
 
-// A11Y-023: PageUp/PageDown move by one viewport minus one content line.
 function pageScrollDelta(viewportHeight, lineHeight) {
   var line = Math.max(1, Number(lineHeight) || 1)
   var view = Math.max(line, Number(viewportHeight) || line)
@@ -71,7 +66,6 @@ function scrollEndY(contentHeight, viewportHeight) {
   return maxContentY(contentHeight, viewportHeight)
 }
 
-// Panel shortcuts suspended while a native editor owns focus (A11Y-008).
 function panelShortcutsBlocked(editorActive) {
   return !!editorActive
 }
@@ -111,8 +105,6 @@ function routeProviderDelta(providerIds, selectedId, delta) {
   return ids[next]
 }
 
-// Map item geometry into flickable content and return a contentY that fully
-// reveals the item when possible (A11Y-011).
 function contentYForItem(contentY, viewportHeight, contentHeight, itemY, itemHeight) {
   var y = Number(itemY)
   var h = Math.max(0, Number(itemHeight))

--- a/CoreService.js
+++ b/CoreService.js
@@ -1,4 +1,3 @@
-// Envelope + consts, IPC/probe, pending, lanes, popup ownership.
 .pragma library
 
 var CLOSED_PROVIDERS = {
@@ -25,11 +24,6 @@ var PROVIDER_STATES = {
   "provider_error": true
 }
 
-// ---------------------------------------------------------------------------
-// Plugin tree
-// ---------------------------------------------------------------------------
-
-// Filesystem path of a file:// directory URL (Qt.resolvedUrl(".")); "" otherwise.
 function pluginRootFromUrl(url) {
   var text = String(url || "")
   if (text.indexOf("file://") !== 0)
@@ -39,10 +33,6 @@ function pluginRootFromUrl(url) {
     path = path.slice(0, -1)
   return path
 }
-
-// ---------------------------------------------------------------------------
-// Version / health / IPC refresh
-// ---------------------------------------------------------------------------
 
 function health(versionReady, versionFailed, helperVersion, manifestVersion, expectedVersion, runtimeHealthValue) {
   if (runtimeHealthValue === "stalled")
@@ -135,10 +125,6 @@ function parseVersionStdout(stdout, stderr, exitCode) {
   return m ? m[1] : null
 }
 
-// ---------------------------------------------------------------------------
-// Pending forced targets (CACHE-012): set of provider IDs or all
-// ---------------------------------------------------------------------------
-
 function emptyPending() {
   return { all: false, ids: {} }
 }
@@ -165,7 +151,6 @@ function pendingIsEmpty(pending) {
   return true
 }
 
-// Union request into pending. forceAll dominates. Returns new pending object.
 function unionForced(pending, providerIdOrAll) {
   var next = clonePending(pending)
   if (providerIdOrAll === "all" || providerIdOrAll === true) {
@@ -182,7 +167,6 @@ function unionForced(pending, providerIdOrAll) {
   return next
 }
 
-// Capture and clear pending for a follow-up run.
 function takePending(pending) {
   return {
     captured: clonePending(pending),
@@ -190,9 +174,6 @@ function takePending(pending) {
   }
 }
 
-// Build helper argv for status.
-// force / all → cache bypass; otherwise cache use.
-// notifications always evaluate for the shared service.
 function statusArgv(helperPath, forceOrTargets) {
   var cacheMode = "use"
   if (forceOrTargets === true || forceOrTargets === "all")
@@ -212,7 +193,6 @@ function statusArgv(helperPath, forceOrTargets) {
     "cache", cacheMode,
     "notifications", "evaluate"
   ]
-  // Single-provider force: include provider clause.
   if (forceOrTargets && forceOrTargets.ids && !forceOrTargets.all) {
     var only = null
     var count = 0
@@ -227,10 +207,6 @@ function statusArgv(helperPath, forceOrTargets) {
   }
   return argv
 }
-
-// ---------------------------------------------------------------------------
-// Status envelope validation (before snapshot replace)
-// ---------------------------------------------------------------------------
 
 function isFinitePercent(n) {
   return typeof n === "number" && isFinite(n) && n >= 0 && n <= 100
@@ -252,15 +228,13 @@ function validateProvider(p) {
     if (!isFinitePercent(w.usedPercent) || !isFinitePercent(w.remainingPercent))
       return "invalid window percent"
     if (w.action && w.action.kind && !ACTION_KINDS[w.action.kind])
-      return "invalid window action" // windows shouldn't have action; provider does
+      return "invalid window action"
   }
   if (p.action && p.action.kind && !ACTION_KINDS[p.action.kind])
     return "invalid action kind"
   return null
 }
 
-// Returns { ok: true, envelope } or { ok: false, reason }
-// expectedHelperVersion: when non-empty, must match envelope.helperVersion
 function parseStatusEnvelope(stdout, expectedHelperVersion) {
   var text = String(stdout || "").trim()
   if (!text.length)
@@ -287,17 +261,10 @@ function parseStatusEnvelope(stdout, expectedHelperVersion) {
   return { ok: true, envelope: env }
 }
 
-// Stale-callback rule: accept only if generation still matches.
 function shouldApplyGeneration(activeGeneration, callbackGeneration) {
   return activeGeneration === callbackGeneration
 }
 
-// ---------------------------------------------------------------------------
-// Popup ownership
-// ---------------------------------------------------------------------------
-
-// owner: opaque id (monitor/widget instance). Returns new popup state object.
-// { owner, providerId, view }
 function requestPopup(current, owner, providerId, view) {
   var o = owner
   if (o === null || o === undefined)
@@ -309,7 +276,6 @@ function requestPopup(current, owner, providerId, view) {
   }
 }
 
-// Same-owner close only; cross-owner close is ignored.
 function closePopup(current, owner) {
   if (!current || current.owner === null || current.owner === undefined)
     return null
@@ -318,12 +284,10 @@ function closePopup(current, owner) {
   return null
 }
 
-// Outside-click / foreign-monitor dismiss: clear ownership unconditionally.
 function dismissPopup(_current) {
   return null
 }
 
-// True when this monitor/widget is not the popup owner but a popup is open.
 function foreignPopupOpen(popupOwner, selfOwner) {
   if (!popupOwner || popupOwner.owner === null || popupOwner.owner === undefined)
     return false
@@ -332,12 +296,10 @@ function foreignPopupOpen(popupOwner, selfOwner) {
   return popupOwner.owner !== selfOwner
 }
 
-// Cross-monitor transfer: new owner takes popup (requestPopup always transfers).
 function popupOwnerId(popup) {
   return popup ? popup.owner : null
 }
 
-// Popup open for this owner only (UX-021 / UX-022).
 function popupOpenForOwner(popupOwner, owner) {
   if (!popupOwner || owner === null || owner === undefined)
     return false
@@ -350,21 +312,10 @@ function popupView(popupOwner) {
   return String(popupOwner.view)
 }
 
-// ---------------------------------------------------------------------------
-// Lane guards: never start same-lane exec while running
-// ---------------------------------------------------------------------------
-
 function canStartLane(laneBusy) {
   return !laneBusy
 }
 
-// ---------------------------------------------------------------------------
-// Default settings (shared primitive: consumed by CoreSettings and QML)
-// ---------------------------------------------------------------------------
-
-// Poll timer interval from applied settings. The SET-005 range (30..3600) is
-// enforced by validation before anything reaches appliedSettings; null means
-// no settings applied yet and falls back to the 60 s default.
 function pollIntervalMs(settings) {
   if (settings && settings.refreshIntervalSeconds)
     return Number(settings.refreshIntervalSeconds) * 1000
@@ -388,9 +339,6 @@ function defaultSettings() {
   }
 }
 
-// Automatic updates are on unless the applied settings say otherwise. No
-// settings yet, or a document from a helper that predates the block, means
-// the product default.
 function automaticUpdatesEnabled(settings) {
   if (!settings || !settings.updates || typeof settings.updates.automatic !== "boolean")
     return true

--- a/CoreSettings.js
+++ b/CoreSettings.js
@@ -1,10 +1,5 @@
-// Settings state machine + draft mutations/validation.
 .pragma library
 .import "CoreService.js" as Kernel
-
-// ---------------------------------------------------------------------------
-// Settings state machine (SET-014..): closed → loading → clean → dirty → saving
-// ---------------------------------------------------------------------------
 
 function settingsClosed() {
   return {
@@ -17,7 +12,6 @@ function settingsClosed() {
   }
 }
 
-// Begin load on open — controls locked until config show completes (SET-014/015).
 function settingsBeginLoad(generation) {
   return {
     phase: "loading",
@@ -29,7 +23,6 @@ function settingsBeginLoad(generation) {
   }
 }
 
-// Successful config show → clean draft/snapshot. Generation must match.
 function settingsFinishLoad(state, generation, doc) {
   if (!state || state.generation !== generation)
     return state
@@ -48,10 +41,6 @@ function settingsFinishLoad(state, generation, doc) {
   }
 }
 
-// Legacy alias used by older harnesses: open directly into clean with a doc.
-// SET-026: a failed dialog load is a visible terminal state, not an endless
-// locked "Loading". Generation must match so a stale read never flips a
-// newer load.
 function settingsFailLoad(state, generation) {
   if (!state || state.generation !== generation)
     return state
@@ -106,7 +95,6 @@ function settingsMarkDirty(state) {
   return next
 }
 
-// SET-016/018: save receives a new generation; payload is immutable capture.
 function settingsBeginSave(state, generation, payload) {
   if (!state || state.phase === "closed" || state.phase === "loading" || state.phase === "load_failed")
     return state
@@ -120,7 +108,6 @@ function settingsBeginSave(state, generation, payload) {
   return next
 }
 
-// Apply only when generation matches and a save is in flight (SET-017 / SET-021).
 function settingsFinishSave(state, generation, ok, canonical) {
   if (!state || state.generation !== generation)
     return state
@@ -153,7 +140,6 @@ function settingsCancel(state) {
   return next
 }
 
-// SET-022: restore defaults mutates draft only.
 function settingsRestoreDefaults(state) {
   if (!state || state.phase === "closed" || state.phase === "loading"
       || state.phase === "load_failed" || state.phase === "saving")
@@ -164,16 +150,11 @@ function settingsRestoreDefaults(state) {
   return next
 }
 
-// Keep settings machine across popup hide while load/save in flight (SET-019/020).
 function settingsShouldRetainOnClose(state) {
   if (!state)
     return false
   return state.phase === "loading" || state.phase === "saving" || !!state.busy
 }
-
-// ---------------------------------------------------------------------------
-// Settings draft mutations + validation
-// ---------------------------------------------------------------------------
 
 function cloneDraft(draft) {
   return JSON.parse(JSON.stringify(draft || Kernel.defaultSettings()))
@@ -274,17 +255,11 @@ function validateSettingsDraft(draft) {
   if (!isFinite(reminder) || reminder !== Math.floor(reminder)
       || reminder < 15 || reminder > 1440)
     return { ok: false, reason: "notifications.reminderMinutes" }
-  // Optional: a helper older than the block omits it (SET-025 skew).
   if (draft.updates !== undefined
       && (!draft.updates || typeof draft.updates.automatic !== "boolean"))
     return { ok: false, reason: "updates.automatic" }
   if (!Array.isArray(draft.providers))
     return { ok: false, reason: "providers length" }
-  // SET-025: every provider this QML knows must be present exactly once. A
-  // row with an id it does not know is tolerated and kept opaque: a helper
-  // newer than the loaded QML (the direction every update produces until
-  // the shell restarts) lists providers the QML has not heard of, and the
-  // row must round-trip to config apply untouched.
   var seen = {}
   for (var i = 0; i < draft.providers.length; i++) {
     var p = draft.providers[i]
@@ -303,11 +278,6 @@ function validateSettingsDraft(draft) {
   return { ok: true, reason: null }
 }
 
-// Startup bootstrap (SET-023): decide what appliedSettings becomes after the
-// boot-time `config show`. A dialog read/save that finished first is newer
-// than the boot read and wins; any failure keeps in-memory defaults (SET-008)
-// and never touches the dialog state machine (SET-014..022 own their own
-// snapshot and generations).
 function settingsBootstrapResult(currentApplied, stdout, exitCode) {
   if (currentApplied)
     return currentApplied
@@ -330,7 +300,6 @@ function settingsCanSave(state, draft) {
     return false
   if (state.busy || state.phase === "saving" || state.phase === "loading")
     return false
-  // Allow save from dirty only (or clean if user re-saves — disable when clean)
   if (state.phase !== "dirty")
     return false
   return validateSettingsDraft(draft).ok

--- a/CoreView.js
+++ b/CoreView.js
@@ -1,4 +1,3 @@
-// Chip + popup presentation and time formatting.
 .pragma library
 .import "CoreService.js" as Kernel
 
@@ -54,8 +53,6 @@ function placeholderProvider(id) {
   }
 }
 
-// Enabled providers in settings order, joined with snapshot data.
-// Without settings, uses snapshot order (helper already filters/orders).
 function visibleProviders(snapshot, settings) {
   var byId = {}
   if (snapshot && Array.isArray(snapshot.providers)) {
@@ -92,11 +89,6 @@ function visibleProviders(snapshot, settings) {
   return out
 }
 
-// UX-002 / UX-032A (amended 2026-08-07, 2026-09-04): the chip renders the
-// elected lead window's used|remaining percent — the same election the popup
-// runs, which pins a session window first — or an em-dash when there is no
-// window. Chip and popup can never disagree on which window a number
-// belongs to.
 function chipPercentText(provider, metric, nowMs) {
   var lines = windowDisplayLines(provider, metric, nowMs)
   var lead = electLeadIndex(lines)
@@ -105,8 +97,6 @@ function chipPercentText(provider, metric, nowMs) {
   return lines[lead].percentText
 }
 
-// Typed error/collection-failure states shared by the chip cue and the
-// tooltip/copy qualifiers (plan 03 §5.1-5.3).
 var ERROR_STATES = {
   "cli_missing": true,
   "unauthenticated": true,
@@ -115,16 +105,9 @@ var ERROR_STATES = {
   "provider_error": true
 }
 
-// Severity thresholds on usedPercent (visual design §7). These duplicate
-// NotificationLevel::from_used_percent (src/notifications/state.rs): the
-// status schema is frozen at v2 and must not gain a field, so the numbers
-// live on both sides and tests/severity_parity.rs fails the build if either
-// side moves alone. Change one, change both.
 var SEVERITY_CRITICAL_USED_PERCENT = 95
 var SEVERITY_WARNING_USED_PERCENT = 90
 
-// "critical" | "warning" | "". Always from usedPercent, never from the
-// displayed metric — switching to `used` must not change what is critical.
 function severityLevel(usedPercent) {
   var v = Number(usedPercent)
   if (!isFinite(v))
@@ -136,8 +119,6 @@ function severityLevel(usedPercent) {
   return ""
 }
 
-// The word the header tag renders. Warning shows as "Low" (§7 table);
-// "warning" stays the internal level name shared with the Rust notifier.
 function severityTagText(level) {
   if (level === "critical")
     return "Critical"
@@ -146,8 +127,6 @@ function severityTagText(level) {
   return ""
 }
 
-// The provider's worst window. A11Y-012: this drives a word, never a colour
-// on its own.
 function providerSeverity(provider) {
   if (!provider || !Kernel.isArrayLike(provider.windows))
     return ""
@@ -165,22 +144,11 @@ function providerSeverity(provider) {
   return worst
 }
 
-// UX-028 (amended): a stale provider holds a real reading that the helper
-// retained through a failed refresh, so the bar renders it exactly like a
-// ready one. `presentsReading` is the single place that decides which states
-// own a number worth showing; everything below asks it instead of testing
-// `=== "ready"` on its own, so the bar can never disagree with itself.
 function presentsReading(state) {
   var s = String(state || "")
   return s === "ready" || s === "stale"
 }
 
-// Severity tints the bar for any provider presenting a reading: the remaining
-// states dim the whole chip and spend the cue on the state itself, so an
-// urgent tint there would mean two things at once. Approved mockup: critical
-// Claude is urgent, disconnected Grok is not. A retained reading keeps its
-// severity — UsageWindow already paints a critical stale window urgent, and
-// suppressing it here would make bar and popup contradict each other.
 function chipSeverityUrgent(provider) {
   if (!provider)
     return false
@@ -188,10 +156,6 @@ function chipSeverityUrgent(provider) {
       && providerSeverity(provider) === "critical"
 }
 
-// UX-012 (amended): text cue beyond color for error states. No leading space
-// — the chip separates cue from numeral with layout spacing (visual design
-// §5). Stale is deliberately absent: it is retained data, not a fault, and
-// marking it made a woken machine look broken for one poll interval.
 function chipStateCue(provider) {
   if (!provider)
     return ""
@@ -203,11 +167,6 @@ function chipStateCue(provider) {
   return ""
 }
 
-// Plan 02 deferred minor: the cue exposed its raw glyph to screen readers.
-// It now carries a word — the severity when severity produced the cue,
-// otherwise the same qualifier the tooltip already speaks. Stale produces no
-// cue, so it contributes no word either (A11Y-012 parity: assistive tech
-// hears what the eye sees, never more).
 function chipCueLabel(provider) {
   if (!provider)
     return ""
@@ -229,9 +188,6 @@ var STATE_QUALIFIERS = {
   "provider_error": "failed"
 }
 
-// Copy design §5.4: lowercase trailing qualifier for the chip tooltip and
-// for the cue's accessible name. It replaced `connectionLabel`, which plan 03
-// deleted together with the meta footer.
 function stateQualifier(state) {
   var s = String(state || "")
   if (s === "ready")
@@ -241,30 +197,18 @@ function stateQualifier(state) {
   return "unknown"
 }
 
-// Numeral box content: loading renders the loading cue in place of the
-// number so the cue is visually distinct from the — no-data glyph (§5).
 function chipNumeralText(provider, metric, nowMs) {
   if (provider && String(provider.state || "") === "loading")
     return "···"
   return chipPercentText(provider, metric, nowMs)
 }
 
-// Dimming means "no number to trust here" — missing CLI (PROD-022/UX-029),
-// the error states, and the loading placeholder. Stale is excluded: it has a
-// number, so it renders at full strength like ready.
 function chipDimmed(provider) {
   if (!provider)
     return true
   return !presentsReading(provider.state)
 }
 
-// UX-011 (superseded 2026-08-06): the chip renders no hover tooltip. The
-// former tooltip's first line survives as the chip's accessible name — the
-// provider, the displayed percentage when one exists, and a plain-language
-// qualifier when the provider presents no reading. The raw enum value never
-// renders (copy design §5.4). Single-line by construction: no window detail,
-// no live clock. A stale chip is visually identical to a ready one, so it
-// reads identically too (A11Y-012).
 function chipAccessibleLabel(provider, metric, nowMs) {
   if (!provider)
     return ""
@@ -282,22 +226,17 @@ function chipAccessibleLabel(provider, metric, nowMs) {
   return parts.join(" · ")
 }
 
-// Visual design §5/§10: per-provider optical scale on the shared 16px
-// canvas. Grok's mark is a thin ring that fills its own box edge to edge.
 function iconOpticalScale(id) {
   if (String(id || "") === "grok")
     return 0.875
   return 1.0
 }
 
-// §10: monochrome brands inherit the theme ink at render time; polychrome
-// brands keep their official color and are never tinted.
 function iconTinted(id) {
   var key = String(id || "")
   return key === "codex" || key === "grok"
 }
 
-// Map mouse button to typed service intention (UX-004..009).
 // button: Qt.LeftButton(1) | RightButton(2) | MiddleButton(4) or string.
 function routeChipClick(button, owner, providerId, popupOwner) {
   var b = button
@@ -326,10 +265,6 @@ function routeChipClick(button, owner, providerId, popupOwner) {
   }
   return { action: "noop" }
 }
-
-// ---------------------------------------------------------------------------
-// Popup / provider presentation (UX-013..032A, JSON-023..028)
-// ---------------------------------------------------------------------------
 
 var ACTION_INTENTS = {
   "retry": true,
@@ -375,7 +310,6 @@ function planBadge(provider) {
   return ""
 }
 
-// Render only the safe English message from the typed error object.
 function errorMessage(provider) {
   if (!provider || !provider.error)
     return ""
@@ -408,8 +342,6 @@ function stateTitle(provider) {
   var s = String(provider.state || "")
   if (s === "loading")
     return ""
-  // Stale walks the ready branch: a retained empty reading still means the
-  // account reports no quota, not that something failed.
   if (presentsReading(s) && (!provider.windows || provider.windows.length === 0))
     return name + " reports no quota"
   if (presentsReading(s))
@@ -436,8 +368,6 @@ function stateBody(provider) {
     return ""
   if (presentsReading(s) && (!provider.windows || provider.windows.length === 0))
     return emptyWindowsMessage()
-  // Reached only by the states with no reading: a stale provider carries a
-  // retryable error in JSON, but the pane must never surface it as a fault.
   if (presentsReading(s))
     return ""
   var err = errorMessage(provider)
@@ -464,17 +394,11 @@ function defaultActionLabel(kind) {
   return String(kind || "")
 }
 
-// Closed action list for the current provider state (JSON-025).
 function stateActions(provider) {
   var out = []
   if (!provider)
     return out
   var state = String(provider.state || "")
-  // UX-028 (amended): a provider presenting a reading offers no recovery
-  // action. Stale still carries `action: retry` in JSON — the helper's
-  // contract — but surfacing it would put a repair button next to a perfectly
-  // good number, which is the fault impression this pane exists to avoid. The
-  // header's refresh control remains available in every state.
   if (presentsReading(state))
     return out
   var seen = {}
@@ -501,8 +425,6 @@ function stateActions(provider) {
   if (state === "unauthenticated" && !seen.login && !seen.view_installation)
     pushAction("login", "Sign in", null)
 
-  // JSON-025 addendum: a typed non-retryable error must never offer Retry,
-  // regardless of which branch above produced it.
   var retryAllowed = !provider || !provider.error
       || provider.error.retryable === undefined
       || provider.error.retryable === true
@@ -518,11 +440,6 @@ function mapActionKind(kind) {
     return null
   return k
 }
-
-// ---------------------------------------------------------------------------
-// Humanized time (UX Fase 2: countdown + absolute local time)
-// ---------------------------------------------------------------------------
-
 
 function parseIsoMs(iso) {
   if (iso === null || iso === undefined)
@@ -546,8 +463,6 @@ function countdownText(diffMs) {
   return minutes + "m"
 }
 
-// §6: the popup renders the countdown alone — no absolute clock, no weekday.
-// "" when there is no usable timestamp, "now" once the reset has passed.
 function resetCountdownText(iso, nowMs) {
   var ms = parseIsoMs(iso)
   if (!isFinite(ms))
@@ -558,11 +473,6 @@ function resetCountdownText(iso, nowMs) {
   return countdownText(diff)
 }
 
-// §6 amended 2026-08-03 (owner decision on live mockups): the lead window
-// appends the reset's wall-clock time after the countdown — "(13:31)" here,
-// "(1:31 PM)" on an en-US machine. The format string is the caller's locale
-// short-time format, never hardcoded; weekday names stay deleted, so compact
-// rows (days away) remain countdown-only.
 function resetClockText(iso, localeTimeFormat) {
   var ms = parseIsoMs(iso)
   if (!isFinite(ms))
@@ -573,8 +483,6 @@ function resetClockText(iso, localeTimeFormat) {
   return "(" + Qt.formatTime(new Date(ms), fmt) + ")"
 }
 
-// The muted lead-in the lead window prints before the countdown:
-// "Session (5h) · resets in 3h 1m" / "Session (5h) · resets now".
 function resetPhrase(countdown) {
   var c = String(countdown || "")
   if (!c.length)
@@ -582,7 +490,6 @@ function resetPhrase(countdown) {
   return c === "now" ? "resets" : "resets in"
 }
 
-// "just now" | "5m ago" | "3h ago" | "2d ago" | "".
 function formatAgoText(iso, nowMs) {
   var ms = parseIsoMs(iso)
   if (!isFinite(ms))
@@ -614,7 +521,6 @@ function windowDisplayLines(provider, metric, nowMs) {
     var pct = mode === "used" ? used : remaining
     var finite = isFinite(pct)
     var rounded = finite ? Math.round(pct) : null
-    // Keep the escaped form the rest of this file already uses.
     var pctText = finite ? (rounded + "%") : "\u2014"
     var countdown = w.resetsAt
         ? resetCountdownText(String(w.resetsAt), effectiveNowMs)
@@ -623,10 +529,7 @@ function windowDisplayLines(provider, metric, nowMs) {
       id: String(w.id || ("w" + i)),
       label: plainText(w.label || w.id || "Window"),
       percentText: pctText,
-      // 0–100 for progress track; -1 when unavailable.
       percent: finite ? Math.max(0, Math.min(100, rounded)) : -1,
-      // Raw percentages drive severity (§7) and election (§8); they never
-      // follow the displayed metric. null when the provider omitted them.
       usedPercent: isFinite(used) ? used : null,
       remainingPercent: isFinite(remaining) ? remaining : null,
       severity: severityLevel(used),
@@ -638,31 +541,16 @@ function windowDisplayLines(provider, metric, nowMs) {
   return lines
 }
 
-// A critical window with no usable remainingPercent sorts last among its
-// peers instead of winning the comparison by accident.
 function remainingRank(line) {
   return line.remainingPercent === null ? Infinity : line.remainingPercent
 }
 
-// UX-020D (amended 2026-09-04, 2026-09-10): the window ids the Rust mappers
-// emit for a provider's short rolling window (Claude/Codex `session`,
-// Antigravity `gemini-5h` and `3p-5h`). Typed schema data, like the `plan-`
-// prefix below — this list only promotes known ids; an id it does not know is
-// never demoted.
 var SESSION_WINDOW_IDS = ["session", "gemini-5h", "3p-5h"]
 
 function isSessionWindowId(id) {
   return SESSION_WINDOW_IDS.indexOf(String(id)) >= 0
 }
 
-// §8: deterministic five-step lead election: session, critical, plan, nearest
-// future reset, then first delivered. This replaces the old id allowlist that
-// silently demoted any window id it did not know. Returns an index into
-// `lines`, or -1 when there is nothing to lead.
-//
-// Delivered order is unique per line, so `<` on the index is already a total
-// tiebreak; the spec's further "then by window id" step is unreachable and is
-// deliberately not written as dead code.
 function electLeadIndex(lines) {
   if (!lines || !lines.length)
     return -1
@@ -670,15 +558,6 @@ function electLeadIndex(lines) {
   var i
   var best = -1
 
-  // 0. UX-020D (amended 2026-09-04): a session window leads whenever one is
-  //    delivered, even after its reset elapsed and even when a weekly window
-  //    is critical — the weekly still tints the chip and shows the "!" cue
-  //    through providerSeverity, it just never takes the number. Without
-  //    this, every morning the elapsed session reset handed the chip to the
-  //    weekly percentage.
-  //    (amended 2026-09-10) Antigravity delivers one session per model
-  //    family; the family in use drains its own, so the lowest remaining
-  //    leads and a tie keeps the delivered order.
   for (i = 0; i < lines.length; i++) {
     if (!isSessionWindowId(lines[i].id))
       continue
@@ -688,7 +567,6 @@ function electLeadIndex(lines) {
   if (best >= 0)
     return best
 
-  // 1. Any critical window leads; among criticals, the lowest remaining.
   for (i = 0; i < lines.length; i++) {
     if (lines[i].severity !== "critical")
       continue
@@ -698,10 +576,6 @@ function electLeadIndex(lines) {
   if (best >= 0)
     return best
 
-  // 2. UX-020D (amended 2026-08-07): a plan window (id prefix "plan-")
-  //    outranks every non-plan window; among plan windows the lowest
-  //    remaining leads. Ids are typed schema data authored by the Rust
-  //    mappers, so the prefix is a contract, not raw-output parsing.
   for (i = 0; i < lines.length; i++) {
     if (lines[i].id.indexOf("plan-") !== 0)
       continue
@@ -711,8 +585,6 @@ function electLeadIndex(lines) {
   if (best >= 0)
     return best
 
-  // 3. Otherwise the nearest reset still in the future. A missing timestamp
-  //    or one that already elapsed ("now") does not compete.
   var bestMs = NaN
   for (i = 0; i < lines.length; i++) {
     if (!lines[i].resetCountdown.length || lines[i].resetCountdown === "now")
@@ -728,12 +600,9 @@ function electLeadIndex(lines) {
   if (best >= 0)
     return best
 
-  // 4. Nothing has a future reset: the first delivered window leads.
   return 0
 }
 
-// §3.4: the popup leads with one window; every other window renders as a
-// compact row, in delivered order.
 function windowLayout(provider, metric, nowMs) {
   var lines = windowDisplayLines(provider, metric, nowMs)
   var leadIndex = electLeadIndex(lines)
@@ -747,8 +616,6 @@ function windowLayout(provider, metric, nowMs) {
   return layout
 }
 
-// Codex rate-limit reset count (JSON-022C). Singular/plural, empty when
-// absent or zero so the popup stays byte-identical for every other provider.
 function rateLimitResetsText(provider) {
   if (!provider)
     return ""
@@ -776,10 +643,6 @@ function headerModel(provider, refreshing) {
   }
 }
 
-// UX-028 (amended): stale shares the ready path — the dedicated
-// "stale_windows" mode is gone, so a retained reading draws the same pane a
-// fresh one would. Its age is the only difference, and ProviderView carries
-// that as one neutral line.
 function contentMode(provider) {
   if (!provider)
     return "skeleton"

--- a/MaintenanceView.qml
+++ b/MaintenanceView.qml
@@ -4,7 +4,6 @@ import qs.Ui
 import "CoreMaintenance.js" as Core
 import "components"
 
-// Maintenance section: version, update check/apply, uninstall (UX-040..047).
 Item {
   id: root
 
@@ -119,7 +118,6 @@ Item {
       foreground: root.foreground
     }
 
-    // Danger zone — visually separated (UX-044)
     Column {
       width: parent.width
       spacing: Style.space(6)
@@ -149,7 +147,6 @@ Item {
     }
   }
 
-  // Update confirmation (UX-043)
   ConfirmDialog {
     opened: !!ui.updateConfirmOpen
     title: "Confirm update"
@@ -169,7 +166,6 @@ Item {
     }
   }
 
-  // Uninstall confirmation (UX-045..047)
   ConfirmDialog {
     opened: !!ui.uninstallConfirmOpen
     title: "Uninstall Agent Bar"
@@ -192,7 +188,6 @@ Item {
         root.agentService.armOrConfirmUninstall()
     }
 
-    // UX-046: purge checkbox default unchecked
     Toggle {
       label: "Also delete saved settings and backups"
       description: "Unchecked by default. Standard uninstall preserves settings."

--- a/Popup.qml
+++ b/Popup.qml
@@ -7,8 +7,6 @@ import "CoreView.js" as Core
 import "CoreScroll.js" as Scroll
 import "components"
 
-// Monitor-local consolidated popup (UX-013..025, A11Y-001..023).
-//
 // Do NOT redeclare KeyboardPanel's required anchorItem/bar here. Redeclaring
 // them as required on this derived type makes Loader/createObject treat the
 // base required props as unset (createObject returns null; chip click is a
@@ -21,12 +19,10 @@ KeyboardPanel {
 
   property int maxContentWidth: Style.space(540)
   property int maxContentHeight: Style.space(560)
-  // Compact floor: header + one window row + rail stack — not a 280px void.
   property int minContentHeight: Style.space(160)
   property int contentLineHeight: Style.font.body + Style.space(8)
   property int contentMargins: Style.spacing.popupPadding
 
-  // A11Y-008: Settings/NumberField can raise this while editing.
   property bool editorActive: contentLoader.item && contentLoader.item.editorOwnsFocus
       ? !!contentLoader.item.editorOwnsFocus
       : false
@@ -47,8 +43,6 @@ KeyboardPanel {
   readonly property string selectedId: {
     if (!agentService)
       return ""
-    // Prefer the open popup's provider so the rail plate matches the pane
-    // (selectedProviderId alone could lag / fallback to Claude).
     if (agentService.popupOwner && agentService.popupOwner.providerId
         && String(agentService.popupOwner.providerId).length)
       return String(agentService.popupOwner.providerId)
@@ -72,7 +66,6 @@ KeyboardPanel {
     owner
   )
 
-  // Prefer real content height; rail min height prevents icon crush/overlap.
   readonly property int measuredBodyHeight: {
     var col = contentColumn ? contentColumn.implicitHeight : 0
     var margins = contentMargins * 2
@@ -197,7 +190,6 @@ KeyboardPanel {
     scheduleFocusRebuild()
   }
   onSelectedIdChanged: Qt.callLater(function () {
-    // FocusController may not be ready on the first selectedId emission.
     if (focusController && typeof focusController.clampScroll === "function")
       focusController.clampScroll()
     if (typeof root.rebuildFocusTargets === "function")
@@ -260,7 +252,6 @@ KeyboardPanel {
       ProviderRail {
         id: rail
         width: rail.railWidth
-        // Fill panel height so ColumnLayout spacer can expand; min via measuredBodyHeight.
         height: parent.height
         providers: root.railProviders
         selectedProviderId: root.selectedId
@@ -271,7 +262,6 @@ KeyboardPanel {
         onSettingsClicked: root.openSettings()
       }
 
-      // Gutter between bordered rail and content (must match content width math).
       Item {
         id: railGutter
         width: Style.space(8)
@@ -279,8 +269,6 @@ KeyboardPanel {
       }
 
       Item {
-        // Exact remaining width — previous `- 1` made content too wide and
-        // clipped the first glyphs of titles / body / action labels.
         width: Math.max(0, parent.width - rail.width - railGutter.width)
         height: parent.height
         clip: true

--- a/ProviderRail.qml
+++ b/ProviderRail.qml
@@ -4,11 +4,6 @@ import qs.Commons
 import qs.Ui
 import "CoreView.js" as Core
 
-// Left rail — stack: providers → spacer → Settings.
-// No own frame (§6): the card border already bounds the popup, so the slot
-// stack shares the popup's inset token and fits the rail width exactly.
-// Selected = brainstorming “A” plate (soft fill + thin border), only on the
-// active provider id — never a sticky focus ring on Claude.
 Item {
   id: root
 
@@ -26,13 +21,12 @@ Item {
   readonly property int stackGap: Style.space(8)
   readonly property int spacerMin: Style.space(4)
 
-  // No own frame (§6) — the slot fits exactly, horizontal inset is 0.
   readonly property int railWidth: slotSize
 
   readonly property int minStackHeight: {
     var n = providers && providers.length ? providers.length : 0
     var slots = n + 1
-    var gaps = n + 1 // n providers + spacer + settings → n+2 items → n+1 gaps
+    var gaps = n + 1
     return Style.spacing.popupPadding * 2
         + slots * slotSize
         + gaps * stackGap
@@ -91,7 +85,6 @@ Item {
 
       Item {
         id: railItem
-        // Prefer index lookup — more reliable than modelData.id for JS arrays.
         required property int index
         required property var modelData
 
@@ -123,7 +116,6 @@ Item {
         Component.onCompleted: root.registerRailItem(railItem)
         Component.onDestruction: root.unregisterRailItem(railItem)
 
-        // Active provider: soft fill + neutral border only (no accent tick).
         Rectangle {
           anchors.fill: parent
           radius: Style.cornerRadius

--- a/ProviderView.qml
+++ b/ProviderView.qml
@@ -4,12 +4,6 @@ import qs.Ui
 import "CoreView.js" as Core
 import "components"
 
-// Single selected-provider content pane, visual design §3.4/§8:
-// header -> [age line] -> lead window (large) -> compact rows
-// -> state message (non-window modes). Plan 03 removed the meta footer;
-// last-success age now lives in one neutral caption shown while the reading
-// is retained (UX-028 amended). Staleness changes no colour, no opacity, and
-// no layout — only that caption's presence.
 Item {
   id: root
 
@@ -18,17 +12,12 @@ Item {
   property bool refreshing: false
   property color foreground: Color.foreground
   property string fontFamily: Style.font.family
-  // Popup open state (Popup.qml's contentLoader keeps this instance alive
-  // across close/open, so a child `visible` prop never gates the tick —
-  // the owner must drive this explicitly).
   property bool active: true
 
   signal refreshRequested(string providerId)
   signal actionRequested(string providerId, string kind, var target)
 
-  // Re-humanize countdowns while the popup stays open.
   property double nowMs: Date.now()
-  // Test hook: expose whether the tick is actually running.
   property alias nowTickRunning: nowTimer.running
   onActiveChanged: if (active) nowMs = Date.now()
   Timer {
@@ -44,10 +33,6 @@ Item {
   readonly property var windows: Core.windowLayout(provider, displayMetric, nowMs)
   readonly property string severity: Core.providerSeverity(provider)
   readonly property var actions: Core.stateActions(provider)
-  // UX-028 (amended): staleness is reported as a fact, never as a fault. The
-  // pane states when the reading was taken and stops there — no glyph, no
-  // urgent colour, no error text, no Retry (the header's own refresh control
-  // already covers the action).
   readonly property bool showsAge: String(root.provider && root.provider.state || "") === "stale"
   readonly property string ageText: {
     var age = Core.formatAgoText(
@@ -86,10 +71,6 @@ Item {
       foreground: root.foreground
     }
 
-    // Age line (UX-028 amended): one caption in the pane's own foreground at
-    // the same 0.72 alpha the header tags use. Plain statement of when the
-    // reading was taken — the eye reads it as metadata, not as an alert, and
-    // assistive tech hears exactly the same words (A11Y-012).
     Text {
       visible: root.showsAge && root.ageText.length > 0
       width: parent.width
@@ -102,9 +83,6 @@ Item {
       Accessible.name: text
     }
 
-    // §3.4/§8: one elected lead window rendered large, every other window as
-    // a compact row in delivered order. No rule between them — the size
-    // difference is the hierarchy (approved mockup).
     Column {
       width: parent.width
       spacing: Style.spacing.xxxl
@@ -175,9 +153,6 @@ Item {
 
     StateMessage {
       width: parent.width
-      // No stale exception is needed: contentMode routes stale through the
-      // ready branch, so it lands on "windows"/"empty_windows" like any other
-      // provider holding a reading.
       visible: root.mode === "skeleton" || root.mode === "empty_windows" || root.mode === "state"
       skeleton: root.mode === "skeleton"
       title: root.mode === "skeleton" ? "" : Core.stateTitle(root.provider)

--- a/Service.qml
+++ b/Service.qml
@@ -6,11 +6,9 @@ import "CoreSettings.js" as Settings
 import "CoreMaintenance.js" as Maintenance
 import "CoreView.js" as View
 
-// Shared Agent Bar service — one instance per shell (ARCH-023 / ARCH-024).
 Item {
   id: root
 
-  // --- Quattro injection ---
   property string omarchyPath: ""
   property var shell: null
   property var manifest: null
@@ -21,9 +19,7 @@ Item {
   // no source path for third-party plugins (Omarchy 4.0.3).
   readonly property string pluginRoot: Core.pluginRootFromUrl(Qt.resolvedUrl("."))
 
-  // Test harness: absolute helper path. Production uses pluginRoot/bin/agent-bar.
   property string helperPath: ""
-  // Skip auto Process start; tests drive apply* methods.
   property bool testMode: false
   property int versionProbeTimeoutMs: 2000
   property int statusTimeoutMs: 60000
@@ -32,35 +28,28 @@ Item {
   property int maintenanceHandoffTimeoutMs: 120000
   property int pollIntervalMs: Core.pollIntervalMs(appliedSettings)
   property int collectionDelayMs: 0
-  // Automatic updates: first check shortly after the helper answers, then
-  // every six hours while the shell runs.
   property int autoUpdateFirstDelayMs: 120000
   property int autoUpdateIntervalMs: 21600000
   readonly property bool autoUpdateScheduled: autoUpdateTimer.running
   readonly property int autoUpdateDelayMs: autoUpdateTimer.interval
-  // True while the in-flight update check was started by the timer.
   property bool automaticCheck: false
 
-  // --- Public service surface (Task 9 / Task 10) ---
   property var snapshot: null
   property bool refreshing: false
   property string selectedProviderId: ""
-  property var popupOwner: null // { owner, providerId, view } or null
+  property var popupOwner: null
   property var settingsState: Settings.settingsClosed()
   property var settingsDraft: null
-  // Applied product settings for bar chips (order / metric). Null → defaults.
   property var appliedSettings: null
   property var maintenanceState: Maintenance.maintenanceIdle()
   property var maintenanceUi: Maintenance.maintenanceUiIdle("")
   property var pendingForcedTargets: Core.emptyPending()
-  // Login bookkeeping + last detached argv (testable without exec).
   property int loginRequestCount: 0
   property string lastLoginProviderId: ""
   property var lastLoginArgv: null
   property var lastRestartShellArgv: null
   property int restartShellRequestCount: 0
   property string lastViewInstallationUrl: ""
-  // Pending maintenance intention after confirm (update apply / uninstall).
   property var pendingMaintenanceIntention: null
   property string pendingMaintenancePayload: ""
   property var timedOutLanes: ({})
@@ -68,14 +57,12 @@ Item {
   property int completedCallbackCount: 0
   readonly property string runtimeHealth: Core.runtimeHealth(timedOutLanes)
 
-  // Version probe
   property string helperVersion: ""
   property bool versionReady: false
   property bool versionFailed: false
   property bool versionProbeRunning: false
   property bool collectionStarted: false
 
-  // Lane busy flags (one Process per lane; never re-exec while running)
   property bool statusBusy: false
   property bool settingsReadBusy: false
   property bool settingsBootstrapBusy: false
@@ -83,7 +70,6 @@ Item {
   property bool maintenanceCheckBusy: false
   property bool maintenanceHandoffBusy: false
 
-  // Generation counters for stale-callback rejection
   property int statusGeneration: 0
   property int settingsGeneration: 0
   property int versionProbeGeneration: 0
@@ -104,11 +90,9 @@ Item {
   property int settingsWriteStartedGeneration: 0
   property int maintenanceCheckStartedGeneration: 0
   property int maintenanceHandoffStartedGeneration: 0
-  // Immutable captured JSON for the in-flight config apply (SET-018).
   property string pendingSettingsPayload: ""
   property int pendingSettingsPayloadGeneration: 0
 
-  // Bookkeeping
   property int refreshRequestCount: 0
   property string lastRefreshProviderId: ""
   property int statusStartCount: 0
@@ -118,10 +102,6 @@ Item {
   readonly property string manifestVersion: manifest && manifest.version
       ? String(manifest.version)
       : ""
-
-  // -------------------------------------------------------------------------
-  // Paths / IPC
-  // -------------------------------------------------------------------------
 
   function resolvedHelperPath() {
     if (helperPath && helperPath.length > 0)
@@ -176,10 +156,6 @@ Item {
     return "ok"
   }
 
-  // -------------------------------------------------------------------------
-  // Public methods
-  // -------------------------------------------------------------------------
-
   function refreshAll(force) {
     if (maintenanceState.blocked)
       return
@@ -206,14 +182,12 @@ Item {
 
   function closePopup(owner) {
     popupOwner = Core.closePopup(popupOwner, owner)
-    // SET-019: closing never fabricates load/save completion.
     if (!popupOwner && !Settings.settingsShouldRetainOnClose(settingsState)) {
       settingsState = Settings.settingsClosed()
       settingsDraft = null
     }
   }
 
-  // Outside-click on any monitor (including foreign-monitor dismiss layer).
   function dismissPopup() {
     popupOwner = Core.dismissPopup(popupOwner)
     if (!popupOwner && !Settings.settingsShouldRetainOnClose(settingsState)) {
@@ -226,7 +200,6 @@ Item {
     if (maintenanceState.blocked)
       return
     requestPopup(owner, selectedProviderId || null, "settings")
-    // SET-014/020: only start a new load when closed; reopen during save keeps busy.
     if (!settingsState || settingsState.phase === "closed") {
       settingsGeneration++
       activeSettingsReadGeneration = settingsGeneration
@@ -235,8 +208,6 @@ Item {
       kickSettingsRead()
     }
   }
-
-  // ---- Draft mutations (dirty only when unlocked) ----
 
   function settingsLocked() {
     return Settings.settingsControlsLocked(settingsState)
@@ -249,7 +220,6 @@ Item {
       return
     settingsDraft = mutator(settingsDraft)
     settingsState = Settings.settingsMarkDirty(settingsState)
-    // Keep draft pointer on state for consumers that read settingsState.draft.
     if (settingsState && settingsState.phase !== "closed") {
       var next = Settings.cloneState(settingsState)
       next.draft = settingsDraft
@@ -324,12 +294,10 @@ Item {
       return false
     if (!Core.canStartLane(settingsWriteBusy))
       return false
-    // SET-018: capture immutable payload before process start.
     var payloadObj = JSON.parse(JSON.stringify(settingsDraft))
     var validation = Settings.validateSettingsDraft(payloadObj)
     if (!validation.ok)
       return false
-    // SET-016: every save gets a new generation id.
     settingsGeneration++
     var gen = settingsGeneration
     pendingSettingsPayload = JSON.stringify(payloadObj)
@@ -342,7 +310,6 @@ Item {
     return true
   }
 
-  // JSON-025: map closed action kinds to typed service methods.
   function retryProvider(providerId) {
     refreshProvider(providerId, true)
   }
@@ -363,7 +330,6 @@ Item {
     loginRequestCount++
     if (testMode)
       return
-    // Exact argv array — never shell-string construction (UX-048).
     Quickshell.execDetached(argv)
   }
 
@@ -375,8 +341,6 @@ Item {
       return
     Quickshell.execDetached(argv)
   }
-
-  // ---- Maintenance UI (update / uninstall) ----
 
   function syncMaintenanceVersion() {
     var ver = helperVersion || manifestVersion || ""
@@ -395,8 +359,6 @@ Item {
     startUpdateCheck(false)
   }
 
-  // Timer entry point. Reschedules itself, then checks when the gate allows;
-  // returns whether a check started.
   function automaticUpdateTick() {
     autoUpdateTimer.interval = autoUpdateIntervalMs
     autoUpdateTimer.restart()
@@ -415,8 +377,6 @@ Item {
   function startUpdateCheck(automatic) {
     if (maintenanceState.blocked)
       return false
-    // A click during a silent automatic check adopts it: the result will be
-    // painted like any manual check, and never applied without a click.
     if (!automatic && maintenanceCheckBusy && automaticCheck) {
       automaticCheck = false
       maintenanceUi = Maintenance.maintenanceUiChecking(maintenanceUi)
@@ -428,7 +388,6 @@ Item {
     maintenanceCheckGeneration++
     activeMaintenanceCheckGeneration = maintenanceCheckGeneration
     automaticCheck = !!automatic
-    // An automatic check stays invisible until it has something to show.
     if (!automaticCheck)
       maintenanceUi = Maintenance.maintenanceUiChecking(maintenanceUi)
     maintenanceCheckBusy = true
@@ -469,8 +428,6 @@ Item {
       maintenanceUi = next
       return
     }
-    // A failed automatic check retries on the next tick without painting an
-    // error nobody asked for, and never repaints an update already handed off.
     if (next.phase === "error" || maintenanceState.blocked)
       return
     maintenanceUi = next
@@ -515,7 +472,6 @@ Item {
     maintenanceUi = Maintenance.maintenanceUiSetPurge(maintenanceUi, purge)
   }
 
-  // UX-047: first click arms, second confirms.
   function armOrConfirmUninstall() {
     var result = Maintenance.maintenanceUiArmOrConfirmUninstall(maintenanceUi)
     maintenanceUi = result.ui
@@ -567,10 +523,6 @@ Item {
     }
   }
 
-  // -------------------------------------------------------------------------
-  // Version probe lane
-  // -------------------------------------------------------------------------
-
   function applyVersionProbeResult(generation, stdout, stderr, exitCode, fromTimeout) {
     if (!Core.shouldApplyGeneration(activeVersionProbeGeneration, generation))
       return
@@ -582,9 +534,6 @@ Item {
       finishVersionProbeFailure()
   }
 
-  // pluginRoot resolves at construction. It is empty only when Service.qml was
-  // loaded from a non-file URL; say so instead of idling silently, and keep
-  // retrying if a helperPath arrives later.
   function tryStartProduction() {
     if (testMode)
       return
@@ -606,7 +555,6 @@ Item {
       return
     var helper = resolvedHelperPath()
     if (!helper.length) {
-      // Wait for onHelperPathChanged rather than locking out.
       return
     }
     versionProbeRunning = true
@@ -654,10 +602,6 @@ Item {
     kickStatus()
   }
 
-  // -------------------------------------------------------------------------
-  // Status lane
-  // -------------------------------------------------------------------------
-
   function kickStatus() {
     if (!versionReady || versionFailed)
       return
@@ -689,7 +633,6 @@ Item {
     statusProcess.command = argv
     statusStartedGeneration = gen
     if (testMode) {
-      // Tests call applyStatusResult(gen, stdout, stderr, code)
       return
     }
     statusProcess.running = true
@@ -702,22 +645,17 @@ Item {
     statusBusy = false
     refreshing = false
     recordCompletedCallback(!!fromTimeout, "status")
-    // A handoff that began while this run was in flight waits for the free
-    // lane; without this retry it waits forever with polling stopped.
     tryMaintenanceDetach()
 
     if (exitCode !== 0) {
-      // Keep last snapshot (CACHE-021 / malformed retention).
       maybeFollowUpStatus()
       return
     }
     var parsed = Core.parseStatusEnvelope(stdout, helperVersion)
     if (!parsed.ok) {
-      // Malformed envelope: retain previous snapshot.
       maybeFollowUpStatus()
       return
     }
-    // Immutable replacement.
     snapshot = parsed.envelope
     maybeFollowUpStatus()
   }
@@ -731,12 +669,6 @@ Item {
     return Core.pendingIsEmpty(pendingForcedTargets)
   }
 
-  // -------------------------------------------------------------------------
-  // Settings lanes (read / write)
-  // -------------------------------------------------------------------------
-
-  // SET-023: adopt persisted settings at service start. Reads only — the
-  // dialog state machine (SET-014..022) keeps its own snapshot untouched.
   function kickSettingsBootstrap() {
     if (appliedSettings || settingsBootstrapBusy || maintenanceState.blocked)
       return
@@ -765,7 +697,6 @@ Item {
   }
 
   function kickSettingsRead() {
-    // ARCH-024: maintenance rejects new writes/polling; reads may still start.
     if (!Core.canStartLane(settingsReadBusy))
       return
     var helper = resolvedHelperPath()
@@ -789,9 +720,6 @@ Item {
     recordCompletedCallback(!!fromTimeout, "settingsRead")
     if (!settingsState || settingsState.phase === "closed")
       return
-    // SET-026: any failure is a visible terminal state, never an endless
-    // locked "Loading". The helper's message is not shown (plain-text rule);
-    // the dialog renders its own fixed copy.
     if (exitCode !== 0) {
       settingsState = Settings.settingsFailLoad(settingsState, generation)
       settingsDraft = null
@@ -823,7 +751,6 @@ Item {
       return
     settingsWriteBusy = true
     settingsWriteTimeout.restart()
-    // Re-arm stdin: each save closes it after writing (EOF delivery below).
     settingsWriteProcess.stdinEnabled = true
     settingsWriteProcess.command = Settings.settingsArgvApplyStdin(helper)
     settingsWriteStartedGeneration = activeSettingsWriteGeneration
@@ -849,10 +776,6 @@ Item {
       appliedSettings = canonical
     tryMaintenanceDetach()
   }
-
-  // -------------------------------------------------------------------------
-  // Maintenance handoff
-  // -------------------------------------------------------------------------
 
   function beginMaintenanceHandoff() {
     maintenanceState = Maintenance.maintenanceBeginHandoff(maintenanceState)
@@ -884,7 +807,6 @@ Item {
       maintenanceHandoffBusy = false
       return
     }
-    // Uninstall confirmation document is written on stdin (BUNDLE-036).
     if (intention && intention.kind === "uninstall" && pendingMaintenancePayload.length) {
       maintenanceHandoffProcess.stdinEnabled = true
     } else {
@@ -914,8 +836,6 @@ Item {
     if (intention && intention.kind === "update_apply") {
       if (exitCode === 0) {
         maintenanceUi = Maintenance.maintenanceUiIdle(helperVersion || intention.version)
-        // `update apply` returns once the unit is queued; the unit restarts
-        // the shell when the new tree is in place.
         maintenanceUi.message = "Update started. The shell reloads when it finishes."
       } else {
         maintenanceUi = Maintenance.cloneMaintenanceUi(maintenanceUi)
@@ -1011,10 +931,6 @@ Item {
     applyMaintenanceHandoffDone(gen, exitCode)
   }
 
-  // -------------------------------------------------------------------------
-  // Processes (isolated lanes)
-  // -------------------------------------------------------------------------
-
   Process {
     id: versionProbe
     stdout: StdioCollector { id: versionOut; waitForEnd: true }
@@ -1049,7 +965,6 @@ Item {
     stdout: StdioCollector { id: settingsWriteOut; waitForEnd: true }
     stderr: StdioCollector { id: settingsWriteErr; waitForEnd: true }
     onStarted: {
-      // Write the immutable captured payload; never re-read live draft (SET-018).
       // config apply stdin reads until EOF — write() alone does not deliver it;
       // stdinEnabled=false closes the write channel (same as maintenance handoff).
       if (root.pendingSettingsPayloadGeneration === root.settingsWriteStartedGeneration
@@ -1074,7 +989,6 @@ Item {
     stdout: StdioCollector { id: maintenanceHandoffOut; waitForEnd: true }
     stderr: StdioCollector { id: maintenanceHandoffErr; waitForEnd: true }
     onStarted: {
-      // BUNDLE-036 / UX-048: non-TTY uninstall confirmation uses read_to_end.
       // write() alone does not deliver EOF; stdinEnabled=false closes the write channel.
       if (root.pendingMaintenancePayload && root.pendingMaintenancePayload.length
           && maintenanceHandoffProcess.stdinEnabled) {
@@ -1084,9 +998,6 @@ Item {
     }
     onExited: function (exitCode) { root.maintenanceHandoffExited(exitCode) }
   }
-
-  // Single completed handler — QML rejects duplicate assignments of this
-  // handler (live Quattro: "Property value set multiple times" at service load).
 
   Timer {
     id: versionTimeout
@@ -1192,7 +1103,6 @@ Item {
     onTriggered: root.beginCollection()
   }
 
-  // One automatic poll timer (CACHE-005).
   Timer {
     id: pollTimer
     interval: root.pollIntervalMs

--- a/SettingsView.qml
+++ b/SettingsView.qml
@@ -4,7 +4,6 @@ import qs.Ui
 import "CoreView.js" as Core
 import "components"
 
-// Race-safe Settings UI (SET-014..022, UX-033..039). Mutations go through Service.
 Item {
   id: root
 
@@ -12,7 +11,6 @@ Item {
   property color foreground: Color.foreground
   property string fontFamily: Style.font.family
   property url iconBase: Qt.resolvedUrl("icons/")
-  // A11Y-008: true while NumberField (or other editor) owns focus.
   property bool editorOwnsFocus: (intervalField && intervalField.field
         ? !!intervalField.field.activeFocus
         : false)
@@ -107,8 +105,6 @@ Item {
       textFormat: Text.PlainText
     }
 
-    // SET-026: a failed load names the recovery step instead of locking the
-    // dialog behind "Loading" forever. Plain fixed copy; no helper output.
     Text {
       visible: root.loadFailed
       width: parent.width
@@ -149,7 +145,6 @@ Item {
       textFormat: Text.PlainText
     }
 
-    // Providers
     Column {
       width: parent.width
       spacing: Style.space(4)
@@ -202,7 +197,6 @@ Item {
       foreground: root.foreground
     }
 
-    // Display metric
     Column {
       width: parent.width
       spacing: Style.space(6)
@@ -251,7 +245,6 @@ Item {
       }
     }
 
-    // Refresh interval — native NumberField (UX-035)
     Column {
       width: parent.width
       spacing: Style.space(4)
@@ -296,7 +289,6 @@ Item {
       }
     }
 
-    // Notifications
     Column {
       width: parent.width
       spacing: Style.space(4)
@@ -349,7 +341,6 @@ Item {
       }
     }
 
-    // Updates
     Toggle {
       opacity: root.locked ? 0.55 : 1.0
       enabled: !root.locked
@@ -369,7 +360,6 @@ Item {
       foreground: root.foreground
     }
 
-    // Actions — English text labels (UX-036..038)
     Flow {
       width: parent.width
       spacing: Style.space(8)

--- a/components/ConfirmDialog.qml
+++ b/components/ConfirmDialog.qml
@@ -2,7 +2,6 @@ import QtQuick
 import qs.Commons
 import qs.Ui
 
-// Modal confirmation overlay for update / uninstall (UX-043..047).
 Item {
   id: root
 
@@ -16,7 +15,6 @@ Item {
   property color foreground: Color.foreground
   property string fontFamily: Style.font.family
 
-  // Optional extra content slot (e.g. purge checkbox row).
   default property alias extraContent: extraCol.data
 
   signal canceled()
@@ -49,16 +47,13 @@ Item {
     radius: Style.cornerRadius
     color: Color.popups.background
     border.width: 1
-    // Destructive keeps its urgent-tinted border (UX-044: danger actions stay
-    // visually separated); a Style state token would erase that signal, so
-    // only the non-destructive branch moves to the shared token.
     border.color: root.destructive
         ? Util.alpha(Color.urgent, 0.55)
         : Style.normalBorderColor
 
     MouseArea {
       anchors.fill: parent
-      onClicked: {} // swallow
+      onClicked: {}
     }
 
     Column {

--- a/components/FocusController.qml
+++ b/components/FocusController.qml
@@ -1,11 +1,6 @@
 import QtQuick
 import "../CoreScroll.js" as Core
 
-// Ordered focus ring for popup actions (A11Y-003/010/011).
-// Targets are plain Items that may expose:
-//   - forceActiveFocus()
-//   - focusActivate()  → typed activation callback
-//   - enabled / visible
 Item {
   id: root
 
@@ -76,7 +71,6 @@ Item {
       index = -1
       return null
     }
-    // Map current into live list
     var curLive = -1
     if (current) {
       for (var i = 0; i < live.length; i++) {
@@ -88,7 +82,6 @@ Item {
     }
     var nextLive = Core.focusNextIndex(curLive, direction, live.length)
     var item = live[nextLive]
-    // Sync index into full targets array
     for (var j = 0; j < targets.length; j++) {
       if (targets[j] === item) {
         index = j
@@ -117,13 +110,11 @@ Item {
       return true
     }
     if (typeof item.clicked === "function") {
-      // Prefer typed callback; Qt Quick Controls often expose clicked as signal.
     }
     if (item.Accessible && typeof item.Accessible.pressAction === "function") {
       item.Accessible.pressAction()
       return true
     }
-    // Fall back to Accessible.onPressAction via pressAction if present
     if (typeof item.pressAction === "function") {
       item.pressAction()
       return true
@@ -134,7 +125,6 @@ Item {
   function ensureVisible(item) {
     if (!flickable || !item)
       return
-    // Prefer mapToItem when available; else item.y relative to content item.
     var y = 0
     var h = item.height || 0
     try {

--- a/components/HeaderTag.qml
+++ b/components/HeaderTag.qml
@@ -1,11 +1,6 @@
 import QtQuick
 import qs.Commons
 
-// Header tag (visual design §6): a 1px border at the host corner radius,
-// caption type, uppercase. Plan and severity share this one shape; `urgent`
-// is the severity variant (§7), and Color.urgent is the only severity colour
-// in the product. Uppercasing also normalises plan labels that arrive
-// lowercase from the API, such as Codex's `plus`.
 Rectangle {
   id: root
 

--- a/components/ProviderChip.qml
+++ b/components/ProviderChip.qml
@@ -21,11 +21,8 @@ WidgetButton {
   property bool severityUrgent: false
   property string cueLabel: ""
 
-  // The host tooltip is intentionally never set; this label exists for
-  // assistive tech only and must stay single-line.
   property string accessibleLabel: ""
 
-  // §7: Color.urgent is the single severity colour; no new colour exists.
   readonly property color numeralColor: root.severityUrgent ? Color.urgent : root.foreground
 
   readonly property int paintedIconSize: Math.round(Style.bar.iconCanvas * iconScale)
@@ -112,11 +109,4 @@ WidgetButton {
       Accessible.role: Accessible.StaticText
     }
   }
-
-  // §5: the numeral box is tight — width follows the text (amended
-  // 2026-08-04). The reserved box sized on the widest numeral parked ~2
-  // digits of slack in the inter-chip gap when every numeral was short,
-  // reading as disproportionate spacing with an inflated right edge. Chips
-  // may shift when a value crosses a digit boundary; the state cues (! / ln)
-  // already resized them, so width stability was never absolute.
 }

--- a/components/ProviderHeader.qml
+++ b/components/ProviderHeader.qml
@@ -2,10 +2,6 @@ import QtQuick
 import qs.Commons
 import qs.Ui
 
-// Provider content header — name, plan tag, severity tag, refresh only
-// (Fase 2 slim-down). Connection state is implied structurally (UX-017);
-// last-success age appears in the pane's own age caption, not here.
-// UX-016: deliberately no provider icon here (icon lives only on the rail).
 Item {
   id: root
 
@@ -30,7 +26,6 @@ Item {
 
     Text {
       id: nameLabel
-      // Cap name so the row never forces content wider than the pane.
       width: Math.min(implicitWidth, Math.max(Style.space(48), parent.width * 0.42))
       text: root.name
       color: root.foreground
@@ -63,9 +58,6 @@ Item {
     }
 
     Item {
-      // Flexible spacer; never negative. Pushes the refresh glyph right.
-      // Subtracts what is actually rendered — an invisible tag takes no
-      // room in the Row, so it must take none here either.
       width: Math.max(Style.space(4),
           parent.width
           - nameLabel.width
@@ -76,7 +68,6 @@ Item {
       height: 1
     }
 
-    // UX-051 refresh glyph
     PanelActionButton {
       size: Style.space(22)
       iconText: "󰑐"

--- a/components/SettingsProviderRow.qml
+++ b/components/SettingsProviderRow.qml
@@ -2,7 +2,6 @@ import QtQuick
 import qs.Commons
 import qs.Ui
 
-// One provider row: icon, English name, enable toggle, up/down order.
 Item {
   id: root
 
@@ -53,7 +52,6 @@ Item {
 
     Item { width: Style.space(8); height: 1 }
 
-    // Native toggle via qs.Ui.Toggle would be tall; use compact ButtonGroup-like text switch.
     Button {
       anchors.verticalCenter: parent.verticalCenter
       text: root.enabled ? "On" : "Off"
@@ -75,7 +73,6 @@ Item {
       height: 1
     }
 
-    // UX-034 native chevrons (Quattro dropdown uses 󰅀 down; 󰅃 up)
     PanelActionButton {
       anchors.verticalCenter: parent.verticalCenter
       iconText: "󰅃"

--- a/components/StateMessage.qml
+++ b/components/StateMessage.qml
@@ -2,13 +2,12 @@ import QtQuick
 import qs.Commons
 import qs.Ui
 
-// Provider non-window state body: title, plain-text body, allowlisted actions.
 Column {
   id: root
 
   property string title: ""
   property string body: ""
-  property var actions: [] // [{ kind, label, target }]
+  property var actions: []
   property color foreground: Color.foreground
   property string fontFamily: Style.font.family
   property bool skeleton: false
@@ -30,7 +29,6 @@ Column {
     return targets
   }
 
-  // UX-026 skeleton placeholders (no plugin-authored motion).
   Column {
     visible: root.skeleton
     width: parent.width
@@ -62,7 +60,6 @@ Column {
     spacing: Style.space(8)
 
     Text {
-      // Bind to available width; avoid implicit-width grow that clips left glyphs.
       width: Math.max(0, parent.width)
       text: root.title
       color: root.foreground
@@ -105,7 +102,6 @@ Column {
           fontFamily: root.fontFamily
           bordered: true
           focusable: true
-          // Keep action labels fully inside content (no left clip).
           leftAlign: true
           Accessible.name: text
           function focusActivate() {

--- a/components/UsageWindow.qml
+++ b/components/UsageWindow.qml
@@ -1,28 +1,17 @@
 import QtQuick
 import qs.Commons
 
-// One normalized percentage window. The elected lead renders large (label
-// line with the promoted reset -> 2.5x numeral + unit -> track); every other
-// window renders as a compact row that carries its own track (UX-020A
-// extended by the visual design §6). Severity paints numeral and fill in
-// Color.urgent (§7) and always travels with a word — see Accessible.name.
 Item {
   id: root
 
   property string label: ""
   property string percentText: "—"
-  // 0–100 when known; negative when unavailable (hide fill).
   property real percent: -1
-  // Countdown only: the popup shows no absolute clock (§6).
   property string resetCountdown: ""
-  // Lead-only wall-clock suffix, already parenthesised ("(13:31)"); compact
-  // rows leave it empty (§6 amendment 2026-08-03).
   property string resetClock: ""
   property string resetPhrase: ""
   property string unitText: "left"
-  // "critical" | "warning" | "" — computed from usedPercent by CoreView.
   property string severity: ""
-  // The elected lead renders large; every other window renders compact.
   property bool emphasis: true
   property bool dimmed: false
   property color foreground: Color.foreground
@@ -35,19 +24,10 @@ Item {
       : 0
   readonly property bool isCritical: root.severity === "critical"
   readonly property color valueColor: root.isCritical ? Color.urgent : root.foreground
-  // Severity describes the numbers on screen, so it outranks dimming: a
-  // window still shows its reading, and a critical reading is still
-  // critical. valueColor and fillColor must agree on this; they disagreed
-  // once, and the numeral and its own track rendered two different verdicts.
-  // UX-028 (amended) retired the one caller that ever set `dimmed` — stale
-  // no longer dims anything. The property stays because it is the component's
-  // own low-emphasis mode, not a staleness signal; no caller sets it today.
   readonly property color fillColor: root.isCritical
       ? Color.urgent
       : (root.dimmed ? root.foreground : root.accent)
   readonly property real fillOpacity: root.dimmed ? 0.45 : (root.isCritical ? 1.0 : 0.9)
-  // Data surface, not control chrome — no host token covers it. Declared
-  // once here; both layouts tint from the same place.
   readonly property color trackColor: Util.alpha(root.foreground, 0.12)
 
   width: parent ? parent.width : implicitWidth
@@ -55,11 +35,6 @@ Item {
   height: implicitHeight
   opacity: root.dimmed ? 0.6 : 1.0
 
-  // §6: the compact reset column is sized for the widest countdown the
-  // humaniser produces below 24 hours — countdownText() pads no digits, so
-  // two-digit hours plus two-digit minutes is the worst case — and the
-  // value column for a full 100%. Never a hardcoded pixel: both scale with
-  // [font] base-size.
   TextMetrics {
     id: countdownMetrics
     font.family: root.fontFamily
@@ -80,9 +55,6 @@ Item {
     width: parent.width
     spacing: Style.spacing.sm
 
-    // Label line with the reset promoted into it: the label and the lead-in
-    // recede, the countdown itself keeps full ink. Not uppercased — this line
-    // is now a sentence, not a kicker.
     Row {
       width: parent.width
       spacing: Style.spacing.sm
@@ -234,7 +206,6 @@ Item {
     }
   }
 
-  // A11Y-012: severity reaches assistive tech as a word, in both layouts.
   Accessible.name: {
     var parts = [root.label, root.percentText + " " + root.unitText]
     if (root.severity === "critical")

--- a/scripts/agent-bar-cut-release
+++ b/scripts/agent-bar-cut-release
@@ -33,8 +33,6 @@ case "$MAJOR$MINOR$PATCH" in
     exit 1
     ;;
 esac
-# Notes cover everything since the last release tag, which for a deliberate
-# version is not v${CUR}.
 PREV="$(git describe --tags --abbrev=0 --match 'v[0-9]*' 2>/dev/null || true)"
 
 if git rev-parse -q --verify "refs/tags/v${CUR}" >/dev/null; then
@@ -87,7 +85,6 @@ fi
 sed -i "0,/^version = \"${CUR}\"/s//version = \"${NEXT}\"/" Cargo.toml
 cargo update --workspace --offline --quiet
 
-# Root manifest carries the released version (single-repo layout).
 sed -i "s/\"version\": \"${CUR}\"/\"version\": \"${NEXT}\"/" manifest.json
 grep -q "\"version\": \"${NEXT}\"" manifest.json || {
   echo "manifest.json version stamp failed" >&2
@@ -96,7 +93,6 @@ grep -q "\"version\": \"${NEXT}\"" manifest.json || {
 
 printf '%s\n' "$NOTES" > "$NOTES_PATH"
 
-# Prepend the matching CHANGELOG section right after the intro block.
 CHANGELOG_ENTRY="$(printf '## [%s] - %s\n\n### Changed\n\n%s\n' \
   "$NEXT" "$TODAY" "$SUBJECTS")"
 awk -v entry="$CHANGELOG_ENTRY" '

--- a/scripts/agent-bar-open-terminal
+++ b/scripts/agent-bar-open-terminal
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# Interactive provider login launcher for the othavi0.agent-bar plugin bundle.
 # Exact contract: login <provider> → xdg-terminal-exec → private bin/agent-bar.
 set -euo pipefail
 
@@ -27,7 +26,6 @@ case "$provider" in
     ;;
 esac
 
-# Physical absolute plugin root from this script's directory (…/scripts → …/).
 source_path="${BASH_SOURCE[0]}"
 if [[ -L "$source_path" ]]; then
   # Resolve one level of symlink when present; fall back to readlink -f when available.
@@ -44,8 +42,6 @@ if [[ ! -f "$helper" || ! -x "$helper" ]]; then
   exit 1
 fi
 
-# Omarchy owns terminal preference via xdg-terminal-exec. No emulator table,
-# no shell-string construction, no global agent-bar lookup.
 exec xdg-terminal-exec \
   --app-id=org.omarchy.terminal \
   --title="Agent Bar Login" \

--- a/scripts/check-version
+++ b/scripts/check-version
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
-# Confirm Cargo.toml version equals optional release tag and (when present)
-# the staged plugin manifest / bundle receipt.
 # Usage: scripts/check-version [vX.Y.Z] [plugin-dir]
 set -euo pipefail
 

--- a/scripts/verify-v10-ui
+++ b/scripts/verify-v10-ui
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# Capture and verify the exact CP2/CP4 UI evidence inventory.
 set -euo pipefail
 
 ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd -P)"
@@ -57,7 +56,6 @@ for name in "${REQUIRED[@]}"; do
   fi
 done
 
-# Reject unexpected PNGs
 shopt -s nullglob
 extras=()
 for path in "${EVIDENCE}"/*.png; do
@@ -82,7 +80,6 @@ if [[ "${missing}" -ne 0 ]]; then
   exit 1
 fi
 
-# Sorted SHA256SUMS of the exact inventory
 (
   cd "${EVIDENCE}"
   # shellcheck disable=SC2086

--- a/src/app_identity.rs
+++ b/src/app_identity.rs
@@ -1,5 +1,3 @@
-//! Product identity constants. Prefer these over hardcoded strings.
-
 pub const APP_NAME: &str = "agent-bar";
 pub const TERMINAL_HELPER_NAME: &str = "agent-bar-open-terminal";
 /// Omarchy Quattro plugin ID (bar-widget). The `omarchy.*` prefix is reserved.
@@ -7,9 +5,6 @@ pub const OMARCHY_PLUGIN_ID: &str = "othavi0.agent-bar";
 /// Omarchy Quickshell root — detection signal only.
 pub const OMARCHY_SHELL_DIR: &str = "/usr/share/omarchy/shell";
 
-// Release identity (version == manifest == helper == tag) is enforced by
-// scripts/check-version inside the auto-release workflow; a literal pin here
-// would fail every automated bump.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[cfg(test)]

--- a/src/bin/agent-bar-bundle.rs
+++ b/src/bin/agent-bar-bundle.rs
@@ -72,8 +72,6 @@ fn run_stamp(args: &mut [String]) -> Result<PathBuf, String> {
     Ok(repo_root)
 }
 
-/// Parse alternating keyword value pairs. Required keywords must appear
-/// exactly once; optional ones at most once.
 fn parse_kv(
     args: &[String],
     required: &[&str],
@@ -104,7 +102,6 @@ fn parse_kv(
 }
 
 fn repo_root() -> Result<PathBuf, String> {
-    // Prefer CARGO_MANIFEST_DIR when invoked via cargo run; else walk from cwd.
     if let Ok(m) = env::var("CARGO_MANIFEST_DIR") {
         return Ok(PathBuf::from(m));
     }

--- a/src/cache/coordinator.rs
+++ b/src/cache/coordinator.rs
@@ -1,5 +1,3 @@
-//! In-process generation tracking for cache-use / cache-bypass coordination.
-
 use std::sync::Mutex;
 
 use time::OffsetDateTime;

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -1,5 +1,3 @@
-//! Status-v2 cache store and coordination.
-
 pub mod coordinator;
 pub mod schema;
 pub mod store;

--- a/src/cache/schema.rs
+++ b/src/cache/schema.rs
@@ -1,5 +1,3 @@
-//! Normalized status-v2 cache document (CACHE schema).
-
 use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
@@ -102,6 +100,3 @@ impl std::fmt::Display for CacheSchemaError {
 }
 
 impl std::error::Error for CacheSchemaError {}
-
-// ProviderStatus needs a public validate_state_shape - it's private today.
-// We'll add a thin public wrapper on ProviderStatus.

--- a/src/cache/store.rs
+++ b/src/cache/store.rs
@@ -1,5 +1,3 @@
-//! Atomic load/store for the normalized status-v2 cache.
-
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -117,8 +115,6 @@ impl CacheStore {
         doc.providers.insert(id.as_str().to_owned(), entry);
         doc.revision = doc.revision.saturating_add(1);
         doc.validate()?;
-        // Expiry is caller-provided; `_now` is accepted for call-site symmetry
-        // with the collection timestamp but is not read here.
         let bytes = serde_json::to_vec_pretty(&doc).map_err(|err| {
             CacheStoreError::Schema(CacheSchemaError::InvalidJson(err.to_string()))
         })?;

--- a/src/cli/command.rs
+++ b/src/cli/command.rs
@@ -1,8 +1,5 @@
-//! Closed v10 CLI command types.
-
 use std::path::PathBuf;
 
-/// Supported provider identifiers (closed catalog).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ProviderId {
     Claude,
@@ -49,28 +46,24 @@ impl std::fmt::Display for ProviderId {
     }
 }
 
-/// Status stdout format.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StatusFormat {
     Human,
     Json,
 }
 
-/// Cache mode for status collection.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CacheMode {
     Use,
     Bypass,
 }
 
-/// Notification evaluation mode for status.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum NotificationMode {
     Evaluate,
     Skip,
 }
 
-/// Options for `status` (and bare `agent-bar`).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StatusOptions {
     pub format: StatusFormat,
@@ -90,17 +83,12 @@ impl Default for StatusOptions {
     }
 }
 
-/// Config subcommands backed by the canonical settings store (schema v1).
-///
-/// `show` is read-only. `apply` accepts exactly one complete document, validates
-/// before taking the shared maintenance lock, and returns the stored JSON.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ConfigCommand {
     Show,
     Apply(ConfigInput),
 }
 
-/// Input source for `config apply` (complete-document only).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ConfigInput {
     Stdin,
@@ -108,11 +96,6 @@ pub enum ConfigInput {
     Json(String),
 }
 
-/// Update subcommands. `Apply` takes no argument: `update apply` starts a
-/// detached unit and returns (git-plugin-distribution Task 2), not a
-/// version-gated apply of a specific release. `Run` is that unit's body: it
-/// delegates to `omarchy plugin update othavi0.agent-bar --yes` and restarts
-/// the shell when the tree changed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UpdateCommand {
     Interactive,
@@ -121,14 +104,12 @@ pub enum UpdateCommand {
     Run,
 }
 
-/// Doctor subcommands.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DoctorCommand {
     Scan,
     Clean,
 }
 
-/// Accepted `help <topic>` values.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HelpTopic {
     Status,
@@ -185,10 +166,6 @@ impl HelpTopic {
     }
 }
 
-/// Top-level parsed command. `Setup` is settings-migration only
-/// (git-plugin-distribution Task 4): `omarchy plugin add`/`update`/`remove`
-/// own the plugin tree now, so there is no injected-install-target variant
-/// to carry — it takes no payload.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Command {
     Status(StatusOptions),

--- a/src/cli/grammar.rs
+++ b/src/cli/grammar.rs
@@ -1,5 +1,3 @@
-//! Single-pass word-based CLI grammar. No filesystem or provider I/O.
-
 use std::path::PathBuf;
 
 use super::command::{
@@ -10,10 +8,6 @@ use super::exit::CliFailure;
 
 const CONFIG_APPLY_USAGE: &str = "config apply requires stdin, file <path>, or json <value>";
 
-/// Parse argv words after the program name into a closed [`Command`].
-///
-/// Grammar failures map to exit code 2. Parsing never touches the filesystem,
-/// network, or provider adapters.
 pub fn parse<I, S>(args: I) -> Result<Command, CliFailure>
 where
     I: IntoIterator<Item = S>,
@@ -162,8 +156,6 @@ fn parse_status(tokens: &[String]) -> Result<Command, CliFailure> {
     Ok(Command::Status(opts))
 }
 
-/// Both status clause errors — no value present, and a value that looks like
-/// a flag — take the same `word` and want the same sentence.
 fn missing_status_value(word: &str) -> CliFailure {
     CliFailure::grammar(format!("missing value for status {word}"))
 }
@@ -215,9 +207,6 @@ fn parse_config(tokens: &[String]) -> Result<Command, CliFailure> {
     }
 }
 
-/// `setup` takes no arguments (git-plugin-distribution Task 4): install is
-/// `omarchy plugin add`/git clone now, so the former `plugins-dir <path>`
-/// injected-install-target form is an ordinary unknown argument.
 fn parse_setup(tokens: &[String]) -> Result<Command, CliFailure> {
     match tokens {
         [] => Ok(Command::Setup),

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,5 +1,3 @@
-//! Strict word-based CLI for the private Agent Bar helper.
-
 mod command;
 mod exit;
 mod grammar;
@@ -18,14 +16,10 @@ use std::path::{Path, PathBuf};
 
 use serde::Serialize;
 
-/// Package version line for `version` / `--version` (exact semver + newline).
 pub fn version_stdout() -> String {
     format!("{}\n", env!("CARGO_PKG_VERSION"))
 }
 
-/// Closed provider vocabulary as help prose: exactly the words `status
-/// provider <id>` accepts, in catalog order, derived so a new provider can
-/// never be missing from the footer.
 fn provider_word_list() -> String {
     ProviderId::ALL
         .iter()
@@ -34,7 +28,6 @@ fn provider_word_list() -> String {
         .join(", ")
 }
 
-/// Public help text for the plugin-first product.
 pub fn help_text(topic: Option<HelpTopic>) -> String {
     match topic {
         None => {
@@ -71,9 +64,7 @@ pub fn help_text(topic: Option<HelpTopic>) -> String {
              \n\
              Bare agent-bar equals status format human.\n"
             .to_owned(),
-        // The login topic lists fewer providers than the footer on purpose:
-        // only these four ship an official login command (catalog
-        // `login_argv`); Antigravity signs in inside its own CLI.
+        // Antigravity signs in inside its own CLI, so it has no login verb.
         Some(HelpTopic::Login) => {
             "login <provider> — delegate to the official provider login command\n\
              Providers: claude, codex, amp, grok\n"
@@ -108,9 +99,6 @@ pub fn help_text(topic: Option<HelpTopic>) -> String {
     }
 }
 
-/// Dispatch a fully parsed command for the private helper binary.
-///
-/// Commands not yet implemented after the grammar freeze exit with code 70.
 pub fn dispatch(command: Command) -> Result<(), CliFailure> {
     match command {
         Command::Version => {
@@ -134,15 +122,6 @@ pub fn dispatch(command: Command) -> Result<(), CliFailure> {
     }
 }
 
-/// `setup`: settings migration only (git-plugin-distribution Task 4).
-///
-/// The plugin tree install/activate that used to live here is gone —
-/// `omarchy plugin add othavi0.agent-bar` is the install now, and `update`
-/// (Task 2) / `uninstall` (Task 3) already delegate their tree mutations to
-/// the omarchy CLI the same way. `setup` keeps the one piece of state only
-/// this helper owns: MIG-007..016 explicit settings/shell v9-to-v10
-/// migration, run once under the exclusive maintenance gate. Reads never
-/// write; setup is the authorized apply path.
 fn dispatch_setup() -> Result<(), CliFailure> {
     use crate::plugin::PluginPaths;
     use crate::settings::{default_settings_path, migrate_live_paths};
@@ -301,10 +280,6 @@ where
     }
 }
 
-/// Exact successful `uninstall` stdout document (git-plugin-distribution
-/// Task 3). Own-state purge only — the plugin tree, shell.json entry, and
-/// cache/backups GC that the old worker chain owned all belong to
-/// `omarchy plugin remove` now.
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct UninstallDelegation<'a> {
@@ -315,8 +290,6 @@ struct UninstallDelegation<'a> {
     unit: &'a str,
 }
 
-/// Remove `path` and everything under it; a missing path is success
-/// (idempotent purge), any other I/O error propagates.
 fn remove_dir_all_idempotent(path: &Path) -> Result<(), CliFailure> {
     match std::fs::remove_dir_all(path) {
         Ok(()) => Ok(()),
@@ -328,16 +301,6 @@ fn remove_dir_all_idempotent(path: &Path) -> Result<(), CliFailure> {
     }
 }
 
-/// `uninstall [purge]`: own-XDG-state purge under the maintenance gate, then
-/// unconditional detached delegation to the omarchy CLI (git-plugin-
-/// distribution Task 3).
-///
-/// The old worker chain quarantined the plugin tree, stripped the exact
-/// shell.json entry, and polled for absence itself over a copied worker
-/// binary — none of that survives git-native distribution: `omarchy plugin
-/// remove` owns the plugin tree and shell.json now, and this helper only
-/// purges the state it exclusively owns (settings, cache, XDG state)
-/// before handing off, mirroring `update apply`'s Task 2 delegation shape.
 fn dispatch_uninstall(purge: bool) -> Result<(), CliFailure> {
     use crate::plugin::{
         resolve_absolute_executable, txid_from_bytes, CommandRunner, PluginPaths,
@@ -353,20 +316,12 @@ fn dispatch_uninstall(purge: bool) -> Result<(), CliFailure> {
     let xdg_state = std::env::var_os("XDG_STATE_HOME").map(PathBuf::from);
     let paths = PluginPaths::production(home.clone(), xdg_state);
 
-    // Exclusive barrier (ARCH-026), mirroring dispatch_update_apply (Task 2):
-    // block shared status/settings and any other maintenance operation while
-    // the purge and handoff run.
     let gate = MaintenanceGate::open(&paths.maintenance_lock)
         .map_err(|e| CliFailure::plugin(format!("open maintenance lock: {e}")))?;
     let exclusive = gate
         .lock_exclusive()
         .map_err(|e| CliFailure::plugin(format!("exclusive maintenance lock: {e}")))?;
 
-    // Resolve the delegation tools before consuming the confirmation or
-    // touching any state: a missing `omarchy`/`systemd-run` must fail closed
-    // before anything destructive happens, not after the purge already ran
-    // and the plugin was never actually removed (mirrors the pre-Task-3
-    // preflight-before-confirmation ordering).
     let omarchy_bin =
         resolve_absolute_executable("omarchy").map_err(|e| CliFailure::plugin(e.to_string()))?;
     let systemd_run = resolve_absolute_executable("systemd-run")
@@ -396,12 +351,6 @@ fn dispatch_uninstall(purge: bool) -> Result<(), CliFailure> {
         remove_dir_all_idempotent(&cache_dir)?;
     }
 
-    // `paths.xdg_state` ($XDG_STATE_HOME/agent-bar) holds `maintenance.lock`
-    // itself. Drop the exclusive guard before removing that directory:
-    // unlinking a file while its flock is still held is safe on Linux, but
-    // the drop-then-remove order is kept explicit — and covered by the
-    // `uninstall_purge_removes_xdg_state_and_delegates_remove` test — rather
-    // than relying on that platform detail.
     drop(exclusive);
     if purge {
         remove_dir_all_idempotent(&paths.xdg_state)?;
@@ -476,12 +425,6 @@ fn dispatch_update_check() -> Result<(), CliFailure> {
     Ok(())
 }
 
-/// Exact successful `update apply` stdout document (git-plugin-distribution
-/// Task 2). `update apply` no longer downloads, stages, or swaps the plugin
-/// tree itself — it hands the whole fast-forward to
-/// `omarchy plugin update othavi0.agent-bar --yes`, running as a detached
-/// transient unit so this process can return as soon as the handoff is
-/// accepted.
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct UpdateApplyDelegation<'a> {
@@ -491,11 +434,6 @@ struct UpdateApplyDelegation<'a> {
     unit: &'a str,
 }
 
-/// `update apply`: unconditional detached delegation to the omarchy CLI.
-///
-/// BUNDLE-021 v-next carries no archive/checksum/source-commit fields (Task
-/// 1), so the old download/stage/exchange/health worker chain cannot run
-/// anymore — `omarchy plugin update` owns the git fast-forward instead.
 fn dispatch_update_apply() -> Result<(), CliFailure> {
     use crate::plugin::{
         resolve_absolute_executable, txid_from_bytes, CommandRunner, PluginPaths,
@@ -509,16 +447,12 @@ fn dispatch_update_apply() -> Result<(), CliFailure> {
     let xdg_state = std::env::var_os("XDG_STATE_HOME").map(PathBuf::from);
     let paths = PluginPaths::production(PathBuf::from(home), xdg_state);
 
-    // Exclusive barrier (ARCH-026): block shared status/settings and any other
-    // maintenance operation while the handoff is issued.
     let gate = MaintenanceGate::open(&paths.maintenance_lock)
         .map_err(|e| CliFailure::plugin(format!("open maintenance lock: {e}")))?;
     let _exclusive = gate
         .lock_exclusive()
         .map_err(|e| CliFailure::plugin(format!("exclusive maintenance lock: {e}")))?;
 
-    // Fail closed here, where QML sees the error, rather than inside the
-    // detached unit where nobody would: every tool `update run` requires.
     for tool in ["omarchy", "omarchy-restart-shell", "git", "timeout"] {
         resolve_absolute_executable(tool).map_err(|e| CliFailure::plugin(e.to_string()))?;
     }
@@ -571,7 +505,6 @@ fn dispatch_update_apply() -> Result<(), CliFailure> {
     Ok(())
 }
 
-/// `update run` stdout document: one line for the unit's journal.
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct UpdateRunReport {
@@ -591,11 +524,8 @@ fn print_update_run_report(outcome: &'static str) -> Result<(), CliFailure> {
     Ok(())
 }
 
-/// `update run`: the detached unit's body (see `plugin::update_run`).
-///
-/// A second run while one is still retrying a restart exits 0 at once: the
-/// run lock, separate from the maintenance lock, is never waited on, so
-/// status and settings keep working during a long fetch or a locked session.
+/// Takes only the run lock, never the maintenance lock: this run can retry a
+/// restart for hours, and status and settings must keep working meanwhile.
 fn dispatch_update_run() -> Result<(), CliFailure> {
     use crate::plugin::update_run::{
         run_update, UpdateRunLimits, UpdateRunOutcome, UpdateRunTools,
@@ -671,11 +601,6 @@ fn unit_argv_path(path: String) -> Result<String, CliFailure> {
     }
 }
 
-/// `update` (no subcommand): the old TTY confirmation flow required a
-/// version-gated apply to offer, which git-native delegation no longer has —
-/// `update apply` now applies unconditionally. Bare `update` just points
-/// callers at the two real subcommands instead of pretending to be
-/// interactive.
 fn dispatch_update_interactive() -> Result<(), CliFailure> {
     eprintln!("agent-bar update has no interactive flow.");
     eprintln!("Use 'agent-bar update check' or 'agent-bar update apply'.");
@@ -877,23 +802,19 @@ mod tests {
         let mut stderr = Vec::new();
         confirm_uninstall(false, false, &mut stdin, &mut stderr).unwrap();
 
-        // command/purge mismatch
         let mut stdin = Cursor::new(good.as_slice());
         let err = confirm_uninstall(false, true, &mut stdin, &mut stderr).unwrap_err();
         assert_eq!(err.exit_code, VALIDATION);
 
-        // false confirmation
         let bad = br#"{"schemaVersion":1,"operation":"uninstall","confirmed":false,"purgeSettingsAndBackups":false}"#;
         let mut stdin = Cursor::new(bad.as_slice());
         let err = confirm_uninstall(false, false, &mut stdin, &mut stderr).unwrap_err();
         assert_eq!(err.exit_code, VALIDATION);
 
-        // malformed
         let mut stdin = Cursor::new(b"{not-json".as_slice());
         let err = confirm_uninstall(false, false, &mut stdin, &mut stderr).unwrap_err();
         assert_eq!(err.exit_code, VALIDATION);
 
-        // trailing garbage
         let mut stdin = Cursor::new(
             br#"{"schemaVersion":1,"operation":"uninstall","confirmed":true,"purgeSettingsAndBackups":false}{}"#
                 .as_slice(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,6 @@
 use agent_bar::cli::{self, SUCCESS};
 
 fn main() {
-    // RUST_LOG controls diagnostics (CLI-008); no verbose flag. Stderr only.
     let _ = env_logger::Builder::new()
         .filter_level(log::LevelFilter::Warn)
         .target(env_logger::Target::Stderr)

--- a/src/notifications/mod.rs
+++ b/src/notifications/mod.rs
@@ -1,5 +1,3 @@
-//! Usage threshold notifications (at-least-once, notify-send backend).
-
 pub mod state;
 
 pub use state::{
@@ -16,27 +14,20 @@ use crate::settings::schema::{DisplayMetric, Settings as SettingsDocument};
 use crate::status::schema::{DataSource, ProviderState, StatusEnvelope};
 use crate::support::redact::strip_ansi_and_controls;
 
-/// Planned notification before dispatch.
 #[derive(Debug, Clone, PartialEq)]
 pub struct PendingNotification {
     pub provider_id: ProviderId,
     pub provider_name: String,
     pub window_id: String,
     pub window_label: String,
-    /// What fired the notification. Always the trigger, never the sentence.
     pub used_percent: f64,
     pub remaining_percent: f64,
-    /// The unit the user chose in Settings (copy design §6.2).
     pub metric: DisplayMetric,
     pub reset_at: Option<time::OffsetDateTime>,
-    /// Humanised countdown at evaluation time; `None` when the window carries
-    /// no reset timestamp. Precomputed by the evaluator, which owns the clock,
-    /// so `build_spec` stays a pure function of this struct.
     pub reset_in: Option<String>,
     pub level: NotificationLevel,
 }
 
-/// Dispatch backend (production uses `notify-send`).
 pub trait NotificationDispatcher: Send + Sync {
     fn dispatch(
         &self,
@@ -44,7 +35,6 @@ pub trait NotificationDispatcher: Send + Sync {
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<(), String>> + Send + '_>>;
 }
 
-/// `notify-send` argv builder and runner.
 #[derive(Debug, Clone)]
 pub struct NotifySendDispatcher<R: ProcessRunner> {
     pub runner: R,
@@ -64,8 +54,6 @@ impl<R: ProcessRunner> NotifySendDispatcher<R> {
             NotificationLevel::Warning => "normal",
             NotificationLevel::Critical => "critical",
         };
-        // Copy design §5.5: the title names what is running out. The old
-        // "{Name} usage warning" said the category, not the thing.
         let title = match pending.level {
             NotificationLevel::Warning => format!(
                 "{} {} is running low",
@@ -76,18 +64,14 @@ impl<R: ProcessRunner> NotifySendDispatcher<R> {
                 pending.provider_name, pending.window_label
             ),
         };
-        // §6.2: one unit across the product. The threshold that fired this is
-        // always usedPercent; the sentence follows the user's chosen metric.
         let (value, unit) = match pending.metric {
             DisplayMetric::Used => (pending.used_percent, "used"),
             DisplayMetric::Remaining => (pending.remaining_percent, "left"),
         };
         let value = value.round() as i64;
         let body = match pending.reset_in.as_deref() {
-            // "Resets in now." is not English; the popup avoids it the same way.
             Some("now") => format!("{value}% {unit}. Resets now."),
             Some(countdown) => format!("{value}% {unit}. Resets in {countdown}."),
-            // §5.5: with no timestamp the clause is omitted, not filled in.
             None => format!("{value}% {unit}."),
         };
         let title = strip_ansi_and_controls(&title);
@@ -131,13 +115,10 @@ impl<R: ProcessRunner + 'static> NotificationDispatcher for NotifySendDispatcher
     }
 }
 
-/// Evaluate envelope windows, dispatch escalations, persist per success.
 pub struct NotificationEvaluator<'a, D: NotificationDispatcher> {
     pub store: &'a NotificationStateStore,
     pub dispatcher: &'a D,
     pub settings: &'a SettingsDocument,
-    /// Supplied by the caller that already read the clock for this collect
-    /// cycle, so the countdown agrees with the rest of the envelope.
     pub now: time::OffsetDateTime,
 }
 
@@ -152,23 +133,15 @@ impl<'a, D: NotificationDispatcher> NotificationEvaluator<'a, D> {
         let mut state = self.store.load().map_err(|err| err.to_string())?;
         let order: Vec<ProviderId> = self.settings.providers.iter().map(|p| p.id.0).collect();
 
-        // Collect candidates in settings provider order, then window order.
         let mut pending: Vec<PendingNotification> = Vec::new();
         for id in order {
             let Some(provider) = envelope.providers().iter().find(|p| p.id() == id) else {
                 continue;
             };
             if provider.state() != ProviderState::Ready {
-                // NOTIFY-006: stale/failures do not trigger.
                 continue;
             }
 
-            // Pruning runs before the window loop, so the rearms, upserts and
-            // de-escalations below are never undone by it. The elapsed-reset
-            // branch needs a live reading: a Ready provider can be replayed
-            // from cache for up to its TTL while still reporting the
-            // pre-reset timestamp, and treating that as proof the window
-            // restarted would fire an alert about a window that already reset.
             let live_reading = provider.source() == Some(DataSource::Live);
             let live: Vec<&str> = provider.windows().iter().map(|w| w.id()).collect();
             state.prune_ready_provider(id, &live, self.now, live_reading);
@@ -177,24 +150,15 @@ impl<'a, D: NotificationDispatcher> NotificationEvaluator<'a, D> {
                 let used = window.used_percent();
                 let observed = window.resets_at();
                 let Some(level) = NotificationLevel::from_used_percent(used) else {
-                    // Recovery below the warning threshold rearms.
                     state.remove_key(id, window.id());
                     continue;
                 };
                 let saved = state.entry_for(id, window.id()).cloned();
                 let should_emit = match saved.as_ref() {
-                    // Never spoken for this window.
                     None => true,
-                    // The window advanced; a genuinely new quota period.
                     Some(prev) if !NotificationState::same_window(prev.reset_at, observed) => true,
-                    // NOTIFY-002: severity only ever escalates.
                     Some(prev) if level > prev.level => true,
-                    // Same severity: the reminder decides, not the poll.
                     Some(prev) if level == prev.level => self.now - prev.notified_at >= reminder,
-                    // De-escalation inside the same window. NOTIFY-002 forbids
-                    // speaking, but the tracked severity must follow the window
-                    // down or the reminder can never match again, silencing a
-                    // window that is still above its threshold.
                     Some(prev) => {
                         state.upsert(NotificationEntry {
                             provider_id: id.as_str().to_owned(),
@@ -224,7 +188,6 @@ impl<'a, D: NotificationDispatcher> NotificationEvaluator<'a, D> {
             }
         }
 
-        // Persist silent rearms and de-escalations first.
         self.store.save(&state).map_err(|err| err.to_string())?;
 
         for item in pending {
@@ -237,10 +200,7 @@ impl<'a, D: NotificationDispatcher> NotificationEvaluator<'a, D> {
                         level: item.level,
                         notified_at: self.now,
                     });
-                    // Persist after each success (at-least-once algorithm).
                     if let Err(err) = self.store.save(&state) {
-                        // The incident this replaces ran for days behind a bare
-                        // stderr line nobody reads.
                         log::warn!(
                             "notification state save failed for {}/{}: {err}",
                             item.provider_id.as_str(),
@@ -250,7 +210,6 @@ impl<'a, D: NotificationDispatcher> NotificationEvaluator<'a, D> {
                     }
                 }
                 Err(err) => {
-                    // Leave the row unadvanced; stop later notifications.
                     return Err(err);
                 }
             }
@@ -333,8 +292,6 @@ mod tests {
         .unwrap()
     }
 
-    /// Sibling of `envelope_with_used` for tests that need a window with a
-    /// real `resets_at`, since `envelope_with_used` hardcodes `None`.
     fn envelope_with_reset(used: f64, resets_at: time::OffsetDateTime) -> StatusEnvelope {
         let window =
             UsageWindow::try_new("session", "Session", used, 100.0 - used, Some(resets_at))
@@ -372,9 +329,6 @@ mod tests {
 
     #[tokio::test]
     async fn sub_second_reset_jitter_does_not_renotify() {
-        // The incident, end to end: three consecutive collections of the same
-        // Claude window, each carrying a different microsecond reset. Before
-        // this task that dispatched three times and persisted nothing.
         let dir = tempfile::tempdir().unwrap();
         let store = store_in(&dir);
         let runner = ScriptedNotify {
@@ -454,7 +408,7 @@ mod tests {
             now: datetime!(2026-07-26 18:42:00 UTC),
         };
         eval.evaluate(&envelope_with_used(90.0)).await.unwrap();
-        eval.evaluate(&envelope_with_used(90.0)).await.unwrap(); // no second warning
+        eval.evaluate(&envelope_with_used(90.0)).await.unwrap();
         eval.evaluate(&envelope_with_used(96.0)).await.unwrap();
         let specs = dispatcher.runner.specs.lock().unwrap();
         assert_eq!(specs.len(), 2);
@@ -520,13 +474,6 @@ mod tests {
 
     #[tokio::test]
     async fn evaluate_threads_its_own_clock_into_the_dispatched_countdown() {
-        // Every other evaluate()-driven test above uses envelope_with_used(),
-        // whose window carries resets_at: None, so the reset_in closure in
-        // the pending push (`reset_countdown(self.now, ts)`) never runs.
-        // This test gives the window a real reset timestamp and asserts the
-        // exact dispatched body, so it fails if the arguments to
-        // reset_countdown were ever swapped, or if self.now were ever
-        // replaced by a fresh OffsetDateTime::now_utc() call.
         let dir = tempfile::tempdir().unwrap();
         let store = NotificationStateStore::new(
             NotificationPaths {
@@ -541,12 +488,8 @@ mod tests {
         };
         let dispatcher = NotifySendDispatcher::new(runner);
         let settings = SettingsDocument::defaults();
-        // Fixed instants, both already years behind the real wall clock this
-        // suite runs under, so a stray OffsetDateTime::now_utc() would land
-        // the reset far in the past and read "now", not "3h 1m" — it cannot
-        // coincidentally reproduce the expected string.
         let now = datetime!(2026-07-26 18:42:00 UTC);
-        let resets_at = datetime!(2026-07-26 21:43:00 UTC); // now + 3h 1m
+        let resets_at = datetime!(2026-07-26 21:43:00 UTC);
         let eval = NotificationEvaluator {
             store: &store,
             dispatcher: &dispatcher,
@@ -558,7 +501,6 @@ mod tests {
             .unwrap();
         let specs = dispatcher.runner.specs.lock().unwrap();
         assert_eq!(specs.len(), 1);
-        // Default display metric is Remaining: 100 - 92 = 8% left.
         assert_eq!(specs[0].args[3], "8% left. Resets in 3h 1m.");
     }
 
@@ -586,8 +528,6 @@ mod tests {
 
     #[test]
     fn notification_body_follows_the_display_metric() {
-        // The trigger is always usedPercent, but the sentence is not: the
-        // notification must not be the one surface speaking a different unit.
         let mut pending = PendingNotification {
             provider_id: ProviderId::Claude,
             provider_name: "Claude".into(),
@@ -603,8 +543,6 @@ mod tests {
         let spec = NotifySendDispatcher::<ScriptedNotify>::build_spec(&pending);
         assert_eq!(spec.args[1], "--urgency=critical");
         assert_eq!(spec.args[2], "Claude Session (5h) is almost out");
-        // No timestamp: the reset clause is omitted entirely, not filled with
-        // a placeholder.
         assert_eq!(spec.args[3], "4% left.");
 
         pending.metric = DisplayMetric::Used;
@@ -658,12 +596,11 @@ mod tests {
             fail: false,
         };
         let dispatcher = NotifySendDispatcher::new(runner);
-        let settings = SettingsDocument::defaults(); // reminderMinutes == 120
+        let settings = SettingsDocument::defaults();
         let reset = datetime!(2026-08-21 22:00:00 UTC);
         let first = datetime!(2026-08-21 10:00:00 UTC);
         let envelope = envelope_with_reset(96.0, reset);
 
-        // A fresh evaluator per instant: `now` is a field, not an argument.
         NotificationEvaluator {
             store: &store,
             dispatcher: &dispatcher,
@@ -703,10 +640,6 @@ mod tests {
 
     #[tokio::test]
     async fn de_escalation_lowers_the_tracked_level_without_notifying() {
-        // Critical -> Warning while still above 90 must not dispatch
-        // (NOTIFY-002), but the stored level has to follow the window down.
-        // If it stays Critical, the reminder arm never matches again and the
-        // user stops hearing about a window that is still at 92 percent.
         let dir = tempfile::tempdir().unwrap();
         let store = store_in(&dir);
         let runner = ScriptedNotify {
@@ -745,7 +678,6 @@ mod tests {
         let state = store.load().unwrap();
         assert_eq!(state.entries[0].level, NotificationLevel::Warning);
 
-        // The reminder now fires at the level the window is actually at.
         NotificationEvaluator {
             store: &store,
             dispatcher: &dispatcher,
@@ -797,10 +729,6 @@ mod tests {
 
     #[tokio::test]
     async fn evaluate_keeps_rows_for_providers_absent_from_the_envelope() {
-        // Pruning is Ready-only. A provider missing from this envelope has
-        // confirmed nothing, so its dedupe must survive or it notifies again
-        // the moment it recovers. The sibling case — present but not Ready —
-        // is covered by evaluate_keeps_rows_for_a_stale_provider below.
         let dir = tempfile::tempdir().unwrap();
         let store = store_in(&dir);
         let mut seeded = NotificationState::empty();
@@ -834,10 +762,6 @@ mod tests {
 
     #[tokio::test]
     async fn evaluate_keeps_rows_for_a_stale_provider() {
-        // Present in the envelope but not Ready: the provider confirmed
-        // nothing this cycle, so neither pruning nor rearming may touch it
-        // (NOTIFY-006). No pre-existing test covered this — the guard was
-        // only a comment.
         use crate::status::schema::{ErrorCode, ProviderAction, ProviderError};
 
         let dir = tempfile::tempdir().unwrap();

--- a/src/notifications/state.rs
+++ b/src/notifications/state.rs
@@ -1,5 +1,3 @@
-//! Persisted notification deduplication state (schema v2).
-
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -62,22 +60,15 @@ impl NotificationLevel {
 pub struct NotificationEntry {
     pub provider_id: String,
     pub window_id: String,
-    /// Last observed reset for this window. Evidence, not identity: see
-    /// `RESET_JITTER_TOLERANCE`.
     #[serde(with = "time::serde::rfc3339::option")]
     pub reset_at: Option<OffsetDateTime>,
     pub level: NotificationLevel,
-    /// When the last successful dispatch happened; drives the reminder.
     #[serde(with = "time::serde::rfc3339")]
     pub notified_at: OffsetDateTime,
 }
 
 impl NotificationEntry {
     /// The one definition of a notification's identity.
-    ///
-    /// v1 spelled this comparison out by hand in four places; `validate`
-    /// truncated the reset to whole seconds while the other three compared
-    /// nanoseconds, and the disagreement blocked every write.
     pub fn key(&self) -> (&str, &str) {
         (self.provider_id.as_str(), self.window_id.as_str())
     }
@@ -120,7 +111,6 @@ impl NotificationState {
         self.entries.sort_by(|a, b| a.key().cmp(&b.key()));
     }
 
-    /// True when two observed resets describe the same quota window.
     pub fn same_window(saved: Option<OffsetDateTime>, observed: Option<OffsetDateTime>) -> bool {
         match (saved, observed) {
             (None, None) => true,
@@ -325,10 +315,6 @@ mod tests {
 
     #[test]
     fn sub_second_reset_jitter_is_the_same_window() {
-        // The Claude usage endpoint derives resets_at from its own clock per
-        // response, so the same window returns with millisecond drift. v1
-        // treated that as a new key, which is what produced the notification
-        // loop this test exists to prevent.
         let a = datetime!(2026-08-21 11:59:59.707742 UTC);
         let b = datetime!(2026-08-21 11:59:59.854947 UTC);
         let c = datetime!(2026-08-21 12:00:00.024238 UTC);
@@ -344,7 +330,6 @@ mod tests {
         assert!(!NotificationState::same_window(Some(now), Some(next_week)));
         assert!(!NotificationState::same_window(Some(now), None));
         assert!(!NotificationState::same_window(None, Some(now)));
-        // Just outside the tolerance, so the boundary is pinned, not implied.
         let just_past = datetime!(2026-08-21 12:01:00.001 UTC);
         assert!(!NotificationState::same_window(Some(now), Some(just_past)));
     }
@@ -368,8 +353,6 @@ mod tests {
         });
         assert_eq!(state.entries.len(), 1);
         assert_eq!(state.entries[0].level, NotificationLevel::Critical);
-        // The exact document that made save() fail with "duplicate
-        // notification key" on the reporting install.
         state.validate().unwrap();
     }
 
@@ -397,10 +380,6 @@ mod tests {
 
     #[test]
     fn prune_keeps_elapsed_rows_when_the_reading_came_from_cache() {
-        // A Ready provider can be served straight from cache for up to its
-        // TTL (300s for Claude) while still reporting the pre-reset
-        // timestamp. Treating that as proof the window restarted would rearm
-        // against a reading the provider never confirmed.
         let now = datetime!(2026-08-21 12:00:00 UTC);
         let mut state = NotificationState::empty();
         state.upsert(NotificationEntry {

--- a/src/plugin/bundle.rs
+++ b/src/plugin/bundle.rs
@@ -1,10 +1,3 @@
-//! Plugin release stamping, receipt (`bundle.json`), and tree validation.
-//!
-//! The plugin QML/JS/manifest tree lives at the repo root (monorepo
-//! migration). `BundleBuilder::stamp` does not assemble a separate tree; it
-//! stamps release artifacts (private helper, `bundle.json`) directly into
-//! that root and validates the shipped scope.
-
 use std::collections::{BTreeMap, BTreeSet};
 use std::ffi::OsStr;
 use std::fs::{self, File, OpenOptions};
@@ -273,14 +266,12 @@ impl BundleBuilder {
             )));
         }
 
-        // Private helper.
         let bin_dir = repo_root.join("bin");
         fs::create_dir_all(&bin_dir)?;
         let dest_helper = bin_dir.join("agent-bar");
         fs::copy(helper_bin, &dest_helper)?;
         set_unix_mode(&dest_helper, 0o755)?;
 
-        // Deterministic non-exec modes for ordinary shipped files.
         normalize_bundle_modes(repo_root)?;
 
         let receipt = BundleValidator::build_receipt(self, repo_root)?;
@@ -288,7 +279,6 @@ impl BundleBuilder {
         let json = receipt.to_pretty_json()?;
         write_bytes_atomic(&receipt_path, json.as_bytes(), 0o644)?;
 
-        // Final validation including the written receipt.
         BundleValidator::validate_tree(repo_root)?;
         Ok(receipt)
     }
@@ -340,7 +330,6 @@ impl BundleValidator {
                 plugin_root.display()
             )));
         }
-        // No symlinks / special files anywhere in the tree.
         reject_special_files(plugin_root)?;
 
         let receipt_path = plugin_root.join("bundle.json");
@@ -400,7 +389,6 @@ impl BundleValidator {
         }
 
         validate_manifest_matches(&plugin_root.join("manifest.json"), &receipt.version)?;
-        // Helper version must match manifest/receipt exactly (BUNDLE-006 / BUNDLE-027).
         let helper = plugin_root.join("bin/agent-bar");
         if !helper.is_file() {
             return Err(BundleError::msg("bin/agent-bar is missing"));
@@ -428,7 +416,6 @@ impl BundleValidator {
             }
         }
 
-        // Required top-level files.
         for required in [
             "manifest.json",
             "Service.qml",
@@ -449,10 +436,6 @@ impl BundleValidator {
         Ok(receipt)
     }
 }
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
 
 pub fn validate_source_commit(s: &str) -> Result<(), BundleError> {
     if s.len() != 40 {
@@ -487,7 +470,6 @@ pub fn validate_build_run(s: &str) -> Result<(), BundleError> {
 pub fn validate_semver_strict(v: &str) -> Result<(), BundleError> {
     let parsed = semver::Version::parse(v)
         .map_err(|e| BundleError::msg(format!("invalid semantic version '{v}': {e}")))?;
-    // Disallow leading zeros / weird forms by round-trip.
     if parsed.to_string() != v {
         return Err(BundleError::msg(format!(
             "version must be strict semver canonical form, got '{v}'"
@@ -578,7 +560,6 @@ fn validate_manifest_matches(manifest_path: &Path, version: &str) -> Result<(), 
     Ok(())
 }
 
-/// Run `bin/agent-bar version` and return the trimmed first line (BUNDLE-006).
 fn read_helper_version(helper: &Path) -> Result<String, BundleError> {
     let output = Command::new(helper)
         .arg("version")
@@ -601,9 +582,6 @@ fn read_helper_version(helper: &Path) -> Result<String, BundleError> {
     Ok(line)
 }
 
-/// Walk a shipped directory (`components/` or `icons/`) recursively,
-/// invoking `visit` for each regular file found. Rejects symlinks and other
-/// special files anywhere in the walk.
 fn walk_shipped_dir(
     root: &Path,
     dir_name: &str,
@@ -654,8 +632,6 @@ fn walk_shipped_dir(
 fn normalize_bundle_modes(root: &Path) -> Result<(), BundleError> {
     for rel in SHIPPED_ROOT_FILES {
         let path = root.join(rel);
-        // Presence check first, so an absent shipped file is refused by name
-        // instead of surfacing as a bare OS error from the chmod below.
         fs::symlink_metadata(&path)
             .map_err(|e| BundleError::msg(format!("missing shipped file {rel}: {e}")))?;
         if *rel == "bin/agent-bar" || *rel == "scripts/agent-bar-open-terminal" {
@@ -670,24 +646,12 @@ fn normalize_bundle_modes(root: &Path) -> Result<(), BundleError> {
     Ok(())
 }
 
-/// True for a real directory named `.git` sitting directly under `root`.
-///
-/// Unlike omarchy-plugin-validate's `find "$PLUGIN_DIR" -name .git -prune`,
-/// which skips a `.git` directory anywhere in the tree, this tolerance is
-/// deliberately root-only: installed plugins are git checkouts, so a `.git`
-/// at the tree root is expected and never part of the plugin contract, but a
-/// `.git` nested deeper is unexpected and still trips the ordinary
-/// extra-file-not-in-receipt check below. A `.git` that is itself a symlink
-/// at the root gets no pass either -- the symlink check always runs first.
+/// Root-only on purpose, unlike `omarchy-plugin-validate`: installed plugins are
+/// git checkouts, but a nested `.git` must still fail the receipt check.
 fn is_root_git_dir(root: &Path, dir: &Path, name: &OsStr, is_dir: bool) -> bool {
     is_dir && dir == root && name == OsStr::new(".git")
 }
 
-/// Collect (relative path with `/`, sha256, size, mode) for every shipped
-/// regular file: [`SHIPPED_ROOT_FILES`] plus a full walk of [`SHIPPED_DIRS`].
-/// The repo root also holds `src/`, `docs/`, `target/`, and other non-shipped
-/// trees; those are outside this inventory's scope entirely, not merely
-/// tolerated.
 fn collect_inventory(root: &Path) -> Result<Vec<(String, String, u64, String)>, BundleError> {
     let mut out = Vec::new();
     for rel in SHIPPED_ROOT_FILES {
@@ -727,11 +691,6 @@ fn collect_inventory(root: &Path) -> Result<Vec<(String, String, u64, String)>, 
     Ok(out)
 }
 
-/// Reject symlinks and other special files within the shipped scope, plus
-/// the repo root's own immediate entries (excluding a root `.git`). This
-/// deliberately does not descend into non-shipped subdirectories like
-/// `src/` or `docs/` -- a symlink there is the shell's own full-tree
-/// validator's job at install time, not this bundle's.
 fn reject_special_files(root: &Path) -> Result<(), BundleError> {
     for entry in fs::read_dir(root)? {
         let entry = entry?;
@@ -834,10 +793,6 @@ fn write_bytes_atomic(path: &Path, bytes: &[u8], mode: u32) -> Result<(), Bundle
     }
     Ok(())
 }
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
@@ -971,14 +926,10 @@ mod tests {
         assert!(r.validate_shape().is_err());
         assert!(validate_receipt_path("..").is_err());
         assert!(validate_receipt_path("").is_err());
-        assert!(validate_receipt_path("bundle.json").is_ok()); // path ok; shape forbids in files
+        assert!(validate_receipt_path("bundle.json").is_ok());
         assert!(validate_receipt_path("../evil").is_err());
     }
 
-    /// A fully-stamped shipped root: every `SHIPPED_ROOT_FILES` entry plus
-    /// non-empty `SHIPPED_DIRS`, ready for `BundleValidator` calls directly
-    /// (as opposed to `write_stamp_source_root`, which is missing the two
-    /// artifacts `stamp` itself creates).
     fn write_minimal_plugin(root: &Path, version: &str) {
         fs::create_dir_all(root.join("bin")).unwrap();
         fs::create_dir_all(root.join("scripts")).unwrap();
@@ -1036,7 +987,6 @@ mod tests {
             fs::write(root.join(name), format!("// {name}\n")).unwrap();
             fs::set_permissions(root.join(name), fs::Permissions::from_mode(0o644)).unwrap();
         }
-        // Fake helper that answers `version` with the staged receipt version.
         fs::write(
             root.join("bin/agent-bar"),
             format!(
@@ -1081,9 +1031,6 @@ mod tests {
         }
     }
 
-    /// A stamp-input root: everything `stamp` expects to already exist,
-    /// minus the one artifact it creates itself (`bin/agent-bar`). The
-    /// committed `preview.png` is part of the input tree.
     fn write_stamp_source_root(root: &Path, version: &str) {
         write_minimal_plugin(root, version);
         fs::remove_file(root.join("bin/agent-bar")).unwrap();
@@ -1121,9 +1068,6 @@ mod tests {
         let receipt = BundleValidator::build_receipt(&builder, &root).unwrap();
         fs::write(root.join("bundle.json"), receipt.to_pretty_json().unwrap()).unwrap();
 
-        // Extra file after receipt was built, inside the shipped scope
-        // (`components/`) -- outside it, e.g. loose at the repo root, is
-        // deliberately not this validator's business.
         fs::write(root.join("components/evil.txt"), b"x").unwrap();
         assert!(BundleValidator::validate_tree(&root).is_err());
 
@@ -1160,11 +1104,8 @@ mod tests {
         let dir = tempdir().unwrap();
         let root = dir.path().join("othavi0.agent-bar");
         write_minimal_plugin(&root, "10.0.0");
-        // Inside the shipped scope (`components/`) -- a symlink loose at the
-        // repo root is outside collect_inventory's business now.
         std::os::unix::fs::symlink("/etc/passwd", root.join("components/link")).unwrap();
         let builder = BundleBuilder::new("10.0.0", ZERO_COMMIT).unwrap();
-        // build_receipt itself walks and rejects symlinks.
         assert!(BundleValidator::build_receipt(&builder, &root).is_err());
     }
 
@@ -1176,7 +1117,6 @@ mod tests {
         write_stamp_source_root(&root, version);
 
         let helper = dir.path().join("agent-bar");
-        // Stand-in helper that reports the package version for BUNDLE-006.
         fs::write(
             &helper,
             format!(
@@ -1190,8 +1130,6 @@ mod tests {
         let receipt = builder.stamp(&root, &helper).unwrap();
         assert_eq!(receipt.version, version);
         assert_eq!(receipt.plugin_id, PLUGIN_ID);
-        // stamp creates the helper fresh; the committed preview.png is
-        // carried into the receipt as-is.
         assert!(root.join("bin/agent-bar").is_file());
         assert!(root.join("preview.png").is_file());
         assert!(root.join("bundle.json").is_file());

--- a/src/plugin/doctor.rs
+++ b/src/plugin/doctor.rs
@@ -1,5 +1,3 @@
-//! v10 doctor scan/clean using ownership classification (CLEAN-001..007).
-
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -40,21 +38,15 @@ pub fn default_legacy_candidates(home: &Path) -> Vec<PathBuf> {
     let config = home.join(".config");
     let cache = home.join(".cache");
     let local = home.join(".local");
-    // Legacy history DB filename (split so the active-legacy gate stays clean).
     let legacy_usage_db = concat!("usage", ".", "re", "db");
     vec![
-        // Pre-Quickshell bar integration leftovers
         config.join("waybar/agent-bar"),
         config.join("waybar/scripts/agent-bar-open-terminal"),
-        // History database from the removed local-usage engine
         cache.join("agent-bar").join(legacy_usage_db),
         cache.join("agent-bar/history"),
-        // Old notification state filenames (v9, and v1 superseded by v2)
         cache.join("agent-bar/notify-state.json"),
         cache.join("agent-bar/notification-state-v1.json"),
-        // Standalone install leftovers
         local.join("share/agent-bar"),
-        // Old global bin is not auto-removed without hash proof — listed for scan only
         local.join("bin/agent-bar"),
     ]
 }
@@ -76,7 +68,6 @@ pub fn default_ownership_rules(home: &Path) -> OwnershipRules {
 pub fn doctor_scan(home: &Path, extra: &[PathBuf], rules: &OwnershipRules) -> DoctorReport {
     let mut paths = default_legacy_candidates(home);
     paths.extend(extra.iter().cloned());
-    // Dedup
     paths.sort();
     paths.dedup();
 
@@ -95,7 +86,6 @@ pub fn doctor_scan(home: &Path, extra: &[PathBuf], rules: &OwnershipRules) -> Do
                 retained.push(path.clone());
             }
             OwnershipClass::OwnedCurrent | OwnershipClass::Unrelated => {
-                // Unrelated not listed beyond minimum — skip Unrelated from findings.
                 if ev.class == OwnershipClass::Unrelated {
                     continue;
                 }
@@ -129,7 +119,6 @@ pub fn doctor_clean(
 
     let mut removed = Vec::new();
     for path in &scan.removable {
-        // Double-check classification at clean time.
         let ev = classify_artifact(path, rules);
         if !ev.class.may_auto_remove() {
             continue;
@@ -212,7 +201,6 @@ mod tests {
         let home = Path::new("/home/example");
         let candidates = default_legacy_candidates(home);
         assert!(candidates.contains(&home.join(".cache/agent-bar/notification-state-v1.json")));
-        // The v9 filename stays listed; v1 joins it rather than replacing it.
         assert!(candidates.contains(&home.join(".cache/agent-bar/notify-state.json")));
     }
 
@@ -249,7 +237,6 @@ mod tests {
             report.retained.iter().any(|p| p == &ambiguous)
                 || !report.removable.contains(&ambiguous)
         );
-        // Backup of removed file
         assert!(
             backup
                 .join(".cache/agent-bar")
@@ -270,7 +257,6 @@ mod tests {
         let path = home.join(".config/waybar/agent-bar/style.css");
         let original = b"/* agent-bar generated */\noriginal";
         let h = seed_file(&path, original).unwrap();
-        // User edits file
         fs::write(&path, b"user changed").unwrap();
         let rules = OwnershipRules {
             legacy_hashes: vec![(path.clone(), h)],

--- a/src/plugin/maintenance.rs
+++ b/src/plugin/maintenance.rs
@@ -1,9 +1,3 @@
-//! Update check, uninstall confirmation, and executable-path resolution.
-//! `update apply` and `uninstall` both delegate their live mutation to the
-//! omarchy CLI (git-plugin-distribution Tasks 2-3) — this module no longer
-//! runs a worker over a copied helper binary, stages a tarball, or polls a
-//! rescan for health.
-
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -57,10 +51,6 @@ impl MaintenanceError {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Update check document
-// ---------------------------------------------------------------------------
-
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct UpdateCurrent {
@@ -110,7 +100,6 @@ impl UpdateCheckDocument {
                 "update check schemaVersion must be 1",
             ));
         }
-        // RFC3339 checkedAt
         OffsetDateTime::parse(&self.checked_at, &Rfc3339)
             .map_err(|e| MaintenanceError::msg(format!("checkedAt is not RFC3339: {e}")))?;
         if self.current.target != OFFICIAL_TARGET {
@@ -121,8 +110,6 @@ impl UpdateCheckDocument {
         if self.current.omarchy_contract != OMARCHY_CONTRACT {
             return Err(MaintenanceError::msg("current.omarchyContract must be 1"));
         }
-        // A reinstall-required document cannot also offer an update: the QML
-        // side (later task) shows only the reinstall message in that phase.
         if self.reinstall_required && (self.available || self.latest_compatible.is_some()) {
             return Err(MaintenanceError::msg(
                 "reinstallRequired documents must have available:false and latestCompatible:null",
@@ -166,10 +153,6 @@ impl UpdateCheckDocument {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Injectable HTTP for releases
-// ---------------------------------------------------------------------------
-
 #[derive(Debug, Clone)]
 pub struct ReleaseHttpResponse {
     pub status: u16,
@@ -211,7 +194,6 @@ impl ReleaseHttp for ReqwestReleaseHttp {
         url: &str,
         headers: &[(&str, &str)],
     ) -> Result<ReleaseHttpResponse, MaintenanceError> {
-        // Never attach Authorization / Cookie.
         for (k, _) in headers {
             let lower = k.to_ascii_lowercase();
             if lower == "authorization" || lower == "cookie" || lower == "proxy-authorization" {
@@ -309,10 +291,6 @@ impl ReleaseHttp for ScriptedReleaseHttp {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Update check
-// ---------------------------------------------------------------------------
-
 #[derive(Debug, Clone)]
 pub struct UpdateCheckProbe {
     pub current_version: String,
@@ -332,9 +310,6 @@ impl Default for UpdateCheckProbe {
     }
 }
 
-/// Distribution repo `bundle.json` receipt shape (BUNDLE-012 producer, this
-/// task's consumer). Unknown fields (`sourceCommit`, `files`, ...) are
-/// intentionally tolerated — `update check` only needs discovery fields.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct DistReceipt {
@@ -423,7 +398,6 @@ impl UpdateCheck {
                 }),
             )
         } else {
-            // Locally incompatible — not an error, just nothing to offer.
             (false, None)
         };
 
@@ -450,10 +424,6 @@ impl UpdateCheck {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Uninstall confirmation
-// ---------------------------------------------------------------------------
-
 /// Non-TTY structured uninstall confirmation (CLI-036 / BUNDLE-036).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -479,13 +449,8 @@ impl UninstallConfirmation {
         let text = std::str::from_utf8(bytes)
             .map_err(|_| MaintenanceError::msg("uninstall confirmation is not valid UTF-8"))?;
         let trimmed = text.trim();
-        // Reject concatenated second values / trailing garbage by requiring the
-        // entire trimmed buffer to be exactly one JSON value.
         let doc: Self = serde_json::from_str(trimmed)
             .map_err(|e| MaintenanceError::msg(format!("malformed uninstall confirmation: {e}")))?;
-        // `from_str` tolerates trailing whitespace only; re-check by round-trip
-        // stream: if a second value exists, Value::deserialize from remaining fails
-        // the "exactly one object" rule via trailing non-ws after first value.
         let mut stream =
             serde_json::Deserializer::from_str(trimmed).into_iter::<serde_json::Value>();
         let first = stream
@@ -544,11 +509,6 @@ pub const UNINSTALL_TTY_PHRASE: &str = "uninstall agent-bar";
 /// TTY prompt text written to stderr (no trailing newline required by contract).
 pub const UNINSTALL_TTY_PROMPT: &str = "Type uninstall agent-bar to continue:";
 
-// ---------------------------------------------------------------------------
-// Executable resolution
-// ---------------------------------------------------------------------------
-
-/// Locate `cmd` on `$PATH` (first regular file hit).
 fn which_in_path(cmd: &str) -> Option<PathBuf> {
     let path = std::env::var_os("PATH")?;
     std::env::split_paths(&path)
@@ -596,10 +556,6 @@ pub fn require_absolute_executable(path: &str) -> Result<(), MaintenanceError> {
     Ok(())
 }
 
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -628,9 +584,6 @@ mod tests {
         }
     }
 
-    /// A `bundle.json`-shaped dist receipt (BUNDLE-012 producer shape,
-    /// including fields `update check` does not read) so parsing coverage
-    /// matches what `BundleBuilder` actually emits.
     fn receipt_json(version: &str, minimum_quickshell_version: &str) -> Vec<u8> {
         serde_json::to_vec(&serde_json::json!({
             "schemaVersion": 1,
@@ -667,7 +620,6 @@ mod tests {
         assert!(json.contains("\"reinstallRequired\":false"));
         let parsed = UpdateCheckDocument::parse_json(json.trim_end().as_bytes()).unwrap();
         assert!(parsed.available);
-        // Unknown fields rejected.
         let mut v = serde_json::to_value(&doc).unwrap();
         v.as_object_mut()
             .unwrap()
@@ -756,7 +708,6 @@ mod tests {
             "https://github.com/othavi0/omarchy-agent-bar/releases/tag/v10.1.0"
         );
 
-        // Exactly one GET, to the dist receipt URL with the expected headers.
         let calls = http.calls.lock().unwrap();
         assert_eq!(calls.len(), 1);
         assert_eq!(calls[0].0, DIST_RECEIPT_URL);
@@ -799,7 +750,6 @@ mod tests {
             quickshell_version: "0.3.0".into(),
             ..UpdateCheckProbe::default()
         };
-        // Locally incompatible is not an error — just nothing to offer.
         let doc = UpdateCheck::run(&http, &clock, &probe, false).unwrap();
         assert!(!doc.available);
         assert!(doc.latest_compatible.is_none());
@@ -807,8 +757,6 @@ mod tests {
 
     #[test]
     fn update_check_reinstall_required_forces_null_offer() {
-        // Even a genuinely newer, compatible receipt must not surface as an
-        // offer when the live plugin root is not a git checkout.
         let http = ScriptedReleaseHttp::with_responses(vec![Ok(ReleaseHttpResponse {
             status: 200,
             headers: vec![],
@@ -993,7 +941,6 @@ mod tests {
 
     #[test]
     fn no_global_executable_in_bundle_layout() {
-        // Product is plugin-only: helper lives at bin/agent-bar inside the plugin.
         let dir = tempdir().unwrap();
         let root = dir.path().join("othavi0.agent-bar");
         write_min_plugin(&root, "10.0.0");
@@ -1009,20 +956,9 @@ mod tests {
         let bin = fake_abs_bin(dir.path(), "tool");
         require_absolute_executable(&bin).unwrap();
         assert!(require_absolute_executable("tool").is_err());
-        // Absolute path that exists is accepted by resolve.
         let again = resolve_absolute_executable(&bin).unwrap();
         assert_eq!(again, bin);
     }
-
-    // -----------------------------------------------------------------------
-    // Uninstall confirmation (Task 18 / BUNDLE-036). The quarantine/rollback
-    // fault matrix that used to live here tested the worker chain deleted in
-    // git-plugin-distribution Task 3 — `uninstall` no longer runs a worker at
-    // all, so there is nothing left to fault-inject. `worker_holds_exclusive_
-    // maintenance_gate`, which exercised `MaintenanceGate` through the same
-    // dead journal/payload ceremony, is likewise gone — the primitive's own
-    // exclusive-lock coverage lives in `support::maintenance_gate`'s tests.
-    // -----------------------------------------------------------------------
 
     #[test]
     fn uninstall_confirmation_accepts_exact_document() {
@@ -1039,7 +975,6 @@ mod tests {
 
     #[test]
     fn uninstall_confirmation_rejects_false_mismatch_extra_and_malformed() {
-        // confirmed: false
         let err = UninstallConfirmation::parse_strict(
             br#"{"schemaVersion":1,"operation":"uninstall","confirmed":false,"purgeSettingsAndBackups":false}"#,
             false,
@@ -1047,7 +982,6 @@ mod tests {
         .unwrap_err();
         assert!(err.to_string().contains("confirmed"));
 
-        // purge mismatch
         let err = UninstallConfirmation::parse_strict(
             br#"{"schemaVersion":1,"operation":"uninstall","confirmed":true,"purgeSettingsAndBackups":true}"#,
             false,
@@ -1055,7 +989,6 @@ mod tests {
         .unwrap_err();
         assert!(err.to_string().contains("purge"));
 
-        // trailing non-whitespace
         let err = UninstallConfirmation::parse_strict(
             br#"{"schemaVersion":1,"operation":"uninstall","confirmed":true,"purgeSettingsAndBackups":false} extra"#,
             false,
@@ -1063,7 +996,6 @@ mod tests {
         .unwrap_err();
         assert!(err.to_string().contains("trailing") || err.to_string().contains("malformed"));
 
-        // unknown field
         let err = UninstallConfirmation::parse_strict(
             br#"{"schemaVersion":1,"operation":"uninstall","confirmed":true,"purgeSettingsAndBackups":false,"extra":1}"#,
             false,
@@ -1071,7 +1003,6 @@ mod tests {
         .unwrap_err();
         assert!(err.to_string().contains("malformed") || err.to_string().contains("unknown"));
 
-        // wrong operation
         let err = UninstallConfirmation::parse_strict(
             br#"{"schemaVersion":1,"operation":"update","confirmed":true,"purgeSettingsAndBackups":false}"#,
             false,

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -1,5 +1,3 @@
-//! Plugin bundle paths, ownership classification, and maintenance.
-
 pub mod bundle;
 pub mod doctor;
 pub mod maintenance;

--- a/src/plugin/omarchy.rs
+++ b/src/plugin/omarchy.rs
@@ -1,11 +1,3 @@
-//! Process execution seam for the omarchy CLI (MIG-019A/B lineage).
-//!
-//! `update apply` / `uninstall` build their own detached-unit argv inline
-//! (git-plugin-distribution Tasks 2-3) and run it through [`CommandRunner`];
-//! the argv-builder/`OmarchyClient` wrapper that used to sit in front of that
-//! is gone with it — nothing calls `omarchy plugin enable|rescan` from this
-//! helper anymore (`omarchy plugin add` is the install now).
-
 use thiserror::Error;
 
 #[derive(Debug, Error, PartialEq, Eq)]

--- a/src/plugin/ownership.rs
+++ b/src/plugin/ownership.rs
@@ -1,5 +1,3 @@
-//! Ownership classification and before-hash evidence (CLEAN-001..005).
-
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -123,7 +121,6 @@ pub fn classify_artifact(path: &Path, rules: &OwnershipRules) -> OwnershipEviden
     let size = Some(meta.len());
     let mode = mode_of(&meta);
 
-    // Symlinks are never auto-owned without following policy: treat as ambiguous.
     if file_type == FileKind::Symlink {
         return OwnershipEvidence {
             class: OwnershipClass::Ambiguous,
@@ -169,7 +166,6 @@ pub fn classify_artifact(path: &Path, rules: &OwnershipRules) -> OwnershipEviden
                 };
             }
         }
-        // Same path as known legacy/current but different hash → modified legacy.
         for (p, _) in rules
             .legacy_hashes
             .iter()
@@ -219,7 +215,6 @@ pub fn classify_artifact(path: &Path, rules: &OwnershipRules) -> OwnershipEviden
         }
     }
 
-    // Path looks agent-bar-ish but no proof → ambiguous (report, do not remove).
     let name = path
         .file_name()
         .and_then(|s| s.to_str())

--- a/src/plugin/paths.rs
+++ b/src/plugin/paths.rs
@@ -1,5 +1,3 @@
-//! Plugin path layout and path-safety helpers (MIG-002A, BUNDLE-007A).
-
 use std::io;
 use std::path::{Component, Path, PathBuf};
 
@@ -82,7 +80,6 @@ pub fn validate_archive_entry_path(rel: &str) -> Result<(), PathError> {
             "absolute archive path rejected: {rel}"
         )));
     }
-    // Windows drive / UNC style
     if rel.len() >= 2 && rel.as_bytes()[1] == b':' {
         return Err(PathError::msg(format!(
             "absolute archive path rejected: {rel}"

--- a/src/plugin/update_run.rs
+++ b/src/plugin/update_run.rs
@@ -161,7 +161,6 @@ mod tests {
                 .borrow()
                 .iter()
                 .map(|c| {
-                    // `timeout` wraps the real program: report what it runs.
                     if c[0] == "/usr/bin/timeout" {
                         c.iter()
                             .skip(1)
@@ -315,7 +314,6 @@ mod tests {
 
     #[test]
     fn a_refused_restart_is_retried_until_the_session_unlocks() {
-        // omarchy-restart-shell exits 1 while the session is locked.
         let runner = FakeRunner::new(&["aaa", "bbb"], 0, &[1, 1, 0]);
         let (outcome, sleeps) = run(&runner, false, 5);
         assert_eq!(outcome, UpdateRunOutcome::Updated);

--- a/src/providers/adapter.rs
+++ b/src/providers/adapter.rs
@@ -1,5 +1,3 @@
-//! v10 provider adapter interface and collection context.
-
 use std::future::Future;
 use std::path::Path;
 use std::pin::Pin;
@@ -80,10 +78,6 @@ pub trait ProviderAdapter: Send + Sync {
     }
 
     fn login_command(&self, discovery: &Discovery) -> Result<ProcessSpec, LoginError> {
-        // Two different answers share one `None` from `login_process_argv`:
-        // no executable to run, and a provider that publishes no login argv
-        // at all. Installing a CLI fixes the first and can never fix the
-        // second, so they must not report the same failure.
         if self.descriptor().login_argv.is_empty() {
             return Err(LoginError::UnsupportedProvider);
         }
@@ -188,7 +182,6 @@ pub async fn run_login<R: ProcessRunner + ?Sized, I: ProcessRunner + ?Sized>(
     )
     .with_timeout(std::time::Duration::from_secs(5))
     .with_max_output(64 * 1024);
-    // Best-effort: ignore errors and non-zero.
     let _ = ipc_runner.run(&refresh_spec).await;
 
     Ok(LoginOutcome {
@@ -268,9 +261,6 @@ mod tests {
 
     #[test]
     fn unsupported_login_wins_over_missing_executable_from_real_discovery() {
-        // `discover()` never reports login as available for an empty argv, so
-        // the unsupported answer must come before the executable check or it
-        // is unreachable in production.
         let env = ExecutionEnvironment {
             home: PathBuf::from("/nonexistent"),
             path_dirs: vec![],
@@ -299,8 +289,6 @@ mod tests {
 
     #[test]
     fn absent_login_executable_is_cli_missing() {
-        // Grok publishes a login argv, so a missing executable is the only
-        // reason login cannot run.
         assert_eq!(
             GROK_ADAPTER
                 .login_command(&discovery_with_login(None))

--- a/src/providers/adapters.rs
+++ b/src/providers/adapters.rs
@@ -1,5 +1,3 @@
-//! Concrete [`ProviderAdapter`] implementations for the four locked providers.
-
 use crate::cli::ProviderId;
 use crate::status::schema::{Account, Plan, ProviderResult};
 use crate::support::redact::strip_ansi_and_controls;
@@ -17,10 +15,6 @@ use super::v2_map::{
     codex_from_rate_limits_json, grok_from_billing_json,
 };
 use super::{Discovery, ProviderDescriptor};
-
-// ---------------------------------------------------------------------------
-// Amp
-// ---------------------------------------------------------------------------
 
 pub struct AmpAdapter;
 
@@ -93,14 +87,7 @@ fn classify_amp_failure(out: &ProcessOutput, login_available: bool) -> ProviderR
     }
 }
 
-// ---------------------------------------------------------------------------
-// Grok
-// ---------------------------------------------------------------------------
-
-/// Authenticated billing endpoint (literal; equality-tested).
 pub const GROK_BILLING_URL: &str = "https://cli-chat-proxy.grok.com/v1/billing?format=credits";
-/// Monthly-limit billing shape, consulted only when the credits shape carries
-/// no percentage (literal; equality-tested).
 pub const GROK_MONTHLY_BILLING_URL: &str = "https://cli-chat-proxy.grok.com/v1/billing";
 
 pub struct GrokAdapter;
@@ -141,8 +128,6 @@ impl ProviderAdapter for GrokAdapter {
             let auth_path = grok_home.join("auth.json");
             let login = login_available(discovery);
 
-            // Token is used only for the Authorization header — never stored in
-            // ProviderResult, logs, or error messages.
             let mut creds = match read_grok_credentials(context, &auth_path) {
                 Ok(creds) => creds,
                 Err(err) => return grok_auth_failure(err, login),
@@ -174,8 +159,6 @@ impl ProviderAdapter for GrokAdapter {
                         | Err(err @ GrokAuthError::Unreadable) => {
                             return grok_auth_failure(err, login);
                         }
-                        // Torn mid-rewrite: fall through with the expired
-                        // token and report the session expired.
                         Err(GrokAuthError::Torn) => {}
                     }
                 }
@@ -228,12 +211,6 @@ impl ProviderAdapter for GrokAdapter {
     }
 }
 
-/// Second billing shape for accounts whose credits payload publishes no
-/// percentage (monthly-limit teams). Network errors and 5xx are the same
-/// typed operational results as the primary request, so the coordinator's
-/// stale retention keeps the last good reading instead of an empty `Ready`
-/// overwriting it. A 4xx, or a 2xx body without a window, keeps the credits
-/// reading, including its `plan`/`account`.
 async fn grok_monthly_fallback(
     context: &CollectionContext<'_>,
     headers: &[(&str, &str)],
@@ -251,10 +228,6 @@ async fn grok_monthly_fallback(
         max_body,
     )
     .await;
-    // The credits request just proved the token, so a 4xx here (including
-    // 401/403 or a missing route) is not a fault of this account: keep the
-    // credits reading. Network errors and 5xx are typed failures so stale
-    // retention can protect a cached monthly window.
     let resp = match response {
         Ok(resp) if (200..300).contains(&resp.status) => resp,
         Ok(resp) if resp.status < 500 => return credits,
@@ -292,8 +265,6 @@ async fn grok_monthly_fallback(
     }
 }
 
-/// Map a non-2xx or failed billing request to its typed result. Shared by
-/// the credits and monthly requests.
 fn grok_http_failure(
     response: Result<super::adapter::HttpResponse, super::adapter::HttpError>,
     login: bool,
@@ -339,34 +310,22 @@ fn grok_http_failure(
     }
 }
 
-/// A token this close to `expires_at` counts as expired, so a request never
-/// carries a token that dies in flight.
 const GROK_TOKEN_EXPIRY_MARGIN: time::Duration = time::Duration::seconds(60);
 
-/// What the adapter keeps from Grok `auth.json`: the access token (header
-/// only), the display label, and the token's expiry when the file states one.
-/// `refresh_token` is never read.
 struct GrokCredentials {
     token: String,
     account: Option<String>,
     expires_at: Option<time::OffsetDateTime>,
 }
 
-/// Grok `auth.json` outcomes the caller maps to typed results.
 enum GrokAuthError {
-    /// No file, or a well-formed document without a token: signed out.
     NotAuthenticated,
     /// The file exists but is not a whole JSON document — the CLI rewrites
     /// it non-atomically, so this is transient.
     Torn,
-    /// The file exists but cannot be read (permissions, I/O): neither a
-    /// sign-out nor a rewrite window, so neither "Sign in" nor stale
-    /// retention is honest.
     Unreadable,
 }
 
-/// Read and parse `auth.json`. A missing file is `NotAuthenticated`, any
-/// other I/O error is `Unreadable`, and a partial document is `Torn`.
 fn read_grok_credentials(
     context: &CollectionContext<'_>,
     auth_path: &std::path::Path,
@@ -408,13 +367,6 @@ fn grok_auth_failure(err: GrokAuthError, login: bool) -> ProviderResult {
     }
 }
 
-/// Extract the access token, optional `first_name` label, and optional
-/// `expires_at` from Grok `auth.json`.
-///
-/// An unparseable document is `Torn`; a parseable one with no non-empty
-/// `key` is `NotAuthenticated`. A missing or malformed `expires_at` means "no
-/// known expiry" and the token is used as is. The token must only be used for
-/// the HTTP Authorization header and must never enter `ProviderResult`.
 fn parse_grok_credentials(bytes: &[u8]) -> Result<GrokCredentials, GrokAuthError> {
     let value: serde_json::Value =
         serde_json::from_slice(bytes).map_err(|_| GrokAuthError::Torn)?;
@@ -449,10 +401,6 @@ fn grok_token_expired(creds: &GrokCredentials, now: time::OffsetDateTime) -> boo
         .is_some_and(|expires_at| expires_at <= now + GROK_TOKEN_EXPIRY_MARGIN)
 }
 
-// ---------------------------------------------------------------------------
-// Codex
-// ---------------------------------------------------------------------------
-
 pub struct CodexAdapter;
 
 pub static CODEX_ADAPTER: CodexAdapter = CodexAdapter;
@@ -478,7 +426,6 @@ impl ProviderAdapter for CodexAdapter {
                 };
             }
 
-            // 1. App-server when collection exe is present (one timeout retry).
             if let Some(exe) = collection_exe(discovery) {
                 let version = crate::app_identity::VERSION;
                 let timeout = CODEX.timeout;
@@ -491,8 +438,6 @@ impl ProviderAdapter for CodexAdapter {
                     AppServerOutcome::Ok(bytes) => {
                         return codex_from_rate_limits_json(&bytes, context.clock.now_utc());
                     }
-                    // JSON-004 / JSON-007: a signed-out account never falls
-                    // through to obsolete session-log usage.
                     AppServerOutcome::Unauthenticated => {
                         return unauthenticated(
                             ProviderId::Codex,
@@ -507,9 +452,6 @@ impl ProviderAdapter for CodexAdapter {
                 }
             }
 
-            // 2. Bounded session-log fallback (~/.codex/sessions/**/*.jsonl).
-            // The log's own event timestamp — not collection time — becomes
-            // last_success_at, since this data may be hours or days old.
             if let Some((bytes, log_timestamp)) =
                 find_latest_rate_limits(&home.join(".codex/sessions"))
             {
@@ -517,7 +459,6 @@ impl ProviderAdapter for CodexAdapter {
                 return codex_from_rate_limits_json(&bytes, now);
             }
 
-            // 3. Typed miss / cli_missing
             if collection_exe(discovery).is_none() {
                 return missing_collection(
                     ProviderId::Codex,
@@ -534,10 +475,6 @@ impl ProviderAdapter for CodexAdapter {
         })
     }
 }
-
-// ---------------------------------------------------------------------------
-// Claude
-// ---------------------------------------------------------------------------
 
 pub const CLAUDE_USAGE_URL: &str = "https://api.anthropic.com/api/oauth/usage";
 
@@ -602,7 +539,6 @@ impl ProviderAdapter for ClaudeAdapter {
                 );
             }
 
-            // Never log the token. Pass only as Authorization header value.
             let bearer = format!("Bearer {}", creds.token);
             let headers = [
                 ("Authorization", bearer.as_str()),
@@ -637,7 +573,6 @@ impl ProviderAdapter for ClaudeAdapter {
                     retryable: false,
                 },
                 Ok(resp) => {
-                    // Redact: never store Authorization values in the domain result.
                     let _ = resp.final_url;
                     claude_from_usage_json(
                         &resp.body,
@@ -706,8 +641,6 @@ fn parse_claude_credentials(bytes: &[u8]) -> Option<ClaudeCredentials> {
     })
 }
 
-/// Prefer the granular rate-limit tier ("max_20x" → "Max 20x"); fall back to
-/// the capitalized subscription type. Mirrors the native widget's formatTier.
 fn claude_plan(subscription_type: Option<&str>, rate_limit_tier: Option<&str>) -> Option<Plan> {
     if let Some(tier) = rate_limit_tier.filter(|t| !t.is_empty()) {
         if let Some(pos) = tier.find("max_") {
@@ -740,7 +673,6 @@ fn capitalize_ascii(raw: &str) -> String {
     }
 }
 
-/// Test-only fixed clock.
 #[cfg(test)]
 pub struct FixedClock(pub time::OffsetDateTime);
 
@@ -750,10 +682,6 @@ impl crate::support::Clock for FixedClock {
         self.0
     }
 }
-
-// ---------------------------------------------------------------------------
-// Antigravity
-// ---------------------------------------------------------------------------
 
 pub struct AntigravityAdapter;
 
@@ -802,9 +730,6 @@ impl ProviderAdapter for AntigravityAdapter {
                     };
                 }
                 Ok(out) => {
-                    // A non-zero exit leaves us without a version, which is
-                    // the same answer as an unparseable one: we may not run
-                    // the usage command.
                     let supported = out.exit_code == Some(0)
                         && parse_version_prefix(&out.stdout)
                             .is_some_and(|found| found >= ANTIGRAVITY_MIN_VERSION);
@@ -873,8 +798,6 @@ fn antigravity_spec(exe: &std::path::Path, args: &[&str]) -> ProcessSpec {
         .with_env("TERM", "dumb")
 }
 
-/// Typed refusal for a CLI too old to answer `/usage` without spending quota.
-/// Not retryable: only reinstalling the CLI can change the answer.
 fn antigravity_unsupported_version() -> ProviderResult {
     let (major, minor, patch) = ANTIGRAVITY_MIN_VERSION;
     ProviderResult::ProviderError {
@@ -940,7 +863,6 @@ fn classify_antigravity_failure(out: &ProcessOutput, login_available: bool) -> P
     }
 }
 
-/// In-memory filesystem for adapter tests.
 #[cfg(test)]
 #[derive(Default)]
 pub struct MapFileSystem {
@@ -982,11 +904,8 @@ mod tests {
     use time::macros::datetime;
 
     struct ScriptedProcess {
-        /// Pending results in reverse order: `run` pops from the back.
         outputs: Mutex<Vec<Result<ProcessOutput, ProcessError>>>,
         pub last_spec: Mutex<Option<ProcessSpec>>,
-        /// Every spec seen, in call order, so a multi-call adapter can be
-        /// asserted invocation by invocation.
         pub specs: Mutex<Vec<ProcessSpec>>,
     }
 
@@ -995,7 +914,6 @@ mod tests {
             Self::sequence(vec![Ok(out)])
         }
 
-        /// Script consecutive runs: `outputs[0]` answers the first call.
         fn sequence(outputs: Vec<Result<ProcessOutput, ProcessError>>) -> Self {
             let mut reversed = outputs;
             reversed.reverse();
@@ -1090,7 +1008,6 @@ mod tests {
 
     #[test]
     fn amp_network_flavored_auth_substring_is_not_unauthenticated() {
-        // "authorization server unavailable" contains "auth" but is operational.
         let out = fake_process_output(1, "", "authorization server unavailable");
         let result = classify_amp_failure(&out, true);
         assert!(matches!(result, ProviderResult::ProviderError { .. }));
@@ -1166,7 +1083,6 @@ mod tests {
         first: HttpResponse,
         second: Result<HttpResponse, HttpError>,
     ) -> ScriptedHttpClient {
-        // Responses pop from the end: push the second call first.
         let client = ScriptedHttpClient::single(second);
         client
             .responses
@@ -1212,8 +1128,6 @@ mod tests {
 
     #[tokio::test]
     async fn grok_monthly_fallback_network_failure_is_typed() {
-        // A failed second request must not become an empty `Ready` that
-        // evicts a cached monthly window; it is a retryable operational result.
         let credits =
             include_bytes!("../../tests/fixtures/providers/grok/billing-credits-no-quota.json");
         let http = scripted_pair(
@@ -1599,12 +1513,11 @@ mod tests {
 
     #[tokio::test]
     async fn claude_expired_token_skips_http_and_is_retryable() {
-        let http = ScriptedHttpClient::default(); // any HTTP call would error
+        let http = ScriptedHttpClient::default();
         let process = empty_process();
         let mut fs = MapFileSystem::default();
         fs.files.insert(
             std::path::PathBuf::from("/home/u/.claude/.credentials.json"),
-            // expiresAt in the past relative to the fixed clock below.
             br#"{"claudeAiOauth":{"accessToken":"tok","expiresAt":1690000000000}}"#.to_vec(),
         );
         let env = ExecutionEnvironment {
@@ -1664,7 +1577,6 @@ mod tests {
         let grok_home = home.join(".grok");
         fs.files.insert(
             grok_home.join("auth.json"),
-            // Synthetic key — not a real JWT or credential.
             br#"{"acct":{"key":"SYNTH_GROK_KEY_NOT_REAL","first_name":"Ada"}}"#.to_vec(),
         );
         ExecutionEnvironment {
@@ -1777,8 +1689,6 @@ mod tests {
         let result = GROK_ADAPTER.collect(&ctx, &discovery).await;
         let dbg = format!("{result:?}");
         assert!(!dbg.contains("SYNTH_GROK_KEY_NOT_REAL"));
-        // A valid token the server rejects is a real sign-in request: never
-        // retryable, so no stale reading survives it (JSON-007, CACHE-023).
         assert!(
             matches!(
                 result,
@@ -1791,9 +1701,6 @@ mod tests {
         );
     }
 
-    /// Filesystem whose reads of one path answer from a script, so a test can
-    /// hand the adapter an expired credential first and a renewed one after
-    /// the refresh process ran. The last entry repeats once exhausted.
     struct ScriptedFs {
         path: std::path::PathBuf,
         reads: Mutex<Vec<Result<Vec<u8>, std::io::ErrorKind>>>,
@@ -1840,7 +1747,6 @@ mod tests {
     }
 
     fn grok_auth_json(key: &str, expires_at: &str) -> Vec<u8> {
-        // Synthetic key — not a real JWT or credential.
         format!(
             r#"{{"https://auth.x.ai::client":{{"key":"{key}","first_name":"Ada","refresh_token":"SYNTH_GROK_REFRESH_NOT_REAL","expires_at":"{expires_at}","auth_mode":"oidc"}}}}"#
         )
@@ -2002,7 +1908,6 @@ mod tests {
             let http = grok_billing_ok();
             let process = ScriptedProcess::sequence(vec![outcome]);
             let env = grok_env();
-            // The file never changes: the CLI did not renew anything.
             let fs = ScriptedFs::new(
                 grok_auth_path(&env),
                 vec![Ok(grok_auth_json(
@@ -2041,7 +1946,6 @@ mod tests {
 
     #[tokio::test]
     async fn grok_expiry_margin_treats_a_token_about_to_expire_as_expired() {
-        // 30 s of validity left: refresh. 120 s left: use it.
         for (expires_at, expect_refresh) in [
             ("2026-09-04T06:00:30Z", true),
             ("2026-09-04T06:02:00Z", false),
@@ -2153,7 +2057,6 @@ mod tests {
 
     #[tokio::test]
     async fn grok_auth_file_without_expiry_keeps_the_current_flow() {
-        // The pre-OIDC shape (no expires_at) is neither expired nor refreshed.
         let http = grok_billing_ok();
         let process = empty_process();
         let mut fs = MapFileSystem::default();
@@ -2210,9 +2113,6 @@ mod tests {
 
     #[tokio::test]
     async fn grok_unreadable_auth_file_is_a_typed_non_retryable_error() {
-        // EACCES (root-owned file after `sudo grok`) is neither a sign-out
-        // nor a rewrite window: a retryable result would keep days-old usage
-        // on the bar forever, and "Sign in" would be a lie.
         let http = grok_billing_ok();
         let process = empty_process();
         let env = grok_env();
@@ -2244,8 +2144,6 @@ mod tests {
 
     #[tokio::test]
     async fn grok_refresh_that_clears_credentials_asks_to_sign_in() {
-        // A dead refresh token makes the CLI delete auth.json. The second read
-        // then says signed out, and that must win over "session expired".
         let http = grok_billing_ok();
         let process = empty_process();
         let env = grok_env();
@@ -2285,9 +2183,6 @@ mod tests {
 
     #[tokio::test]
     async fn grok_second_read_after_refresh_keeps_torn_and_unreadable_apart() {
-        // Same rules as the first read: a torn document mid-rewrite falls
-        // through to "session expired" (retryable); a file that cannot be
-        // read is the typed non-retryable error, never stale retention.
         for (second_read, expect_retryable_expired) in [
             (
                 Ok(b"{\"https://auth.x.ai::client\":{\"key\":\"SYNTH_GROK_KEY_NOT_REAL\"".to_vec()),
@@ -2347,8 +2242,6 @@ mod tests {
 
     #[tokio::test]
     async fn grok_non_string_expires_at_means_no_known_expiry() {
-        // Fail open on purpose: a shape this adapter does not understand is
-        // used as is, exactly like a file that carries no expiry at all.
         let http = grok_billing_ok();
         let process = empty_process();
         let env = grok_env();
@@ -2376,8 +2269,6 @@ mod tests {
 
     #[tokio::test]
     async fn grok_missing_auth_file_or_key_is_not_retryable() {
-        // No file, or a well-formed file without a key (logged out), is a real
-        // sign-in request, never a stale reading.
         for read in [
             Err(std::io::ErrorKind::NotFound),
             Ok(br#"{"https://auth.x.ai::client":{"first_name":"Ada"}}"#.to_vec()),
@@ -2438,8 +2329,6 @@ mod tests {
         let http = ScriptedHttpClient::default();
         let fs = MapFileSystem::default();
 
-        // Real tempdir: find_latest_rate_limits walks std::fs directly, not
-        // the injected fs seam.
         let home_dir = tempfile::tempdir().expect("tempdir");
         let home = home_dir.path().to_path_buf();
         let sessions = home.join(".codex/sessions/2026/07/28");
@@ -2455,8 +2344,6 @@ mod tests {
             path_dirs: vec![],
             grok_home: None,
         };
-        // Fake clock's "now" is far after the log's own timestamp — asserts
-        // last_success_at reflects data generation, not collection time.
         let clock = FixedClock(datetime!(2026-08-06 12:00:00 UTC));
         let ctx = CollectionContext {
             env: &env,
@@ -2466,9 +2353,6 @@ mod tests {
             http: &http,
             plugin_root: None,
         };
-        // Non-existent exe so app-server spawn fails immediately and
-        // collection falls through to the session-log fallback (no live
-        // Codex dependency, no rate-limits.json — that stage is gone).
         let discovery = discovery_with_exe(Path::new("/nonexistent/codex"));
         let result = CODEX_ADAPTER.collect(&ctx, &discovery).await;
         assert_no_money(&result);
@@ -2485,8 +2369,6 @@ mod tests {
         }
     }
 
-    /// Writes an executable fake `codex` that speaks just enough app-server
-    /// protocol to answer initialize, account/read, and refuse rateLimits.
     fn write_fake_codex_unauthenticated(dir: &Path) -> std::path::PathBuf {
         use std::os::unix::fs::PermissionsExt;
         let exe = dir.join("codex");
@@ -2512,7 +2394,6 @@ done
         let home = dir.path().join("home");
         let sessions = home.join(".codex/sessions/2026/07/28");
         std::fs::create_dir_all(&sessions).expect("mkdir");
-        // Old usage on disk must NOT be presented for a signed-out account (JSON-007).
         std::fs::write(
             sessions.join("rollout.jsonl"),
             concat!(
@@ -2595,9 +2476,6 @@ done
             other => panic!("expected ready, got {other:?}"),
         }
 
-        // The version guard runs first, then the usage call; both must carry
-        // the catalog timeout/cap and the two env vars that keep `agy` from
-        // drawing a TUI.
         let calls = process.calls();
         assert_eq!(calls.len(), 2, "{calls:?}");
         assert_eq!(calls[0].args, vec!["--version".to_owned()]);
@@ -2627,8 +2505,6 @@ done
         }
     }
 
-    /// Run the Antigravity adapter against a scripted `--version` result
-    /// followed by a scripted usage result.
     async fn antigravity_collect_scripted(process: ScriptedProcess) -> (ProviderResult, usize) {
         let http = ScriptedHttpClient::default();
         let fs = MapFileSystem::default();
@@ -2652,7 +2528,6 @@ done
         (result, calls)
     }
 
-    /// Collect with a supported CLI version, scripting only the usage result.
     async fn antigravity_collect(usage: ProcessOutput) -> ProviderResult {
         let (result, _) = antigravity_collect_scripted(ScriptedProcess::sequence(vec![
             Ok(antigravity_output(0, "1.1.18\n")),
@@ -2662,8 +2537,6 @@ done
         result
     }
 
-    /// Collect with `--version` answering `version`, and a usage call that
-    /// would succeed — so a refusal proves the guard, not the usage path.
     async fn antigravity_collect_at_version(version: ProcessOutput) -> (ProviderResult, usize) {
         let fixture = include_str!("../../tests/fixtures/antigravity/usage.json");
         antigravity_collect_scripted(ScriptedProcess::sequence(vec![
@@ -2686,7 +2559,6 @@ done
 
     #[tokio::test]
     async fn antigravity_collect_unauthenticated() {
-        // A non-zero exit is only a login problem when the banner says so.
         let fixture = include_str!("../../tests/fixtures/antigravity/unauthorized.json");
         let result = antigravity_collect(antigravity_output(1, fixture)).await;
         assert_no_money(&result);
@@ -2700,8 +2572,6 @@ done
 
     #[tokio::test]
     async fn antigravity_logged_out_banner_on_exit_zero_is_unauthenticated() {
-        // `agy` prints the logged-out banner and still exits 0, so the exit
-        // code alone would let an empty Ready through.
         let fixture = include_str!("../../tests/fixtures/antigravity/unauthorized.json");
         let result = antigravity_collect(antigravity_output(0, fixture)).await;
         match result {
@@ -2734,9 +2604,6 @@ done
 
     #[tokio::test]
     async fn antigravity_too_old_a_cli_is_refused_before_the_usage_call() {
-        // The whole point of the guard: on 1.1.10 the "/usage" text reaches
-        // the model as a prompt and spends quota, so the usage call must never
-        // be made.
         let (result, calls) =
             antigravity_collect_at_version(antigravity_output(0, "1.1.10\n")).await;
         assert_eq!(calls, 1, "the usage command must not run");
@@ -2768,8 +2635,6 @@ done
 
     #[tokio::test]
     async fn antigravity_unparseable_version_is_refused_not_assumed_new() {
-        // Failing open would spend quota on an unknown build; the guard treats
-        // "no version" exactly like "too old".
         for stdout in ["not a version\n", "", "1.1\n", "abc.def.ghi\n"] {
             let (result, calls) =
                 antigravity_collect_at_version(antigravity_output(0, stdout)).await;
@@ -2785,8 +2650,6 @@ done
 
     #[tokio::test]
     async fn antigravity_failing_version_command_is_refused() {
-        // A non-zero `--version` leaves us without a version, which is the
-        // same answer as an unparseable one.
         let (result, calls) =
             antigravity_collect_at_version(antigravity_output(1, "1.1.18\n")).await;
         assert_eq!(calls, 1);
@@ -2838,7 +2701,6 @@ done
         assert_eq!(parse_version_prefix("1.1"), None);
         assert_eq!(parse_version_prefix("nope"), None);
         assert_eq!(parse_version_prefix(""), None);
-        // The boundary the constant encodes.
         assert!(parse_version_prefix("1.1.11").unwrap() >= ANTIGRAVITY_MIN_VERSION);
         assert!(parse_version_prefix("1.1.10").unwrap() < ANTIGRAVITY_MIN_VERSION);
         assert!(parse_version_prefix("1.0.99").unwrap() < ANTIGRAVITY_MIN_VERSION);
@@ -2889,8 +2751,6 @@ done
         };
         let result = ANTIGRAVITY_ADAPTER.collect(&ctx, &discovery).await;
         assert!(matches!(result, ProviderResult::CliMissing { .. }));
-        // Neither the version guard nor the usage call may run without an
-        // executable to run them with.
         assert_eq!(process.calls().len(), 0, "{:?}", process.calls());
     }
 

--- a/src/providers/catalog.rs
+++ b/src/providers/catalog.rs
@@ -1,7 +1,3 @@
-//! Locked v10 provider catalog and executable discovery.
-//!
-//! Descriptors hold metadata only. Collection behavior lives in adapters.
-
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -482,15 +478,12 @@ mod tests {
         assert_eq!(ANTIGRAVITY.cache_ttl, Duration::from_secs(90));
         assert_eq!(ANTIGRAVITY.timeout, Duration::from_secs(10));
         assert_eq!(ANTIGRAVITY.max_output_bytes, ONE_MIB);
-        // The only catalog entry that does not retry: see the descriptor.
         assert_eq!(ANTIGRAVITY.retry_policy, RetryPolicy::None);
         assert_eq!(ANTIGRAVITY.retry_delay(), None);
     }
 
     #[test]
     fn empty_login_argv_keeps_login_missing_even_with_the_executable() {
-        // Collection availability and login availability are distinct: `agy`
-        // being on PATH must never advertise a login action.
         let dir = tempfile::tempdir().unwrap();
         let home = dir.path().join("home");
         let path_dir = dir.path().join("path");

--- a/src/providers/codex_app_server.rs
+++ b/src/providers/codex_app_server.rs
@@ -1,9 +1,3 @@
-//! Codex `app-server` JSON-RPC collection over bidirectional stdio.
-//!
-//! Spawns `codex app-server`, runs initialize → account/read →
-//! account/rateLimits/read, and normalizes the camelCase payload into JSON
-//! accepted by [`crate::providers::v2_map::codex_from_rate_limits_json`].
-
 use std::collections::BTreeMap;
 use std::path::Path;
 use std::process::Stdio;
@@ -42,8 +36,6 @@ fn error_is_auth_required(error: &serde_json::Value) -> bool {
         .unwrap_or(false)
 }
 
-// ---- App-server wire types (camelCase) ----
-
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct CodexAppServerWindow {
@@ -70,7 +62,6 @@ struct CodexAppServerResetCredits {
     available_count: Option<u32>,
 }
 
-// credits{balance,...} is monetary and intentionally undeclared (JSON-022B).
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct CodexAppServerLimitBucket {
@@ -122,8 +113,6 @@ struct AppServerResponse {
     error: Option<serde_json::Value>,
 }
 
-// ---- Normalization → codex_from_rate_limits_json shape ----
-
 fn window_to_json(raw: &CodexAppServerWindow, fallback_minutes: i64) -> serde_json::Value {
     serde_json::json!({
         "usedPercent": raw.used_percent,
@@ -164,20 +153,10 @@ fn normalize_to_rate_limits_json(
     let mut secondary = root.and_then(|r| r.secondary.as_ref());
     let mut individual_limit = root.and_then(|r| r.individual_limit.as_ref());
 
-    // Preferred bucket: root `rateLimits` first when it carries windows,
-    // otherwise explicit `codex` key (mirrors the upstream backend's own
-    // preference), then any bucket that actually carries windows. Every
-    // other data-carrying bucket in `rateLimitsByLimitId` is preserved as an
-    // extra bucket instead of being silently dropped — this must happen even
-    // when the root already supplied primary/secondary, since the real
-    // payload has root and the by-id map coexist.
     let root_has_windows = primary.is_some() || secondary.is_some();
     let mut extra: Vec<serde_json::Value> = Vec::new();
     if let Some(by_id) = raw.rate_limits_by_limit_id.as_ref() {
         if root_has_windows {
-            // Root already won; skip only the map entry that IS the root
-            // bucket (same limit_id, falling back to "codex" when absent) so
-            // it isn't duplicated into extraBuckets.
             let root_limit_id = root.and_then(|r| r.limit_id.as_deref()).unwrap_or("codex");
             for (k, b) in by_id.iter() {
                 if k.as_str() != root_limit_id && has_window_data(b) {
@@ -312,13 +291,11 @@ where
     }
 
     let mut lines = BufReader::new(reader).lines();
-    // None = not yet; Some(None) = received without plan_type; Some(Some) = plan.
     let mut account_plan: Option<Option<String>> = None;
     let mut rate_limits: Option<CodexAppServerRateLimitsReadResult> = None;
 
     let hard = tokio::time::sleep(timeout);
     tokio::pin!(hard);
-    // Grace starts far enough that it cannot fire before armed.
     let grace = tokio::time::sleep(timeout + Duration::from_secs(1));
     tokio::pin!(grace);
     let mut grace_armed = false;
@@ -326,7 +303,6 @@ where
     loop {
         tokio::select! {
             _ = &mut hard => {
-                // Prefer already-parsed rate limits over classifying as timeout.
                 return match rate_limits.as_ref().and_then(|r| {
                     let plan = account_plan.as_ref().and_then(|o| o.as_deref());
                     normalize_to_rate_limits_json(r, plan)
@@ -355,7 +331,6 @@ where
                 };
                 match msg.id {
                     Some(0) => {
-                        // Initialize response: error or missing result → fail now.
                         if msg.error.is_some() || msg.result.is_none() {
                             log::debug!(
                                 "Codex app-server initialize returned error or no result"
@@ -421,7 +396,6 @@ where
                     }
                     Some(2) => {
                         if let Some(error) = msg.error.as_ref() {
-                            // Immediate failure; do not wait for hard timeout.
                             if error_is_auth_required(error) {
                                 log::debug!("Codex app-server: account not authenticated");
                                 return AppServerOutcome::Unauthenticated;
@@ -517,7 +491,6 @@ mod tests {
         let (read_half, mut write_half) = tokio::io::split(server);
         let mut lines = BufReader::new(read_half).lines();
 
-        // initialize
         let init = lines.next_line().await.expect("init").expect("line");
         assert!(init.contains("initialize"), "{init}");
         write_half
@@ -526,7 +499,6 @@ mod tests {
             .expect("write init result");
         write_half.write_all(b"\n").await.expect("nl");
 
-        // initialized + account/read + rateLimits/read (order may vary across lines)
         let mut saw_account = false;
         let mut saw_limits = false;
         while !(saw_account && saw_limits) {
@@ -548,9 +520,7 @@ mod tests {
                     .expect("limits");
                 write_half.write_all(b"\n").await.expect("nl");
             }
-            // ignore "initialized" notification
         }
-        // Keep the stream open briefly so the client can finish.
         tokio::time::sleep(Duration::from_millis(50)).await;
     }
 
@@ -702,14 +672,13 @@ mod tests {
         let server_task = tokio::spawn(async move {
             let (read_half, mut write_half) = tokio::io::split(server);
             let mut lines = BufReader::new(read_half).lines();
-            let _ = lines.next_line().await; // initialize
+            let _ = lines.next_line().await;
             write_half
                 .write_all(br#"{"id":0,"result":{}}"#)
                 .await
                 .expect("init");
             write_half.write_all(b"\n").await.expect("nl");
 
-            // Drain client follow-ups; respond id=2 with error immediately.
             let mut saw_limits = false;
             while !saw_limits {
                 let line = match lines.next_line().await {
@@ -755,7 +724,7 @@ mod tests {
         tokio::spawn(async move {
             let (read_half, mut write_half) = tokio::io::split(server);
             let mut lines = BufReader::new(read_half).lines();
-            let _ = lines.next_line().await; // initialize
+            let _ = lines.next_line().await;
             write_half
                 .write_all(br#"{"id":0,"result":{}}"#)
                 .await
@@ -860,7 +829,6 @@ mod tests {
     async fn appserver_protocol_timeout_is_timed_out_outcome() {
         let (client, _server) = duplex(64 * 1024);
         let (client_read, client_write) = tokio::io::split(client);
-        // No server responses → hard timeout.
         let outcome = run_appserver_protocol_outcome(
             client_read,
             client_write,
@@ -879,15 +847,13 @@ mod tests {
         let server_task = tokio::spawn(async move {
             let (read_half, mut write_half) = tokio::io::split(server);
             let mut lines = BufReader::new(read_half).lines();
-            let _ = lines.next_line().await; // initialize
+            let _ = lines.next_line().await;
             write_half
                 .write_all(br#"{"id":0,"result":{}}"#)
                 .await
                 .expect("init");
             write_half.write_all(b"\n").await.expect("nl");
 
-            // Send rate limits (id=2) but never account/read (id=1), so the
-            // client arms grace and then hits hard timeout with limits held.
             let mut saw_limits = false;
             while !saw_limits {
                 let line = match lines.next_line().await {
@@ -904,9 +870,7 @@ mod tests {
                         .expect("limits");
                     write_half.write_all(b"\n").await.expect("nl");
                 }
-                // Deliberately ignore account/read so account_plan stays None.
             }
-            // Hold the stream open past hard timeout.
             tokio::time::sleep(Duration::from_secs(2)).await;
         });
 
@@ -941,7 +905,7 @@ mod tests {
         let server_task = tokio::spawn(async move {
             let (read_half, mut write_half) = tokio::io::split(server);
             let mut lines = BufReader::new(read_half).lines();
-            let _ = lines.next_line().await; // initialize
+            let _ = lines.next_line().await;
             write_half
                 .write_all(br#"{"id":0,"error":{"code":-32000,"message":"init failed"}}"#)
                 .await
@@ -978,8 +942,7 @@ mod tests {
         let server_task = tokio::spawn(async move {
             let (read_half, mut write_half) = tokio::io::split(server);
             let mut lines = BufReader::new(read_half).lines();
-            let _ = lines.next_line().await; // initialize
-                                             // id=0 with neither result nor error → treat as failed.
+            let _ = lines.next_line().await;
             write_half.write_all(br#"{"id":0}"#).await.expect("empty");
             write_half.write_all(b"\n").await.expect("nl");
             tokio::time::sleep(Duration::from_millis(50)).await;

--- a/src/providers/codex_session_log.rs
+++ b/src/providers/codex_session_log.rs
@@ -1,9 +1,3 @@
-//! Bounded Codex session-log extraction for rate limits fallback.
-//!
-//! Scans `.codex/sessions/**/*.jsonl` for the latest `token_count` event that
-//! carries a `rate_limits` object, then re-serializes that object for
-//! [`crate::providers::v2_map::codex_from_rate_limits_json`].
-
 use std::path::Path;
 
 use time::format_description::well_known::Rfc3339;
@@ -108,8 +102,6 @@ pub fn find_latest_rate_limits(sessions_dir: &Path) -> Option<(Vec<u8>, Option<O
     });
     candidates.truncate(256);
 
-    // Prefer newest candidate that yields extractable limits (not merely
-    // newest file without limits). Skip files larger than 1 MiB.
     for (_mtime, path) in &candidates {
         let Ok(meta) = fs::metadata(path) else {
             continue;
@@ -194,7 +186,6 @@ mod tests {
         let now = datetime!(2026-07-26 18:00:00 UTC);
         match codex_from_rate_limits_json(&raw, now) {
             ProviderResult::Ready { windows, .. } => {
-                // Reverse scan → last token_count line wins.
                 assert!((windows[0].used_percent() - 99.0).abs() < 0.01);
             }
             other => panic!("{other:?}"),
@@ -206,7 +197,6 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let sessions = dir.path().join("sessions");
         std::fs::create_dir_all(&sessions).expect("mkdir");
-        // File without usable limits (sorts first by path when mtimes match).
         std::fs::write(
             sessions.join("empty.jsonl"),
             b"{\"payload\":{\"type\":\"message\"}}\n",
@@ -234,14 +224,10 @@ mod tests {
         let sessions = dir.path().join("sessions");
         std::fs::create_dir_all(&sessions).expect("mkdir");
 
-        // Oversized candidate sorts first by path ("a-huge.jsonl" < "z-good.jsonl")
-        // when mtimes match; must be skipped due to 1 MiB cap.
         let huge_path = sessions.join("a-huge.jsonl");
         {
             use std::io::Write;
             let mut f = std::fs::File::create(&huge_path).expect("create huge");
-            // Write just over 1 MiB of JSONL-shaped content with a fake rate_limits
-            // so a size-blind reader would succeed — size cap must prevent that.
             let line = concat!(
                 r#"{"payload":{"type":"token_count","rate_limits":{"primary":{"used_percent":1.0,"window_minutes":10080}}}}"#,
                 "\n"

--- a/src/providers/http.rs
+++ b/src/providers/http.rs
@@ -1,5 +1,3 @@
-//! Injectable HTTP client for provider collection (Claude).
-
 use std::time::Duration;
 
 pub use super::adapter::HttpResponse;
@@ -43,16 +41,15 @@ impl HttpClient for ReqwestHttpClient {
             for (k, v) in &headers {
                 req = req.header(k.as_str(), v.as_str());
             }
-            let response = req.send().await.map_err(|err| {
-                // Never include authorization-bearing error details.
-                HttpError::Network(err.without_url().to_string())
-            })?;
+            let response = req
+                .send()
+                .await
+                .map_err(|err| HttpError::Network(err.without_url().to_string()))?;
             let status = response.status().as_u16();
             let final_url = response.url().to_string();
             if response.status().is_redirection() {
                 return Err(HttpError::RedirectRefused(final_url));
             }
-            // Cap body before buffering the full payload.
             let mut body = Vec::new();
             let mut stream = response.bytes_stream();
             use futures::StreamExt;

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -1,5 +1,3 @@
-//! Provider catalog, process seams, adapters, and v2 domain mapping.
-
 pub mod adapter;
 pub mod adapters;
 pub mod catalog;

--- a/src/providers/process.rs
+++ b/src/providers/process.rs
@@ -1,5 +1,3 @@
-//! Argv-only process execution with timeout, output limits, and no shell.
-
 use std::path::PathBuf;
 use std::process::Stdio;
 use std::time::Duration;
@@ -117,7 +115,6 @@ impl ProcessRunner for TokioProcessRunner {
 
 /// Execute `spec` without a shell, enforcing timeout and output caps.
 pub async fn run_process(spec: &ProcessSpec) -> Result<ProcessOutput, ProcessError> {
-    // Hard guard: program path must not be a shell used with -c.
     let program_name = spec
         .program
         .file_name()
@@ -132,8 +129,6 @@ pub async fn run_process(spec: &ProcessSpec) -> Result<ProcessOutput, ProcessErr
     }
 
     let mut command = Command::new(&spec.program);
-    // No terminal: a CLI that would fall back to an interactive prompt hits
-    // EOF at once instead of waiting for the timeout's SIGKILL.
     command
         .args(&spec.args)
         .stdin(Stdio::null())
@@ -240,7 +235,6 @@ pub async fn run_process(spec: &ProcessSpec) -> Result<ProcessOutput, ProcessErr
         }
         Ok(Err(err)) => Err(ProcessError::Io(err)),
         Err(_elapsed) => {
-            // Timeout: kill and reap.
             let _ = child.kill().await;
             let _ = child.wait().await;
             Ok(ProcessOutput {
@@ -260,9 +254,6 @@ mod tests {
     use super::*;
     use std::path::Path;
 
-    /// Every one-shot provider command runs without a terminal: a CLI that
-    /// falls back to an interactive prompt must hit EOF, never a waiting
-    /// stdin that the timeout later kills with SIGKILL.
     #[tokio::test]
     async fn stdin_is_closed_for_every_process() {
         let spec =
@@ -292,8 +283,6 @@ mod tests {
 
     #[tokio::test]
     async fn enforces_stdout_limit() {
-        // Print more than the cap via printf-like python or yes | head.
-        // Use a small shell-free generator: /usr/bin/printf if available.
         let program = if Path::new("/usr/bin/printf").exists() {
             "/usr/bin/printf"
         } else {
@@ -321,7 +310,7 @@ mod tests {
         let program = if Path::new("/usr/bin/printf").exists() {
             "/usr/bin/printf"
         } else {
-            return; // environment without printf; skip
+            return;
         };
         let spec = ProcessSpec::new(program, [r"%b", r"\033[31mred\033[0m"]);
         let out = TokioProcessRunner.run(&spec).await.unwrap();

--- a/src/providers/retry.rs
+++ b/src/providers/retry.rs
@@ -1,8 +1,3 @@
-//! Shared one-transient-retry loop for HTTP collection.
-//!
-//! The catalog declares [`RetryPolicy::OneTransient`] for every provider; this
-//! is the single implementation of that promise. Only network errors retry.
-
 use super::adapter::{HttpClient, HttpError, HttpResponse};
 use super::catalog::ProviderDescriptor;
 
@@ -43,7 +38,6 @@ mod tests {
 
     #[tokio::test]
     async fn retries_once_after_network_error() {
-        // ScriptedHttpClient pops from the END: last entry is served first.
         let http = ScriptedHttpClient {
             responses: std::sync::Mutex::new(vec![
                 Ok(ok_response()),

--- a/src/providers/v2_map.rs
+++ b/src/providers/v2_map.rs
@@ -1,8 +1,3 @@
-//! Pure parsers that map provider fixtures/payloads into schema-v2 domain results.
-//!
-//! Adapters never serialize schema v2; they only produce [`ProviderResult`].
-//! Monetary fields, credits, and arbitrary extras are discarded here.
-
 use std::path::Path;
 
 use regex::Regex;
@@ -17,8 +12,6 @@ use crate::support::redact::strip_ansi_and_controls;
 
 use super::catalog::{AMP, ANTIGRAVITY, CLAUDE, CODEX, GROK};
 
-/// Display labels for the shared window ids. Every provider mapper uses these;
-/// QML renders them verbatim and never re-derives.
 const LABEL_SESSION: &str = "Session (5h)";
 const LABEL_DAILY: &str = "Daily (1d)";
 const LABEL_WEEKLY: &str = "Weekly (7d)";
@@ -30,11 +23,6 @@ const LABEL_GEMINI_SESSION: &str = "Gemini · 5h";
 const LABEL_THIRD_PARTY_WEEKLY: &str = "Claude/GPT · 7d";
 const LABEL_THIRD_PARTY_SESSION: &str = "Claude/GPT · 5h";
 
-// ---------------------------------------------------------------------------
-// Amp
-// ---------------------------------------------------------------------------
-
-/// Parse `amp usage` text into a domain result. Credits/dollar lines are ignored.
 pub fn amp_from_usage_text(stdout: &str, now: OffsetDateTime) -> ProviderResult {
     let text = strip_ansi_and_controls(stdout);
     let account = Regex::new(r"Signed in as (\S+)")
@@ -42,7 +30,6 @@ pub fn amp_from_usage_text(stdout: &str, now: OffsetDateTime) -> ProviderResult 
         .and_then(|re| re.captures(&text))
         .and_then(|c| c.get(1).map(|m| m.as_str().to_owned()));
 
-    // Prefer percentage form; never emit spend/credits windows.
     let free_pct = Regex::new(r"Amp Free:\s*([0-9.]+)%\s*remaining")
         .ok()
         .and_then(|re| re.captures(&text))
@@ -137,10 +124,6 @@ fn next_utc_midnight(now: OffsetDateTime) -> OffsetDateTime {
         .unwrap_or(now)
 }
 
-// ---------------------------------------------------------------------------
-// Grok
-// ---------------------------------------------------------------------------
-
 #[derive(Debug, Deserialize)]
 struct GrokSignals {
     #[serde(default, rename = "contextTokensUsed")]
@@ -161,13 +144,10 @@ struct GrokBillingDoc {
     subscription_tiers: Option<String>,
     /// Monthly-limit shape (`/v1/billing` without `format=credits`): only the
     /// `used / monthlyLimit` ratio survives; the amounts are never emitted.
-    /// Kept as raw values (like the discarded fields below) so an unexpected
-    /// shape can never fail the whole payload.
     #[serde(default, rename = "monthlyLimit")]
     monthly_limit: Option<Value>,
     #[serde(default)]
     used: Option<Value>,
-    /// Discarded monetary fields.
     #[serde(default, rename = "prepaidBalance")]
     prepaid_balance: Option<Value>,
     #[serde(default, rename = "onDemandCap")]
@@ -226,7 +206,6 @@ pub fn grok_from_billing_json(
         }
     };
 
-    // prepaid_balance / on_demand_* are deserialized only to document discard.
     let _ = (
         &doc.prepaid_balance,
         &doc.on_demand_cap,
@@ -291,8 +270,6 @@ fn parse_grok_billing_doc(bytes: &[u8]) -> Result<GrokBillingDoc, serde_json::Er
     serde_json::from_value(payload)
 }
 
-/// `used / monthlyLimit` as a percentage. A zero, negative, or absent limit,
-/// or an absent `used`, is "no quota published", never a fabricated 0 %.
 /// The live shape is `{"val": N}`; a bare number is tolerated.
 fn grok_monthly_used_percent(doc: &GrokBillingDoc) -> Option<f64> {
     let limit = grok_amount(doc.monthly_limit.as_ref()?)?;
@@ -322,10 +299,6 @@ fn grok_billing_resets_at(doc: &GrokBillingDoc) -> Option<OffsetDateTime> {
         .map(|ts| ts.to_offset(UtcOffset::UTC))
 }
 
-/// Build Grok result from auth flag + optional signals JSON bytes.
-///
-/// Legacy helper retained for unauthenticated/auth fixtures. Product collect
-/// uses [`grok_from_billing_json`] (weekly only); do not treat context as primary.
 pub fn grok_from_auth_and_signals(
     logged_in: bool,
     account_label: Option<String>,
@@ -375,10 +348,6 @@ pub fn grok_from_auth_and_signals(
     }
 }
 
-// ---------------------------------------------------------------------------
-// Codex
-// ---------------------------------------------------------------------------
-
 #[derive(Debug, Deserialize)]
 struct CodexWindowRaw {
     #[serde(rename = "usedPercent", alias = "used_percent")]
@@ -397,7 +366,6 @@ struct CodexRateLimitsDoc {
     secondary: Option<CodexWindowRaw>,
     #[serde(default)]
     plan_type: Option<String>,
-    /// Explicitly ignored monetary field.
     #[serde(default)]
     credits: Option<Value>,
     #[serde(default, rename = "individualLimit")]
@@ -492,7 +460,7 @@ pub fn codex_from_rate_limits_json(bytes: &[u8], now: OffsetDateTime) -> Provide
         }
     }
 
-    let _ = doc.credits; // discarded
+    let _ = doc.credits;
 
     ProviderResult::Ready {
         id: ProviderId::Codex,
@@ -509,8 +477,6 @@ pub fn codex_from_rate_limits_json(bytes: &[u8], now: OffsetDateTime) -> Provide
     }
 }
 
-/// Lowercase ASCII letters/digits/hyphens; empty input falls back to `bucket`.
-/// Mirrors the sanitization in [`weekly_model_id`].
 fn sanitize_bucket_id(raw: &str) -> String {
     let sanitized: String = raw
         .chars()
@@ -524,7 +490,6 @@ fn sanitize_bucket_id(raw: &str) -> String {
     }
 }
 
-/// Display label for a Codex extra rate-limit bucket window.
 fn codex_extra_bucket_label(sanitized: &str, window_minutes: Option<i64>) -> String {
     let name = format_plan_label(sanitized);
     match window_minutes {
@@ -534,11 +499,6 @@ fn codex_extra_bucket_label(sanitized: &str, window_minutes: Option<i64>) -> Str
     }
 }
 
-/// Map a Codex rate-limit duration to window id and display label.
-///
-/// Known durations: 300 → session, 10080 → weekly. Other positive minutes use
-/// `other:{n}:{ordinal}`. Missing duration falls back by slot ordinal (primary
-/// → session, secondary → weekly) for incomplete payloads.
 fn codex_window_identity(window_minutes: Option<i64>, ordinal: usize) -> (String, String) {
     match window_minutes {
         Some(10080) => ("weekly".into(), LABEL_WEEKLY.into()),
@@ -568,10 +528,6 @@ fn codex_window(id: &str, label: &str, raw: &CodexWindowRaw) -> Option<UsageWind
     UsageWindow::try_new(id, label, used, remaining, resets).ok()
 }
 
-// ---------------------------------------------------------------------------
-// Claude
-// ---------------------------------------------------------------------------
-
 #[derive(Debug, Deserialize, Default)]
 struct ClaudeUsageDoc {
     #[serde(default)]
@@ -588,7 +544,6 @@ struct ClaudeUsageDoc {
     error: Option<ClaudeErrorRaw>,
     #[serde(default)]
     limits: Vec<ClaudeLimitRaw>,
-    /// Discarded monetary block.
     #[serde(default)]
     spend: Option<Value>,
     #[serde(default)]
@@ -597,7 +552,6 @@ struct ClaudeUsageDoc {
 
 #[derive(Debug, Deserialize)]
 struct ClaudeWindowRaw {
-    /// Utilization is already a percentage 0..=100 (never treat as 0..=1).
     utilization: f64,
     #[serde(default)]
     resets_at: Option<String>,
@@ -641,12 +595,6 @@ struct ClaudeLimitModel {
     id: Option<String>,
 }
 
-/// Map Claude usage JSON to a domain result.
-///
-/// - `token_expired` → unauthenticated
-/// - utilization is percent (double-division regression guard)
-/// - spend/extra_usage discarded
-/// - unknown limits without usable windows → ready with empty windows
 pub fn claude_from_usage_json(
     bytes: &[u8],
     now: OffsetDateTime,
@@ -685,7 +633,7 @@ pub fn claude_from_usage_json(
         };
     }
 
-    let _ = (doc.spend, doc.extra_usage); // discarded
+    let _ = (doc.spend, doc.extra_usage);
 
     let mut windows = Vec::new();
     if let Some(w) = doc.five_hour.as_ref() {
@@ -710,7 +658,7 @@ pub fn claude_from_usage_json(
         };
         let kind = limit.kind.as_deref().unwrap_or("");
         if kind == "five_hour" || kind == "seven_day" || kind == "seven_day_oauth_apps" {
-            continue; // legacy vocabulary: dedicated fields own these
+            continue;
         }
         let raw = ClaudeWindowRaw {
             utilization: util,
@@ -768,8 +716,6 @@ pub fn claude_from_usage_json(
     }
 }
 
-/// Insert keeping window ids unique; first occurrence wins (dynamic limits[]
-/// entries are pushed before legacy seven_day_* fields on purpose).
 fn push_window_unique(windows: &mut Vec<UsageWindow>, window: UsageWindow) {
     if windows.iter().any(|w| w.id() == window.id()) {
         return;
@@ -793,7 +739,6 @@ fn parse_reset_timestamp(raw: &str) -> Option<OffsetDateTime> {
     if numeric <= 0 {
         return None;
     }
-    // < 1e12 → seconds; otherwise milliseconds (mirrors the reference widget).
     let nanos = if numeric < 1_000_000_000_000 {
         numeric.checked_mul(1_000_000_000)?
     } else {
@@ -808,14 +753,12 @@ fn claude_window(id: &str, label: &str, raw: &ClaudeWindowRaw) -> Option<UsageWi
     if !raw.utilization.is_finite() {
         return None;
     }
-    // Utilization is already percent scale (1.0 == 1%); clamp only.
     let used = raw.utilization.clamp(0.0, 100.0);
     let remaining = (100.0 - used).clamp(0.0, 100.0);
     let resets = raw.resets_at.as_deref().and_then(parse_reset_timestamp);
     UsageWindow::try_new(id, label, used, remaining, resets).ok()
 }
 
-/// Lowercase ASCII letters/digits/hyphens, prefixed with `weekly-model:`.
 pub fn weekly_model_id(raw: &str, ordinal: usize) -> String {
     let mut sanitized: String = raw
         .chars()
@@ -833,11 +776,6 @@ pub fn weekly_model_id(raw: &str, ordinal: usize) -> String {
     }
 }
 
-/// Title-case a raw plan/tier id for display: "pro" → "Pro",
-/// "self_serve_business_usage_based" → "Self Serve Business Usage Based".
-///
-/// Amp keeps its own label verbatim; Grok (Task 3) and Codex (PR2 Task 9)
-/// consume this for their raw tier ids.
 pub(crate) fn format_plan_label(raw: &str) -> String {
     raw.split('_')
         .filter(|s| !s.is_empty())
@@ -861,7 +799,6 @@ fn sanitize_account_label(raw: &str) -> String {
     cleaned
 }
 
-/// Assert a domain result never carries monetary residue in Debug form.
 pub fn assert_no_money(result: &ProviderResult) {
     let text = format!("{result:?}");
     for banned in ["spend", "credits", "balance", "currency", "usd", "BRL"] {
@@ -872,7 +809,6 @@ pub fn assert_no_money(result: &ProviderResult) {
     }
 }
 
-/// Walk limits for Grok/Codex filesystem discovery tests.
 pub fn path_is_absolute_home(path: &Path) -> bool {
     path.is_absolute()
 }
@@ -923,7 +859,6 @@ struct AntigravityBucket {
     reset_time: Option<String>,
 }
 
-/// Typed refusal with a fixed message; provider output never reaches the user.
 fn antigravity_error(message: &str) -> ProviderResult {
     ProviderResult::ProviderError {
         id: ProviderId::Antigravity,
@@ -944,10 +879,6 @@ fn antigravity_error(message: &str) -> ProviderResult {
 /// A window starts on first use. A full bucket has none running, and `agy`
 /// reports its `reset_time` as now plus the whole window, a moving target, so
 /// a full bucket carries no reset.
-///
-/// The logged-out banner is not handled here: `Unauthenticated` needs to know
-/// whether login is available, which is discovery state the adapter owns, so
-/// [`super::adapters`] checks the marker on raw stdout before calling this.
 pub fn antigravity_from_usage_json(stdout: &str, now: OffsetDateTime) -> ProviderResult {
     let text = strip_ansi_and_controls(stdout);
 
@@ -958,9 +889,6 @@ pub fn antigravity_from_usage_json(stdout: &str, now: OffsetDateTime) -> Provide
         return antigravity_error("Antigravity usage command failed.");
     }
 
-    // Named slots rather than a push list: they give the fixed family, then
-    // weekly -> 5h, order and the per-id dedupe (first bucket wins) in one
-    // move.
     let mut gemini_weekly: Option<UsageWindow> = None;
     let mut gemini_session: Option<UsageWindow> = None;
     let mut third_party_weekly: Option<UsageWindow> = None;
@@ -1073,7 +1001,6 @@ mod tests {
                 assert!((windows[1].used_percent() - 8.0).abs() < 0.01);
                 assert_eq!(windows[2].label(), "Plan · orbs");
                 assert!((windows[2].remaining_percent() - 100.0).abs() < 0.01);
-                // Amp exposes no subscription reset timestamp ("monthly" only).
                 assert!(windows[1].resets_at().is_none());
                 assert!(windows[2].resets_at().is_none());
                 let plan = plan.expect("plan from Subscription line");
@@ -1099,7 +1026,6 @@ mod tests {
 
     #[test]
     fn amp_individual_credits_line_never_emits_window() {
-        // Only the monetary line plus account: Ready with zero windows, no money.
         let text = "Signed in as user@email.com (nick)\nIndividual credits: $4.19 remaining (replenishes automatically)\n";
         let result = amp_from_usage_text(text, datetime!(2026-08-07 12:00:00 UTC));
         assert_no_money(&result);
@@ -1147,13 +1073,10 @@ mod tests {
     fn parse_reset_timestamp_accepts_iso_and_epoch() {
         let iso = parse_reset_timestamp("2026-08-01T00:00:00Z");
         assert!(iso.is_some());
-        // Epoch seconds (10 digits).
         let secs = parse_reset_timestamp("1785272823");
         assert_eq!(secs.map(|t| t.unix_timestamp()), Some(1_785_272_823));
-        // Epoch milliseconds (13 digits).
         let millis = parse_reset_timestamp("1785272823412");
         assert_eq!(millis.map(|t| t.unix_timestamp()), Some(1_785_272_823));
-        // Garbage and non-positive are rejected.
         assert!(parse_reset_timestamp("soon").is_none());
         assert!(parse_reset_timestamp("0").is_none());
         assert!(parse_reset_timestamp("-5").is_none());
@@ -1180,7 +1103,6 @@ mod tests {
 
     #[test]
     fn claude_utilization_one_means_one_percent() {
-        // The endpoint reports percent scale: 1.0 is 1%, never 100%.
         let body = br#"{"five_hour":{"utilization":1.0,"resets_at":"2026-07-28T22:00:00Z"}}"#;
         let result =
             claude_from_usage_json(body, datetime!(2026-07-28 18:00:00 UTC), None, None, true);
@@ -1337,10 +1259,6 @@ mod tests {
 
     #[test]
     fn codex_dedupes_extra_bucket_window_ids_across_case_variants() {
-        // Two limitId keys that differ only by case sanitize to the same
-        // window id ("codex:team-a"); the second must be dropped, not
-        // silently pushed twice (duplicate window ids make
-        // ensure_unique_window_ids reject the entire status).
         let json = serde_json::json!({
             "primary": {"usedPercent": 36.0, "windowDurationMins": 10080, "resetsAt": 1791000000},
             "extraBuckets": [
@@ -1505,8 +1423,6 @@ mod tests {
 
     #[test]
     fn grok_scalar_amounts_never_fail_the_credits_payload() {
-        // The same struct parses both endpoints: an unexpected scalar for
-        // `used`/`monthlyLimit` must not turn a SuperGrok reading into an error.
         let json = br#"{"creditUsagePercent": 33.0, "used": 12.5, "monthlyLimit": 200}"#;
         let result = grok_from_billing_json(json, None, datetime!(2026-08-26 12:00:00 UTC), true);
         match result {
@@ -1541,8 +1457,6 @@ mod tests {
 
     #[test]
     fn claude_dedupes_model_window_ids_across_sources() {
-        // limits[] entry AND legacy seven_day_opus for the same model must not
-        // produce duplicate window ids (schema rejects the whole row otherwise).
         let body = br#"{
             "five_hour": {"utilization": 10.0},
             "limits": [{"kind": "seven_day_model", "utilization": 20.0,
@@ -1551,8 +1465,6 @@ mod tests {
         }"#;
         let result =
             claude_from_usage_json(body, datetime!(2026-07-28 18:00:00 UTC), None, None, true);
-        // The whole row must survive schema validation downstream (duplicate
-        // window ids make ensure_unique_window_ids reject the entire status).
         let status = crate::status::collect::provider_status_from_result(result.clone());
         assert!(status.is_ok(), "row failed schema validation: {status:?}");
         match result {
@@ -1562,7 +1474,6 @@ mod tests {
                     .filter(|w| w.id() == "weekly-model:opus")
                     .collect();
                 assert_eq!(opus.len(), 1, "duplicate weekly-model:opus windows");
-                // limits[] (dynamic) wins over the legacy field.
                 assert!((opus[0].used_percent() - 20.0).abs() < 0.01);
             }
             other => panic!("expected ready, got {other:?}"),
@@ -1571,11 +1482,6 @@ mod tests {
 
     #[test]
     fn claude_reads_current_limits_shape_with_fable() {
-        // Captured live 2026-08-01: limits[] entries carry `percent` (not
-        // `utilization`), kinds are session/weekly_all/weekly_scoped, the
-        // scoped entry names the model only via display_name, and
-        // seven_day_oauth_apps is null. The Fable window must come through
-        // and the grouped entries must not duplicate session/weekly.
         let body = br#"{
             "five_hour": {"utilization": 10.0, "resets_at": "2026-08-02T02:00:00+00:00"},
             "seven_day": {"utilization": 12.0, "resets_at": "2026-08-07T12:00:00+00:00"},
@@ -1613,9 +1519,6 @@ mod tests {
 
     #[test]
     fn claude_limits_only_payload_still_yields_windows() {
-        // The API already retired seven_day_oauth_apps once; if the legacy
-        // top-level fields go next, limits[] must be able to carry the
-        // canonical windows alone.
         let body = br#"{
             "limits": [
                 {"kind": "session", "percent": 7.0, "resets_at": "2026-08-02T02:00:00+00:00"},
@@ -1687,8 +1590,6 @@ mod tests {
                     Some(datetime!(2026-08-23 04:25:14 UTC))
                 );
 
-                // The Claude/GPT pair is untouched in this capture: full, so
-                // no window is running and its reset is dropped.
                 assert_eq!(windows[2].id(), "3p-weekly");
                 assert_eq!(windows[2].label(), "Claude/GPT · 7d");
                 assert!((windows[2].remaining_percent() - 100.0).abs() < 0.01);
@@ -1708,8 +1609,6 @@ mod tests {
 
     #[test]
     fn antigravity_ignores_unknown_bucket_ids() {
-        // Only the four ids `agy` 1.2.0 reports are mapped. Guessed aliases
-        // such as `claude-5h` stay unknown and never become a window.
         let payload = r#"{"status":"SUCCESS","command":{"name":"usage","data":{"groups":[
             {"name":"Claude and GPT models","buckets":[
               {"id":"claude-weekly","window":"weekly","remaining_fraction":0.5},
@@ -1722,10 +1621,6 @@ mod tests {
 
     #[test]
     fn antigravity_full_bucket_carries_no_reset() {
-        // A window starts on first use. Until then `agy` reports the bucket
-        // full with `reset_time` = now + the whole window, a moving target
-        // that never arrives, so a full bucket carries no reset. A bucket
-        // with any use keeps the fixed reset `agy` reports.
         let payload = r#"{"status":"SUCCESS","command":{"name":"usage","data":{"groups":[
             {"name":"Gemini Models","buckets":[
               {"id":"gemini-weekly","window":"weekly","remaining_fraction":1.4,
@@ -1751,9 +1646,6 @@ mod tests {
 
     #[test]
     fn antigravity_zero_windows_is_ready_not_an_error() {
-        // Same rule as Amp: a connected provider without a percentage window
-        // is valid and renders "—" (CLAUDE.md, provider rules). An account
-        // whose buckets carry no id Agent Bar maps is exactly this case.
         let payload = r#"{"status":"SUCCESS","command":{"name":"usage","data":{"groups":[
             {"name":"Other models","buckets":[
               {"id":"other-weekly","window":"weekly","remaining_fraction":1,
@@ -1805,9 +1697,6 @@ mod tests {
 
     #[test]
     fn antigravity_logged_out_payload_carries_no_windows() {
-        // The banner itself is classified by the adapter, which knows whether
-        // login is available; the parser only has to refuse to invent windows
-        // out of the empty group list that comes with it.
         let fixture = include_str!("../../tests/fixtures/antigravity/unauthorized.json");
         let result = antigravity_from_usage_json(fixture, datetime!(2026-08-21 12:00:00 UTC));
         assert_no_money(&result);
@@ -1819,9 +1708,6 @@ mod tests {
 
     #[test]
     fn antigravity_ignores_a_repeated_bucket_id() {
-        // Idempotence against repeated records: whatever makes a bucket id
-        // appear twice, the first occurrence wins, so a duplicated group can
-        // never double the window list.
         let payload = r#"{"status":"SUCCESS","command":{"name":"usage","data":{"groups":[
             {"name":"Gemini Models","buckets":[
               {"id":"gemini-weekly","window":"weekly","remaining_fraction":0.86,
@@ -1840,8 +1726,6 @@ mod tests {
 
     #[test]
     fn antigravity_orders_windows_by_family_then_weekly_first() {
-        // The CLI is free to reorder groups and buckets; the rendered order
-        // is not: Gemini weekly, Gemini 5h, Claude/GPT weekly, Claude/GPT 5h.
         let payload = r#"{"status":"SUCCESS","command":{"name":"usage","data":{"groups":[
             {"name":"Claude and GPT models","buckets":[
               {"id":"3p-5h","window":"5h","remaining_fraction":1},
@@ -1853,7 +1737,6 @@ mod tests {
             ProviderResult::Ready { windows, .. } => {
                 let ids: Vec<&str> = windows.iter().map(|w| w.id()).collect();
                 assert_eq!(ids, ["gemini-weekly", "gemini-5h", "3p-weekly", "3p-5h"]);
-                // A bucket without `reset_time` is still a window.
                 assert_eq!(windows[0].resets_at(), None);
             }
             other => panic!("expected ready, got {other:?}"),
@@ -1880,8 +1763,6 @@ mod tests {
 
     #[test]
     fn antigravity_never_echoes_provider_prose() {
-        // `description` and `response` carry human text (and, on a logged-out
-        // run, an account hint); none of it may reach a domain result.
         let fixture = include_str!("../../tests/fixtures/antigravity/usage.json");
         let result = antigravity_from_usage_json(fixture, datetime!(2026-08-21 12:00:00 UTC));
         let debug = format!("{result:?}");

--- a/src/settings/migration.rs
+++ b/src/settings/migration.rs
@@ -1,5 +1,3 @@
-//! v9 → v10 data migration for settings and shell.json inline keys (MIG-007..016).
-
 use std::collections::{BTreeSet, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -65,7 +63,6 @@ impl MigrationPlan {
         settings_raw: Option<&[u8]>,
         shell_raw: Option<&[u8]>,
     ) -> Result<Self, MigrationError> {
-        // Track whether refresh came from an explicit settings/waybar value.
         let mut refresh_from_settings = false;
         let (mut settings, unknown_keys, already_settings) = match settings_raw {
             None => (Settings::defaults(), Vec::new(), false),
@@ -73,30 +70,17 @@ impl MigrationPlan {
                 (Settings::defaults(), Vec::new(), false)
             }
             Some(raw) => {
-                // Migration is the only path allowed to rewrite a v10 document
-                // that predates a catalog addition; an injection means the file
-                // must be written back, so it is not "already migrated".
-                //
-                // The repair is gated on `carries_original_v10_providers`: a
-                // document whose `providers` array is empty or truncated is not
-                // "v10 minus the providers added later", it is a v9-era or
-                // damaged file, and filling it from the catalog would invent an
-                // enablement set the user never chose. Those fall through to
-                // the v9 path, which derives enablement from the waybar block.
                 if let Some((v10, injected)) = parse_complete_v10(raw) {
                     refresh_from_settings = true;
                     (v10, Vec::new(), !injected)
                 } else {
                     let (s, unk, _) = migrate_v9_settings(raw)?;
-                    // migrate_v9_settings always sets a concrete interval (default 60
-                    // or waybar.interval). Mark explicit when waybar.interval present.
                     refresh_from_settings = waybar_interval_present(raw);
                     (s, unk, false)
                 }
             }
         };
 
-        // MIG-010/015: validate and store shell inline refresh BEFORE strip.
         let inline_refresh = match shell_raw {
             Some(raw) => extract_inline_refresh_seconds(raw)?,
             None => None,
@@ -105,8 +89,6 @@ impl MigrationPlan {
             if !refresh_from_settings {
                 settings.refresh_interval_seconds = n;
             }
-            // If settings already supplied interval, keep it; inline still must
-            // have been valid (extract already aborted on invalid).
         }
 
         settings
@@ -172,7 +154,6 @@ pub fn apply_migration_plan(
     fs::create_dir_all(backup_root.join("settings"))
         .map_err(|e| MigrationError::msg(format!("create settings backup dir: {e}")))?;
 
-    // Preserve exact pre-migration settings bytes when present (MIG-014 report path).
     if settings_path.is_file() {
         let prev = fs::read(settings_path)
             .map_err(|e| MigrationError::msg(format!("read settings for backup: {e}")))?;
@@ -214,7 +195,6 @@ pub fn apply_migration_plan(
         shell_written = true;
     }
 
-    // Lightweight operation record for operators (not a full transaction journal).
     let manifest = serde_json::json!({
         "operation": "v9-settings-migration",
         "settingsWritten": true,
@@ -260,13 +240,6 @@ pub fn migrate_live_paths(
     apply_migration_plan(&plan, settings_path, shell_path, backup_root)
 }
 
-/// Parse `raw` as a v10 document, completing it from the catalog only when it
-/// already lists every original v10 provider (the guard lives in
-/// [`Settings::parse_with_policy`], shared with the read path).
-///
-/// Returns the document plus whether any provider row was filled in (which
-/// obliges the caller to rewrite the file). `None` means "not a v10 document
-/// we may repair" and sends the caller to the v9 migration path.
 fn parse_complete_v10(raw: &[u8]) -> Option<(Settings, bool)> {
     Settings::parse_with_policy(raw, MissingProviders::FillFromCatalog).ok()
 }
@@ -282,7 +255,6 @@ fn waybar_interval_present(raw: &[u8]) -> bool {
         .is_some()
 }
 
-/// Read Agent Bar inline refresh from shell entry; abort if present but invalid.
 fn extract_inline_refresh_seconds(raw: &[u8]) -> Result<Option<u32>, MigrationError> {
     let value: Value = serde_json::from_slice(raw)
         .map_err(|e| MigrationError::msg(format!("invalid shell.json: {e}")))?;
@@ -329,14 +301,6 @@ fn extract_inline_refresh_seconds(raw: &[u8]) -> Result<Option<u32>, MigrationEr
 }
 
 /// The provider IDs a v9 document could name in `waybar.providers`.
-///
-/// v9 shipped exactly these four; Antigravity and anything added later cannot
-/// appear in a v9 file, so no v9 document carries a choice for them.
-///
-/// Identical today to `schema::ORIGINAL_V10_PROVIDERS` and deliberately kept
-/// separate: that one is the gate for repairing a v10 document, this one is a
-/// fact about what v9 shipped. Neither grows when the catalog does, but they
-/// answer different questions and would diverge for different reasons.
 const V9_PROVIDERS: &[ProviderId] = &[
     ProviderId::Claude,
     ProviderId::Codex,
@@ -346,25 +310,14 @@ const V9_PROVIDERS: &[ProviderId] = &[
 
 /// What a migrated document says about which providers the user wanted.
 enum V9Choice {
-    /// `waybar.providers` named them. That list IS the choice.
     Listed(HashSet<ProviderId>),
-    /// A v9 document whose `waybar` block omits `providers`: v9 rendered every
-    /// provider it knew, so the user was seeing all four and never opted out.
     AllV9Providers,
-    /// No `waybar` block at all — not a v9 document, so there is no choice to
-    /// carry over and the fresh-install defaults apply.
     NoV9Block,
 }
 
 /// Whether a migrated row starts enabled.
-///
-/// MIG-009 / PROD-024: migration preserves the user's choice instead of
-/// applying fresh defaults, so a provider that ships opt-in today still comes
-/// across enabled when the v9 install had it on. Only an ID v9 never had, or a
-/// document that was never v9 to begin with, falls back to `default_enabled`.
 fn v9_enabled(id: ProviderId, choice: &V9Choice) -> bool {
     if !V9_PROVIDERS.contains(&id) {
-        // Added after v9: no v9 document carries a choice for it.
         return default_enabled(id);
     }
     match choice {
@@ -382,7 +335,6 @@ fn migrate_v9_settings(raw: &[u8]) -> Result<(Settings, Vec<String>, bool), Migr
         .ok_or_else(|| MigrationError::msg("v9 settings must be a JSON object"))?;
 
     let mut unknown = Vec::new();
-    // Split legacy monetary key so the active-legacy gate does not flag source.
     let legacy_fx = concat!("fx", "Rate");
     let known_top = BTreeSet::from([
         "version",
@@ -396,7 +348,6 @@ fn migrate_v9_settings(raw: &[u8]) -> Result<(Settings, Vec<String>, bool), Migr
         "menu",
         "glyphMode",
         legacy_fx,
-        // accidental v10-ish keys we still treat as unknown for v9 path
         "providers",
         "display",
         "refreshIntervalSeconds",
@@ -408,7 +359,6 @@ fn migrate_v9_settings(raw: &[u8]) -> Result<(Settings, Vec<String>, bool), Migr
         }
     }
 
-    // Prefer waybar block when present (v9 shape).
     let waybar = obj.get("waybar").and_then(|v| v.as_object());
 
     let display_mode = waybar
@@ -470,14 +420,9 @@ fn migrate_v9_settings(raw: &[u8]) -> Result<(Settings, Vec<String>, bool), Migr
         })
         .unwrap_or_else(|| enabled_list.clone());
 
-    // Validate provider ids are known; unknown names abort if listed as "recognized" attempts.
     for name in enabled_list.iter().chain(order_list.iter()) {
-        if ProviderId::parse_word(name).is_none() {
-            // Unknown provider names are treated as unknown keys, not hard abort —
-            // only closed set participates in v10.
-            if !unknown.iter().any(|k| k == name) {
-                unknown.push(format!("provider:{name}"));
-            }
+        if ProviderId::parse_word(name).is_none() && !unknown.iter().any(|k| k == name) {
+            unknown.push(format!("provider:{name}"));
         }
     }
 
@@ -486,9 +431,6 @@ fn migrate_v9_settings(raw: &[u8]) -> Result<(Settings, Vec<String>, bool), Migr
         .filter_map(|s| ProviderId::parse_word(s))
         .collect();
 
-    // `enabled_list` stands in the full catalog when the key is absent so that
-    // ordering and validation still see every ID. Enablement needs the finer
-    // distinction, which only the raw document carries.
     let choice = match waybar {
         None => V9Choice::NoV9Block,
         Some(w) => match w.get("providers").and_then(|v| v.as_array()) {
@@ -497,7 +439,6 @@ fn migrate_v9_settings(raw: &[u8]) -> Result<(Settings, Vec<String>, bool), Migr
         },
     };
 
-    // Build order: first closed IDs from providerOrder, then remaining ALL.
     let mut providers = Vec::new();
     let mut seen: HashSet<ProviderId> = HashSet::new();
     for name in &order_list {
@@ -519,9 +460,6 @@ fn migrate_v9_settings(raw: &[u8]) -> Result<(Settings, Vec<String>, bool), Migr
         }
     }
 
-    // Nothing survived the mapping: the document named zero providers, or only
-    // names this catalog no longer knows. Fall back to the fresh-install
-    // defaults rather than handing the user an empty bar.
     if providers.iter().all(|p| !p.enabled) {
         for p in &mut providers {
             p.enabled = default_enabled(p.id.0);
@@ -546,9 +484,6 @@ fn migrate_v9_settings(raw: &[u8]) -> Result<(Settings, Vec<String>, bool), Migr
     Ok((settings, unknown, false))
 }
 
-/// Remove only Agent Bar-owned inline keys from shell.json entries with our plugin id.
-/// Preserves section, index, formatting-insensitive structure via serde re-serialize
-/// only when a key is stripped; callers keep `shell_before` for exact rollback.
 fn strip_agent_bar_inline_keys(raw: &[u8]) -> Result<Vec<u8>, MigrationError> {
     let mut value: Value = serde_json::from_slice(raw)
         .map_err(|e| MigrationError::msg(format!("invalid shell.json: {e}")))?;
@@ -557,7 +492,6 @@ fn strip_agent_bar_inline_keys(raw: &[u8]) -> Result<Vec<u8>, MigrationError> {
     if !changed {
         return Ok(raw.to_vec());
     }
-    // Stable pretty JSON with trailing newline for readability in tests.
     let mut out = serde_json::to_vec_pretty(&value)
         .map_err(|e| MigrationError::msg(format!("serialize shell.json: {e}")))?;
     if !out.ends_with(b"\n") {
@@ -574,7 +508,6 @@ fn strip_inline_in_value(value: &mut Value, changed: &mut bool) {
             }
         }
         Value::Object(map) => {
-            // Plugin entry objects: { "id": "agent-bar.usage", ...inline }
             let is_entry = map
                 .get("id")
                 .and_then(|v| v.as_str())
@@ -729,10 +662,8 @@ mod tests {
         assert_eq!(plan.settings.refresh_interval_seconds, 120);
         assert_eq!(plan.settings.display.metric, DisplayMetric::Used);
         assert!(!plan.settings.notifications.enabled);
-        // order: codex first
         assert_eq!(plan.settings.providers[0].id.0, ProviderId::Codex);
         assert!(plan.settings.providers[0].enabled);
-        // claude disabled
         let claude = plan
             .settings
             .providers
@@ -744,9 +675,6 @@ mod tests {
 
     #[test]
     fn v9_provider_choice_outranks_the_v10_default() {
-        // MIG-009 / PROD-024: the v9 `waybar.providers` list IS the user's
-        // explicit choice. A provider that ships opt-in in v10 must still come
-        // across enabled when the v9 document asked for it.
         let raw = read_fixture("settings-valid.json");
         let plan = MigrationPlan::from_v9(Some(&raw), None).unwrap();
         for id in [ProviderId::Codex, ProviderId::Amp, ProviderId::Grok] {
@@ -769,11 +697,6 @@ mod tests {
 
     #[test]
     fn a_v9_block_without_a_provider_list_keeps_every_v9_provider() {
-        // v9 rendered all four providers unless the user opted out through
-        // `waybar.providers`. A document that never wrote the key was showing
-        // all four, so migration must not read the absent key as consent to
-        // the v10 opt-in defaults (MIG-009, PROD-024) — the plan is written to
-        // disk, which would make the loss permanent.
         for raw in [
             br#"{"version":3,"waybar":{"displayMode":"remaining","interval":60}}"#.as_slice(),
             br#"{"version":3,"waybar":{"providerOrder":["grok","claude"],"interval":60}}"#
@@ -804,8 +727,6 @@ mod tests {
 
     #[test]
     fn an_empty_v9_provider_list_falls_back_to_the_defaults() {
-        // Naming zero providers leaves nothing to preserve. Rather than an
-        // empty bar, the user gets what a fresh install would give them.
         let raw = br#"{"version":3,"waybar":{"providers":[],"interval":60}}"#;
         let plan = MigrationPlan::from_v9(Some(raw), None).unwrap();
         for row in &plan.settings.providers {
@@ -852,9 +773,6 @@ mod tests {
 
     #[test]
     fn v10_document_missing_a_provider_is_repaired_once() {
-        // A v10 file written before Antigravity joined the catalog: the first
-        // plan must rewrite it (injecting the provider disabled), the second
-        // must be a no-op.
         let dir = tempfile::tempdir().unwrap();
         let settings_path = dir.path().join("settings.json");
         let shell_path = dir.path().join("shell.json");
@@ -892,13 +810,6 @@ mod tests {
 
     #[test]
     fn injected_rows_follow_default_enabled() {
-        // The injected row must be whatever `default_enabled` says, not a
-        // hard-coded false: the catalog is the single source for that. Today
-        // both spellings agree, since antigravity is the only injectable row
-        // and its default is false; the assertion starts biting when a
-        // provider that ships enabled joins the catalog. The four rows the
-        // document already carries are the user's and survive untouched, even
-        // where the fresh-install default now differs.
         let four = br#"{"schemaVersion":1,"providers":[{"id":"claude","enabled":true},{"id":"codex","enabled":true},{"id":"amp","enabled":true},{"id":"grok","enabled":true}],"display":{"metric":"remaining"},"refreshIntervalSeconds":60,"notifications":{"enabled":true}}"#;
         let plan = MigrationPlan::from_v9(Some(four), None).unwrap();
         for id in V9_PROVIDERS {
@@ -921,10 +832,6 @@ mod tests {
 
     #[test]
     fn a_truncated_providers_array_is_not_treated_as_a_v10_document() {
-        // An empty or truncated `providers` array is not "v10 minus the
-        // providers added later" — completing it from the catalog would turn
-        // the whole set off. These take the v9 path, which enables everything
-        // `default_enabled` allows.
         for raw in [
             br#"{"schemaVersion":1,"providers":[],"display":{"metric":"remaining"},"refreshIntervalSeconds":60,"notifications":{"enabled":true}}"#.as_slice(),
             br#"{"schemaVersion":1,"providers":[{"id":"claude","enabled":true}],"display":{"metric":"remaining"},"refreshIntervalSeconds":60,"notifications":{"enabled":true}}"#.as_slice(),
@@ -953,19 +860,15 @@ mod tests {
         let shell = read_fixture("shell-left-index1.json");
         let plan = MigrationPlan::from_v9(None, Some(&shell)).unwrap();
         assert!(plan.shell_changed);
-        // MIG-010: inline 90 stored into settings before strip
         assert_eq!(plan.settings.refresh_interval_seconds, 90);
         let after = plan.shell_after.as_ref().unwrap();
         assert!(remaining_inline_keys(after).unwrap().is_empty());
         let value: Value = serde_json::from_slice(after).unwrap();
-        // Still present once
         assert_eq!(count_plugin_entries(&value), 1);
-        // Section left still has three entries; agent-bar at index 1
         let left = value["bar"]["left"].as_array().unwrap();
         assert_eq!(left.len(), 3);
         assert_eq!(left[1]["id"], LEGACY_PLUGIN_ID);
         assert!(left[1].get("refreshIntervalSec").is_none());
-        // Unrelated plugins untouched
         assert_eq!(left[0]["id"], "omarchy.menu");
     }
 
@@ -981,8 +884,8 @@ mod tests {
 
     #[test]
     fn settings_interval_wins_over_inline() {
-        let settings = read_fixture("settings-valid.json"); // interval 120
-        let shell = read_fixture("shell-left-index1.json"); // inline 90
+        let settings = read_fixture("settings-valid.json");
+        let shell = read_fixture("shell-left-index1.json");
         let plan = MigrationPlan::from_v9(Some(&settings), Some(&shell)).unwrap();
         assert_eq!(plan.settings.refresh_interval_seconds, 120);
         assert!(plan.shell_changed);

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -1,5 +1,3 @@
-//! Settings: v10 canonical store and v9→v10 data migration.
-
 pub mod migration;
 pub mod schema;
 pub mod store;

--- a/src/settings/schema.rs
+++ b/src/settings/schema.rs
@@ -1,5 +1,3 @@
-//! Canonical settings schema v1 domain types and validation.
-
 use std::collections::HashSet;
 use std::fmt;
 
@@ -13,15 +11,12 @@ const MIN_REFRESH: u32 = 30;
 const MAX_REFRESH: u32 = 3600;
 const MIN_REMINDER_MINUTES: u32 = 15;
 const MAX_REMINDER_MINUTES: u32 = 1440;
-/// Two hours. Hourly was judged too frequent by the product owner; the field
-/// exists so this is a default, not a floor.
 const DEFAULT_REMINDER_MINUTES: u32 = 120;
 
 pub(crate) fn default_reminder_minutes() -> u32 {
     DEFAULT_REMINDER_MINUTES
 }
 
-/// Display metric for chips and windows.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum DisplayMetric {
@@ -29,7 +24,6 @@ pub enum DisplayMetric {
     Remaining,
 }
 
-/// One provider membership row.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ProviderSetting {
@@ -37,7 +31,6 @@ pub struct ProviderSetting {
     pub enabled: bool,
 }
 
-/// Serde adapter for closed provider IDs.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct ProviderIdJson(pub ProviderId);
 
@@ -62,14 +55,12 @@ impl<'de> Deserialize<'de> for ProviderIdJson {
     }
 }
 
-/// Display block.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct DisplaySettings {
     pub metric: DisplayMetric,
 }
 
-/// Notifications block.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct NotificationSettings {
@@ -94,7 +85,6 @@ impl Default for UpdateSettings {
     }
 }
 
-/// Canonical settings document (schema v1).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct Settings {
@@ -134,18 +124,6 @@ impl fmt::Display for SettingsError {
 impl std::error::Error for SettingsError {}
 
 /// Whether a provider is on by default in a freshly written document.
-///
-/// Single source for "which providers start enabled": `Settings::defaults`
-/// and every v9 → v10 migration path read it instead of re-testing IDs.
-///
-/// A first run enables only Claude and Codex (SET-027). Every other provider
-/// ships opt-in: its CLI is not installed for most users, so enabling it by
-/// default would show a permanent CLI-missing chip nobody asked for. Users
-/// turn the rest on from Settings.
-///
-/// The exhaustive `match` is deliberate. An exclusion list would let a new
-/// catalog entry inherit a default nobody decided; this way adding a
-/// `ProviderId` fails to compile until someone picks its arm.
 pub fn default_enabled(id: ProviderId) -> bool {
     match id {
         ProviderId::Claude | ProviderId::Codex => true,
@@ -228,19 +206,11 @@ impl Settings {
             .map_err(|err| SettingsError::new(format!("invalid settings document: {err}")))?;
 
         let mut injected = false;
-        // Only a document that already lists every provider v10 shipped with
-        // is a real v10 file that merely predates a later catalog addition.
-        // Anything shorter (hand-edited, truncated) is rejected by
-        // `validate` below exactly as SET-006 demands: filling it from the
-        // catalog would invent an enablement set the user never chose.
         if policy == MissingProviders::FillFromCatalog
             && carries_original_v10_providers(&settings.providers)
         {
             for id in ProviderId::ALL {
                 if !settings.providers.iter().any(|p| p.id.0 == id) {
-                    // `default_enabled` is the single source for "which
-                    // providers start enabled": a filled-in row must look
-                    // exactly like the one `Settings::defaults` would write.
                     settings.providers.push(ProviderSetting {
                         id: ProviderIdJson(id),
                         enabled: default_enabled(id),
@@ -273,9 +243,6 @@ impl Settings {
                 "reminderMinutes must be in {MIN_REMINDER_MINUTES}..={MAX_REMINDER_MINUTES}"
             )));
         }
-        // Name the offending provider before falling back to the cardinality
-        // message: a document written before a catalog addition fails here,
-        // and the operator needs the ID to fix it by hand.
         let mut seen = HashSet::new();
         for item in &self.providers {
             if !seen.insert(item.id.0) {
@@ -407,9 +374,6 @@ mod tests {
 
     #[test]
     fn missing_provider_is_rejected_only_under_the_strict_policy() {
-        // SET-006 keeps `config apply` strict: it writes the whole document,
-        // so it must be handed the whole document. Reads and the migration
-        // fill the gap from the catalog instead.
         let four = br#"{"schemaVersion":1,"providers":[{"id":"claude","enabled":true},{"id":"codex","enabled":true},{"id":"amp","enabled":true},{"id":"grok","enabled":true}],"display":{"metric":"remaining"},"refreshIntervalSeconds":60,"notifications":{"enabled":true}}"#;
         let err = Settings::parse_strict(four).unwrap_err();
         assert!(err.message().contains("antigravity"), "{}", err.message());
@@ -425,7 +389,6 @@ mod tests {
             .expect("antigravity injected");
         assert!(!antigravity.enabled);
 
-        // A complete document reports no injection under either policy.
         let complete = Settings::defaults().to_canonical_json_line().unwrap();
         let (parsed, injected) =
             Settings::parse_with_policy(complete.as_bytes(), MissingProviders::FillFromCatalog)
@@ -436,16 +399,6 @@ mod tests {
 
     #[test]
     fn filled_rows_come_from_default_enabled_not_a_hard_coded_false() {
-        // A document with the four original providers but without the later
-        // addition. Two things are being pinned. The rows the user already has
-        // are theirs: a read never rewrites them to the default (SET-007),
-        // which is why amp and grok stay on here while a fresh install ships
-        // them off. And the filled row reads `default_enabled` rather than a
-        // hard-coded false, so a future provider that ships enabled is not
-        // silently turned off by a read. Only the second half is weakly
-        // covered today: antigravity is the sole injectable row and its
-        // default is already false, so the two spellings agree by accident.
-        // Adding a provider that ships enabled is what makes this bite.
         let four = br#"{"schemaVersion":1,"providers":[{"id":"claude","enabled":true},{"id":"codex","enabled":true},{"id":"amp","enabled":true},{"id":"grok","enabled":true}],"display":{"metric":"remaining"},"refreshIntervalSeconds":60,"notifications":{"enabled":true}}"#;
         let (filled, injected) =
             Settings::parse_with_policy(four, MissingProviders::FillFromCatalog).unwrap();
@@ -472,9 +425,6 @@ mod tests {
 
     #[test]
     fn fill_from_catalog_never_repairs_a_truncated_document() {
-        // Missing one of the original v10 providers means the user removed a
-        // row (or the file is corrupt); completing it would re-enable
-        // providers they never chose. SET-006 applies on every path.
         let truncated = br#"{"schemaVersion":1,"providers":[{"id":"claude","enabled":true}],"display":{"metric":"remaining"},"refreshIntervalSeconds":60,"notifications":{"enabled":true}}"#;
         let err =
             Settings::parse_with_policy(truncated, MissingProviders::FillFromCatalog).unwrap_err();
@@ -503,9 +453,6 @@ mod tests {
 
     #[test]
     fn only_claude_and_codex_start_enabled() {
-        // SET-027: a first run shows the two providers nearly every user has a
-        // CLI for. Amp, Grok, and Antigravity are opt-in from Settings, so a
-        // missing CLI never renders as a permanent chip nobody asked for.
         assert!(default_enabled(ProviderId::Claude));
         assert!(default_enabled(ProviderId::Codex));
         assert!(!default_enabled(ProviderId::Amp));
@@ -515,8 +462,6 @@ mod tests {
 
     #[test]
     fn reminder_minutes_defaults_when_absent() {
-        // Settings reads never rewrite (SET-007), so an existing settings.json
-        // predating this field must parse and take the default silently.
         let doc = br#"{"schemaVersion":1,"providers":[{"id":"claude","enabled":true},{"id":"codex","enabled":true},{"id":"amp","enabled":true},{"id":"grok","enabled":true},{"id":"antigravity","enabled":false}],"display":{"metric":"remaining"},"refreshIntervalSeconds":60,"notifications":{"enabled":true}}"#;
         let parsed = Settings::parse_strict(doc).unwrap();
         assert_eq!(
@@ -544,9 +489,6 @@ mod tests {
 
     #[test]
     fn reminder_minutes_survives_the_hand_written_allowlist() {
-        // deny_unknown_fields is not the only gate: reject_unknown_top_level
-        // walks raw JSON before deserialization and would reject the key on
-        // its own.
         let doc = br#"{"schemaVersion":1,"providers":[{"id":"claude","enabled":true},{"id":"codex","enabled":true},{"id":"amp","enabled":true},{"id":"grok","enabled":true},{"id":"antigravity","enabled":false}],"display":{"metric":"remaining"},"refreshIntervalSeconds":60,"notifications":{"enabled":true,"reminderMinutes":240}}"#;
         let parsed = Settings::parse_strict(doc).unwrap();
         assert_eq!(parsed.notifications.reminder_minutes, 240);
@@ -554,8 +496,6 @@ mod tests {
 
     #[test]
     fn automatic_updates_default_on_when_absent() {
-        // Every settings.json written before this block must keep parsing
-        // (SET-007), and it takes the product default: updates are automatic.
         let doc = br#"{"schemaVersion":1,"providers":[{"id":"claude","enabled":true},{"id":"codex","enabled":true},{"id":"amp","enabled":true},{"id":"grok","enabled":true},{"id":"antigravity","enabled":false}],"display":{"metric":"remaining"},"refreshIntervalSeconds":60,"notifications":{"enabled":true}}"#;
         let parsed = Settings::parse_strict(doc).unwrap();
         assert!(parsed.updates.automatic);

--- a/src/settings/store.rs
+++ b/src/settings/store.rs
@@ -1,5 +1,3 @@
-//! Read-pure show and atomic complete-document apply for settings v1.
-
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -45,7 +43,6 @@ impl From<io::Error> for StoreError {
     }
 }
 
-/// Canonical settings.json store.
 #[derive(Debug, Clone)]
 pub struct SettingsStore {
     path: PathBuf,
@@ -60,7 +57,6 @@ impl SettingsStore {
         }
     }
 
-    /// Convenience constructor: settings path + sibling maintenance lock path.
     pub fn with_paths(
         settings_path: impl Into<PathBuf>,
         lock_path: impl Into<PathBuf>,
@@ -79,13 +75,6 @@ impl SettingsStore {
 
     /// Read-only show: missing file returns defaults without creating anything.
     /// Existing file is never rewritten, migrated, or touched (mtime preserved).
-    ///
-    /// A document that predates a catalog addition is completed in memory from
-    /// the catalog ([`MissingProviders::FillFromCatalog`]) so a settings.json
-    /// written by an older build still yields a usable document. The injection
-    /// is deliberately not persisted: SET-007 forbids a read from writing, and
-    /// only the explicit migration may rewrite the file. Unknown IDs,
-    /// duplicates, and every other validation failure stay hard errors.
     pub fn show(&self) -> Result<Settings, StoreError> {
         match fs::read(&self.path) {
             Ok(bytes) => {
@@ -104,7 +93,6 @@ impl SettingsStore {
         document.validate()?;
         let canonical = document.clone();
         let bytes = canonical.to_canonical_json_line()?;
-        // Shared gate: blocks behind exclusive maintenance without writing first.
         let _guard = self.gate.lock_shared()?;
         replace_atomically(&self.path, bytes.as_bytes(), 0o600)?;
         Ok(canonical)
@@ -136,7 +124,6 @@ impl SettingsStore {
     }
 }
 
-/// Snapshot mtime for purity tests.
 pub fn file_mtime(path: &Path) -> io::Result<Option<SystemTime>> {
     match fs::metadata(path) {
         Ok(meta) => Ok(Some(meta.modified()?)),
@@ -210,14 +197,10 @@ mod tests {
         assert_eq!(file_mtime(store.path()).unwrap().unwrap(), before_mtime);
     }
 
-    /// A settings.json written before Antigravity joined the catalog.
     const FOUR_PROVIDER_DOCUMENT: &[u8] = br#"{"schemaVersion":1,"providers":[{"id":"claude","enabled":true},{"id":"codex","enabled":true},{"id":"amp","enabled":true},{"id":"grok","enabled":true}],"display":{"metric":"remaining"},"refreshIntervalSeconds":60,"notifications":{"enabled":true}}"#;
 
     #[test]
     fn show_fills_a_missing_provider_in_memory_without_writing() {
-        // A document from an older build must still read; SET-007 means the
-        // repair happens in memory only, so the file keeps its exact bytes and
-        // mtime and the explicit migration remains the only writer.
         let dir = tempfile::tempdir().unwrap();
         let store = store_in(dir.path());
         fs::write(store.path(), FOUR_PROVIDER_DOCUMENT).unwrap();
@@ -238,9 +221,6 @@ mod tests {
 
     #[test]
     fn show_rejects_a_truncated_provider_list() {
-        // Tolerance covers "the catalog grew", never "the user deleted rows":
-        // filling codex/amp/grok back in would re-enable providers the user
-        // removed. Such a file stays a hard error, exactly as on master.
         let dir = tempfile::tempdir().unwrap();
         let store = store_in(dir.path());
         fs::write(
@@ -262,7 +242,6 @@ mod tests {
 
     #[test]
     fn show_still_rejects_an_unknown_or_duplicated_provider() {
-        // Tolerance is scoped to "the catalog grew", not to a corrupt file.
         let dir = tempfile::tempdir().unwrap();
         let store = store_in(dir.path());
 
@@ -291,8 +270,6 @@ mod tests {
 
     #[test]
     fn apply_raw_still_demands_every_provider() {
-        // SET-006: `config apply` replaces the whole document, so accepting a
-        // partial one would silently drop the caller's intent for the rest.
         let dir = tempfile::tempdir().unwrap();
         let store = store_in(dir.path());
         match store.apply_raw(FOUR_PROVIDER_DOCUMENT).unwrap_err() {
@@ -361,7 +338,6 @@ mod tests {
             assert!(matches!(err, StoreError::Io(_)));
             assert_eq!(fs::read(store.path()).unwrap(), previous_bytes);
         }
-        // Control: success still works.
         store.try_apply_with(&next, &StdFileMutator).unwrap();
         assert_eq!(store.show().unwrap().refresh_interval_seconds, 90);
     }
@@ -376,7 +352,6 @@ mod tests {
         let previous_mtime = file_mtime(store.path()).unwrap().unwrap();
 
         let exclusive = store.gate().lock_exclusive().unwrap();
-        // Non-blocking path proves we do not write while exclusive is held.
         let mut next = Settings::defaults();
         next.refresh_interval_seconds = 180;
         let err = store.try_apply_with(&next, &StdFileMutator).unwrap_err();
@@ -394,14 +369,12 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let store = store_in(dir.path());
         let fixture = include_str!("../../tests/fixtures/settings-v1/valid-defaults.json");
-        // Fixture may lack trailing newline; apply_raw accepts object body.
         let mut raw = fixture.trim().to_owned();
         let stored = store.apply_raw(raw.as_bytes()).unwrap();
         assert_eq!(stored, Settings::defaults());
         let line = stored.to_canonical_json_line().unwrap();
         assert!(line.ends_with('\n'));
         raw.push('\n');
-        // Canonical encoding may differ in spacing; semantic equality is enough.
         assert_eq!(Settings::parse_strict(line.as_bytes()).unwrap(), stored);
     }
 }

--- a/src/status/collect.rs
+++ b/src/status/collect.rs
@@ -1,10 +1,7 @@
-//! Map temporary [`ProviderResult`] values into validated [`ProviderStatus`].
-
 use super::schema::{
     ErrorCode, ProviderAction, ProviderError, ProviderResult, ProviderStatus, SchemaError,
 };
 
-/// Convert a typed collection result into a completed provider status row.
 pub fn provider_status_from_result(result: ProviderResult) -> Result<ProviderStatus, SchemaError> {
     match result {
         ProviderResult::Ready {

--- a/src/status/coordinator.rs
+++ b/src/status/coordinator.rs
@@ -1,5 +1,3 @@
-//! Status collection coordinator: cache, adapters, optional notifications.
-
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -21,7 +19,6 @@ use crate::status::schema::{
 };
 use crate::support::{Clock, FileSystem, RealFileSystem, SharedMaintenanceGate, SystemClock};
 
-/// Request for a status collection cycle (mirrors CLI status options).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CollectRequest {
     pub format: StatusFormat,
@@ -41,7 +38,6 @@ impl Default for CollectRequest {
     }
 }
 
-/// Dependencies for status collection.
 pub struct StatusCoordinator<C, F, P, H>
 where
     C: Clock,
@@ -62,7 +58,6 @@ where
 }
 
 impl StatusCoordinator<SystemClock, RealFileSystem, TokioProcessRunner, ReqwestHttpClient> {
-    /// Production constructor from XDG paths and process environment.
     pub fn production(gate: SharedMaintenanceGate) -> Result<Self, String> {
         let env = ExecutionEnvironment::from_process();
         let settings_store = SettingsStore::with_paths(
@@ -103,7 +98,6 @@ where
     P: ProcessRunner,
     H: HttpClient,
 {
-    /// Collect provider status into a validated envelope.
     pub async fn collect(
         &self,
         request: CollectRequest,
@@ -145,8 +139,6 @@ where
                     to_collect.push(*id);
                 }
                 CacheMode::Bypass => {
-                    // CACHE-010: accept a live generation only if it started at or
-                    // after this request, and the cache entry matches that generation.
                     if self.cache_coord.bypass_accepts(*id, requested_at) {
                         if let Some(entry) = cache_doc.get(*id) {
                             if entry.started_at >= requested_at {
@@ -173,7 +165,6 @@ where
             let completed = self.clock.now_utc();
             let ttl = descriptor_ttl(id);
             let entry = entry_from_status(status.clone(), started, completed, ttl);
-            // CACHE-019A: live collection must atomically update the cache.
             cache_doc = self
                 .cache_store
                 .merge_provider(id, entry, completed)
@@ -183,7 +174,6 @@ where
             statuses.push(status);
         }
 
-        // Order statuses by settings / request order.
         let mut ordered = Vec::new();
         for id in &targets {
             if let Some(status) = statuses.iter().find(|s| s.id() == *id) {
@@ -238,7 +228,6 @@ where
     }
 }
 
-/// If live result is a temporary failure and prior ready/stale data exists, retain as stale.
 fn apply_stale_retention(
     live: ProviderStatus,
     prior: Option<&ProviderStatus>,
@@ -414,8 +403,6 @@ mod tests {
         }
     }
 
-    /// HTTP seam that rejects every bearer token, the answer a real server
-    /// gives to an expired Grok access token.
     struct RejectingHttp;
     impl HttpClient for RejectingHttp {
         fn get(
@@ -513,10 +500,6 @@ mod tests {
 
     #[tokio::test]
     async fn collect_survives_a_settings_file_predating_a_catalog_addition() {
-        // A settings.json written before Antigravity joined the catalog must
-        // not break `status`: the store completes it from the catalog in
-        // memory, the newcomer stays disabled by default, and the file is left
-        // exactly as it was (SET-007).
         let dir = tempfile::tempdir().unwrap();
         let coord = coord_at(dir.path(), datetime!(2026-07-26 18:42:00 UTC));
         let four = br#"{"schemaVersion":1,"providers":[{"id":"claude","enabled":true},{"id":"codex","enabled":true},{"id":"amp","enabled":true},{"id":"grok","enabled":true}],"display":{"metric":"remaining"},"refreshIntervalSeconds":60,"notifications":{"enabled":true}}"#;
@@ -593,7 +576,6 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let now = datetime!(2026-08-25 11:50:31 UTC);
         let coord = coord_at(dir.path(), now);
-        // A failure row that would still be inside Claude's 300 s success TTL.
         let failed = fallback_provider_error(ProviderId::Claude, "Claude returned no limits.");
         let entry = entry_from_status(failed, now, now, std::time::Duration::from_secs(300));
         coord
@@ -611,10 +593,6 @@ mod tests {
             .await
             .unwrap();
         let row = &envelope.providers()[0];
-        // The primed cache row is ProviderError; coord_at has no Claude
-        // credentials file, so a live collection yields Unauthenticated
-        // instead. Only a real re-collection can produce this state — a
-        // served cache hit would keep ProviderError.
         assert_eq!(
             row.state(),
             ProviderState::Unauthenticated,
@@ -641,8 +619,6 @@ mod tests {
         assert!(doc.is_fresh(ProviderId::Claude, now));
         assert!(!doc.is_fresh(ProviderId::Claude, now + time::Duration::seconds(301)));
 
-        // A Stale row (retained prior windows after a temporary failure) must
-        // stay fresh too, exercising the ProviderState::Stale arm.
         let live = ProviderStatus::network_error(
             ProviderId::Claude,
             "Claude",
@@ -680,7 +656,6 @@ mod tests {
 
     #[tokio::test]
     async fn retryable_auth_failure_retains_prior_ready_as_stale() {
-        // Expired-token style failure (retryable) keeps last good windows.
         let now = datetime!(2026-07-28 18:42:00 UTC);
         let prior = ready_claude(now);
         let live = ProviderStatus::unauthenticated(
@@ -696,19 +671,13 @@ mod tests {
         assert!(out.error().is_some_and(|e| e.retryable));
     }
 
-    /// End to end through the real Grok adapter: an expired `auth.json` with
-    /// no `grok` executable to refresh it keeps the cached reading as stale
-    /// (CACHE-024) instead of overwriting it with `unauthenticated`.
     #[tokio::test]
     async fn expired_grok_token_keeps_cached_reading_as_stale() {
         let dir = tempfile::tempdir().unwrap();
         let now = datetime!(2026-09-04 06:00:00 UTC);
-        // Without the local expiry check the adapter would send the expired
-        // token, get 401, and report a non-retryable rejection.
         let coord = coord_with_http(dir.path(), now, RejectingHttp);
         coord.fs.files.lock().unwrap().insert(
             dir.path().join("home").join(".grok").join("auth.json"),
-            // Synthetic key — not a real credential.
             br#"{"https://auth.x.ai::client":{"key":"SYNTH_GROK_KEY_NOT_REAL","first_name":"Ada","expires_at":"2026-09-04T05:39:31.448014581Z","auth_mode":"oidc"}}"#
                 .to_vec(),
         );
@@ -776,7 +745,6 @@ mod tests {
         let t2 = datetime!(2026-07-26 18:00:02 UTC);
         let coord = coord_at(dir.path(), t2);
 
-        // Generation started before a hypothetical request at t1 must not satisfy it.
         let rev = coord.cache_coord.start_generation(ProviderId::Amp, t0);
         let status = ProviderStatus::ready(
             ProviderId::Amp,
@@ -796,7 +764,6 @@ mod tests {
         coord.cache_coord.complete_generation(rev, t0);
         assert!(!coord.cache_coord.bypass_accepts(ProviderId::Amp, t1));
 
-        // Generation started at t1 satisfies request at t1.
         let rev2 = coord.cache_coord.start_generation(ProviderId::Amp, t1);
         let status2 = ProviderStatus::ready(
             ProviderId::Amp,
@@ -816,7 +783,6 @@ mod tests {
         coord.cache_coord.complete_generation(rev2, t2);
         assert!(coord.cache_coord.bypass_accepts(ProviderId::Amp, t1));
 
-        // Coordinator bypass path should serve without recollecting when generation qualifies.
         let envelope = coord
             .collect(CollectRequest {
                 format: StatusFormat::Json,
@@ -826,8 +792,6 @@ mod tests {
             })
             .await
             .unwrap();
-        // Requested_at is coord clock t2; generation started at t1 < t2 so bypass must recollect.
-        // Recollect with NoopProcess yields non-ready Amp; just assert one row.
         assert_eq!(envelope.providers().len(), 1);
     }
 
@@ -854,7 +818,6 @@ mod tests {
     async fn bypass_serves_qualifying_generation_without_recollect() {
         let dir = tempfile::tempdir().unwrap();
         let t1 = datetime!(2026-07-26 18:00:01 UTC);
-        // Clock stays at t1 so requested_at == generation start.
         let coord = coord_at(dir.path(), t1);
         let rev = coord.cache_coord.start_generation(ProviderId::Amp, t1);
         let status = ProviderStatus::ready(

--- a/src/status/human.rs
+++ b/src/status/human.rs
@@ -1,8 +1,5 @@
-//! Terminal-safe English human status formatting (CLI-012).
-
 use super::schema::{DataSource, ProviderState, StatusEnvelope};
 
-/// Format a validated envelope as plain English text for `status format human`.
 pub fn format_human(envelope: &StatusEnvelope) -> String {
     let mut out = String::new();
     out.push_str("Agent Bar status\n");

--- a/src/status/mod.rs
+++ b/src/status/mod.rs
@@ -1,5 +1,3 @@
-//! Status collection domain: schema-v2 types, mapping, and human formatting.
-
 pub mod collect;
 pub mod coordinator;
 pub mod human;

--- a/src/status/schema.rs
+++ b/src/status/schema.rs
@@ -16,7 +16,6 @@ use crate::cli::{CacheMode, ProviderId, SERIALIZATION};
 const SCHEMA_VERSION: u32 = 2;
 const PERCENT_SUM_TOLERANCE: f64 = 0.01;
 
-/// Semantic or construction failure for status schema v2.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SchemaError {
     message: String,
@@ -42,7 +41,6 @@ impl fmt::Display for SchemaError {
 
 impl std::error::Error for SchemaError {}
 
-/// Failure writing status JSON (maps to helper exit code 4).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StatusOutputError {
     message: String,
@@ -84,7 +82,6 @@ impl From<SchemaError> for StatusOutputError {
     }
 }
 
-/// Completed provider state (helper response; never `loading`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ProviderState {
@@ -111,7 +108,6 @@ impl ProviderState {
     }
 }
 
-/// Provenance of retained provider data.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum DataSource {
@@ -128,7 +124,6 @@ impl DataSource {
     }
 }
 
-/// Closed error codes for provider failures.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ErrorCode {
@@ -151,7 +146,6 @@ impl ErrorCode {
     }
 }
 
-/// Closed action kinds for QML service methods.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ActionKind {
@@ -170,7 +164,6 @@ impl ActionKind {
     }
 }
 
-/// Typed provider error payload.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ProviderError {
@@ -189,7 +182,6 @@ impl ProviderError {
     }
 }
 
-/// Typed provider action payload.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ProviderAction {
@@ -233,7 +225,6 @@ impl ProviderAction {
     }
 }
 
-/// Plan identity shown in the UI.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Plan {
@@ -248,7 +239,6 @@ pub struct Account {
     pub label: String,
 }
 
-/// One percentage quota window with validated percentages.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct UsageWindow {
@@ -261,7 +251,6 @@ pub struct UsageWindow {
 }
 
 impl UsageWindow {
-    /// Construct a window after enforcing finite range and sum invariants.
     pub fn try_new(
         id: impl Into<String>,
         label: impl Into<String>,
@@ -318,7 +307,6 @@ impl UsageWindow {
     }
 }
 
-/// One provider row in a status envelope.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ProviderStatus {
@@ -337,7 +325,6 @@ pub struct ProviderStatus {
     rate_limit_resets_available: Option<u32>,
 }
 
-/// Serde adapter so [`ProviderId`] serializes as a lowercase string.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct ProviderIdSerde(ProviderId);
 
@@ -407,15 +394,11 @@ impl ProviderStatus {
         self.rate_limit_resets_available
     }
 
-    /// Attach a provider-granted rate-limit reset count after construction.
-    /// Used by the `ProviderResult::Ready` conversion and by stale/cache-hit
-    /// rebuilds that must carry the previous value through.
     pub(crate) fn with_rate_limit_resets_available(mut self, value: Option<u32>) -> Self {
         self.rate_limit_resets_available = value;
         self
     }
 
-    /// When serving a previously live ready row from cache, label source as `cache`.
     pub fn for_cache_hit(&self) -> Result<Self, SchemaError> {
         match self.state {
             ProviderState::Ready => {
@@ -435,12 +418,10 @@ impl ProviderStatus {
                     status.with_rate_limit_resets_available(self.rate_limit_resets_available)
                 })
             }
-            // Stale already uses source=cache; other states keep their shape.
             _ => Ok(self.clone()),
         }
     }
 
-    /// Retain last good connected data after a temporary refresh failure (CACHE-022).
     pub fn retain_as_stale(&self, error: ProviderError) -> Result<Self, SchemaError> {
         let last = self
             .last_success_at
@@ -463,8 +444,6 @@ impl ProviderStatus {
         .map(|status| status.with_rate_limit_resets_available(self.rate_limit_resets_available))
     }
 
-    /// Temporary failures eligible for stale retention. Rejected auth and
-    /// missing CLI never retain; an expired session (retryable auth) does.
     pub fn is_temporary_failure(&self) -> bool {
         match self.state {
             ProviderState::NetworkError | ProviderState::RateLimited => true,
@@ -766,7 +745,6 @@ fn failure_state(
     })
 }
 
-/// Request echo embedded in the status envelope.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct StatusRequest {
@@ -800,7 +778,6 @@ where
     serializer.serialize_str(word)
 }
 
-/// Completed status schema-v2 envelope.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct StatusEnvelope {
@@ -831,7 +808,6 @@ impl StatusEnvelope {
         Ok(envelope)
     }
 
-    /// Build an envelope using the running package version as `helperVersion`.
     pub fn try_new_for_package(
         generated_at: OffsetDateTime,
         request: StatusRequest,
@@ -860,7 +836,6 @@ impl StatusEnvelope {
         &self.providers
     }
 
-    /// Every Rust-owned semantic invariant for a completed envelope.
     pub fn validate_semantics(&self) -> Result<(), SchemaError> {
         if self.schema_version != SCHEMA_VERSION {
             return Err(SchemaError::new("schemaVersion must be 2"));
@@ -874,7 +849,6 @@ impl StatusEnvelope {
         }
         require_utc(self.generated_at, "generatedAt")?;
 
-        // Explicit-provider response contains exactly that provider.
         if let Some(expected) = self.request.provider {
             if self.providers.len() != 1 {
                 return Err(SchemaError::new(
@@ -916,14 +890,9 @@ impl StatusEnvelope {
             }
         }
 
-        // Request/settings order: when no explicit provider, IDs must be unique
-        // (already checked) and callers supply settings order. We only prove
-        // uniqueness here; order preservation is the coordinator's duty and is
-        // checked when a requested order is provided.
         Ok(())
     }
 
-    /// Validate then serialize exactly one JSON object plus a trailing newline.
     pub fn to_json_line(&self) -> Result<String, StatusOutputError> {
         self.validate_semantics()?;
         let mut body = serde_json::to_string(self).map_err(|err| {
@@ -933,7 +902,6 @@ impl StatusEnvelope {
         Ok(body)
     }
 
-    /// Validate request/settings provider order against an expected sequence.
     pub fn validate_provider_order(&self, expected: &[ProviderId]) -> Result<(), SchemaError> {
         let actual: Vec<ProviderId> = self.providers.iter().map(ProviderStatus::id).collect();
         if actual.as_slice() != expected {
@@ -945,7 +913,6 @@ impl StatusEnvelope {
     }
 }
 
-/// Temporary collection result owned here until Task 6 moves it to providers.
 #[derive(Debug, Clone, PartialEq)]
 pub enum ProviderResult {
     Ready {
@@ -1015,7 +982,6 @@ fn require_utc(ts: OffsetDateTime, field: &str) -> Result<(), SchemaError> {
     if ts.offset() != UtcOffset::UTC {
         return Err(SchemaError::new(format!("{field} must be UTC RFC 3339")));
     }
-    // Round-trip through RFC3339 to reject pathological values early.
     ts.format(&Rfc3339).map_err(|err| {
         SchemaError::new(format!("{field} is not a valid RFC 3339 timestamp: {err}"))
     })?;
@@ -1035,7 +1001,6 @@ fn ensure_unique_window_ids(windows: &[UsageWindow]) -> Result<(), SchemaError> 
     Ok(())
 }
 
-/// Test-only hook: force `to_json_line` serialization path failure mapping.
 #[cfg(test)]
 pub(crate) fn map_serialize_error(err: impl fmt::Display) -> StatusOutputError {
     StatusOutputError::serialize(format!("status serialization failed: {err}"))
@@ -1304,7 +1269,6 @@ mod tests {
 
     #[test]
     fn helper_version_must_equal_package_version() {
-        // Deliberately wrong helperVersion — must never equal CARGO_PKG_VERSION.
         let err = StatusEnvelope::try_new(
             "0.0.0-not-package",
             ts(),
@@ -1384,7 +1348,6 @@ mod tests {
         let raw =
             fs::read_to_string(root.join("tests/fixtures/status-v2/money-field.json")).unwrap();
         let value: Value = serde_json::from_str(&raw).unwrap();
-        // Domain construction has no spend field; fixture remains a rejection sample only.
         assert!(value["providers"][0]["windows"][0]
             .get("spendUsd")
             .is_some());
@@ -1457,8 +1420,6 @@ mod tests {
 
     #[test]
     fn provider_status_serializes_reset_count_only_when_present() {
-        // ProviderStatus derives Deserialize: build both rows via serde and
-        // assert the key round-trips only when present.
         let base = serde_json::json!({
             "id": "codex", "name": "Codex", "state": "ready", "source": "live",
             "plan": null, "account": null, "windows": [],

--- a/src/support/atomic_file.rs
+++ b/src/support/atomic_file.rs
@@ -1,5 +1,3 @@
-//! Same-filesystem atomic file replacement with restrictive permissions.
-
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
@@ -7,7 +5,6 @@ use std::path::{Path, PathBuf};
 #[cfg(unix)]
 use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 
-/// Failure injection points for atomic replacement tests.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AtomicFailPoint {
     Write,
@@ -16,7 +13,6 @@ pub enum AtomicFailPoint {
     FsyncDir,
 }
 
-/// Mutable filesystem operations used by [`replace_atomically_with`].
 pub trait FileMutator: Send + Sync {
     fn create_temp(&self, dir: &Path) -> io::Result<(PathBuf, File)>;
     fn write_all(&self, file: &mut File, bytes: &[u8]) -> io::Result<()>;
@@ -26,7 +22,6 @@ pub trait FileMutator: Send + Sync {
     fn sync_dir(&self, dir: &Path) -> io::Result<()>;
 }
 
-/// Production mutator backed by `std::fs`.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct StdFileMutator;
 
@@ -39,7 +34,6 @@ impl FileMutator for StdFileMutator {
         {
             opts.mode(0o600);
         }
-        // Unique temp name on the same filesystem as the target directory.
         let name = format!(
             ".agent-bar-{}.tmp",
             std::time::SystemTime::now()
@@ -93,7 +87,6 @@ pub fn replace_atomically(target: &Path, bytes: &[u8], mode: u32) -> io::Result<
     replace_atomically_with(&StdFileMutator, target, bytes, mode)
 }
 
-/// Atomic replacement with an injectable filesystem mutator.
 pub fn replace_atomically_with<M: FileMutator + ?Sized>(
     mutator: &M,
     target: &Path,
@@ -134,7 +127,6 @@ pub fn replace_atomically_with<M: FileMutator + ?Sized>(
     Ok(())
 }
 
-/// Test mutator that fails at a configured step after optionally writing.
 #[cfg(test)]
 #[derive(Debug)]
 pub struct FailingMutator {

--- a/src/support/clock.rs
+++ b/src/support/clock.rs
@@ -1,13 +1,9 @@
-//! Injectable wall-clock seam for deterministic tests.
-
 use time::OffsetDateTime;
 
-/// Produces the current UTC instant.
 pub trait Clock: Send + Sync {
     fn now_utc(&self) -> OffsetDateTime;
 }
 
-/// Production clock backed by the system wall clock.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct SystemClock;
 

--- a/src/support/countdown.rs
+++ b/src/support/countdown.rs
@@ -74,8 +74,6 @@ mod tests {
 
     #[test]
     fn seconds_never_round_the_minute_up() {
-        // 59 seconds short of an hour is 59m, not 1h — the popup would
-        // otherwise promise a reset that has not arrived.
         let now = datetime!(2026-07-28 15:00:00 UTC);
         assert_eq!(
             reset_countdown(now, datetime!(2026-07-28 15:59:59 UTC)),

--- a/src/support/fs.rs
+++ b/src/support/fs.rs
@@ -1,10 +1,7 @@
-//! Injectable filesystem seam for deterministic tests and plugin transactions.
-
 use std::io;
 use std::path::Path;
 use std::time::SystemTime;
 
-/// Metadata subset required by settings, cache, and plugin transactions.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FileMetadata {
     pub len: u64,
@@ -13,7 +10,6 @@ pub struct FileMetadata {
     pub is_symlink: bool,
 }
 
-/// Read-only filesystem operations used by pure domain code.
 pub trait FileSystem: Send + Sync {
     fn read(&self, path: &Path) -> io::Result<Vec<u8>>;
     fn metadata(&self, path: &Path) -> io::Result<FileMetadata>;
@@ -22,7 +18,6 @@ pub trait FileSystem: Send + Sync {
     }
 }
 
-/// Production filesystem backed by `std::fs`.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct RealFileSystem;
 

--- a/src/support/maintenance_gate.rs
+++ b/src/support/maintenance_gate.rs
@@ -1,5 +1,3 @@
-//! Shared/exclusive maintenance gate for settings, cache, and plugin work.
-
 use std::fs::{File, OpenOptions};
 use std::io;
 use std::path::{Path, PathBuf};
@@ -14,13 +12,11 @@ pub struct MaintenanceGate {
     path: PathBuf,
 }
 
-/// RAII guard holding a shared maintenance lock.
 #[derive(Debug)]
 pub struct SharedMaintenanceGuard {
     file: File,
 }
 
-/// RAII guard holding an exclusive maintenance lock.
 #[derive(Debug)]
 pub struct ExclusiveMaintenanceGuard {
     file: File,
@@ -39,13 +35,11 @@ impl Drop for ExclusiveMaintenanceGuard {
 }
 
 impl MaintenanceGate {
-    /// Open (or create) the lock file at `path`.
     pub fn open(path: impl Into<PathBuf>) -> io::Result<Self> {
         let path = path.into();
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)?;
         }
-        // Ensure the lock file exists for reopen() callers.
         let _file = OpenOptions::new()
             .read(true)
             .write(true)
@@ -59,7 +53,6 @@ impl MaintenanceGate {
         &self.path
     }
 
-    /// Block until a shared lock is available.
     pub fn lock_shared(&self) -> io::Result<SharedMaintenanceGuard> {
         let file = self.reopen()?;
         // Prefer fs2 over std::fs::File locks (Rust 1.89+) for stable io::Error.
@@ -67,7 +60,6 @@ impl MaintenanceGate {
         Ok(SharedMaintenanceGuard { file })
     }
 
-    /// Non-blocking shared lock attempt.
     pub fn try_lock_shared(&self) -> io::Result<Option<SharedMaintenanceGuard>> {
         let file = self.reopen()?;
         match FileExt::try_lock_shared(&file) {
@@ -77,14 +69,12 @@ impl MaintenanceGate {
         }
     }
 
-    /// Block until an exclusive lock is available.
     pub fn lock_exclusive(&self) -> io::Result<ExclusiveMaintenanceGuard> {
         let file = self.reopen()?;
         FileExt::lock_exclusive(&file)?;
         Ok(ExclusiveMaintenanceGuard { file })
     }
 
-    /// Non-blocking exclusive lock attempt.
     pub fn try_lock_exclusive(&self) -> io::Result<Option<ExclusiveMaintenanceGuard>> {
         let file = self.reopen()?;
         match FileExt::try_lock_exclusive(&file) {
@@ -111,7 +101,6 @@ fn is_lock_busy(err: &io::Error) -> bool {
         || err.to_string().to_ascii_lowercase().contains("would block")
 }
 
-/// Shared ownership wrapper for process-wide gate injection in stores.
 pub type SharedMaintenanceGate = Arc<MaintenanceGate>;
 
 pub fn shared_gate(path: impl Into<PathBuf>) -> io::Result<SharedMaintenanceGate> {
@@ -156,7 +145,6 @@ mod tests {
         let gate2 = Arc::clone(&gate);
         let (tx, rx) = mpsc::channel();
         let handle = thread::spawn(move || {
-            // Must not obtain shared while exclusive is held.
             assert!(gate2.try_lock_shared().unwrap().is_none());
             tx.send(()).unwrap();
             let _shared = gate2.lock_shared().unwrap();

--- a/src/support/mod.rs
+++ b/src/support/mod.rs
@@ -1,5 +1,3 @@
-//! Shared test seams and filesystem/clock primitives for v10.
-
 pub mod atomic_file;
 mod clock;
 pub mod countdown;

--- a/src/support/redact.rs
+++ b/src/support/redact.rs
@@ -1,5 +1,3 @@
-//! Sanitization of external process and provider strings.
-
 /// Strip ANSI CSI/OSC sequences and non-whitespace C0 control characters.
 ///
 /// Keeps TAB/LF/CR. Used at the process and adapter boundary so raw control
@@ -10,7 +8,6 @@ pub fn strip_ansi_and_controls(input: &str) -> String {
     let mut i = 0usize;
     while i < bytes.len() {
         let b = bytes[i];
-        // ESC ... ANSI / OSC sequences
         if b == 0x1b {
             i += 1;
             if i >= bytes.len() {
@@ -50,7 +47,6 @@ pub fn strip_ansi_and_controls(input: &str) -> String {
             }
             continue;
         }
-        // Allow printable UTF-8 via chars for multi-byte; handle ASCII controls.
         if b < 0x20 {
             if matches!(b, b'\t' | b'\n' | b'\r') {
                 out.push(b as char);
@@ -62,7 +58,6 @@ pub fn strip_ansi_and_controls(input: &str) -> String {
             i += 1;
             continue;
         }
-        // Copy one UTF-8 character starting at i.
         let rest = &input[i..];
         if let Some(ch) = rest.chars().next() {
             out.push(ch);
@@ -74,7 +69,6 @@ pub fn strip_ansi_and_controls(input: &str) -> String {
     out
 }
 
-/// Redact bytes as lossy UTF-8 then strip controls/ANSI.
 pub fn redact_process_bytes(bytes: &[u8]) -> String {
     strip_ansi_and_controls(&String::from_utf8_lossy(bytes))
 }

--- a/tests/active_docs.rs
+++ b/tests/active_docs.rs
@@ -1,9 +1,4 @@
-//! Active documentation gates (DOC-001–DOC-004 / TEST-032 / TEST-033).
-//!
-//! - Every executable helper command example parses under the v10 grammar.
-//! - Every status/settings JSON example validates against checked-in schemas.
-//! - Every relative Markdown link resolves inside the repository.
-//! - Active product docs no longer carry pre-implementation target-only banners.
+//! DOC-001–DOC-004 / TEST-032 / TEST-033
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -16,7 +11,6 @@ fn workspace_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
 }
 
-/// Product and engineering documentation under the active language/legacy gate.
 fn active_doc_paths(root: &Path) -> Vec<PathBuf> {
     let mut paths = Vec::new();
     let top_level = [
@@ -34,7 +28,6 @@ fn active_doc_paths(root: &Path) -> Vec<PathBuf> {
         }
     }
 
-    // Active docs under docs/, excluding historical cuts and the specification package.
     let docs_root = root.join("docs");
     if docs_root.is_dir() {
         let mut stack = vec![docs_root];
@@ -56,7 +49,7 @@ fn active_doc_paths(root: &Path) -> Vec<PathBuf> {
                 if !path.is_file() || !name.ends_with(".md") {
                     continue;
                 }
-                // ADR bodies 0001–0003 remain historical (DOC-003).
+                // DOC-003
                 let rel = path
                     .strip_prefix(root)
                     .map(|p| p.to_string_lossy().replace('\\', "/"))
@@ -89,7 +82,7 @@ fn read_text(path: &Path) -> String {
     })
 }
 
-/// CHANGELOG: only the Unreleased section is active (DOC-003).
+/// DOC-003
 fn changelog_active_slice(content: &str) -> String {
     let mut active = String::new();
     let mut in_unreleased = false;
@@ -162,8 +155,6 @@ fn extract_fences(content: &str) -> Vec<Fence> {
     out
 }
 
-/// Non-helper commands / shell tools that appear in bash fences but are not
-/// private-helper grammar.
 fn is_non_helper_line(line: &str) -> bool {
     let t = line.trim();
     if t.is_empty() || t.starts_with('#') {
@@ -196,7 +187,6 @@ fn is_non_helper_line(line: &str) -> bool {
         || t.starts_with("export ")
 }
 
-/// Lines that are grammar synopsis, not executable examples.
 fn is_synopsis_placeholder(line: &str) -> bool {
     let t = line.trim();
     t.contains('|')
@@ -207,13 +197,6 @@ fn is_synopsis_placeholder(line: &str) -> bool {
         || t.contains("...")
 }
 
-/// Extract private-helper argv from one documentation line.
-///
-/// Accepts:
-/// - `"$PLUGIN" status format json`
-/// - `$PLUGIN status …`
-/// - `agent-bar status …`
-/// - bare synopsis forms without placeholders
 fn extract_helper_argv(line: &str) -> Option<Vec<String>> {
     let trimmed = line.trim();
     if trimmed.is_empty() || is_non_helper_line(trimmed) {
@@ -224,14 +207,11 @@ fn extract_helper_argv(line: &str) -> Option<Vec<String>> {
     }
 
     let mut rest = trimmed;
-    // Strip optional surrounding shell prefixes such as env assignments on the
-    // same line (none expected). Handle quoted/unquoted plugin path forms.
     if rest.starts_with("\"$PLUGIN\"") {
         rest = rest["\"$PLUGIN\"".len()..].trim_start();
     } else if rest.starts_with("$PLUGIN") {
         rest = rest["$PLUGIN".len()..].trim_start();
     } else if let Some(after) = rest.strip_prefix("agent-bar") {
-        // Reject archive/product filenames like `othavi0.agent-bar-10.0.0-…`.
         if !after.is_empty() && !after.starts_with(char::is_whitespace) {
             return None;
         }
@@ -245,14 +225,12 @@ fn extract_helper_argv(line: &str) -> Option<Vec<String>> {
     }
 
     if rest.is_empty() {
-        // Bare `agent-bar` / `"$PLUGIN"` equals default status.
         return Some(Vec::new());
     }
 
     Some(shell_split(rest))
 }
 
-/// Minimal shell-word split supporting single-quoted and double-quoted tokens.
 fn shell_split(input: &str) -> Vec<String> {
     let mut words = Vec::new();
     let mut cur = String::new();
@@ -315,7 +293,7 @@ fn looks_like_settings_v1(value: &Value) -> bool {
         && value.get("display").is_some()
 }
 
-/// Phrases that mark pre-implementation target-only documentation (DOC-005 → DOC-004).
+/// DOC-005 / DOC-004
 const TARGET_ONLY_BANNERS: &[&str] = &[
     "Target documentation for v10",
     "Target product contract for v10",
@@ -352,8 +330,6 @@ fn active_docs_command_examples_parse() {
             if fence.lang != "bash" && fence.lang != "text" && !fence.lang.is_empty() {
                 continue;
             }
-            // Only parse bash fences and plain `agent-bar` text synopsis that are
-            // fully concrete. Skip pure path/text blocks without helper tokens.
             if fence.lang == "text" && !fence.body.contains("agent-bar") {
                 continue;
             }
@@ -405,7 +381,6 @@ fn active_docs_json_examples_validate() {
             if trimmed.is_empty() {
                 continue;
             }
-            // Incomplete placeholder JSON must not appear in active docs.
             if trimmed.contains("...") {
                 failures.push(format!(
                     "{rel}:{}: JSON example contains ellipsis placeholder",
@@ -451,7 +426,6 @@ fn active_docs_json_examples_validate() {
                     ));
                 }
             }
-            // Other JSON (manifest shapes, partial objects) is structural prose only.
         }
     }
 
@@ -471,7 +445,6 @@ fn active_docs_internal_links_resolve() {
     let root = workspace_root();
     let mut checked = 0usize;
     let mut failures = Vec::new();
-    // [text](target) — ignore images that use the same form when target is URL.
     let link_re = regex_lite_links();
 
     for path in active_doc_paths(&root) {
@@ -488,14 +461,12 @@ fn active_docs_internal_links_resolve() {
                 {
                     continue;
                 }
-                // Strip anchor fragments.
                 let path_part = target.split('#').next().unwrap_or(target.as_str());
                 if path_part.is_empty() {
                     continue;
                 }
                 checked += 1;
                 let resolved = if path_part.starts_with('/') {
-                    // Repo-root absolute style is not used; treat as relative miss.
                     root.join(path_part.trim_start_matches('/'))
                 } else {
                     parent.join(path_part)
@@ -524,14 +495,12 @@ fn active_docs_internal_links_resolve() {
     );
 }
 
-/// Lightweight Markdown link extractor without an extra dependency.
 fn regex_lite_links() -> impl Fn(&str) -> Vec<String> {
     |line: &str| {
         let mut out = Vec::new();
         let bytes = line.as_bytes();
         let mut i = 0;
         while i < bytes.len() {
-            // Find "]("
             if bytes[i] == b']' && i + 1 < bytes.len() && bytes[i + 1] == b'(' {
                 let start = i + 2;
                 let mut j = start;
@@ -540,9 +509,7 @@ fn regex_lite_links() -> impl Fn(&str) -> Vec<String> {
                 }
                 if j < bytes.len() {
                     let target = &line[start..j];
-                    // Skip reference-style empty and image titles with spaces only if pure URL.
                     if !target.is_empty() && !target.starts_with('<') {
-                        // Drop optional title: url "title"
                         let url = target
                             .split_whitespace()
                             .next()
@@ -567,11 +534,9 @@ fn active_docs_no_target_only_banners() {
     let mut failures = Vec::new();
     for path in active_doc_paths(&root) {
         let rel = rel_str(&root, &path);
-        // Spec package and historical cuts are excluded by active_doc_paths.
         let body = active_body(&root, &path);
         for banner in TARGET_ONLY_BANNERS {
             if body.contains(banner) {
-                // Locate first line for a useful message.
                 let line_no = body
                     .lines()
                     .position(|l| l.contains(banner) || banner.lines().any(|b| l.contains(b)))
@@ -602,8 +567,6 @@ fn active_docs_release_notes_10_0_0_exist() {
         body.contains("10.0.0"),
         "release notes must mention version 10.0.0"
     );
-    // Historical document: 10.0.0 shipped under the original plugin ID and
-    // keeps it (the ID became othavi0.agent-bar on 2026-08-06).
     assert!(
         body.contains("agent-bar.usage"),
         "release notes must name the plugin product agent-bar.usage"

--- a/tests/active_language.rs
+++ b/tests/active_language.rs
@@ -1,6 +1,4 @@
-//! Active-surface language gate.
-//!
-//! Rule: no tracked text file may contain an alphabetic non-ASCII character.
+//! No tracked text file may contain an alphabetic non-ASCII character.
 //! "Alphabetic" is load-bearing — it flags accented letters while ignoring the
 //! Nerd Font glyphs (Private Use Area) and the punctuation this project uses
 //! on purpose.
@@ -8,13 +6,11 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-/// Deliberate non-ASCII, with the reason it stays.
 const ALLOWLIST: &[(&str, &str)] = &[(
     "src/support/redact.rs",
     "accented fixture for the ANSI and control-character stripper",
 )];
 
-/// Empty, and it stays empty. See `translation_backlog_is_empty`.
 const PENDING_TRANSLATION: &[&str] = &[];
 
 const BINARY_EXTENSIONS: &[&str] = &["png", "jpg", "jpeg", "svg", "ico", "lock"];
@@ -60,7 +56,6 @@ fn is_scannable(rel: &str) -> bool {
     }
 }
 
-/// file:line:offending characters:trimmed line
 fn offenders(root: &Path, rel: &str) -> Vec<String> {
     let Ok(text) = std::fs::read_to_string(root.join(rel)) else {
         return Vec::new();

--- a/tests/active_legacy_scan.rs
+++ b/tests/active_legacy_scan.rs
@@ -1,8 +1,4 @@
-//! Active legacy gate (TEST-030 / TEST-031 / TEST-034).
-//!
-//! Closed behavioral set and path inventory from
-//! `docs/specs/v10/07-testing-and-acceptance.md`; the locked deletion map
-//! below is the executable record of the v10 legacy removal.
+//! TEST-030 / TEST-031 / TEST-034
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
@@ -12,7 +8,6 @@ fn workspace_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
 }
 
-/// Locked deletion inventory — every path must be absent after Task 19.
 const LOCKED_DELETION_PATHS: &[&str] = &[
     "src/action_right.rs",
     "src/tui",
@@ -61,7 +56,6 @@ const LOCKED_DELETION_PATHS: &[&str] = &[
     "install.sh",
 ];
 
-/// Forbidden tokens from the closed behavioral set (exact substring match).
 const FORBIDDEN_TOKENS: &[&str] = &[
     "src/tui",
     "src/usage",
@@ -118,14 +112,8 @@ const FORBIDDEN_TOKENS: &[&str] = &[
     "RELEASES_API_URL",
 ];
 
-/// Relative prefixes excluded from content scans (TEST-031 historical cuts).
+/// TEST-031
 fn is_historical_cut(rel: &str) -> bool {
-    // Dated, frozen release-note snapshots describe what a past,
-    // already-published version actually shipped (e.g. `docs/releases/10.0.0.md`
-    // naming that release's real `.tar.zst` asset). Same rationale as the
-    // ADR/CHANGELOG historical-slice exclusions below: never rewritten.
-    // `docs/releases/README.md` is the live index for the current pipeline
-    // (Task 8), not a dated cut, so it is deliberately NOT covered here.
     if rel.starts_with("docs/releases/") && rel != "docs/releases/README.md" {
         return true;
     }
@@ -138,7 +126,6 @@ fn is_historical_cut(rel: &str) -> bool {
     false
 }
 
-/// Fixture / contract paths allowed to mention otherwise-forbidden tokens.
 fn is_allowlisted_path(rel: &str) -> bool {
     if rel.starts_with("tests/fixtures/migration/") {
         return true;
@@ -154,7 +141,6 @@ fn is_allowlisted_path(rel: &str) -> bool {
     )
 }
 
-/// Active documentation may state negative-removal policy; only those lines pass.
 fn is_negative_removal_line(line: &str) -> bool {
     let lower = line.to_ascii_lowercase();
     lower.contains("removed")
@@ -197,11 +183,8 @@ fn collect_active_files(root: &Path) -> Vec<PathBuf> {
         for entry in entries.flatten() {
             let path = entry.path();
             let name = entry.file_name().to_string_lossy().into_owned();
-            if name.starts_with('.') && name != ".github" {
-                // Still walk .github; skip other dot dirs.
-                if path.is_dir() && name != ".github" {
-                    continue;
-                }
+            if name.starts_with('.') && name != ".github" && path.is_dir() {
+                continue;
             }
             if path.is_dir() {
                 if skip_dir_name(&name) {
@@ -239,7 +222,6 @@ fn is_scannable_file(rel: &str) -> bool {
     {
         return false;
     }
-    // Always scan sources, tests, docs, manifests, workflows, packaging, scripts.
     rel.starts_with("src/")
         || rel.starts_with("tests/")
         || rel.starts_with("assets/")
@@ -262,7 +244,6 @@ fn is_scannable_file(rel: &str) -> bool {
         )
 }
 
-/// CHANGELOG: only Unreleased is active; release sections 9.0.0 and older are cuts.
 fn changelog_active_slice(content: &str) -> String {
     let mut active = String::new();
     let mut in_unreleased = false;
@@ -273,18 +254,16 @@ fn changelog_active_slice(content: &str) -> String {
             active.push('\n');
             continue;
         }
-        if line.starts_with("## [") || (line.starts_with("## ") && !line.starts_with("###")) {
-            // Leaving Unreleased into a version section ends the active region.
-            if in_unreleased {
-                break;
-            }
+        if in_unreleased
+            && (line.starts_with("## [") || (line.starts_with("## ") && !line.starts_with("###")))
+        {
+            break;
         }
         if in_unreleased {
             active.push_str(line);
             active.push('\n');
         }
     }
-    // If no Unreleased header, treat whole file as active (fail closed for Task 20).
     if active.is_empty() {
         content.to_owned()
     } else {
@@ -303,7 +282,6 @@ fn scan_content_for_tokens(rel: &str, content: &str, violations: &mut Vec<String
         content.to_owned()
     };
 
-    // Self-scan of this gate file documents the forbidden set; skip token hits here.
     if rel == "tests/active_legacy_scan.rs" {
         return;
     }
@@ -320,7 +298,6 @@ fn scan_content_for_tokens(rel: &str, content: &str, violations: &mut Vec<String
                     | "CHANGELOG.md"
             ));
 
-    // Specs under docs/specs/v10 describe the removal contract; allow tokens there.
     if rel.starts_with("docs/specs/v10/") {
         return;
     }
@@ -345,7 +322,7 @@ fn scan_content_for_tokens(rel: &str, content: &str, violations: &mut Vec<String
     }
 }
 
-/// Direct Cargo dependencies and their required v10 owners (TEST-034).
+/// TEST-034
 fn required_dependency_owners() -> BTreeMap<&'static str, &'static str> {
     BTreeMap::from([
         ("serde", "status/settings/cache/plugin JSON contracts"),
@@ -369,7 +346,6 @@ fn required_dependency_owners() -> BTreeMap<&'static str, &'static str> {
     ])
 }
 
-/// Parse direct dependency names declared under a single `[section]` header.
 fn parse_direct_deps_of_section(cargo_toml: &str, wanted_section: &str) -> BTreeSet<String> {
     let mut deps = BTreeSet::new();
     let mut section = "";
@@ -404,7 +380,6 @@ fn parse_direct_deps(cargo_toml: &str) -> BTreeSet<String> {
     deps
 }
 
-/// Recursively collect `.rs` files under `root/rel_dir`.
 fn walkdir_rs_files(root: &Path, rel_dir: &str) -> Vec<PathBuf> {
     let mut out = Vec::new();
     let mut stack = vec![root.join(rel_dir)];
@@ -524,10 +499,7 @@ fn active_legacy_scan_cargo_and_install_contract() {
     );
 }
 
-/// TEST-034 hardening: a documented owner is not proof of real use — every
-/// `[dependencies]` entry must actually appear (as a Rust identifier) in src/.
-/// `[dev-dependencies]` are intentionally excluded: they are expected to be
-/// referenced only from tests/.
+/// TEST-034
 #[test]
 fn dependencies_are_actually_used_in_src() {
     let root = workspace_root();

--- a/tests/agent_bar_bundle_cli.rs
+++ b/tests/agent_bar_bundle_cli.rs
@@ -1,8 +1,3 @@
-//! Binary-level grammar checks for `agent-bar-bundle` (monorepo migration
-//! Task 2). `stamp` is the binary's only verb; the tarball `release`
-//! packaging command was removed with the rest of the tarball machinery,
-//! and `assemble`/`output` went with the separate-tree assembly step.
-
 use std::process::Command;
 
 fn bin() -> &'static str {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1042,11 +1042,15 @@ fn uninstall_purge_fails_closed_without_touching_state_when_omarchy_missing() {
     {
         use std::io::Write as _;
         let mut stdin = child.stdin.take().unwrap();
-        stdin
-            .write_all(
-                br#"{"schemaVersion":1,"operation":"uninstall","confirmed":true,"purgeSettingsAndBackups":true}"#,
-            )
-            .unwrap();
+        if let Err(err) = stdin.write_all(
+            br#"{"schemaVersion":1,"operation":"uninstall","confirmed":true,"purgeSettingsAndBackups":true}"#,
+        ) {
+            assert_eq!(
+                err.kind(),
+                std::io::ErrorKind::BrokenPipe,
+                "only an early preflight exit may close stdin"
+            );
+        }
     }
     let output = child.wait_with_output().unwrap();
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,5 +1,3 @@
-//! Exhaustive v10 word-based CLI grammar and binary contract tests.
-
 use std::path::{Path, PathBuf};
 use std::process::Command as StdCommand;
 
@@ -205,9 +203,6 @@ fn login_config_setup_update_uninstall_doctor_forms() {
 
 #[test]
 fn setup_rejects_any_argument() {
-    // `setup` takes no arguments now that install is git-clone-based
-    // (git-plugin-distribution Task 4): `plugins-dir` and any other word
-    // after `setup` is an ordinary unknown-argument grammar error.
     let plugins_dir = parse(words(&["setup", "plugins-dir", "/tmp/plugins"])).unwrap_err();
     assert_eq!(plugins_dir.exit_code, GRAMMAR);
     let other = parse(words(&["setup", "extra"])).unwrap_err();
@@ -216,8 +211,6 @@ fn setup_rejects_any_argument() {
 
 #[test]
 fn update_run_parses_and_takes_no_argument() {
-    // `update run` is what the detached update unit executes; QML never
-    // calls it directly.
     assert_eq!(
         parse(words(&["update", "run"])).unwrap(),
         Command::Update(UpdateCommand::Run)
@@ -228,8 +221,6 @@ fn update_run_parses_and_takes_no_argument() {
 
 #[test]
 fn update_apply_rejects_trailing_arguments() {
-    // `update apply` takes no argument (git-plugin-distribution Task 2): it
-    // delegates unconditionally instead of applying a specific version.
     for extra in [
         words(&["update", "apply", "10.0.0"]),
         words(&["update", "apply", "extra", "words"]),
@@ -260,9 +251,6 @@ fn double_dash_aliases_and_legacy_rejections() {
     assert_eq!(parse(words(&["--version"])).unwrap(), Command::Version);
     assert_eq!(parse(words(&["version"])).unwrap(), Command::Version);
 
-    // Legacy words are rejected by the grammar. Tokens that the active-legacy
-    // gate forbids as contiguous source text are built with concat! so the
-    // scan stays clean while runtime strings still match the old CLI surface.
     let action_right = concat!("action", "-", "right");
     let menu_font = concat!("menu", "-", "font");
     let legacy: Vec<Vec<&str>> = vec![
@@ -300,7 +288,6 @@ fn binary_version_prints_exact_package_semver_only() {
         .code(SUCCESS)
         .stdout(format!("{}\n", env!("CARGO_PKG_VERSION")))
         .stderr("");
-    // assert_cmd already checked; keep binding used.
     let _ = assert;
 
     CargoBin::cargo_bin("agent-bar")
@@ -315,7 +302,6 @@ fn binary_version_prints_exact_package_semver_only() {
 #[test]
 fn binary_version_does_not_require_config_home() {
     let dir = tempdir().unwrap();
-    // Point XDG/HOME at an empty tree so accidental discovery would fail.
     CargoBin::cargo_bin("agent-bar")
         .unwrap()
         .arg("version")
@@ -349,8 +335,6 @@ fn binary_grammar_errors_exit_2() {
         .assert()
         .code(GRAMMAR)
         .stdout("");
-    // setup no longer accepts plugins-dir (git-plugin-distribution Task 4):
-    // git clone is the install now, so this is an ordinary unknown argument.
     CargoBin::cargo_bin("agent-bar")
         .unwrap()
         .args(["setup", "plugins-dir", "/tmp/x"])
@@ -371,13 +355,6 @@ fn binary_help_mentions_plugin_first_product() {
         .stderr("");
 }
 
-/// Live QA regression (Task 22): setup must apply v9→v10 settings migration so
-/// `config show` / status can read the strict document. Reproduction of the
-/// failure where leftover v9 `settings.json` caused `unknown settings key`.
-///
-/// Retargeted at plain `setup` (git-plugin-distribution Task 4): setup no
-/// longer installs a plugin tree, so there is no source tree to stage — the
-/// binary under test is the real cargo-built helper, invoked directly.
 #[test]
 fn binary_setup_migrates_v9_settings_to_strict_v10() {
     let dir = tempdir().unwrap();
@@ -390,7 +367,6 @@ fn binary_setup_migrates_v9_settings_to_strict_v10() {
     std::fs::create_dir_all(&state).unwrap();
     std::fs::create_dir_all(&cache).unwrap();
 
-    // Live-shaped v9 settings (unknown keys include `cache`, `waybar`, …).
     let v9 = std::fs::read(
         PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("tests/fixtures/migration/v9/settings-valid.json"),
@@ -399,7 +375,6 @@ fn binary_setup_migrates_v9_settings_to_strict_v10() {
     let settings_path = config.join("agent-bar/settings.json");
     std::fs::write(&settings_path, &v9).unwrap();
 
-    // Clean shell entry (existing layout; no Agent Bar inline keys).
     let shell_path = home.join(".config/omarchy/shell.json");
     std::fs::write(
         &shell_path,
@@ -429,7 +404,6 @@ fn binary_setup_migrates_v9_settings_to_strict_v10() {
         String::from_utf8_lossy(&out.stderr)
     );
 
-    // Settings must be strict v10 (no unknown keys); fixture migrated interval 120.
     let show = StdCommand::new(&helper)
         .args(["config", "show"])
         .env("HOME", &home)
@@ -458,21 +432,18 @@ fn binary_setup_migrates_v9_settings_to_strict_v10() {
         "v9 keys must not remain in config show: {stdout}"
     );
 
-    // On-disk document must parse as strict v10.
     let stored = std::fs::read(&settings_path).unwrap();
     assert!(
         agent_bar::settings::schema::Settings::parse_strict(&stored).is_ok(),
         "stored settings must be strict v10 after setup"
     );
 
-    // shell.json without Agent Bar inline keys must remain byte-identical.
     let shell_after = std::fs::read(&shell_path).unwrap();
     assert_eq!(
         shell_before, shell_after,
         "setup must not rewrite clean shell.json bytes"
     );
 
-    // Pre-migration settings must be backed up under XDG state.
     let backups = state.join("agent-bar/backups");
     assert!(
         backups.is_dir(),
@@ -518,7 +489,6 @@ fn binary_doctor_scan_is_read_only_and_exits_zero() {
 fn binary_doctor_clean_backs_up_and_removes_owned_legacy() {
     let dir = tempdir().unwrap();
     let home = dir.path();
-    // Split filename so active-legacy gates stay clean.
     let legacy_name = concat!("usage", ".", "re", "db");
     let legacy = home.join(".cache/agent-bar").join(legacy_name);
     std::fs::create_dir_all(legacy.parent().unwrap()).unwrap();
@@ -541,10 +511,6 @@ fn binary_doctor_clean_backs_up_and_removes_owned_legacy() {
 
 #[test]
 fn binary_interactive_update_rejects_non_tty() {
-    // Bare `update` has no interactive flow left (git-plugin-distribution
-    // Task 2 removed the TTY confirm-then-apply dance): it always points at
-    // the two real subcommands, TTY or not. Pipe stdin so the process is
-    // non-TTY, matching the historical name of this test.
     let dir = tempdir().unwrap();
     let home = dir.path();
     let bin = assert_cmd::cargo::cargo_bin("agent-bar");
@@ -559,7 +525,6 @@ fn binary_interactive_update_rejects_non_tty() {
         .stderr(std::process::Stdio::piped())
         .spawn()
         .unwrap();
-    // Drop stdin immediately → non-TTY / closed.
     drop(child.stdin.take());
     let output = child.wait_with_output().unwrap();
     assert_eq!(output.status.code(), Some(VALIDATION));
@@ -571,8 +536,6 @@ fn binary_interactive_update_rejects_non_tty() {
     );
 }
 
-/// Write an executable shell script (mirrors `tests/terminal_helper.rs`'s
-/// fake-PATH-tool pattern for `xdg-terminal-exec`).
 fn write_executable(path: &Path, body: &str) {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent).unwrap();
@@ -587,7 +550,6 @@ fn write_executable(path: &Path, body: &str) {
     }
 }
 
-/// Recording shim: records its NUL-separated argv to `out` then exits 0.
 fn recording_shim_body(out: &Path) -> String {
     format!(
         r#"#!/usr/bin/env bash
@@ -613,11 +575,6 @@ fn read_nul_argv(path: &Path) -> Vec<String> {
 
 #[test]
 fn update_apply_emits_delegation_document() {
-    // omarchy, omarchy-restart-shell and systemd-run resolved via fake PATH
-    // shims in a tempdir that record argv (git-plugin-distribution Task 2):
-    // `update apply` never downloads/stages/exchanges anymore, it queues
-    // `systemd-run --user --collect --no-block --unit=... -- <helper> update
-    // run` and prints the delegation document.
     let dir = tempdir().unwrap();
     let home = dir.path().join("home");
     std::fs::create_dir_all(&home).unwrap();
@@ -672,8 +629,6 @@ fn update_apply_emits_delegation_document() {
     );
 
     let argv = read_nul_argv(&systemd_run_argv);
-    // The unit runs this very helper: `update run` owns the fast-forward and
-    // the shell restart, so a rescan that keeps the old QML is not the end.
     let helper = std::fs::canonicalize(&bin).unwrap();
     assert!(
         argv.ends_with(&[
@@ -685,8 +640,6 @@ fn update_apply_emits_delegation_document() {
     );
     assert_eq!(argv.first().map(String::as_str), Some("--user"));
     assert!(argv.contains(&"--collect".to_string()));
-    // Queued, not awaited: the helper and its maintenance lock never wait on
-    // a git fetch or a locked session.
     assert!(argv.contains(&"--no-block".to_string()));
     assert!(argv.contains(&"--property=RuntimeMaxSec=25h".to_string()));
     assert!(argv.iter().any(|a| a == &format!("--unit={unit}")));
@@ -721,9 +674,6 @@ fn update_apply_fails_closed_without_omarchy_restart_shell() {
     assert!(!systemd_run_argv.exists(), "no unit may start");
 }
 
-/// Shims for `update run`: a git that answers `before` then `after` for
-/// `rev-parse HEAD`, an omarchy that succeeds, and a restart that records it
-/// ran. PATH is limited to the shim directory plus `bash` and `timeout`.
 fn update_run_in(root: &Path, before: &str, after: &str) -> (std::process::Output, PathBuf) {
     let home = root.join("home");
     std::fs::create_dir_all(&home).unwrap();
@@ -805,10 +755,6 @@ fn update_run_restarts_the_shell_only_when_the_tree_moved() {
     assert!(!restarted.exists(), "an up-to-date tree must not restart");
 }
 
-/// Fixture for the two `uninstall` delegation tests: isolated XDG roots with
-/// owned content, plus a fake `$HOME/.config/omarchy/shell.json` the helper
-/// must never touch (git-plugin-distribution Task 3: shell.json is
-/// omarchy's now).
 struct UninstallFixture {
     home: PathBuf,
     settings_dir: PathBuf,
@@ -899,12 +845,6 @@ fn run_uninstall(
 
 #[test]
 fn uninstall_purge_removes_xdg_state_and_delegates_remove() {
-    // git-plugin-distribution Task 3: `uninstall purge` no longer runs a
-    // quarantine/rollback worker chain over a copied worker binary — it
-    // purges Agent Bar's own XDG state directly under the maintenance gate,
-    // then hands the plugin tree + shell.json removal to `omarchy plugin
-    // remove` via the same detached-unit shape Task 2 used for `update
-    // apply`.
     let dir = tempdir().unwrap();
     let fx = seed_uninstall_fixture(dir.path());
 
@@ -1016,12 +956,6 @@ fn uninstall_without_purge_preserves_xdg_state_and_delegates_remove() {
 
 #[test]
 fn uninstall_purge_fails_closed_without_touching_state_when_omarchy_missing() {
-    // Review round 1, finding 1: tool resolution must happen before any
-    // destructive purge, so a missing `omarchy` fails the whole command
-    // before the settings/cache/state XDG roots are touched — not after
-    // they are already gone with the plugin never actually removed. PATH is
-    // isolated to just `path_dir` (no real system PATH fallback) so a real
-    // `omarchy` binary elsewhere on this machine cannot mask the failure.
     let dir = tempdir().unwrap();
     let fx = seed_uninstall_fixture(dir.path());
     std::fs::remove_file(fx.path_dir.join("omarchy")).unwrap();

--- a/tests/cli_vocabulary.rs
+++ b/tests/cli_vocabulary.rs
@@ -1,20 +1,6 @@
-//! `clause` is parser vocabulary. It names a concept in the grammar's own
-//! implementation, not anything the person typing the command can see, and it
-//! leaked into six error messages. The word stays in the code — `StatusClause`
-//! and its bindings are exactly the kind of internal name that belongs there —
-//! so this guard scans string literals only.
-//!
-//! Scope is `src/cli/**`. The GUI has its own, wider guard in
-//! `tests/gui_vocabulary.rs`; the two lists differ on purpose, because
-//! `bundle` and `schema` name real things a CLI user deals with.
-
 use std::fs;
 use std::path::{Path, PathBuf};
 
-/// True when `prefix` opens a raw string as a real token on `line` at byte
-/// offset `pos`, not merely as the tail of an ordinary word ending in `r`
-/// right before a closing quote (`"doctor"`, `"provider"` both contain the
-/// literal bytes `r"` but do not open anything).
 fn is_token_boundary(line: &str, pos: usize) -> bool {
     pos == 0 || {
         let prev = line.as_bytes()[pos - 1];
@@ -22,33 +8,12 @@ fn is_token_boundary(line: &str, pos: usize) -> bool {
     }
 }
 
-/// True when `line` opens one of this codebase's raw string prefixes (`r"`,
-/// `r#"`, `br"`, `br#"`) — used by the CLI test module for raw JSON
-/// payloads. See [`is_token_boundary`] for why a plain substring search is
-/// not enough.
 fn opens_raw_string(line: &str) -> bool {
     ["br#\"", "br\"", "r#\"", "r\""]
         .iter()
         .any(|prefix| matches!(line.find(prefix), Some(pos) if is_token_boundary(line, pos)))
 }
 
-/// Double-quoted spans, tracked across lines so a literal continued with a
-/// trailing `\` (the multi-line `HelpTopic` help text) is not lost. `//`
-/// comments are skipped, but only outside a literal — a continuation line
-/// never starts with `//` in this codebase.
-///
-/// `src/cli/mod.rs`'s test module has three raw byte-string literals
-/// (`br#"..."#`, JSON confirmation payloads). Counting quote characters
-/// would misread their embedded `"` as ordinary literal boundaries, so those
-/// lines are detected by [`opens_raw_string`] and skipped rather than
-/// parsed — never scanned for content, and never allowed to flip the
-/// carried in/out-of-string state on a hunch. That skip is safe only when
-/// the line is self-contained (an even number of quote characters); it is
-/// verified per line rather than assumed, because an odd count would mean
-/// the raw string continues past this line and silently skipping it would
-/// desynchronize the parity count for every line after it. Outside of those
-/// three lines, counting quote characters is sound because no other line in
-/// this scope has an escaped quote.
 fn string_literals(source: &str) -> Vec<String> {
     let mut out = Vec::new();
     let mut in_string = false;
@@ -77,13 +42,6 @@ fn string_literals(source: &str) -> Vec<String> {
     out
 }
 
-/// Every `.rs` file under `src/cli/`, found by walking the tree with an
-/// explicit stack rather than reading one directory. `src/cli/mod.rs` is
-/// past a thousand lines; the day it splits into submodules
-/// (`src/cli/help/mod.rs` or similar), a non-recursive `fs::read_dir` would
-/// silently stop covering the new file while every guard below kept
-/// passing. Shape matches `tests/gui_vocabulary.rs::gui_files` on purpose,
-/// so the two guards read as siblings.
 fn cli_files(root: &Path) -> Vec<PathBuf> {
     let mut out = Vec::new();
     let mut stack = vec![root.join("src/cli")];
@@ -107,11 +65,6 @@ fn cli_files(root: &Path) -> Vec<PathBuf> {
     out
 }
 
-/// Concatenation of every `.rs` file under `src/cli/`, for guards that check
-/// whether a message exists anywhere in the tree rather than walking file by
-/// file themselves. A `\n` separator sits between files; none of the needles
-/// these guards check span a file boundary, so the separator only prevents
-/// two files' text from fusing into an accidental match.
 fn all_cli_source(root: &Path) -> String {
     let mut combined = String::new();
     for path in cli_files(root) {
@@ -160,12 +113,6 @@ fn cli_messages_do_not_say_clause() {
     );
 }
 
-/// A message that exists twice drifts: one copy gets fixed, the other does
-/// not, and the user sees two wordings for one condition depending on which
-/// code path noticed. This one was duplicated across the parse and validate
-/// paths before this guard existed. Its former `setup plugins-dir` siblings
-/// were deleted whole with the feature (git-plugin-distribution Task 4:
-/// install is `omarchy plugin add` now) rather than left here unreachable.
 #[test]
 fn cli_messages_are_defined_once() {
     let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -177,8 +124,6 @@ fn cli_messages_are_defined_once() {
         let Ok(source) = fs::read_to_string(path) else {
             continue;
         };
-        // Count only literal occurrences, so the single `const` definition
-        // counts once and every use site counts zero.
         for (idx, needle) in watched.iter().enumerate() {
             totals[idx] += source.matches(needle).count();
         }
@@ -196,15 +141,6 @@ fn cli_messages_are_defined_once() {
     );
 }
 
-/// §7.3: a message names the fix only where the fix is short and certain.
-/// This is the whole remaining set of messages that name a remedy — every
-/// other CLI error either states a grammar mistake the user can see from
-/// their own command line, or a condition whose remedy depends on facts the
-/// helper does not have. The `setup plugins-dir` writability/existence
-/// messages this guard used to also check were deleted whole with the
-/// feature (git-plugin-distribution Task 4: install is `omarchy plugin add`
-/// now), including the writability probe that could not tell a permission
-/// problem from a stale probe file and so deliberately named no fix.
 #[test]
 fn cli_messages_that_can_name_a_fix_do() {
     let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -216,13 +152,6 @@ fn cli_messages_that_can_name_a_fix_do() {
     );
 }
 
-/// `docs/guide/commands.md` documents the same command grammar the CLI's own help
-/// text implements, and it drifted once: the v11-06 plan's own measurement
-/// found "Status clauses" live in this file after `clause` was renamed to
-/// `argument` in the help text it describes. None of the guards above can
-/// see prose in a Markdown file, so this one reads `docs/guide/commands.md`
-/// directly rather than relying on the `src/cli/**` walk to catch prose that
-/// never lives under `src/cli/` in the first place.
 #[test]
 fn docs_commands_do_not_say_clause() {
     let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("docs/guide/commands.md");

--- a/tests/countdown_parity.rs
+++ b/tests/countdown_parity.rs
@@ -1,10 +1,3 @@
-//! `CoreView.countdownText` humanises a reset countdown in QML; the
-//! notification path humanises the same durations in Rust. The repo bans every
-//! JS runtime, so a Rust test cannot call the QML function — instead both
-//! sides are pinned to one shared table of inputs and expected outputs.
-//! `tests/qml/tst_Format.qml` asserts the QML implementation against the same
-//! file, so either side drifting fails its own suite.
-
 use agent_bar::support::countdown::countdown_text;
 use serde::Deserialize;
 
@@ -37,7 +30,6 @@ fn countdown_matches_the_shared_table() {
     }
 }
 
-// The seam is only real while the QML side still exists under that name.
 #[test]
 fn qml_countdown_function_still_exists() {
     let js = std::fs::read_to_string("CoreView.js").expect("read CoreView.js");

--- a/tests/cut_release.rs
+++ b/tests/cut_release.rs
@@ -1,7 +1,3 @@
-//! `scripts/agent-bar-cut-release` version contract (docs/dev/releasing.md,
-//! "Manual boundary"): a version already carrying a tag bumps the patch; a
-//! version set deliberately and not yet tagged is released as set.
-
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -50,7 +46,6 @@ fn write_version(repo: &Path, version: &str) {
     .unwrap();
 }
 
-/// A repository whose last release is `v10.3.27`, then one feature commit.
 fn released_repo(tmp: &Path) -> PathBuf {
     let repo = tmp.join("repo");
     fs::create_dir_all(repo.join("docs/releases")).unwrap();
@@ -106,7 +101,6 @@ fn untagged_version_is_released_as_set() {
     git(&repo, &["commit", "-q", "-am", "chore: set version 10.4.0"]);
     let out = dry_run(&repo);
     assert!(out.contains("next-version: 10.4.0\n"), "{out}");
-    // Notes still cover everything since the last release tag.
     assert!(out.contains("Changes since 10.3.27:"), "{out}");
     assert!(out.contains("- feat: something new"), "{out}");
     assert!(out.contains("- chore: set version 10.4.0"), "{out}");

--- a/tests/gui_vocabulary.rs
+++ b/tests/gui_vocabulary.rs
@@ -1,26 +1,11 @@
-//! Copy design §4 rule 2: GUI strings name what the user sees, not what the
-//! code calls it. Twenty-one strings leaked internal vocabulary before the
-//! rewrite; this test is what stops the twenty-second.
-//!
-//! Scope is the GUI only. The CLI is deliberately exempt (§7): its stderr is
-//! read while debugging and Unix convention there is different.
-
 use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-/// Copy design §4 rule 2's list, complete. `provider` is deliberately absent
-/// — decision 3 keeps it on screen. `bundle` is the one that was actually
-/// leaking: six GUI strings carried it until the maintenance rewrite.
 const BANNED: &[&str] = &[
     "adapter", "schema", "payload", "envelope", "bundle", "collect", "clause", "snapshot",
 ];
 
-/// The GUI tree now lives at the plugin root: top-level `*.qml`/`*.js` files
-/// plus everything under `components/`. Unlike the old `assets/omarchy`
-/// subtree, the repo root also holds Rust sources, docs, and build output,
-/// so the walk only descends into `components/` from the top level — it
-/// must not wander into `src/`, `target/`, `.git/`, or similar.
 fn gui_files(root: &Path) -> Vec<PathBuf> {
     let mut out = Vec::new();
     let mut stack = vec![root.to_path_buf()];
@@ -50,14 +35,6 @@ fn gui_files(root: &Path) -> Vec<PathBuf> {
     out
 }
 
-/// Double-quoted string literals, minus comment lines. Every quoted piece
-/// is scanned, including single-token ids, enum values, and glyphs — there
-/// is no length or shape filter. What keeps identifiers like
-/// `schemaVersion` from tripping the guard is exact whole-token matching
-/// against `BANNED`, not a filter on the literal here. Plural forms
-/// (`bundles`) are a known gap: prefix matching would close it, but at the
-/// cost of a false positive on `schemaVersion`, a legitimate JSON field
-/// name in diagnostic strings in `CoreService.js` and `CoreSettings.js`.
 fn user_facing_literals(source: &str) -> Vec<String> {
     let mut out = Vec::new();
     for line in source.lines() {

--- a/tests/icon_assets.rs
+++ b/tests/icon_assets.rs
@@ -10,25 +10,7 @@
 
 use std::fs;
 
-/// Pins both UX-049-approved monochrome mark assets against silent
-/// regression.
-///
-/// Codex: every assertion below distinguishes the approved mark (adopted
-/// 2026-07-30, sha256
-/// `880a6d7e2fdb3ed4cb7c9f2f9c8c295050294756dd30eb951462a3b2d08c5397`) from
-/// the old filled app-icon puck it replaced (1315 bytes, PNG color type 4
-/// gray+alpha): byte length, dimensions, and color type all differ.
-/// Replacing this asset requires updating both this test and the UX-049
-/// record in `docs/specs/v10/04-quickshell-ux-and-accessibility.md`.
-///
-/// Grok: asserts `fill="white"` IS present, twice — inverted from what a
-/// well-meaning cleanup would expect. Under the runtime's tint math
-/// (`MultiEffect { colorization: 1.0 }` multiplies mask luminance by the
-/// theme foreground — spec §10 correction, 2026-07-30), a white mask is
-/// the only convention that can ever take the theme ink; a black or
-/// absent fill would ship an untintable mark, invisible on both themes.
-/// If a future edit strips `fill="white"` from `grok.svg` believing it to
-/// be dead/legacy styling, this test is the trip wire.
+/// UX-049
 #[test]
 fn icon_assets_are_the_approved_mark_grade_assets() {
     let codex = fs::read("icons/codex.png").expect("read codex.png");
@@ -65,9 +47,6 @@ fn icon_assets_are_the_approved_mark_grade_assets() {
         "codex.png color type drifted from truecolor+alpha (6); the old puck was gray+alpha (4)"
     );
 
-    // Antigravity (adopted 2026-08-22): a 48x48 truecolor+alpha PNG mark.
-    // Pinned the same way as Codex so a re-export at the wrong size or a
-    // palette/gray encoding (which the bar tints differently) fails here.
     let antigravity = fs::read("icons/antigravity.png").expect("read antigravity.png");
     assert_eq!(
         &antigravity[0..8],

--- a/tests/login.rs
+++ b/tests/login.rs
@@ -1,4 +1,4 @@
-//! Login argv, IPC refresh, and CLI-017 exit mapping.
+//! CLI-017
 
 use std::path::PathBuf;
 use std::sync::Mutex;
@@ -87,7 +87,6 @@ async fn login_argv_matches_catalog_with_resolved_executable() {
                 .map(|s| s.to_string())
                 .collect::<Vec<_>>()
         );
-        // Element zero of full argv is absolute path, not bare name.
         assert!(spec.program.is_absolute() || spec.program.starts_with("/"));
     }
     assert_eq!(AMP.login_argv, &["amp", "login"]);

--- a/tests/qml/TestPalette.js
+++ b/tests/qml/TestPalette.js
@@ -1,7 +1,5 @@
-// Test-only palette + screenshot inventory fixtures.
 .pragma library
 
-// Screenshot inventory required by TEST/CP2 (exact basenames).
 function requiredScreenshotNames() {
   return [
     "ready-light.png",

--- a/tests/qml/fixtures/fake-agent-bar
+++ b/tests/qml/fixtures/fake-agent-bar
@@ -1,12 +1,10 @@
 #!/usr/bin/env bash
-# Test-only private helper. Mimics agent-bar version (and optional slow status).
 set -euo pipefail
 
 cmd="${1:-}"
 
 case "$cmd" in
   version)
-    # Exact package-style semver + newline; no stderr.
     printf '%s\n' "${FAKE_AGENT_BAR_VERSION:-10.0.0}"
     exit 0
     ;;

--- a/tests/qml/tst_Accessibility.qml
+++ b/tests/qml/tst_Accessibility.qml
@@ -49,7 +49,6 @@ TestCase {
     var files = v10QmlFiles()
     for (var i = 0; i < files.length; i++) {
       var src = read(files[i])
-      // Strip // comments before checking tokens. Avoid matching boundsBehavior.
       var code = src.replace(/\/\/[^\n]*/g, "")
       verify(!/\bBehavior\b/.test(code), files[i] + " has Behavior")
       verify(!/\bTransition\b/.test(code), files[i] + " has Transition")
@@ -81,14 +80,9 @@ TestCase {
   }
 
   function test_state_cues_not_color_only() {
-    // Chip and state message use text cues beyond color. UX-012 (amended)
-    // scopes this to states with no usable reading; stale keeps showing its
-    // retained number and is deliberately unmarked on the bar.
     verify(Core.chipStateCue({ state: "cli_missing" }).length > 0)
     verify(Core.chipStateCue({ state: "network_error" }).length > 0)
     verify(Core.stateTitle({ state: "network_error", windows: [] }).length > 0)
-    // The qualifier table stays a pure translator — the chip simply stops
-    // asking it about stale (CoreView.js chipCueLabel/chipAccessibleLabel).
     compare(Core.stateQualifier("stale"), "stale")
     compare(Core.chipCueLabel({ state: "stale", windows: [] }), "")
   }

--- a/tests/qml/tst_BarWidget.qml
+++ b/tests/qml/tst_BarWidget.qml
@@ -23,7 +23,6 @@ TestCase {
   property string chipUrl: "file://" + repoRoot + "/components/ProviderChip.qml"
   property string coreViewUrl: "file://" + repoRoot + "/CoreView.js"
 
-  // Minimal shell stand-in with Quattro serviceFor API.
   Item {
     id: fakeShell
     property var _services: ({})
@@ -81,7 +80,6 @@ TestCase {
     }
   }
 
-  // Chip logic matching BarWidget.qml agentService resolution (without qs.Ui).
   component AgentChip: Item {
     property var bar: null
     property string moduleName: "othavi0.agent-bar"
@@ -125,8 +123,6 @@ TestCase {
     }
   }
 
-  // ---- Task 8 carry-over ----
-
   function test_two_widgets_resolve_same_service() {
     var svc = Qt.createQmlObject('import QtQuick; Item { property string helperVersion: "10.0.0"; property bool versionReady: true; property bool versionFailed: false }', testCase)
     fakeShell.registerService("othavi0.agent-bar", svc)
@@ -167,10 +163,8 @@ TestCase {
     var src = String(xhr.responseText)
     verify(src.indexOf("serviceFor(moduleName)") >= 0)
     verify(src.indexOf("moduleName: \"othavi0.agent-bar\"") >= 0)
-    verify(src.indexOf("Qt.resolvedUrl") >= 0) // icons only
+    verify(src.indexOf("Qt.resolvedUrl") >= 0)
   }
-
-  // ---- Task 10: chip model ----
 
   function test_visible_providers_settings_order_and_filter() {
     var settings = {
@@ -225,9 +219,6 @@ TestCase {
     compare(Core.displayMetric(null), "remaining")
   }
 
-  // UX-002 (amended 2026-08-07): the chip shows the elected lead window —
-  // for a subscriber that is the subscription bucket, not windows[0]
-  // (Amp Free), even though the free window has the nearer reset.
   function test_chip_shows_elected_lead_for_subscriber() {
     var p = {
       id: "amp",
@@ -264,8 +255,6 @@ TestCase {
     compare(lines[0].percentText, "100%")
   }
 
-  // UX-028 (amended): stale is retained data, not a fault. The bar renders it
-  // exactly as ready — dimming is reserved for states with no usable reading.
   function test_chip_dimmed_reflects_ready_state() {
     verify(!Core.chipDimmed(makeProvider("claude", "stale", 1, 99)))
     verify(!Core.chipDimmed(makeProvider("claude", "ready", 1, 99)))
@@ -278,27 +267,18 @@ TestCase {
     compare(Core.chipStateCue(null), "")
     compare(Core.chipStateCue({ state: "ready" }), "")
     compare(Core.chipStateCue({ state: "loading" }), "")
-    // UX-012 (amended): stale carries no cue; the bar must not mark it.
     compare(Core.chipStateCue({ state: "stale" }), "")
     compare(Core.chipStateCue({ state: "cli_missing" }), "!")
     compare(Core.chipStateCue({ state: "unauthenticated" }), "!")
     compare(Core.chipStateCue({ state: "rate_limited" }), "!")
     compare(Core.chipStateCue({ state: "network_error" }), "!")
     compare(Core.chipStateCue({ state: "provider_error" }), "!")
-    // §7: a ready provider over the critical threshold earns the same cue.
     compare(Core.chipStateCue({ state: "ready", windows: [{ usedPercent: 96 }] }), "!")
     compare(Core.chipStateCue({ state: "ready", windows: [{ usedPercent: 92 }] }), "")
-    // Severity survives staleness: a critical retained reading is still
-    // critical, so the cue comes from severity alone.
     compare(Core.chipStateCue({ state: "stale", windows: [{ usedPercent: 96 }] }), "!")
     compare(Core.chipStateCue({ state: "stale", windows: [{ usedPercent: 92 }] }), "")
   }
 
-  // The urgent tint belongs to severity, never to the error cue — the
-  // approved mockup shows critical Claude urgent and disconnected Grok plain.
-  // Stale joins ready here: UsageWindow already keeps the severity colour on
-  // a stale reading, so suppressing it on the chip would make bar and popup
-  // disagree about the same number.
   function test_chip_severity_urgent_only_when_ready_and_critical() {
     compare(Core.chipSeverityUrgent(null), false)
     compare(Core.chipSeverityUrgent({ state: "ready", windows: [{ usedPercent: 96 }] }), true)
@@ -308,10 +288,8 @@ TestCase {
     compare(Core.chipSeverityUrgent({ state: "network_error", windows: [] }), false)
   }
 
-  // Plan 02 deferred minor: the cue used to expose its raw glyph.
   function test_chip_cue_label_is_a_word() {
     compare(Core.chipCueLabel({ state: "ready", windows: [{ usedPercent: 96 }] }), "critical")
-    // Stale speaks nothing extra: the cue label must match what the eye sees.
     compare(Core.chipCueLabel({ state: "stale", windows: [] }), "")
     compare(Core.chipCueLabel({ state: "stale", windows: [{ usedPercent: 96 }] }), "critical")
     compare(Core.chipCueLabel({ state: "cli_missing", windows: [] }), "no CLI")
@@ -365,19 +343,13 @@ TestCase {
     var loading = { name: "Claude", state: "loading", windows: [] }
     compare(Core.chipAccessibleLabel(loading, "remaining"), "Claude · loading")
 
-    // Parity with the eye (A11Y-012): the bar no longer marks stale, so the
-    // accessible name must not announce it either — same chip, same words.
     var stale = { name: "Claude", state: "stale",
                   windows: [{ usedPercent: 95, remainingPercent: 5 }] }
     compare(Core.chipAccessibleLabel(stale, "remaining"), "Claude · 5%")
 
-    // Mirrors emptyReady above. Only this case distinguishes
-    // presentsReading(state) from state === "ready" in the percentage branch,
-    // so without it that half of the change is untested.
     var staleEmpty = { name: "Claude", state: "stale", windows: [] }
     compare(Core.chipAccessibleLabel(staleEmpty, "remaining"), "Claude · —")
 
-    // Single-line by construction; no provider stays empty.
     compare(Core.chipAccessibleLabel(null, "remaining"), "")
   }
 
@@ -424,8 +396,6 @@ TestCase {
     verify(!Core.iconTinted(""))
   }
 
-  // ---- Task 10: click routing ----
-
   function test_left_click_opens_provider() {
     var owner = {}
     var route = Core.routeChipClick("left", owner, "claude", null)
@@ -471,8 +441,6 @@ TestCase {
     compare(route.action, "noop")
   }
 
-  // ---- Task 10: registration + source guards ----
-
   function test_provider_chip_registers_and_unregisters() {
     fakeBar.clickTargets = []
     var chip = providerChipComp.createObject(testCase, {
@@ -483,7 +451,6 @@ TestCase {
       accessibleLabel: "Claude · 90% · ready"
     })
     verify(chip !== null)
-    // Allow Component.onCompleted to run.
     wait(0)
     verify(fakeBar.clickTargets.indexOf(chip) >= 0)
     verify(typeof chip.triggerPress === "function")
@@ -528,9 +495,7 @@ TestCase {
       xhr.open("GET", files[i], false)
       xhr.send()
       var src = String(xhr.responseText)
-      // Match type usage, not prose (rg -n 'Process|Timer|...' in the plan).
       verify(!/\bProcess\b/.test(src) || src.indexOf("//") >= 0)
-      // Strip line comments then re-check forbidden owners.
       var code = src.replace(/\/\/[^\n]*/g, "")
       verify(code.indexOf("Process") < 0, files[i] + " must not own Process")
       if (files[i] === chipUrl)
@@ -550,23 +515,12 @@ TestCase {
     xhr.open("GET", chipUrl, false)
     xhr.send()
     var chip = String(xhr.responseText)
-    // UX-010: the protocol is inherited from WidgetButton — exactly one
-    // registration, owned by the host component. Our source must not add a
-    // second protocol layer or a second mouse layer.
     verify(chip.indexOf("WidgetButton {") >= 0)
     verify(chip.indexOf("registerClickTarget") < 0)
     verify(chip.indexOf("MouseArea") < 0)
-    // UX-009: wheel stays a no-op — no handler in our source.
     verify(chip.indexOf("onWheel") < 0)
     verify(chip.indexOf("wheelMoved") < 0)
-    // A11Y-013: no plugin-authored motion (tst_Accessibility also guards).
     verify(chip.indexOf("Behavior") < 0)
-    // §5 amended 2026-08-04 (owner picked it on live mockups): the numeral
-    // box is tight — width follows the text, no reserved "100%" box. The
-    // fixed box parked ~2 digits of slack in the inter-chip gap whenever
-    // every numeral was short, which read as disproportionate spacing and
-    // an inflated right edge. Chips may shift on digit-count changes; the
-    // state cues (! / ln) already moved them, so nothing new is lost.
     verify(chip.indexOf("TextMetrics") < 0)
     verify(chip.indexOf('"100%"') < 0)
     verify(chip.indexOf("advanceWidth") < 0)
@@ -588,10 +542,8 @@ TestCase {
     // required props unset → no panel on chip click).
     verify(widget.indexOf("sourceComponent") < 0)
     verify(widget.indexOf("Popup {") >= 0)
-    // UX-003: no product brand chip label
     verify(widget.indexOf("\"AB\"") < 0)
     verify(widget.indexOf("Agent Bar") < 0)
-    // Task 1 functions actually wired:
     verify(widget.indexOf("chipNumeralText") >= 0)
     verify(widget.indexOf("iconTinted") >= 0)
     verify(widget.indexOf("iconOpticalScale") >= 0)
@@ -602,10 +554,6 @@ TestCase {
     verify(widget.indexOf("fontPixelSize:") < 0)
   }
 
-  // Plan 03 replaced the emoji hourglass with a Nerd Font glyph; UX-028
-  // (amended) then retired the glyph itself. The ban outlives both: the
-  // emoji breaks the monospace surface, so no file that renders
-  // provider-facing copy may reintroduce it.
   function test_no_emoji_hourglass_in_assets() {
     var files = [
       "CoreView.js",
@@ -627,9 +575,6 @@ TestCase {
     }
   }
 
-  // §5 amended 2026-08-01 (owner picked it on live mockups): chips sit at
-  // spacing.md (6). The old xxl (12) read as scattered once the numeral
-  // moved beside the icon and its box slack joined the inter-chip gap.
   function test_chip_row_spacing_is_md() {
     var xhr = new XMLHttpRequest()
     xhr.open("GET", widgetUrl, false)

--- a/tests/qml/tst_Format.qml
+++ b/tests/qml/tst_Format.qml
@@ -5,7 +5,6 @@ import "../../CoreView.js" as Core
 TestCase {
   name: "AgentBarFormat"
 
-  // 2026-07-28T15:00:00Z as fixed "now".
   readonly property double nowMs: Date.parse("2026-07-28T15:00:00Z")
 
   property string repoRoot: {
@@ -47,8 +46,6 @@ TestCase {
     compare(Core.resetCountdownText(null, nowMs), "")
   }
 
-  // The lead window's label line reads "Session (5h) \u00b7 resets in 3h 1m", and
-  // "resets in now" is not English.
   function test_reset_phrase_follows_the_countdown() {
     compare(Core.resetPhrase("3h 1m"), "resets in")
     compare(Core.resetPhrase("now"), "resets")
@@ -63,8 +60,6 @@ TestCase {
     compare(Core.formatAgoText("nope", nowMs), "")
   }
 
-  // The other half of the Rust seam: same table, same expectations, read from
-  // the same file. See tests/countdown_parity.rs.
   function test_countdown_matches_the_shared_table() {
     var rows = JSON.parse(read("tests/fixtures/countdown-table.json"))
     verify(rows.length >= 12, "the shared table must not shrink")

--- a/tests/qml/tst_Keyboard.qml
+++ b/tests/qml/tst_Keyboard.qml
@@ -89,7 +89,6 @@ TestCase {
     var src = read("Popup.qml")
     verify(src.indexOf("scrollShortcuts") >= 0)
     verify(src.indexOf("id: scrollShortcuts") >= 0)
-    // Shortcuts must appear after PanelKeyCatcher opens, not as bare panel children.
     var keyCatcherAt = src.indexOf("id: keyCatcher")
     var firstShortcutAt = src.indexOf("Shortcut {")
     verify(keyCatcherAt >= 0)

--- a/tests/qml/tst_Maintenance.qml
+++ b/tests/qml/tst_Maintenance.qml
@@ -24,8 +24,6 @@ TestCase {
     return String(xhr.responseText || "")
   }
 
-  // ---- Login argv ----
-
   function test_login_detached_argv() {
     var argv = Core.loginDetachedArgv("/home/u/.config/omarchy/plugins/othavi0.agent-bar", "claude")
     compare(argv.length, 3)
@@ -53,8 +51,6 @@ TestCase {
     compare(argv[6], "amp")
   }
 
-  // ---- Update / uninstall argv + confirmation ----
-
   function test_update_and_uninstall_argv() {
     var check = Core.updateCheckArgv("/bin/agent-bar")
     compare(check.join(" "), "/bin/agent-bar update check")
@@ -74,11 +70,6 @@ TestCase {
     compare(purge.purgeSettingsAndBackups, true)
   }
 
-  // The check payloads are the shared fixtures pinned byte-exactly to the
-  // Rust serializer by tests/update_check_parity.rs. Never inline a payload
-  // here: the previous inline documents used a key set the helper never
-  // emitted, and the suite stayed green while the product said
-  // "Update check failed." on every successful check.
   function checkFixture(name) {
     return read("tests/fixtures/update-check/" + name)
   }
@@ -94,7 +85,6 @@ TestCase {
   }
 
   function test_update_check_up_to_date() {
-    // A stale target from an earlier check must not survive the new answer.
     var ui = Core.maintenanceUiIdle("")
     ui.targetVersion = "10.4.0"
     ui.releaseNotesUrl = "https://github.com/othavi0/omarchy-agent-bar/releases/tag/v10.4.0"
@@ -103,15 +93,10 @@ TestCase {
     compare(ui.installedVersion, "10.4.0")
     compare(ui.targetVersion, "")
     compare(ui.releaseNotesUrl, "")
-    // latestCompatible is null when no release fits this target/contract;
-    // there is still nothing to offer, so the UI answer is the same.
     var none = Core.maintenanceUiFromCheck(Core.maintenanceUiIdle("10.3.1"), checkFixture("no-compatible.json"), 0, "10.3.1")
     compare(none.phase, "up_to_date")
   }
 
-  // reinstallRequired short-circuits before the available/up-to-date branches
-  // even though this fixture's `available` is false — the git-less install
-  // sentinel takes priority over the ordinary "nothing to offer" answer.
   function test_update_check_reinstall_required() {
     var ui = Core.maintenanceUiIdle("10.3.1")
     ui.targetVersion = "10.4.0"
@@ -124,8 +109,6 @@ TestCase {
     verify(ui.message.indexOf("omarchy plugin add https://github.com/othavi0/omarchy-agent-bar.git") >= 0)
   }
 
-  // BUNDLE-021: a successful check always writes exactly the JSON document,
-  // so exit 0 with anything else is a failed check, not an implied answer.
   function test_update_check_rejects_unusable_stdout() {
     compare(Core.maintenanceUiFromCheck(Core.maintenanceUiIdle("1.0.0"), "", 1, "1.0.0").phase, "error")
     compare(Core.maintenanceUiFromCheck(Core.maintenanceUiIdle("1.0.0"), "", 0, "1.0.0").phase, "error")
@@ -140,7 +123,6 @@ TestCase {
     var msg = Core.updateConfirmMessage(ui)
     compare(msg, "Updates 10.0.0 → 10.2.0. Settings stay. "
         + "Fast-forwards to the latest release; a failed validation rolls back.")
-    // §5.6 shortened it; the old sentence must not come back.
     verify(msg.indexOf("This replaces the plugin bundle") < 0)
     verify(msg.indexOf("Rolls back if it fails") < 0)
   }
@@ -150,8 +132,6 @@ TestCase {
     verify(src.indexOf("Update check returned an unusable response.") < 0)
     var first = src.indexOf("Update check failed.")
     verify(first >= 0)
-    // One failure exit, one string: a second occurrence means a second
-    // failure branch grew its own copy.
     verify(src.indexOf("Update check failed.", first + 1) < 0,
            "every failure path must share the single string")
   }
@@ -177,10 +157,6 @@ TestCase {
     compare(ui.uninstallArmed, false)
   }
 
-  // The dialog binds its own message from uninstallArmed/purgeSettings, and
-  // the only reader of ui.message sits behind the dialog's scrim, so this
-  // string was set and never seen. The second click is communicated by the
-  // confirm button flipping to "Uninstall now".
   function test_arming_sets_no_unseen_message() {
     var src = read("CoreMaintenance.js")
     verify(src.indexOf("Click Uninstall again") < 0)
@@ -200,8 +176,6 @@ TestCase {
     compare(un.purge, true)
     compare(un.payload.purgeSettingsAndBackups, true)
   }
-
-  // ---- Source contracts ----
 
   function test_service_login_uses_exec_detached() {
     var src = read("Service.qml")
@@ -254,12 +228,9 @@ TestCase {
     verify(src.indexOf("ConfirmDialog") >= 0)
     verify(src.indexOf("Release notes") >= 0)
     verify(src.indexOf("Text.RichText") < 0)
-    // §5.6: the package name is `agent-bar`; every surface says `Agent Bar`.
     verify(src.indexOf("Uninstall agent-bar") < 0)
-    // The installation-type row is gone — it only ever had one value.
     verify(src.indexOf("Installation type") < 0)
     verify(src.indexOf("Plugin bundle") < 0)
-    // Ceremony removed: no "Final confirmation:", no "Click Uninstall again."
     verify(src.indexOf("Final confirmation") < 0)
     verify(src.indexOf("Deletes Agent Bar, your settings and every backup.") >= 0)
     verify(src.indexOf("Deletes Agent Bar. Your settings stay.") >= 0)
@@ -268,7 +239,6 @@ TestCase {
 
   function test_install_type_is_gone_from_the_model() {
     var src = read("CoreMaintenance.js")
-    // Dead the moment the row was deleted; the contract forbids keeping it.
     verify(src.indexOf("installType") < 0)
   }
 
@@ -282,8 +252,6 @@ TestCase {
     var ok = { automatic: true, settingsLoaded: true, versionReady: true,
                blocked: false, checkBusy: false, popupOpen: false }
     compare(Core.automaticUpdateCheckAllowed(ok), true)
-    // settingsLoaded: a failed boot read must not turn an opt-out into an
-    // update (the default is "on", so unknown settings fail closed here).
     var keys = ["automatic", "settingsLoaded", "versionReady"]
     for (var i = 0; i < keys.length; i++) {
       var off = JSON.parse(JSON.stringify(ok))

--- a/tests/qml/tst_Popup.qml
+++ b/tests/qml/tst_Popup.qml
@@ -124,9 +124,7 @@ TestCase {
     verify(src.indexOf("Image") >= 0)
     verify(src.indexOf("settingsBtn") >= 0 || src.indexOf("Settings") >= 0)
     verify(src.indexOf("󰒓") >= 0)
-    // No provider display-name Text labels as primary rail content
     verify(src.indexOf("modelData.name") < 0 || src.indexOf("Accessible.name") >= 0)
-    // Names only via Accessible / tooltip path, not as visible Text content of the icon
     verify(src.indexOf("text: modelData.name") < 0)
     verify(src.indexOf("text: modelData") < 0)
   }
@@ -138,20 +136,11 @@ TestCase {
     verify(src.indexOf("name") >= 0)
     verify(src.indexOf("plan") >= 0)
     verify(src.indexOf("󰑐") >= 0)
-    // Connection state is implied structurally (windows render only when
-    // ready) and update age lives in ProviderView's stale banner (plan 03
-    // deleted the meta footer) — the header no longer owns that prop/text.
     verify(src.indexOf("connection") < 0)
-    // §6: the plan pill becomes an uppercase tag — no more pill radius.
-    // Task 4 extracted the tag shape into HeaderTag.qml (its own uppercase
-    // assertion lives in test_header_renders_plan_and_severity_tags below),
-    // so this file only needs to prove it delegates to that component.
     verify(src.indexOf("HeaderTag") >= 0)
     verify(src.indexOf("radius: height / 2") < 0)
   }
 
-  // §6: name · plan tag · [severity tag] · spacer · refresh. One tag shape,
-  // one urgent variant — not two hand-copied Rectangles.
   function test_header_renders_plan_and_severity_tags() {
     var hdr = read("components/ProviderHeader.qml")
     verify(hdr.indexOf("HeaderTag {") >= 0)
@@ -159,7 +148,6 @@ TestCase {
     verify(hdr.indexOf("id: severityTag") >= 0)
     verify(hdr.indexOf("property string severityText") >= 0)
     verify(hdr.indexOf("property bool severityUrgent") >= 0)
-    // The pill's own Rectangle is gone; the tag lives in one file now.
     verify(hdr.indexOf("border.color: Style.normalBorderColor") < 0)
 
     var tag = read("components/HeaderTag.qml")
@@ -169,8 +157,6 @@ TestCase {
     verify(tag.indexOf("Qt.rgba(") < 0)
   }
 
-  // The refresh glyph must stay inside the pane when both tags render; the
-  // spacer subtracts the real tag widths instead of a lump constant.
   function test_header_spacer_accounts_for_both_tags() {
     var hdr = read("components/ProviderHeader.qml")
     verify(hdr.indexOf("planTag.visible ? planTag.width") >= 0)
@@ -183,8 +169,6 @@ TestCase {
 
   function test_rail_has_no_own_frame() {
     var rail = read("ProviderRail.qml")
-    // §6: the rail draws no fill or border of its own inside an already
-    // bordered card; the selected plate is the only chrome.
     verify(rail.indexOf("normalFill") < 0)
     verify(rail.indexOf("normalBorderColor") < 0)
     verify(rail.indexOf("selectedFill") >= 0)
@@ -203,59 +187,36 @@ TestCase {
   }
 
   function test_no_meta_footer() {
-    // NOTE: repoRoot (above) already pops to the repo root, matching every
-    // sibling read() call in this file ("ProviderView.qml" etc., relative to
-    // repo root); a path like "../../ProviderView.qml" would resolve outside
-    // the repo, so XHR would return "" and the test would pass/fail
-    // vacuously regardless of ProviderView.qml's contents.
     var view = read("ProviderView.qml")
-    // §6/§9: the meta footer is removed in all states; connection state is
-    // structural. The `"Updated "` ban lifted with UX-028 (amended) — the age
-    // is now a neutral line owned by test_stale_age_line_is_neutral. What this
-    // test still guards is the footer's own vocabulary never coming back.
     verify(view.indexOf("connection") < 0)
     verify(view.indexOf('"Cache"') < 0)
     verify(view.indexOf('"Live"') < 0)
   }
 
-  // UX-028 (amended): the urgent stale banner is replaced by one neutral age
-  // line. No glyph, no urgent colour, no Retry — the header's own refresh
-  // control already covers the action, and nothing may read as a fault.
   function test_stale_age_line_is_neutral() {
     var view = read("ProviderView.qml")
     verify(view.length > 0)
     verify(view.indexOf("formatAgoText") >= 0)
     verify(view.indexOf('"Updated "') >= 0)
-    // The alarming shapes the old banner used must all be gone.
     verify(view.indexOf("󰅐") < 0)
     verify(view.indexOf("⌛") < 0)
     verify(view.indexOf('"Last data "') < 0)
     verify(view.indexOf("Color.urgent") < 0)
     verify(view.indexOf("errorMessage") < 0)
-    // formatAgoText already returns "5m ago"/"just now" — an appended " ago"
-    // literal is the regression shape this test exists to catch.
     verify(view.indexOf('+ " ago"') < 0)
   }
 
-  // The retained reading must render at full strength: no opacity knob may
-  // reappear keyed on staleness.
   function test_stale_windows_are_not_dimmed() {
     var view = read("ProviderView.qml")
     verify(view.length > 0)
     verify(view.indexOf("isStale") < 0)
     verify(view.indexOf("stale_windows") < 0)
     verify(view.indexOf("dimmed:") < 0)
-    // Banning the `dimmed` property alone only bans one spelling. An inline
-    // `opacity:` binding keyed on provider.state would restore the same
-    // visual result under a different name, so the pane may assign none.
-    // (Prose may still say "opacity" — only the binding is banned.)
     verify(view.indexOf("opacity:") < 0)
   }
 
   function test_full_width_separator_present() {
     var src = read("ProviderView.qml")
-    // Separator is the host's PanelSeparator (fixed 1px height internally);
-    // this file only needs to place it full-width.
     verify(src.indexOf("PanelSeparator") >= 0)
     verify(src.indexOf("width: parent.width") >= 0)
   }
@@ -274,7 +235,6 @@ TestCase {
       verify(src.indexOf("Text.RichText") < 0, files[i])
       verify(src.indexOf("RichText") < 0, files[i])
       verify(src.indexOf("innerHTML") < 0, files[i])
-      // Prefer explicit PlainText when setting format
       if (src.indexOf("textFormat:") >= 0)
         verify(src.indexOf("Text.PlainText") >= 0, files[i] + " should use PlainText")
     }
@@ -291,7 +251,6 @@ TestCase {
     ]
     for (var i = 0; i < files.length; i++) {
       var src = read(files[i])
-      // Allow the money detector regex itself in CoreView.js
       if (files[i].indexOf("CoreView.js") >= 0)
         continue
       verify(!Core.containsMoneyCopy(src), files[i] + " has money copy")
@@ -341,8 +300,6 @@ TestCase {
     compare(Core.mapActionKind("bash"), null)
   }
 
-  // §6: the lead window is 2.5x the body size with the reset promoted into
-  // its label line; the old bottom "resets" row is gone.
   function test_lead_window_geometry_and_label_line() {
     var win = read("components/UsageWindow.qml")
     verify(win.indexOf("Math.round(Style.font.body * 2.5)") >= 0)
@@ -355,7 +312,6 @@ TestCase {
            "the reset row moved into the label line")
   }
 
-  // UX-020A extended: every window row carries a track, not just the lead.
   function test_compact_rows_carry_their_own_track() {
     var win = read("components/UsageWindow.qml")
     var compact = win.slice(win.indexOf("id: compactRow"))
@@ -368,18 +324,12 @@ TestCase {
            "the reset column is measured with TextMetrics, never hardcoded px")
   }
 
-  // §7: critical paints the numeral and the fill in Color.urgent; nothing
-  // else in this file may introduce a colour.
   function test_critical_window_uses_the_urgent_token() {
     var win = read("components/UsageWindow.qml")
     verify(win.indexOf("Color.urgent") >= 0)
     verify(win.indexOf('root.severity === "critical"') >= 0)
     verify(win.indexOf("Qt.rgba(") < 0)
 
-    // The numeral and its track must agree about severity. They disagreed
-    // once: valueColor ignored `dimmed` while fillColor gave it precedence,
-    // so a stale critical window painted an urgent number beside a neutral
-    // track. Both must reach Color.urgent from `isCritical` alone.
     var value = win.slice(win.indexOf("readonly property color valueColor"))
     value = value.slice(0, value.indexOf("\n"))
     verify(value.indexOf("root.dimmed") < 0,
@@ -396,7 +346,6 @@ TestCase {
     verify(view.indexOf("emphasis: true") >= 0)
     verify(view.indexOf("emphasis: false") >= 0)
     verify(view.indexOf("severityText: ") >= 0)
-    // The quiet rule between lead and rows is gone (approved mockup).
     verify(view.indexOf("strength: 0.08") < 0)
   }
 
@@ -443,10 +392,6 @@ TestCase {
     verify(view.indexOf("groups.secondary") < 0)
   }
 
-  // §6/§3.7 amended 2026-08-03 (owner decision on live mockups): the LEAD
-  // window appends the reset's wall-clock time after the countdown, in the
-  // viewer's locale format. The plan-04 deletions stay deleted: no weekday
-  // table, no fixed-format humaniser, compact rows countdown-only.
   function test_absolute_clock_humaniser_is_gone() {
     var core = read("CoreView.js")
     verify(core.indexOf("formatResetText") < 0)
@@ -458,10 +403,8 @@ TestCase {
   function test_lead_reset_clock_is_locale_formatted() {
     var core = read("CoreView.js")
     verify(core.indexOf("function resetClockText(") >= 0)
-    // The format is the caller's locale format, never hardcoded.
     verify(core.indexOf('"hh:mm"') < 0)
     verify(core.indexOf('"HH:mm"') < 0)
-    // 24h locale shape and 12h locale shape both come from the same seam.
     var h24 = Core.resetClockText("2026-08-02T02:00:00Z", "HH:mm")
     verify(/^\(\d{2}:\d{2}\)$/.test(h24), "got: " + h24)
     var h12 = Core.resetClockText("2026-08-02T02:00:00Z", "h:mm AP")
@@ -472,7 +415,6 @@ TestCase {
 
   function test_only_the_lead_window_gets_the_clock() {
     var view = read("ProviderView.qml")
-    // Exactly one binding site — the lead Repeater; compact rows stay bare.
     var first = view.indexOf("resetClock:")
     verify(first >= 0, "lead window must bind resetClock")
     verify(view.indexOf("resetClock:", first + 1) < 0,
@@ -495,7 +437,6 @@ TestCase {
       verify(before.indexOf('typeof root.rebuildFocusTargets === "function"') >= 0,
              "unguarded rebuildFocusTargets() at offset " + m.index)
     }
-    // One deferral helper instead of a guarded closure per call site.
     verify(src.indexOf("function scheduleFocusRebuild()") >= 0)
     compare(src.split("Qt.callLater(").length - 1, 2,
             "only scheduleFocusRebuild and onSelectedIdChanged defer")

--- a/tests/qml/tst_ProviderStates.qml
+++ b/tests/qml/tst_ProviderStates.qml
@@ -53,21 +53,12 @@ TestCase {
     verify(Core.stateBody(p).indexOf("does not publish a usage percentage") >= 0)
   }
 
-  // UX-028 (amended): stale renders through the ready path. The dedicated
-  // "stale_windows" mode is gone — retained data is data, so the pane draws
-  // the same windows it would draw for a fresh reading.
   function test_stale_retains_windows_and_label() {
     var p = firstProvider("valid-stale.json")
     compare(Core.contentMode(p), "windows")
     compare(Core.stateTitle(p), "")
     compare(Core.stateBody(p), "")
-    // The typed error survives in the JSON for `agent-bar status`; the pane
-    // simply stops rendering it.
     verify(Core.errorMessage(p).length > 0)
-    // No recovery action either: a repair button beside a good number is the
-    // fault impression this change removes. The fixture still carries
-    // action.kind === "retry", so this proves the view filters it, not that
-    // the helper stopped sending it.
     compare(String(p.action && p.action.kind || ""), "retry")
     compare(Core.stateActions(p).length, 0)
     var lines = Core.windowDisplayLines(p, "used")
@@ -76,8 +67,6 @@ TestCase {
     compare(lines[0].percent, 90)
   }
 
-  // A stale provider whose retained reading carries no window must not fall
-  // back to the error pane: it takes the same empty-windows path as ready.
   function test_stale_without_windows_uses_empty_windows_mode() {
     var p = { id: "amp", name: "Amp", state: "stale", windows: [],
               lastSuccessAt: "2026-07-26T18:42:00Z",
@@ -93,8 +82,6 @@ TestCase {
     var acts = Core.stateActions(p)
     var kinds = acts.map(function (a) { return a.kind })
     verify(kinds.indexOf("view_installation") >= 0)
-    // Fixture's error is retryable: false — "Check again" (a Retry action)
-    // must not be offered for a non-retryable error (JSON-025 addendum).
     verify(kinds.indexOf("retry") < 0)
   }
 
@@ -105,7 +92,6 @@ TestCase {
     verify(acts.length >= 1)
     var kind = acts[0].kind
     verify(kind === "login" || kind === "view_installation")
-    // Label should be user-facing Sign in when login
     if (kind === "login")
       verify(acts[0].label.length > 0)
   }
@@ -148,9 +134,6 @@ TestCase {
     verify(h.plan.length > 0)
     verify(h.connection === undefined)
     compare(h.refreshing, true)
-    // showStale was computed, passed to ProviderHeader and asserted here, but
-    // never rendered by anything. UX-028 (amended) retired the concept it
-    // stood for, so the dead field goes with it.
     verify(h.showStale === undefined)
     verify(h.lastSuccessAt.length > 0)
   }
@@ -203,8 +186,6 @@ TestCase {
     compare(Core.severityLevel("nope"), "")
   }
 
-  // The Warning level renders as "Low" (visual design §7); "warning" is the
-  // internal name it shares with Rust.
   function test_severity_tag_words() {
     compare(Core.severityTagText("critical"), "Critical")
     compare(Core.severityTagText("warning"), "Low")
@@ -220,8 +201,6 @@ TestCase {
             "critical")
   }
 
-  // §7: severity is computed from usedPercent, so switching the displayed
-  // metric never changes what counts as critical.
   function test_severity_ignores_the_display_metric() {
     var provider = readyWith([{ id: "s", label: "S", usedPercent: 96, remainingPercent: 4,
                                 resetsAt: "2026-07-28T18:00:00Z" }])
@@ -230,8 +209,6 @@ TestCase {
     compare(Core.windowLayout(provider, "used", now).lead.severity, "critical")
   }
 
-  // Among non-session windows severity still outranks the nearest reset
-  // (a session window would pin the lead first; see the 2026-09-04 tests).
   function test_lead_election_critical_beats_nearest_reset() {
     var layout = layoutOf([
       { id: "daily", label: "Daily (1d)", usedPercent: 10, remainingPercent: 90,
@@ -255,9 +232,6 @@ TestCase {
     compare(layout.lead.id, "b")
   }
 
-  // UX-020D step 2 (amended 2026-08-07): plan windows outrank non-plan
-  // windows when nothing is critical, so a subscriber leads with the
-  // subscription instead of the daily free window's nearer reset.
   function test_lead_election_plan_beats_nearest_reset() {
     var layout = layoutOf([
       { id: "daily", label: "Daily (1d)", usedPercent: 31, remainingPercent: 69,
@@ -268,7 +242,6 @@ TestCase {
         resetsAt: null }
     ], "2026-08-07T15:00:00Z")
     compare(layout.lead.id, "plan-other")
-    // The rest keeps delivered order: free first, then the healthier bucket.
     compare(layout.rest.length, 2)
     compare(layout.rest[0].id, "daily")
     compare(layout.rest[1].id, "plan-orb")
@@ -294,8 +267,6 @@ TestCase {
     compare(layout.lead.id, "plan-other")
   }
 
-  // A critical plan window leads through rule 1 (severity), not rule 2 —
-  // same lead either way, but the severity tag must say Critical.
   function test_lead_election_critical_plan_leads_by_severity() {
     var layout = layoutOf([
       { id: "daily", label: "Daily (1d)", usedPercent: 31, remainingPercent: 69,
@@ -309,8 +280,6 @@ TestCase {
     compare(layout.lead.severity, "critical")
   }
 
-  // Severity is the one signal plan preference never displaces: an exhausted
-  // free window still takes the lead over a healthy subscription.
   function test_lead_election_critical_free_beats_healthy_plan() {
     var layout = layoutOf([
       { id: "daily", label: "Daily (1d)", usedPercent: 96, remainingPercent: 4,
@@ -322,8 +291,6 @@ TestCase {
     compare(layout.lead.severity, "critical")
   }
 
-  // Non-session ids on purpose: a session window would be pinned before this
-  // step ever ran (see the 2026-09-04 tests).
   function test_lead_election_nearest_future_reset_when_healthy() {
     var layout = layoutOf([
       { id: "weekly", label: "Weekly (7d)", usedPercent: 40, remainingPercent: 60,
@@ -332,7 +299,6 @@ TestCase {
         resetsAt: "2026-07-28T18:00:00Z" }
     ], "2026-07-28T15:00:00Z")
     compare(layout.lead.id, "daily")
-    // The rest keeps delivered order, not election order.
     compare(layout.rest.length, 1)
     compare(layout.rest[0].id, "weekly")
   }
@@ -400,8 +366,6 @@ TestCase {
     compare(layout.rest.length, 0)
   }
 
-  // A window id outside the old allowlist is now electable — the exact bug
-  // the allowlist caused (it silently demoted anything unknown).
   function test_unknown_window_id_can_lead() {
     var layout = layoutOf([
       { id: "weekly-model:opus", label: "Opus", usedPercent: 97, remainingPercent: 3,
@@ -412,9 +376,6 @@ TestCase {
     compare(layout.lead.id, "weekly-model:opus")
   }
 
-  // UX-020D (amended 2026-09-04): a session window leads whenever present.
-  // Live data from 2026-09-03: overnight the session reset elapsed, so the
-  // old election handed the chip to the weekly window every morning.
   function test_session_window_leads_over_sooner_weekly_reset() {
     var windows = [
       { id: "session", label: "Session (5h)", usedPercent: 21, remainingPercent: 79,
@@ -428,7 +389,6 @@ TestCase {
     compare(Core.windowLayout(readyWith(windows), "remaining", morning).lead.id, "session")
     compare(Core.chipPercentText(readyWith(windows), "used", morning), "21%")
 
-    // An active session whose reset comes after the weekly reset still leads.
     var active = layoutOf([
       { id: "session", label: "Session (5h)", usedPercent: 3, remainingPercent: 97,
         resetsAt: "2026-09-04T16:00:00Z" },
@@ -440,8 +400,6 @@ TestCase {
     compare(active.rest[0].id, "weekly")
   }
 
-  // A critical weekly window keeps the urgent tint and the "!" cue but never
-  // takes the chip number away from the session.
   function test_session_window_leads_over_critical_weekly() {
     var provider = readyWith([
       { id: "session", label: "Session (5h)", usedPercent: 10, remainingPercent: 90,
@@ -454,12 +412,9 @@ TestCase {
     compare(Core.chipPercentText(provider, "remaining", now), "90%")
     compare(Core.chipSeverityUrgent(provider), true)
     compare(Core.chipStateCue(provider), "!")
-    // The urgent numeral is not the critical number, so the word carried by
-    // the cue is what keeps this from being a colour-only signal (UX-020C).
     compare(Core.chipCueLabel(provider), "critical")
   }
 
-  // Antigravity's five-hour bucket is the same kind of window under its own id.
   function test_gemini_5h_window_leads_like_session() {
     var layout = layoutOf([
       { id: "gemini-weekly", label: "Gemini · 7d", usedPercent: 40,
@@ -470,9 +425,6 @@ TestCase {
     compare(layout.lead.id, "gemini-5h")
   }
 
-  // Antigravity meters Gemini and Claude/GPT on separate quotas. The family in
-  // use is the one draining its five-hour window, so the lowest remaining
-  // session leads; an idle family sits at 100 % and only wins a tie.
   function antigravityWindows(geminiSession, thirdPartySession) {
     return [
       { id: "gemini-weekly", label: "Gemini · 7d", usedPercent: 20,
@@ -519,13 +471,10 @@ TestCase {
     compare(layout.lead.resetPhrase, "resets in")
   }
 
-  // UX-012 (amended): the clock glyph is retired. Stale earns no cue, and no
-  // file may reintroduce one — the bar must stay silent about staleness.
   function test_chip_state_cue_stale_is_silent() {
     compare(Core.chipStateCue({ state: "stale" }), "")
     var view = read("CoreView.js")
     var pane = read("ProviderView.qml")
-    // Guard against a vacuous pass: read() returns "" for a bad path.
     verify(view.length > 0)
     verify(pane.length > 0)
     verify(view.indexOf("󰅐") < 0)
@@ -638,9 +587,6 @@ TestCase {
         "Popup must drive ProviderView.active from its own open state")
   }
 
-  // JSON-022C: Codex's rate-limit reset count renders as a muted popup line,
-  // singular/plural, and stays empty for absent or zero (byte-identical
-  // popup for every other provider).
   function test_reset_line_visible_only_when_positive() {
     var withResets = { id: "codex", name: "Codex", state: "ready", windows: [],
                         rateLimitResetsAvailable: 2 }

--- a/tests/qml/tst_Screenshots.qml
+++ b/tests/qml/tst_Screenshots.qml
@@ -2,7 +2,6 @@ import QtQuick
 import QtTest
 import "TestPalette.js" as Core
 
-// Deterministic UI evidence captures for CP2 (TEST screenshot inventory).
 TestCase {
   id: testCase
   name: "AgentBarScreenshots"
@@ -19,10 +18,8 @@ TestCase {
   }
 
   property string evidenceDir: {
-    // Prefer env from verify-v10-ui; fallback to repo target path.
     var env = ""
     try {
-      // Qt 6: no portable env in pure QML; verify script also passes via file.
       env = ""
     } catch (e) {}
     return repoRoot + "/target/v10-ui-evidence"
@@ -32,7 +29,6 @@ TestCase {
   property int capturesExpected: 0
   property var pendingNames: []
 
-  // Stage that renders state-labelled panels for grabToImage.
   Rectangle {
     id: stage
     width: 480
@@ -41,9 +37,6 @@ TestCase {
     property string titleText: ""
     property string bodyText: ""
     property string badgeText: ""
-    // UX-028 (amended): the age is its own neutral caption, never merged into
-    // the usage text. Modelled separately so the evidence cannot approve a
-    // presentation the pane does not produce.
     property string captionText: ""
     property color fg: "#e4e4e7"
     property color muted: "#a1a1aa"
@@ -103,21 +96,16 @@ TestCase {
     var p = Core.themePalette(mode)
     stage.color = p.background
     stage.fg = p.foreground
-    // Derived from this palette's own foreground at the supporting-text level,
-    // which is what the shipped components compute through Util.alpha. The
-    // literal 0.72 is pinned by tst_Tokens.qml's test_no_third_alpha_value;
-    // Util itself is unreachable here because qs.Commons will not compile
-    // under the bare Qt6 runner.
+    // tst_Tokens.qml pins the 0.72 supporting-text alpha. Util.alpha itself is
+    // unreachable here because qs.Commons will not compile under the bare Qt6
+    // runner.
     var fg = Qt.color(p.foreground)
     stage.muted = Qt.rgba(fg.r, fg.g, fg.b, 0.72)
     stage.badgeColor = p.urgent
   }
 
   function paintState(name) {
-    // Clear per-state fields first: the stage is reused across captures, so an
-    // unset field would leak the previous panel's value into this one.
     stage.captionText = ""
-    // Map evidence basename → deterministic fixture panel
     if (name.indexOf("ready-light") === 0) {
       applyTheme("light")
       stage.titleText = "Claude"
@@ -146,10 +134,6 @@ TestCase {
       stage.badgeText = "Connected · refreshing"
       stage.bodyText = "Weekly (7d) · resets in 23h 1m · 74% left (prior data kept)"
     } else if (name.indexOf("stale-dark") === 0) {
-      // UX-028 (amended): a retained reading is presented as a reading. This
-      // panel is ready-dark plus one neutral age caption — same title, same
-      // badge, same usage text. Any other difference would be evidence of a
-      // presentation the pane no longer produces.
       stage.titleText = "Claude"
       stage.badgeText = "Connected"
       stage.captionText = "Updated 14m ago"
@@ -171,13 +155,10 @@ TestCase {
       stage.badgeText = "Rate limited"
       stage.bodyText = "Codex hit a rate limit. Try again in a few minutes. Retry"
     } else if (name.indexOf("network-error-dark") === 0) {
-      // Provider swapped Grok -> Amp to keep the fixture internally
-      // consistent with the shipped copy (task brief names Amp here).
       stage.titleText = "Amp"
       stage.badgeText = "Network error"
       stage.bodyText = "Cannot reach Amp. Check your connection. Retry"
     } else if (name.indexOf("provider-error-dark") === 0) {
-      // Provider swapped Amp -> Grok to match, same reason as above.
       stage.titleText = "Grok"
       stage.badgeText = "Provider error"
       stage.bodyText = "Grok returned no limits. Retry"
@@ -221,7 +202,6 @@ TestCase {
       capturesDone++
       finished = true
     })
-    // Wait for async grab
     for (var i = 0; i < 50 && !finished; i++)
       wait(20)
     verify(finished, "grab timed out for " + name)

--- a/tests/qml/tst_Scroll.qml
+++ b/tests/qml/tst_Scroll.qml
@@ -49,7 +49,6 @@ TestCase {
   }
 
   function test_short_content_clamp() {
-    // Was scrolled deep; content shrinks
     compare(Core.clampContentY(400, 150, 200), 0)
   }
 
@@ -61,20 +60,15 @@ TestCase {
   }
 
   function test_fitted_popup_content_height() {
-    // No large empty floor: body 120 with min 160 → 160; body 400 → 400; cap 300 → 300
     compare(Core.fittedPopupContentHeight(120, 160, 560), 160)
     compare(Core.fittedPopupContentHeight(400, 160, 560), 400)
     compare(Core.fittedPopupContentHeight(900, 160, 560), 560)
-    // Old 280 floor is not required
     compare(Core.fittedPopupContentHeight(100, 160, 560), 160)
   }
 
   function test_content_y_for_item_reveals() {
-    // Item above viewport
     compare(Core.contentYForItem(100, 200, 1000, 20, 30), 20)
-    // Item below viewport
     compare(Core.contentYForItem(0, 200, 1000, 250, 40), 90)
-    // Item already visible
     compare(Core.contentYForItem(0, 200, 1000, 50, 20), 0)
   }
 
@@ -86,11 +80,8 @@ TestCase {
     verify(src.indexOf("boundsBehavior: Flickable.StopAtBounds") >= 0)
     verify(src.indexOf("ScrollBar.vertical") >= 0)
     verify(src.indexOf("ScrollBar.AsNeeded") >= 0)
-    // Overflow-gated interaction (short content must not scroll)
     verify(src.indexOf("flickableInteractive") >= 0 || src.indexOf("interactive:") >= 0)
-    // No artificial 280px empty floor
     verify(src.indexOf("Style.space(280)") < 0)
-    // No custom wheel inversion / network on scroll
     verify(src.indexOf("onWheel") < 0)
     verify(src.indexOf("angleDelta") < 0)
   }
@@ -103,12 +94,10 @@ TestCase {
 
   function test_provider_rail_stack_no_bottom_pin() {
     var src = read("ProviderRail.qml")
-    // Option A: Settings in ColumnLayout stack, not anchors.bottom over icons.
     verify(src.indexOf("ColumnLayout") >= 0)
     verify(src.indexOf("minStackHeight") >= 0)
     verify(src.indexOf("anchors.bottom: parent.bottom") < 0)
     verify(src.indexOf("border.width") >= 0)
-    // Settings uses same slot size (not PanelActionButton size blow-out).
     verify(src.indexOf("settingsItem") >= 0)
     verify(src.indexOf("PanelActionButton") < 0)
   }
@@ -117,7 +106,6 @@ TestCase {
     var src = read("Popup.qml")
     verify(src.indexOf("railGutter") >= 0)
     verify(src.indexOf("parent.width - rail.width - railGutter.width") >= 0)
-    // Old off-by-one that clipped content text on the left.
     verify(src.indexOf("parent.width - rail.width - 1") < 0)
   }
 }

--- a/tests/qml/tst_Service.qml
+++ b/tests/qml/tst_Service.qml
@@ -22,7 +22,6 @@ TestCase {
   property string fakeHelper: repoRoot + "/tests/qml/fixtures/fake-agent-bar"
   property string manifestPath: repoRoot + "/manifest.json"
 
-  // Harness mirrors Service.qml state machine without Quickshell.Io Process.
   Item {
     id: h
     property string helperVersion: ""
@@ -92,7 +91,6 @@ TestCase {
       statusBusy = true
       refreshing = true
       statusStartCount++
-      // argv available for assertions
       lastArgv = Core.statusArgv("/helper", taken.captured)
     }
     property var lastArgv: []
@@ -127,7 +125,6 @@ TestCase {
         settingsGen++
         settingsState = Settings.settingsBeginLoad(settingsGen)
         settingsDraft = null
-        // Harness completes load immediately with defaults (production uses config show).
         settingsState = Settings.settingsFinishLoad(settingsState, settingsGen, Core.defaultSettings())
         settingsDraft = settingsState.draft
       }
@@ -206,8 +203,6 @@ TestCase {
     return JSON.parse(xhr.responseText)
   }
 
-  // ---- Task 8 carry-over ----
-
   function test_manifest_shape() {
     var m = loadManifest()
     compare(m.id, "othavi0.agent-bar")
@@ -236,19 +231,16 @@ TestCase {
   function test_refresh_closed_providers() {
     reset()
     h.applyVersion("10.0.0\n")
-    h.statusBusy = false // clear auto kick
+    h.statusBusy = false
     h.statusStartCount = 0
     compare(h.refresh("claude"), "ok")
     compare(h.refresh("nope"), "unknown")
     compare(h.refreshRequestCount, 1)
   }
 
-  // ---- Task 9 ----
-
   function test_status_argv_shape_cache_use() {
     reset()
     h.applyVersion("10.0.0\n")
-    // First kick uses empty pending → cache use
     verify(h.lastArgv.indexOf("status") >= 0)
     verify(h.lastArgv.indexOf("format") >= 0)
     verify(h.lastArgv.indexOf("json") >= 0)
@@ -261,7 +253,6 @@ TestCase {
   function test_force_refresh_uses_bypass() {
     reset()
     h.applyVersion("10.0.0\n")
-    // complete in-flight
     h.applyStatus(h.activeStatusGeneration, validEnvelope("10.0.0"), 0)
     h.statusStartCount = 0
     h.refreshAll(true)
@@ -304,9 +295,7 @@ TestCase {
     h.kickStatus()
     var newGen = h.activeStatusGeneration
     verify(newGen !== oldGen)
-    // Late callback from old generation must not clobber.
     h.applyStatus(oldGen, validEnvelope("10.0.0"), 0)
-    // Still refreshing / busy from new gen until applied
     h.applyStatus(newGen, validEnvelope("10.0.0"), 0)
     compare(h.snapshot.schemaVersion, 2)
   }
@@ -315,7 +304,6 @@ TestCase {
     reset()
     h.applyVersion("10.0.0\n")
     var starts = h.statusStartCount
-    // While busy, kick must not start another.
     h.kickStatus()
     compare(h.statusStartCount, starts)
   }
@@ -352,7 +340,6 @@ TestCase {
     reset()
     h.requestPopup("mon-a", "claude", "usage")
     verify(h.popupOwner !== null)
-    // Foreign monitor cannot same-owner close, but dismiss always clears.
     h.closePopup("mon-b")
     verify(h.popupOwner !== null)
     h.dismissPopup()
@@ -520,8 +507,6 @@ TestCase {
   }
 
   // Live Quattro createObject sets manifest after construction completes.
-  // Service must retry production start when helper path appears, and must not
-  // mark versionFailed merely because the path was empty on first attempt.
   function test_service_qml_defers_probe_until_helper_path() {
     var xhr = new XMLHttpRequest()
     xhr.open("GET", serviceUrl, false)
@@ -533,13 +518,11 @@ TestCase {
     verify(src.indexOf("tryStartProduction()") >= 0)
     // The host strips __sourceDir from third-party manifests (Omarchy 4.0.3).
     verify(src.indexOf("__sourceDir") < 0)
-    // Empty helper path must wait, not finishVersionProbeFailure.
     var emptyBranch = src.indexOf("if (!helper.length)")
     verify(emptyBranch >= 0)
     var nextFail = src.indexOf("finishVersionProbeFailure", emptyBranch)
     var nextReturn = src.indexOf("return", emptyBranch)
     verify(nextReturn >= 0)
-    // The immediate empty-path branch must return without permanent failure.
     if (nextFail >= 0)
       verify(nextReturn < nextFail)
   }

--- a/tests/qml/tst_ServiceRaces.qml
+++ b/tests/qml/tst_ServiceRaces.qml
@@ -46,7 +46,6 @@ TestCase {
     property var lastForced: null
 
     function kickSettingsRead() {
-      // ARCH-024: handoff rejects new writes/polling; reads may still start.
       if (!Core.canStartLane(settingsReadBusy))
         return false
       settingsReadBusy = true
@@ -105,12 +104,10 @@ TestCase {
     reset()
     compare(h.kickStatus(false), true)
     compare(h.statusStartCount, 1)
-    // Overlapping forces while busy → union, no second start.
     h.pendingForcedTargets = Core.unionForced(h.pendingForcedTargets, "claude")
     h.pendingForcedTargets = Core.unionForced(h.pendingForcedTargets, "amp")
     compare(h.kickStatus(false), false)
     compare(h.statusStartCount, 1)
-    // Complete → follow-up with unioned targets.
     h.finishStatus(h.activeStatusGeneration, true)
     compare(h.statusStartCount, 2)
     verify(h.lastForced.ids["claude"] === true)
@@ -133,12 +130,10 @@ TestCase {
     compare(h.kickSettingsRead(), true)
     compare(h.kickSettingsWrite(), true)
     compare(h.kickMaintenanceCheck(), true)
-    // Same-lane re-entry blocked.
     compare(h.kickStatus(false), false)
     compare(h.kickSettingsRead(), false)
     compare(h.kickSettingsWrite(), false)
     compare(h.kickMaintenanceCheck(), false)
-    // Counts: one each.
     compare(h.statusStartCount, 1)
     compare(h.settingsReadStartCount, 1)
     compare(h.settingsWriteStartCount, 1)
@@ -150,7 +145,6 @@ TestCase {
     h.maintenanceState = Maintenance.maintenanceBeginHandoff(h.maintenanceState)
     compare(h.kickStatus(false), false)
     compare(h.kickSettingsWrite(), false)
-    // Read/check may still be allowed by policy; write/status blocked.
     compare(h.kickSettingsRead(), true)
   }
 
@@ -175,8 +169,6 @@ TestCase {
     var gen2 = h.activeStatusGeneration
     verify(gen2 > gen1)
     h.finishStatus(gen1, true)
-    // Stale gen1 must not set snapshot when gen2 is active.
-    // finishStatus checks generation — snapshot stays null until gen2 applies.
     compare(h.snapshot, null)
     h.finishStatus(gen2, true)
     verify(h.snapshot !== null)

--- a/tests/qml/tst_ServiceTimeouts.qml
+++ b/tests/qml/tst_ServiceTimeouts.qml
@@ -21,8 +21,6 @@ TestCase {
   function createService() {
     var component = Qt.createComponent(serviceUrl)
     if (component.status === Component.Ready) {
-      // testMode must hold before Component.onCompleted: pluginRoot resolves
-      // at construction and would otherwise start the bundled helper.
       service = component.createObject(testCase, { testMode: true, helperPath: "/nonexistent" })
     } else {
       // Arch packages Quickshell's QML plugins into the quickshell executable,
@@ -405,10 +403,6 @@ TestCase {
     compare(s.maintenanceUi.message, "Update started. The shell reloads when it finishes.")
   }
 
-  // Live 10.3.24: the two-minute tick lands on the second 60 s poll, the
-  // check returns before the status run, and the handoff waited for a status
-  // completion that never retried it: polling stopped and Settings stayed
-  // blocked for good.
   function test_handoff_waiting_on_status_starts_when_status_finishes() {
     var s = createService()
     bootstrapSettings(s)

--- a/tests/qml/tst_ServiceTimeouts.qml
+++ b/tests/qml/tst_ServiceTimeouts.qml
@@ -34,9 +34,10 @@ TestCase {
       var source = String(xhr.responseText)
       source = source.replace("import Quickshell\n", "")
       source = source.replace("import Quickshell.Io\n", "")
-      var processStart = source.indexOf("  // Processes (isolated lanes)")
-      var processEnd = source.indexOf("  // Single completed handler", processStart)
-      verify(processStart >= 0 && processEnd > processStart)
+      var processStart = source.indexOf("\n  Process {") + 1
+      var processEnd = source.indexOf("\n  Timer {", processStart) + 1
+      verify(processStart > 0 && processEnd > processStart)
+      verify(source.indexOf("\n  Process {", processEnd) < 0, "every Process block sits before the first Timer")
       var processMocks = [
         "  QtObject { id: versionProbe; property bool running: false; property var command: [] }",
         "  QtObject { id: statusProcess; property bool running: false; property var command: [] }",

--- a/tests/qml/tst_Settings.qml
+++ b/tests/qml/tst_Settings.qml
@@ -26,8 +26,6 @@ TestCase {
     return String(xhr.responseText || "")
   }
 
-  // ---- Pure draft / validation ----
-
   function test_default_settings_valid() {
     var d = Service.defaultSettings()
     var v = Core.validateSettingsDraft(d)
@@ -35,9 +33,6 @@ TestCase {
   }
 
   function test_default_settings_enable_only_claude_and_codex() {
-    // SET-027: a first run shows only the two providers nearly every user has
-    // a CLI for. This table must stay identical to `default_enabled` on the
-    // Rust side, which tests/servicecore_contract.rs enforces.
     var expected = {
       claude: true,
       codex: true,
@@ -62,12 +57,11 @@ TestCase {
     compare(d.providers[1].id, "codex")
     compare(d.providers[1].enabled, false)
 
-    d = Core.moveProvider(d, "grok", -1) // amp, grok swap near end
-    // default: claude, codex, amp, grok, antigravity → move grok up → claude, codex, grok, amp, antigravity
+    d = Core.moveProvider(d, "grok", -1)
     compare(d.providers[2].id, "grok")
     compare(d.providers[3].id, "amp")
 
-    d = Core.moveProvider(d, "claude", -1) // already top — no-op
+    d = Core.moveProvider(d, "claude", -1)
     compare(d.providers[0].id, "claude")
   }
 
@@ -115,8 +109,6 @@ TestCase {
     compare(Service.automaticUpdatesEnabled(d), false)
     compare(Core.validateSettingsDraft(d).ok, true)
 
-    // A document from a helper that predates the block, or no settings at
-    // all yet, means the product default: automatic.
     var legacy = Service.defaultSettings()
     delete legacy.updates
     compare(Core.validateSettingsDraft(legacy).ok, true)
@@ -143,7 +135,6 @@ TestCase {
     state = Core.settingsRestoreDefaults(state)
     compare(state.phase, "dirty")
     compare(state.draft.providers[0].enabled, true)
-    // Snapshot untouched
     compare(state.snapshot.providers[0].enabled, true)
   }
 
@@ -174,10 +165,10 @@ TestCase {
 
   function test_invalid_save_disabled() {
     var state = Core.settingsOpen(null, Service.defaultSettings(), 3)
-    compare(Core.settingsCanSave(state, state.draft), false) // clean
+    compare(Core.settingsCanSave(state, state.draft), false)
     state = Core.settingsMarkDirty(state)
     state.draft = Core.setRefreshInterval(state.draft, 5)
-    compare(Core.settingsCanSave(state, state.draft), false) // invalid
+    compare(Core.settingsCanSave(state, state.draft), false)
     state.draft = Core.setRefreshInterval(state.draft, 60)
     compare(Core.settingsCanSave(state, state.draft), true)
   }
@@ -203,8 +194,6 @@ TestCase {
     compare(state.pendingPayload.display.metric, "used")
   }
 
-  // ---- Source / UI contracts ----
-
   function test_settings_view_source_contracts() {
     var src = read("SettingsView.qml")
     verify(src.indexOf("Restore defaults") >= 0)
@@ -215,7 +204,6 @@ TestCase {
     verify(src.indexOf("Remaining") >= 0)
     verify(src.indexOf("Used") >= 0)
     verify(src.indexOf("MaintenanceView") >= 0)
-    // SET-026: the failed-load copy is rendered by the view itself.
     verify(src.indexOf("Settings could not be loaded") >= 0)
     verify(src.indexOf("load_failed") >= 0)
     verify(src.indexOf('text: "Restart shell"') >= 0)
@@ -226,14 +214,11 @@ TestCase {
     verify(src.indexOf("return root.loadFailed ? [restartShellButton] : []") >= 0)
     verify(src.indexOf("Keys.onReturnPressed") < 0,
            "Settings must rely on the host Button key mapping")
-    // No credentials / money / theme / cache editor
     verify(src.indexOf("credential") < 0 || src.toLowerCase().indexOf("no credential") >= 0)
     verify(src.indexOf("password") < 0)
     verify(src.indexOf("apiKey") < 0)
     verify(!View.containsMoneyCopy(src))
     verify(src.indexOf("Text.RichText") < 0)
-    // Copy design §5.7. The old labels are banned by name so a revert fails
-    // here rather than silently shipping.
     verify(src.indexOf("Bar shows") >= 0)
     verify(src.indexOf("Chip number") < 0)
     verify(src.indexOf("Refresh every") >= 0)
@@ -293,7 +278,6 @@ TestCase {
     var writeAt = body.indexOf("write(")
     var closeAt = body.indexOf("stdinEnabled = false", writeAt)
     verify(closeAt > writeAt, "stdinEnabled=false must follow write for EOF")
-    // Re-arm before each start so consecutive saves keep a writable stdin.
     var kick = src.indexOf("function kickSettingsWrite")
     verify(kick >= 0)
     var kickEnd = src.indexOf("function applySettingsWriteResult", kick)
@@ -308,13 +292,6 @@ TestCase {
     verify(src.indexOf("SettingsView") >= 0)
     verify(src.indexOf("settingsStub") < 0)
   }
-
-  // ---- Startup bootstrap (SET-023) ----
-  // settings.json is the only product settings source (SET-001), yet the
-  // service used to read it only when the Settings popup opened: every shell
-  // restart rendered defaultSettings() while the disk held the user's
-  // choices. The payloads here are the schema-pinned fixtures in
-  // tests/fixtures/settings-v1/ — never inline a settings document.
 
   function test_bootstrap_applies_persisted_settings() {
     var stdout = read("tests/fixtures/settings-v1/valid-used-metric.json")
@@ -335,10 +312,6 @@ TestCase {
     compare(Core.settingsBootstrapResult(null, invalid, 0), null)
   }
 
-  // SET-025: a helper newer than the loaded QML may list a provider the
-  // QML does not know. That row must validate, survive in the draft, and
-  // round-trip to config apply untouched — otherwise every catalog addition
-  // wedges Settings in "Loading" until the shell is restarted.
   function test_unknown_provider_from_newer_helper_validates_and_round_trips() {
     var doc = Service.defaultSettings()
     doc.providers.push({ id: "future-provider", enabled: true })
@@ -367,8 +340,6 @@ TestCase {
     compare(Core.validateSettingsDraft(doc).reason, "missing provider")
   }
 
-  // SET-026: a failed dialog load is a visible terminal state, not an
-  // endless locked "Loading".
   function test_failed_load_is_visible_and_locked() {
     var state = Core.settingsBeginLoad(4)
     state = Core.settingsFailLoad(state, 4)
@@ -376,15 +347,12 @@ TestCase {
     compare(state.busy, false)
     compare(Core.settingsControlsLocked(state), true)
     compare(Core.settingsCanSave(state, state.draft), false)
-    // A stale generation never flips a newer load.
     var newer = Core.settingsBeginLoad(5)
     compare(Core.settingsFailLoad(newer, 4).phase, "loading")
-    // Cancel has no snapshot to fall back to and must not fabricate one.
     compare(Core.settingsCancel(state).phase, "load_failed")
   }
 
   function test_bootstrap_never_clobbers_dialog_result() {
-    // A dialog read/save that finished first is newer than the boot read.
     var winner = { schemaVersion: 1 }
     var stdout = read("tests/fixtures/settings-v1/valid-used-metric.json")
     compare(Core.settingsBootstrapResult(winner, stdout, 0), winner)

--- a/tests/qml/tst_SettingsRaces.qml
+++ b/tests/qml/tst_SettingsRaces.qml
@@ -9,7 +9,6 @@ TestCase {
   name: "AgentBarSettingsRaces"
   when: windowShown
 
-  // Harness mirrors Service settings lanes without Process I/O.
   Item {
     id: h
     property var settingsState: Core.settingsClosed()
@@ -151,7 +150,6 @@ TestCase {
     var payload = JSON.parse(h.pendingSettingsPayload)
     compare(h.settingsState.phase, "saving")
     h.closePopup("a")
-    // SET-019: still saving after close
     compare(h.settingsState.phase, "saving")
     compare(h.settingsState.busy, true)
     h.applyWrite(gen, true, payload)
@@ -198,7 +196,6 @@ TestCase {
     compare(h.settingsState.phase, "clean")
     compare(h.settingsDraft.display.metric, "used")
 
-    // Stale failure for gen1 must not dirty a completed save
     h.applyWrite(gen1, false, null)
     compare(h.settingsState.phase, "clean")
     compare(h.settingsDraft.display.metric, "used")
@@ -213,8 +210,6 @@ TestCase {
     h.save()
     var gen1 = h.activeSettingsWriteGeneration
     var payload1 = JSON.parse(h.pendingSettingsPayload)
-    // Do not complete gen1 yet — but lane is busy so second save rejected.
-    // Complete gen1 first, then start gen2, then late gen1 fails.
     h.applyWrite(gen1, true, payload1)
 
     h.mutate(function (d) { return Core.setRefreshInterval(d, 90) })
@@ -223,7 +218,6 @@ TestCase {
     verify(gen2 > gen1)
     var payload2 = JSON.parse(h.pendingSettingsPayload)
 
-    // Late gen1 failure must not affect gen2 save
     h.applyWrite(gen1, false, null)
     compare(h.settingsState.phase, "saving")
     h.applyWrite(gen2, true, payload2)
@@ -239,7 +233,6 @@ TestCase {
     h.save()
     var captured = JSON.parse(h.pendingSettingsPayload)
     compare(captured.display.metric, "used")
-    // Edits while saving are locked
     h.mutate(function (d) { return Core.setDisplayMetric(d, "remaining") })
     compare(JSON.parse(h.pendingSettingsPayload).display.metric, "used")
     compare(h.settingsState.pendingPayload.display.metric, "used")
@@ -253,7 +246,6 @@ TestCase {
     h.save()
     var captured = JSON.parse(h.pendingSettingsPayload)
     compare(captured.notifications.reminderMinutes, 240)
-    // Edits while saving are locked
     h.mutate(function (d) { return Core.setReminderMinutes(d, 60) })
     compare(JSON.parse(h.pendingSettingsPayload).notifications.reminderMinutes, 240)
     compare(h.settingsState.pendingPayload.notifications.reminderMinutes, 240)

--- a/tests/qml/tst_Tokens.qml
+++ b/tests/qml/tst_Tokens.qml
@@ -40,9 +40,6 @@ TestCase {
     ]
   }
 
-  // Qt.darker divides HSV value. On a dark theme that recedes; on a light
-  // theme it advances, so secondary text outranks primary. Util.alpha works
-  // in both directions with one value.
   function test_no_qt_darker() {
     var files = tokenScannedFiles()
     for (var i = 0; i < files.length; i++) {
@@ -52,9 +49,6 @@ TestCase {
     }
   }
 
-  // Every numeric literal that appears in the opacity slot of a
-  // Util.alpha(color, opacity) call, read from source. Handles both plain
-  // literals and conditional expressions.
   function alphaArgValues(code) {
     var values = []
     var callRe = /Util\.alpha\(([^()]*)\)/g
@@ -73,19 +67,6 @@ TestCase {
     return values
   }
 
-  // Plan 03 removed ProviderView.qml's only two Util.alpha( call sites
-  // (the meta footer, :222/:232) along with the footer itself. The file
-  // legitimately needs no alpha role afterwards: the stale banner uses
-  // Color.urgent directly and the separators are PanelSeparator. It stays
-  // in tokenScannedFiles() above — the no-raw-Qt.rgba and closed-alpha-set
-  // scans still apply — but drops out of this REQUIRES-Util.alpha list.
-  //
-  // Task 4 moved ProviderHeader.qml's only Util.alpha( call site into the
-  // extracted HeaderTag.qml component (deliberately excluded from this list
-  // per its own file header: it was never "converted", it was born using
-  // Util.alpha). ProviderHeader.qml now composes HeaderTag and has no direct
-  // alpha call of its own, so it drops out of this list for the same reason
-  // ProviderView.qml did; it stays in tokenScannedFiles() above.
   function convertedFiles() {
     return [
       "SettingsView.qml",
@@ -96,26 +77,12 @@ TestCase {
     ]
   }
 
-  // Per-file exceptions to the two-level rule: a raw alpha with no host
-  // token, declared once with its reason so the strict rule keeps applying
-  // everywhere else. An undeclared third value still fails — exceptions only
-  // subtract the exact values listed, only for the file listed.
-  //
-  // The modal scrim that motivated this mechanism ended up binding to the
-  // host's Color.menu.scrim token instead of a raw alpha, so it needs no
-  // entry. The usage track's trackColor is the one real holdout: a data
-  // surface with no host token. Exactly one entry — a second would mean the
-  // mechanism grew into a loophole instead of staying a documented rarity.
   function textAlphaExceptions() {
     return {
       "components/UsageWindow.qml": ["0.12"]
     }
   }
 
-  // The "exactly two levels, no third value" contract that Tasks 5-8 build
-  // on. Values are extracted from the call sites themselves, not hardcoded,
-  // so a future task introducing a third alpha value fails here. Does not
-  // assert a call-site count: later plans legitimately add/remove sites.
   function test_no_third_alpha_value() {
     var files = tokenScannedFiles()
     var exceptions = textAlphaExceptions()
@@ -135,8 +102,6 @@ TestCase {
             "Util.alpha opacity must be exactly 0.55 or 0.72, found: " + distinct.join(","))
   }
 
-  // Closes the substitution hole: a hardcoded Qt.rgba(...) literal would
-  // satisfy test_no_qt_darker without ever using Util.alpha.
   function test_util_alpha_used_in_converted_files() {
     var files = convertedFiles()
     for (var i = 0; i < files.length; i++) {
@@ -183,15 +148,10 @@ TestCase {
            data.tag + ": meta " + meta + " must be under supporting " + supporting)
   }
 
-  // Empty: after this task no file keeps a raw foreground alpha. ConfirmDialog
-  // left the list in Task 5 when its scrim bound to Color.menu.scrim, and the
-  // usage track is the last holdout.
   function allowedRawAlphaFiles() {
     return []
   }
 
-  // The track tint has no host token, so it gets a name and exactly one
-  // declaration. Two would be a parallel system starting over.
   function test_usage_track_declared_once() {
     var code = read("components/UsageWindow.qml")
         .replace(/\/\/[^\n]*/g, "")

--- a/tests/root_tree_validate.rs
+++ b/tests/root_tree_validate.rs
@@ -1,16 +1,3 @@
-//! Root-tree completeness (monorepo migration Task 2).
-//!
-//! The plugin QML/JS/manifest tree now lives at the repo root alongside
-//! `src/`, `docs/`, and `target/`. `BundleBuilder::stamp` reads that root,
-//! stamps in the private helper, and writes
-//! `bundle.json` scoped to `SHIPPED_ROOT_FILES`/`SHIPPED_DIRS` only.
-//! `BundleValidator::validate_tree` covers receipt/filesystem consistency but
-//! never learned the shell's own manifest grammar (id regex, entry point
-//! existence, `kinds`, `defaultSection`), so this test reimplements that
-//! grammar directly in Rust -- mirroring `omarchy-plugin-validate` -- rather
-//! than shelling out to it, so the gate still runs in a CI container that has
-//! never heard of Omarchy.
-
 use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -35,9 +22,6 @@ fn copy_dir_all(src: &Path, dst: &Path) {
     }
 }
 
-/// Shipped top-level files that live directly at the real repo root, copied
-/// verbatim into the fake fixture root. `manifest.json` is included so the
-/// fixture carries the real id/kinds/entryPoints grammar this test checks.
 const ROOT_SOURCE_FILES: &[&str] = &[
     "BarWidget.qml",
     "CoreMaintenance.js",
@@ -54,15 +38,6 @@ const ROOT_SOURCE_FILES: &[&str] = &[
     "manifest.json",
 ];
 
-/// Build a throwaway "source repo" containing everything `stamp` reads.
-///
-/// The QML/JS/manifest/`components`/`icons` tree is the real one, so the
-/// manifest and entry points this test checks are the ones that actually
-/// ship. The terminal helper, README, LICENSE, and preview image are small
-/// fakes: their exact bytes are not under test here, only that `stamp`
-/// picks them up and the resulting root is contract-complete. Non-shipped
-/// noise (`src/`, `docs/dev/`, `Cargo.toml`) stands in for the rest of the
-/// monorepo that `stamp` must tolerate and ignore.
 fn fake_repo(root: &Path) {
     fs::create_dir_all(root).unwrap();
     for name in ROOT_SOURCE_FILES {
@@ -90,7 +65,6 @@ fn fake_repo(root: &Path) {
     )
     .unwrap();
 
-    // Non-shipped noise that must be tolerated and excluded from the receipt.
     fs::create_dir_all(root.join("src")).unwrap();
     fs::write(root.join("src/lib.rs"), b"// noise, not shipped\n").unwrap();
     fs::create_dir_all(root.join("docs/dev")).unwrap();
@@ -98,7 +72,6 @@ fn fake_repo(root: &Path) {
     fs::write(root.join("Cargo.toml"), b"[package]\nname = \"noise\"\n").unwrap();
 }
 
-/// Read `version` back out of the fixture's copied real manifest.json.
 fn manifest_version(repo_root: &Path) -> String {
     let bytes = fs::read(repo_root.join("manifest.json")).unwrap();
     let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
@@ -108,10 +81,7 @@ fn manifest_version(repo_root: &Path) -> String {
         .to_string()
 }
 
-/// A stand-in for the compiled helper binary. `validate_tree` runs it with
-/// `version` (BUNDLE-006), so it has to actually execute; what this test
-/// checks is tree shape, not the helper's real machine code, so a tiny
-/// script filling the same contract is enough.
+/// BUNDLE-006
 fn fake_helper(path: &Path, version: &str) {
     fs::write(
         path,
@@ -155,11 +125,6 @@ const KIND_ENTRY_POINTS: &[(&str, &str)] = &[
     ("service", "service"),
 ];
 
-/// `find`-equivalent walk: every symlink under `root`. Unlike the shell
-/// tool's `find $DIR -name .git -prune -o -type l -print`, which prunes any
-/// `.git` directory in the tree, this walk only skips a `.git` at the root,
-/// matching `BundleValidator`'s deliberately narrower tolerance (see
-/// `is_root_git_dir` in `src/plugin/bundle.rs`).
 fn find_symlinks(root: &Path) -> Vec<PathBuf> {
     let mut hits = Vec::new();
     let mut stack = vec![root.to_path_buf()];
@@ -202,10 +167,8 @@ fn stamped_root_mirrors_omarchy_plugin_validate() {
     let manifest_bytes = fs::read(root.join("manifest.json")).unwrap();
     let manifest: serde_json::Value = serde_json::from_slice(&manifest_bytes).unwrap();
 
-    // schemaVersion must be exactly the JSON number 1.
     assert_eq!(manifest["schemaVersion"], serde_json::json!(1));
 
-    // id grammar and the reserved omarchy.* namespace.
     let id = manifest["id"].as_str().expect("id must be a string");
     assert!(
         matches_omarchy_id_grammar(id),
@@ -216,13 +179,11 @@ fn stamped_root_mirrors_omarchy_plugin_validate() {
         "id '{id}' uses the reserved omarchy.* namespace"
     );
 
-    // kinds must be a non-empty array.
     let kinds = manifest["kinds"]
         .as_array()
         .expect("kinds must be an array");
     assert!(!kinds.is_empty(), "kinds must be non-empty");
 
-    // Every entry point is a safe relative path that exists on disk.
     let entry_points = manifest["entryPoints"]
         .as_object()
         .expect("entryPoints must be an object");
@@ -242,11 +203,6 @@ fn stamped_root_mirrors_omarchy_plugin_validate() {
         );
     }
 
-    // A kind is a promise to supply something to load: for every kind the
-    // real script's table maps to an entry point key, that key must be
-    // present. Claiming a kind without its entry point installs and enables
-    // fine, then does nothing -- exactly the "mirror passes, real tool
-    // fails" gap this test exists to close.
     for kind in kinds {
         let kind_str = kind.as_str().expect("kind must be a string");
         if let Some((_, ep_key)) = KIND_ENTRY_POINTS.iter().find(|(k, _)| *k == kind_str) {
@@ -257,8 +213,6 @@ fn stamped_root_mirrors_omarchy_plugin_validate() {
         }
     }
 
-    // barWidget.defaultSection, when present, is one of the enum values the
-    // shell accepts.
     let default_section = manifest["barWidget"]["defaultSection"]
         .as_str()
         .expect("barWidget.defaultSection must be present");
@@ -267,14 +221,11 @@ fn stamped_root_mirrors_omarchy_plugin_validate() {
         "barWidget.defaultSection must be left, center, or right, got {default_section}"
     );
 
-    // No symlinks anywhere within the shipped scope of a freshly stamped root.
     assert!(
         find_symlinks(&root.join("components")).is_empty(),
         "freshly stamped components/ must contain zero symlinks"
     );
 
-    // README/LICENSE/preview at root, and every one of them accounted for
-    // in the receipt inventory.
     for name in ["README.md", "LICENSE", "preview.png"] {
         assert!(
             root.join(name).is_file(),
@@ -286,7 +237,6 @@ fn stamped_root_mirrors_omarchy_plugin_validate() {
         );
     }
 
-    // Receipt inventories the shipped scope only -- never the source tree.
     for f in &receipt.files {
         assert!(
             agent_bar::plugin::bundle::SHIPPED_ROOT_FILES.contains(&f.path.as_str())
@@ -301,7 +251,6 @@ fn stamped_root_mirrors_omarchy_plugin_validate() {
     assert!(receipt.files.iter().any(|f| f.path == "bin/agent-bar"));
     assert!(receipt.files.iter().any(|f| f.path == "preview.png"));
 
-    // The tree also satisfies our own receipt/filesystem contract.
     BundleValidator::validate_tree(&root).unwrap();
 }
 
@@ -310,15 +259,10 @@ fn validate_tree_tolerates_root_git_but_not_symlinks() {
     let dir = tempfile::tempdir().unwrap();
     let (root, _receipt) = stamp_fake_root(dir.path());
 
-    // A root `.git`, like the one an installed clone carries, does not
-    // break validation.
     fs::create_dir_all(root.join(".git")).unwrap();
     fs::write(root.join(".git/config"), b"[core]\n\tbare = false\n").unwrap();
     BundleValidator::validate_tree(&root).unwrap();
 
-    // A symlink inside the shipped scope still fails, .git tolerance or
-    // not. A symlink under `src/` is not `validate_tree`'s job -- the
-    // shell's own validator covers the full tree at install time.
     std::os::unix::fs::symlink("/etc/passwd", root.join("components/evil-link")).unwrap();
     assert!(BundleValidator::validate_tree(&root).is_err());
 }

--- a/tests/schema_contract.rs
+++ b/tests/schema_contract.rs
@@ -1,9 +1,3 @@
-//! Structural JSON Schema contracts for status v2 and settings v1.
-//!
-//! Cross-field semantic checks (percentage sum, unique IDs, helper version
-//! equality, request ordering) belong to Task 3 and are intentionally out of
-//! scope here.
-
 use std::fs;
 use std::path::{Path, PathBuf};
 

--- a/tests/screenshot_inventory.rs
+++ b/tests/screenshot_inventory.rs
@@ -1,17 +1,5 @@
-//! `tests/qml/TestPalette.js` and `scripts/verify-v10-ui` each hand-copy the
-//! same required-screenshot inventory. Nothing keeps the two lists in sync:
-//! adding a name to one and forgetting the other either leaves a gap in the
-//! QML fixture's own count check or makes the shell script reject the new
-//! PNG as "unexpected evidence" (exactly what happened when `ready-white.png`
-//! was added to the JS list without updating the script). This test keeps
-//! them in lock-step: a screenshot added to one side and forgotten on the
-//! other fails here instead of at whatever point someone next runs the
-//! script.
-
 use std::collections::BTreeSet;
 
-/// Quoted `"name.png"` basenames from `TestPalette.js`'s
-/// `requiredScreenshotNames()` array.
 fn js_required_names(source: &str) -> BTreeSet<String> {
     let mut names = BTreeSet::new();
     for line in source.lines() {
@@ -30,7 +18,6 @@ fn js_required_names(source: &str) -> BTreeSet<String> {
     names
 }
 
-/// Bare `name.png` basenames from `verify-v10-ui`'s `REQUIRED=( ... )` array.
 fn script_required_names(source: &str) -> BTreeSet<String> {
     let mut names = BTreeSet::new();
     let mut in_array = false;

--- a/tests/servicecore_contract.rs
+++ b/tests/servicecore_contract.rs
@@ -1,7 +1,3 @@
-//! CoreService.js hand-copies closed enums from the Rust schema. This test
-//! keeps them in lock-step: a new state/action/provider added on one side
-//! fails here instead of silently freezing the popup at runtime.
-
 use std::collections::BTreeSet;
 
 fn extract_keys(source: &str, var_name: &str) -> BTreeSet<String> {
@@ -13,8 +9,6 @@ fn extract_keys(source: &str, var_name: &str) -> BTreeSet<String> {
     let body = &rest[..end];
     let mut keys = BTreeSet::new();
     for cap in body.split('"').skip(1).step_by(2) {
-        // split('"') alternates outside/inside quotes; skip(1).step_by(2)
-        // yields the quoted keys only ("ready", "stale", ...).
         if !cap.is_empty() && cap.chars().all(|c| c.is_ascii_lowercase() || c == '_') {
             keys.insert(cap.to_owned());
         }
@@ -65,7 +59,6 @@ fn servicecore_enums_match_schema() {
     );
 }
 
-/// `providers` rows of `defaultSettings()` in CoreService.js, in file order.
 fn default_settings_providers(js: &str) -> Vec<(String, bool)> {
     let start = js
         .find("function defaultSettings()")
@@ -92,10 +85,6 @@ fn default_settings_providers(js: &str) -> Vec<(String, bool)> {
         .collect()
 }
 
-/// The QML fallback document is a hand-copy of `Settings::defaults()`. A
-/// disagreement here ships a bar whose default enablement differs from what
-/// the helper writes on first run, which is invisible until a user without a
-/// settings.json opens the popup.
 #[test]
 fn servicecore_default_settings_match_rust_defaults() {
     let js = std::fs::read_to_string("CoreService.js").expect("read CoreService.js");

--- a/tests/severity_parity.rs
+++ b/tests/severity_parity.rs
@@ -1,16 +1,7 @@
-//! The severity thresholds exist twice: in Rust, where they fire
-//! notifications, and in `CoreView.js`, where they colour the popup and the
-//! bar. The status schema is frozen at v2 and must not carry them, so this
-//! test is the seam — it reads the JS constants and fails the build if either
-//! side moves alone.
-
 use agent_bar::notifications::state::{
     NotificationLevel, CRITICAL_USED_PERCENT, WARNING_USED_PERCENT,
 };
 
-/// `var NAME = 95` → `95.0`. Deliberately dumb string parsing, like
-/// `tests/servicecore_contract.rs`: no regex dependency, and a rename on
-/// either side fails loudly instead of silently matching nothing.
 fn js_constant(source: &str, name: &str) -> f64 {
     let needle = format!("var {name} = ");
     let start = source
@@ -46,8 +37,6 @@ fn severity_thresholds_match_core_view() {
 
 #[test]
 fn severity_boundaries_agree_across_the_seam() {
-    // Behaviour, not only literals: every boundary the two sides could
-    // disagree on, driven by the numbers the JS side actually ships.
     let js = core_view();
     let critical = js_constant(&js, "SEVERITY_CRITICAL_USED_PERCENT");
     let warning = js_constant(&js, "SEVERITY_WARNING_USED_PERCENT");

--- a/tests/terminal_helper.rs
+++ b/tests/terminal_helper.rs
@@ -1,5 +1,3 @@
-//! Argv-safe `scripts/agent-bar-open-terminal` contract (Task 13).
-
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
@@ -19,7 +17,6 @@ fn write_executable(path: &Path, body: &str) {
     fs::set_permissions(path, perms).expect("chmod");
 }
 
-/// Minimal plugin root: scripts/helper + bin/agent-bar stub + PATH fake xdg-terminal-exec.
 fn fixture_plugin_root(tmp: &Path) -> PathBuf {
     let plugin = tmp.join("othavi0.agent-bar");
     let scripts = plugin.join("scripts");
@@ -30,7 +27,6 @@ fn fixture_plugin_root(tmp: &Path) -> PathBuf {
     let helper_src = fs::read_to_string(repo_helper_source()).expect("read helper source");
     write_executable(&scripts.join("agent-bar-open-terminal"), &helper_src);
 
-    // Private helper stub — must be regular + executable.
     write_executable(
         &bin.join("agent-bar"),
         "#!/usr/bin/env bash\necho stub-agent-bar \"$@\"\n",
@@ -42,7 +38,6 @@ fn fixture_plugin_root(tmp: &Path) -> PathBuf {
 fn fake_xdg_on_path(tmp: &Path, argv_out: &Path) -> PathBuf {
     let path_dir = tmp.join("pathbin");
     fs::create_dir_all(&path_dir).unwrap();
-    // Records NUL-separated argv then exits 0 (stands in for xdg-terminal-exec).
     let script = format!(
         r#"#!/usr/bin/env bash
 set -euo pipefail
@@ -121,7 +116,6 @@ fn helper_requires_executable_private_helper() {
     let argv_out = tmp.path().join("argv.bin");
     let path_dir = fake_xdg_on_path(tmp.path(), &argv_out);
 
-    // Remove execute bit from private helper.
     let private = plugin.join("bin/agent-bar");
     let mut perms = fs::metadata(&private).unwrap().permissions();
     perms.set_mode(0o644);

--- a/tests/update_check_parity.rs
+++ b/tests/update_check_parity.rs
@@ -1,22 +1,4 @@
-//! `CoreMaintenance.maintenanceUiFromCheck` parses the `update check` stdout
-//! document in QML; `UpdateCheckDocument` is its Rust emitter. The repo bans
-//! every JS runtime, so a Rust test cannot call the QML function — instead
-//! both sides are pinned to the shared fixtures in
-//! `tests/fixtures/update-check/`, which must round-trip byte-exactly through
-//! the real serializer. `tests/qml/tst_Maintenance.qml` feeds the same bytes
-//! to the QML parser, so either side drifting fails its own suite.
-//!
-//! This seam exists because the previous QML parser read a key set the helper
-//! never emitted (`updateAvailable`, `currentVersion`, `targetVersion`,
-//! `releaseNotesUrl` at top level) and its tests fed that invented format
-//! back to it — green tests, broken product.
-//!
-//! BUNDLE-021 v-next (git-plugin-distribution Task 1): the document now
-//! carries `reinstallRequired` and no archive/checksum/source-commit fields
-//! at all — discovery reads the dist repo's `bundle.json` receipt instead of
-//! GitHub Releases. QML reads `reinstallRequired` too (Task 7): this file
-//! pins the Rust-side shape and fixture contents, and asserts the key name
-//! survives into the QML parser.
+//! BUNDLE-021
 
 use agent_bar::plugin::maintenance::UpdateCheckDocument;
 
@@ -29,8 +11,6 @@ fn fixture(name: &str) -> UpdateCheckDocument {
     UpdateCheckDocument::parse_json(&raw).expect("fixture must satisfy the real validator")
 }
 
-/// Every fixture is the exact stdout the helper writes: it passes the
-/// production validator and serializes back to the identical bytes.
 #[test]
 fn fixtures_are_exact_update_check_stdout() {
     let mut names: Vec<String> = Vec::new();
@@ -65,7 +45,6 @@ fn fixtures_are_exact_update_check_stdout() {
     }
 }
 
-/// The four fixtures cover every answer the document can give the UI.
 #[test]
 fn fixture_semantics_cover_every_answer() {
     let available = fixture("available.json");
@@ -96,9 +75,7 @@ fn fixture_semantics_cover_every_answer() {
     assert!(reinstall.latest_compatible.is_none());
 }
 
-/// The rewritten document (BUNDLE-021 v-next) carries no archive-download
-/// fields anywhere: discovery is a dist repo receipt, not a GitHub release
-/// asset list, and `update apply` no longer downloads/verifies an archive.
+/// BUNDLE-021
 #[test]
 fn fixtures_carry_no_archive_fields() {
     for entry in std::fs::read_dir(fixture_dir()).expect("read fixture dir") {
@@ -114,7 +91,6 @@ fn fixtures_carry_no_archive_fields() {
     }
 }
 
-/// The seam is only real while the QML side parses the real key set.
 #[test]
 fn qml_parser_reads_the_real_keys() {
     let js = std::fs::read_to_string("CoreMaintenance.js").expect("read CoreMaintenance.js");


### PR DESCRIPTION
## Why

Many comments restated what the next line of code already says, or kept history that belongs in the changelog. This branch deletes them. A comment stays when it states something the code cannot show: an external tool or platform constraint, a security or crash-safety invariant, or a deliberate choice that would otherwise read as a bug.

## Scope

- `refactor`: comment-only deletions in `src/`, root QML and `Core*.js`, `components/`, `scripts/`, `.github/workflows/`, `Cargo.toml`, and `tests/`. Three nested `if` blocks that the comments hid from clippy's `collapsible_if` are collapsed, one in `src/settings/migration.rs` and two in `tests/active_legacy_scan.rs`. Rustfmt reflowed one closure in `src/providers/http.rs`.
- `test`: `tst_ServiceTimeouts.qml` cut `Service.qml` between two comment banners. It now anchors on the first `Process {` block and the first `Timer {`.
- `test`: `uninstall_purge_fails_closed_without_touching_state_when_omarchy_missing` unwrapped a stdin write to a helper that exits before it reads stdin. It now accepts `BrokenPipe` only.

## Blast Radius

No runtime behavior changes. The merge touches release paths, so it cuts a patch release with the same behavior as 10.4.0.

## Verification

- A script compares each file with `master` and fails when a changed line is not a comment. The only lines it flags are the code edits listed above.
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` pass (402 tests). `git diff --check`, ShellCheck, and `omarchy plugin validate .` are clean.
- `qmltestrunner` passes 316 of 316. qmllint prints the same 1518 lines as on `master`.
- Under 16 parallel runs, the purge test panicked at the stdin unwrap in 10 of 1,280 runs on `master`. With the fix it passed all 1,280.
- An adversarial review mutated the code under each deleted comment and ran the suite. Four deleted comments guarded rules that no test covers, so short versions are back. They cover the run lock in `dispatch_update_run`, the popup re-check in `Service.qml`, the login help topic that omits Antigravity, and the root-only `.git` tolerance in `is_root_git_dir`.
