### PR TITLE
docs: sync stale guides and spec with code

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,9 @@
 
 ## Prerequisites
 
-- Current stable Rust toolchain through rustup.
+- Rust toolchain pinned by `rust-toolchain.toml`, installed automatically by
+  rustup. Bump it deliberately: every bump changes the shipped helper's
+  digest (see the file's header comment).
 - Git.
 - Omarchy Quattro and Quickshell development files for QML validation.
 - Qt Quick Test tools (`qmltestrunner`, `qmllint`).
@@ -32,6 +34,7 @@ explicit final QA gate.
 cargo fmt --check
 cargo test
 cargo clippy --all-targets -- -D warnings
+git diff --check
 ```
 
 QML/plugin verification:
@@ -86,9 +89,9 @@ Active documentation is English and must match executable contracts.
 Every versioned changelog release section, `docs/releases/**`,
 and ADR bodies 0001–0003 remain
 historical: they record how things were and are never rewritten. The
-`[Unreleased]` changelog section, the ADR index, ADR 0004, the numbered
-files under `docs/specs/v10/`, and `docs/guide/**` are active and must match
-the shipped behavior. `docs/specs/v10/amendments/**` are the approved design
+`[Unreleased]` changelog section, the ADR index, ADR 0004 and later, the
+numbered files under `docs/specs/v10/`, and `docs/guide/**` are active and
+must match the shipped behavior. `docs/specs/v10/amendments/**` are the approved design
 documents as written on their approval date: frozen, never rewritten, and
 superseded wherever a numbered spec file or the code says otherwise.
 

--- a/docs/dev/releasing.md
+++ b/docs/dev/releasing.md
@@ -1,8 +1,8 @@
 # Releasing Agent Bar
 
 Releases are automatic. Every push to `master` that touches a product path
-(`src/**`, `scripts/**`, `Cargo.toml`, `Cargo.lock`, `*.qml`, `Core*.js`,
-`components/**`, `icons/**`, `manifest.json`) triggers
+(`src/**`, `scripts/**`, `Cargo.toml`, `Cargo.lock`, `rust-toolchain.toml`,
+`*.qml`, `Core*.js`, `components/**`, `icons/**`, `manifest.json`) triggers
 `.github/workflows/auto-release.yml`, which cuts a release (a patch bump,
 or a minor or major set by hand; see [Manual boundary](#manual-boundary)), stamps
 the release artifacts into the repository root, and publishes the product

--- a/docs/guide/integration.md
+++ b/docs/guide/integration.md
@@ -78,9 +78,10 @@ There is no v9 runtime compatibility layer after migration.
 ## Update and uninstall delegation
 
 `update apply` and `uninstall` no longer stage, exchange, or roll back the
-plugin directory themselves. Each resolves `omarchy` and `systemd-run` to
-absolute executable paths, then hands its live mutation to the Omarchy CLI
-as a detached transient unit:
+plugin directory themselves. Uninstall resolves `omarchy` and `systemd-run`
+to absolute executable paths; update apply additionally resolves
+`omarchy-restart-shell`, `git`, and `timeout`. Both then hand their live
+mutation to the Omarchy CLI as a detached transient unit:
 
 ```text
 systemd-run --user --collect --no-block --unit=agent-bar-update-<txid>.service \
@@ -127,20 +128,15 @@ legacy. Modified and ambiguous paths remain untouched.
 
 ## Uninstall
 
-```bash
-"$PLUGIN" uninstall
-"$PLUGIN" uninstall purge
-```
+See [Uninstall](commands.md#uninstall) for the command forms, confirmation
+flow, and preserved/removed paths.
 
-After confirmation, `uninstall` purges only Agent Bar's own XDG state (when
-invoked with `purge`) under the exclusive maintenance lock, then delegates
-unconditionally to `omarchy plugin remove othavi0.agent-bar --yes` as above.
-Standard uninstall preserves settings, cache, and migration backups; purge
-additionally removes `$XDG_CONFIG_HOME/agent-bar`, `$XDG_CACHE_HOME/agent-bar`,
-and `$XDG_STATE_HOME/agent-bar` before the handoff. Purge and the delegated
-remove are disjoint by construction: purge never touches the plugin
-directory, and `omarchy plugin remove` never touches Agent Bar's own XDG
-state.
+Purge removes the settings and cache directories under the exclusive
+maintenance lock, then releases the lock before it removes
+`$XDG_STATE_HOME/agent-bar`, which holds the lock file. Purge and the
+delegated remove are disjoint by construction: purge never touches
+the plugin directory, and `omarchy plugin remove` never touches Agent Bar's
+own XDG state.
 
 ## Live safety
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -146,17 +146,9 @@ until then.
   version; nothing is left half-installed.
 - **Not a git checkout**: a plugin directory installed before the git-based
   distribution has no `.git`. `omarchy plugin update` silently skips it in
-  a bulk run and refuses it outright when targeted by ID. `update check`
-  detects this and reports `reinstallRequired: true`; the Settings UI shows
-  the one-time migration instruction:
-
-  ```bash
-  omarchy plugin remove othavi0.agent-bar
-  omarchy plugin add https://github.com/othavi0/omarchy-agent-bar.git
-  ```
-
-  Settings, cache, and backups live outside the plugin directory and
-  survive the reinstall.
+  a bulk run and refuses it outright when targeted by ID. See
+  [Migrating a pre-conversion install](integration.md#migrating-a-pre-conversion-install)
+  for the detection, the reinstall commands, and what survives.
 
 Confirm the outcome with:
 

--- a/docs/specs/v10/02-target-architecture.md
+++ b/docs/specs/v10/02-target-architecture.md
@@ -295,7 +295,7 @@ The table is product data, not an example:
 ## Target QML boundaries
 
 ```text
-assets/omarchy/
+<repository root>/
 ├── manifest.json
 ├── Service.qml
 ├── BarWidget.qml
@@ -304,6 +304,11 @@ assets/omarchy/
 ├── ProviderView.qml
 ├── SettingsView.qml
 ├── MaintenanceView.qml
+├── CoreMaintenance.js
+├── CoreScroll.js
+├── CoreService.js
+├── CoreSettings.js
+├── CoreView.js
 ├── components/
 │   ├── ProviderChip.qml
 │   ├── ProviderHeader.qml
@@ -311,12 +316,14 @@ assets/omarchy/
 │   ├── StateMessage.qml
 │   ├── SettingsProviderRow.qml
 │   ├── ConfirmDialog.qml
-│   └── FocusController.qml
+│   ├── FocusController.qml
+│   └── HeaderTag.qml
 └── icons/
     ├── claude.png
     ├── codex.png
     ├── amp.svg
-    └── grok.svg
+    ├── grok.svg
+    └── antigravity.png
 ```
 
 - `Service.qml` owns state and commands; it contains no visual layout.

--- a/docs/specs/v10/07-testing-and-acceptance.md
+++ b/docs/specs/v10/07-testing-and-acceptance.md
@@ -113,7 +113,7 @@ hash file.
 - `TEST-031`: The token scan excludes changelog release sections 9.0.0 and
   older, ADR bodies 0001–0003, dated release notes under `docs/releases/`
   (not its README), and `docs/specs/v10/**`, which describes the removal
-  contract. It scans Unreleased, the ADR index, and ADR 0004.
+  contract. It scans Unreleased, the ADR index, and ADR 0004 and later.
 - `TEST-032`: Every active command example is exercised by CLI parser tests.
 - `TEST-033`: Every active JSON example validates against the checked-in
   schema.
@@ -123,7 +123,7 @@ hash file.
 Legitimate v1 contracts are exact and individually allowlisted:
 
 ```text
-assets/omarchy/manifest.json             Quattro manifest schema 1
+manifest.json                            Quattro manifest schema 1
 settings.json                            Agent Bar settings schema 1
 bundle.json                              Agent Bar bundle receipt schema 1
 *.metadata.json                          Agent Bar release metadata schema 1

--- a/docs/specs/v10/08-plugin-bundle-and-release.md
+++ b/docs/specs/v10/08-plugin-bundle-and-release.md
@@ -32,6 +32,11 @@ othavi0.agent-bar/
 ├── ProviderView.qml
 ├── SettingsView.qml
 ├── MaintenanceView.qml
+├── CoreMaintenance.js
+├── CoreScroll.js
+├── CoreService.js
+├── CoreSettings.js
+├── CoreView.js
 ├── components/
 ├── icons/
 ├── scripts/
@@ -193,7 +198,7 @@ breaks the update check for all of them with no remote-side recovery.
 - `BUNDLE-012`: Reproducible assembly produces the same inventory and content
   hashes from the same source commit.
 - `BUNDLE-012A`: Icons retain their approved source formats:
-  `claude.png`, `codex.png`, `amp.svg`, and `grok.svg`.
+  `claude.png`, `codex.png`, `amp.svg`, `grok.svg`, and `antigravity.png`.
 - `BUNDLE-012B`: **Retired.** There is no separate release-metadata document;
   `bundle.json` (above) is the only discovery document, fetched directly
   from the distribution repository over HTTPS.
@@ -290,7 +295,7 @@ The exact successful `update check` response is:
     "version": "10.1.0",
     "omarchyContract": 1,
     "minimumQuickshellVersion": "0.3.0",
-    "releaseNotesUrl": "https://github.com/othavi0/agent-bar/releases/tag/v10.1.0"
+    "releaseNotesUrl": "https://github.com/othavi0/omarchy-agent-bar/releases/tag/v10.1.0"
   }
 }
 ```


### PR DESCRIPTION
## Why

Four read-only audits checked every active doc and the v10 spec against the code. The docs were mostly current. This branch fixes the statements the code contradicts and replaces two sections that restated other guides with links.

## Scope

- `CONTRIBUTING.md`: the toolchain is pinned in `rust-toolchain.toml`, ADR 0004 and later are active, and the verification block gains `git diff --check`.
- `docs/dev/releasing.md`: the release trigger list gains `rust-toolchain.toml`, matching `auto-release.yml`.
- `docs/guide/integration.md`: `update apply` also resolves `omarchy-restart-shell`, `git`, and `timeout`. Purge releases the maintenance lock before it removes `$XDG_STATE_HOME/agent-bar`. The uninstall section links to `commands.md`.
- `docs/guide/troubleshooting.md`: the "Not a git checkout" entry links to the migration section instead of repeating it.
- `docs/specs/v10/02`, `07`, `08`: the plugin tree sits at the repository root after the monorepo amendment and lists the `Core*.js` modules, `HeaderTag.qml`, and `antigravity.png`. The release notes example uses the `omarchy-agent-bar` repository.

ADR bodies, release notes, the changelog, and amendments stay as written.

## Verification

- `active_docs`, `active_language`, `active_legacy_scan`, `cli_vocabulary`, and `root_tree_validate` pass. `git diff --check` is clean.
- A fact check confirmed each changed statement against the code and caught one wrong claim about purge lock order, which is fixed.
- No release path changes, so this merge does not cut a release.
