### PR TITLE
feat: tabbed Settings and view-aware rail

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-bar"
-version = "10.4.0"
+version = "10.5.0"
 dependencies = [
  "assert_cmd",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-bar"
-version = "10.4.0"
+version = "10.5.0"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT"

--- a/CoreSettings.js
+++ b/CoreSettings.js
@@ -174,6 +174,9 @@ function setProviderEnabled(draft, providerId, enabled) {
   return next
 }
 
+// Settings lists providers in two sections, on the bar and hidden, so a move
+// swaps with the nearest neighbour in the same section and never crosses into
+// the other one.
 function moveProvider(draft, providerId, delta) {
   var next = cloneDraft(draft)
   var id = String(providerId || "")
@@ -188,13 +191,91 @@ function moveProvider(draft, providerId, delta) {
   }
   if (idx < 0)
     return next
-  var target = idx + (delta > 0 ? 1 : -1)
+  var step = delta > 0 ? 1 : -1
+  var enabled = !!next.providers[idx].enabled
+  var target = idx + step
+  while (target >= 0 && target < next.providers.length
+         && !!next.providers[target].enabled !== enabled)
+    target += step
   if (target < 0 || target >= next.providers.length)
     return next
   var tmp = next.providers[idx]
   next.providers[idx] = next.providers[target]
   next.providers[target] = tmp
   return next
+}
+
+function providerSections(draft) {
+  var sections = { shown: [], hidden: [] }
+  var rows = draft && Array.isArray(draft.providers) ? draft.providers : []
+  for (var i = 0; i < rows.length; i++) {
+    if (!rows[i])
+      continue
+    var list = rows[i].enabled ? sections.shown : sections.hidden
+    list.push({ id: String(rows[i].id), enabled: !!rows[i].enabled })
+  }
+  var groups = [sections.shown, sections.hidden]
+  for (var g = 0; g < groups.length; g++) {
+    for (var j = 0; j < groups[g].length; j++) {
+      groups[g][j].canMoveUp = j > 0
+      groups[g][j].canMoveDown = j < groups[g].length - 1
+    }
+  }
+  return sections
+}
+
+var SETTINGS_TABS = [
+  { id: "providers", label: "Providers" },
+  { id: "general", label: "General" },
+  { id: "about", label: "About" }
+]
+
+var FIELD_TABS = [
+  { tab: "general", read: function (d) { return d.display ? d.display.metric : undefined } },
+  { tab: "general", read: function (d) { return d.refreshIntervalSeconds } },
+  { tab: "general", read: function (d) { return d.notifications ? d.notifications.enabled : undefined } },
+  { tab: "general", read: function (d) { return d.notifications ? d.notifications.reminderMinutes : undefined } },
+  { tab: "about", read: function (d) { return Kernel.automaticUpdatesEnabled(d) } }
+]
+
+function providerOrderKey(d) {
+  var rows = Array.isArray(d.providers) ? d.providers : []
+  var ids = []
+  for (var i = 0; i < rows.length; i++)
+    ids.push(rows[i] ? String(rows[i].id) : "")
+  return ids.join(",")
+}
+
+function providerEnabledById(d) {
+  var out = {}
+  var rows = Array.isArray(d.providers) ? d.providers : []
+  for (var i = 0; i < rows.length; i++) {
+    if (rows[i])
+      out[String(rows[i].id)] = !!rows[i].enabled
+  }
+  return out
+}
+
+// Unsaved changes between the persisted snapshot and the draft, counted per
+// Settings tab: each provider whose visibility changed, one for any order
+// change, and one per other field.
+function settingsChanges(snapshot, draft) {
+  var tabs = { providers: 0, general: 0, about: 0 }
+  if (!snapshot || !draft)
+    return { count: 0, tabs: tabs }
+  var before = providerEnabledById(snapshot)
+  var after = providerEnabledById(draft)
+  for (var id in after) {
+    if (before[id] !== after[id])
+      tabs.providers++
+  }
+  if (providerOrderKey(snapshot) !== providerOrderKey(draft))
+    tabs.providers++
+  for (var i = 0; i < FIELD_TABS.length; i++) {
+    if (FIELD_TABS[i].read(snapshot) !== FIELD_TABS[i].read(draft))
+      tabs[FIELD_TABS[i].tab]++
+  }
+  return { count: tabs.providers + tabs.general + tabs.about, tabs: tabs }
 }
 
 function setDisplayMetric(draft, metric) {

--- a/CoreSettings.js
+++ b/CoreSettings.js
@@ -160,17 +160,32 @@ function cloneDraft(draft) {
   return JSON.parse(JSON.stringify(draft || Kernel.defaultSettings()))
 }
 
+// A provider switched on joins the end of the bar, the way Settings lists it.
 function setProviderEnabled(draft, providerId, enabled) {
   var next = cloneDraft(draft)
   var id = String(providerId || "")
   if (!Array.isArray(next.providers))
     next.providers = Kernel.defaultSettings().providers
+  var idx = -1
   for (var i = 0; i < next.providers.length; i++) {
     if (String(next.providers[i].id) === id) {
-      next.providers[i].enabled = !!enabled
+      idx = i
       break
     }
   }
+  if (idx < 0)
+    return next
+  var wasEnabled = !!next.providers[idx].enabled
+  next.providers[idx].enabled = !!enabled
+  if (!enabled || wasEnabled)
+    return next
+  var row = next.providers.splice(idx, 1)[0]
+  var lastOn = -1
+  for (var j = 0; j < next.providers.length; j++) {
+    if (next.providers[j].enabled)
+      lastOn = j
+  }
+  next.providers.splice(lastOn + 1, 0, row)
   return next
 }
 
@@ -238,11 +253,13 @@ var FIELD_TABS = [
   { tab: "about", read: function (d) { return Kernel.automaticUpdatesEnabled(d) } }
 ]
 
-function providerOrderKey(d) {
+function barOrderKey(d) {
   var rows = Array.isArray(d.providers) ? d.providers : []
   var ids = []
-  for (var i = 0; i < rows.length; i++)
-    ids.push(rows[i] ? String(rows[i].id) : "")
+  for (var i = 0; i < rows.length; i++) {
+    if (rows[i] && rows[i].enabled)
+      ids.push(String(rows[i].id))
+  }
   return ids.join(",")
 }
 
@@ -257,8 +274,9 @@ function providerEnabledById(d) {
 }
 
 // Unsaved changes between the persisted snapshot and the draft, counted per
-// Settings tab: each provider whose visibility changed, one for any order
-// change, and one per other field.
+// Settings tab: each provider whose visibility changed, one for a new bar
+// order, and one per other field. The order of hidden providers is invisible,
+// so it never counts.
 function settingsChanges(snapshot, draft) {
   var tabs = { providers: 0, general: 0, about: 0 }
   if (!snapshot || !draft)
@@ -269,7 +287,7 @@ function settingsChanges(snapshot, draft) {
     if (before[id] !== after[id])
       tabs.providers++
   }
-  if (providerOrderKey(snapshot) !== providerOrderKey(draft))
+  if (barOrderKey(snapshot) !== barOrderKey(draft))
     tabs.providers++
   for (var i = 0; i < FIELD_TABS.length; i++) {
     if (FIELD_TABS[i].read(snapshot) !== FIELD_TABS[i].read(draft))

--- a/CoreView.js
+++ b/CoreView.js
@@ -226,6 +226,41 @@ function chipAccessibleLabel(provider, metric, nowMs) {
   return parts.join(" · ")
 }
 
+// The rail plate marks whoever owns the open content: the provider in the
+// usage view, the Settings slot in the settings view.
+function railProviderSelected(view, providerId, selectedId) {
+  if (view === "settings")
+    return false
+  var id = String(providerId || "")
+  return id.length > 0 && id === String(selectedId || "")
+}
+
+function railTooltipText(provider, metric, nowMs) {
+  var label = chipAccessibleLabel(provider, metric, nowMs)
+  if (chipSeverityUrgent(provider))
+    label += " · critical"
+  return label
+}
+
+var SETTINGS_PROVIDER_STATUS = {
+  "cli_missing": "Not installed",
+  "unauthenticated": "Signed out",
+  "rate_limited": "Rate limited",
+  "network_error": "Offline",
+  "provider_error": "Failed"
+}
+
+function settingsProviderStatus(provider) {
+  if (!provider)
+    return ""
+  var s = String(provider.state || "")
+  if (SETTINGS_PROVIDER_STATUS[s] !== undefined)
+    return SETTINGS_PROVIDER_STATUS[s]
+  if (presentsReading(s) && (!provider.windows || provider.windows.length === 0))
+    return "No percentage"
+  return ""
+}
+
 function iconOpticalScale(id) {
   if (String(id || "") === "grok")
     return 0.875

--- a/MaintenanceView.qml
+++ b/MaintenanceView.qml
@@ -165,7 +165,8 @@ Item {
 
       SectionHeader {
         text: "Danger zone"
-        foreground: Color.urgent
+        danger: true
+        foreground: root.foreground
         fontFamily: root.fontFamily
       }
 

--- a/MaintenanceView.qml
+++ b/MaintenanceView.qml
@@ -1,4 +1,5 @@
 import QtQuick
+import QtQuick.Layouts
 import qs.Commons
 import qs.Ui
 import "CoreMaintenance.js" as Core
@@ -10,6 +11,8 @@ Item {
   property var agentService: null
   property color foreground: Color.foreground
   property string fontFamily: Style.font.family
+  property bool settingsLocked: true
+  property bool automaticUpdatesOn: true
 
   readonly property var ui: agentService && agentService.maintenanceUi
       ? agentService.maintenanceUi
@@ -29,119 +32,169 @@ Item {
   Column {
     id: body
     width: parent.width
-    spacing: Style.space(8)
+    spacing: Style.spacing.huge
 
-    Text {
-      text: "Maintenance"
-      color: Util.alpha(root.foreground, 0.55)
-      font.family: root.fontFamily
-      font.pixelSize: Style.font.caption
-      font.bold: true
-      textFormat: Text.PlainText
-    }
-
-    Text {
-      width: parent.width
-      text: "Installed version: "
-          + (ui.installedVersion && ui.installedVersion.length
-              ? ui.installedVersion
-              : "—")
-      color: root.foreground
-      font.family: root.fontFamily
-      font.pixelSize: Style.font.body
-      textFormat: Text.PlainText
-      Accessible.name: text
-    }
-
-    Text {
-      width: parent.width
-      visible: ui.message && ui.message.length > 0
-      text: ui.message
-      color: ui.phase === "error" ? Color.urgent : Util.alpha(root.foreground, 0.55)
-      font.family: root.fontFamily
-      font.pixelSize: Style.font.caption
-      wrapMode: Text.WordWrap
-      textFormat: Text.PlainText
-    }
-
-    Flow {
+    Column {
       width: parent.width
       spacing: Style.space(8)
 
-      Button {
-        text: root.checking ? "Checking\u2026" : "Check for updates"
-        bordered: true
-        focusable: true
-        enabled: !root.blocked && !root.checking && !root.applying
+      SectionHeader {
+        text: "Version"
         foreground: root.foreground
         fontFamily: root.fontFamily
-        Accessible.name: "Check for updates"
-        onClicked: {
-          if (root.agentService)
-            root.agentService.checkForUpdates()
+      }
+
+      RowLayout {
+        width: parent.width
+        spacing: Style.space(8)
+
+        Column {
+          Layout.fillWidth: true
+          spacing: Style.space(2)
+
+          Text {
+            width: parent.width
+            text: "Agent Bar "
+                + (ui.installedVersion && ui.installedVersion.length
+                    ? ui.installedVersion
+                    : "\u2014")
+            color: root.foreground
+            font.family: root.fontFamily
+            font.pixelSize: Style.font.subtitle
+            font.bold: true
+            elide: Text.ElideRight
+            textFormat: Text.PlainText
+            Accessible.name: "Installed version " + (ui.installedVersion || "unknown")
+          }
+
+          Text {
+            width: parent.width
+            visible: ui.message && ui.message.length > 0
+            text: ui.message
+            color: ui.phase === "error" ? Color.urgent : Util.alpha(root.foreground, 0.55)
+            font.family: root.fontFamily
+            font.pixelSize: Style.font.caption
+            wrapMode: Text.WordWrap
+            textFormat: Text.PlainText
+          }
+        }
+
+        Button {
+          text: root.checking ? "Checking\u2026" : "Check for updates"
+          bordered: true
+          focusable: true
+          enabled: !root.blocked && !root.checking && !root.applying
+          foreground: root.foreground
+          fontFamily: root.fontFamily
+          Accessible.name: "Check for updates"
+          onClicked: {
+            if (root.agentService)
+              root.agentService.checkForUpdates()
+          }
         }
       }
 
-      Button {
-        visible: root.updateAvailable && ui.targetVersion && ui.targetVersion.length > 0
-        text: "Update to " + ui.targetVersion
-        bordered: true
-        focusable: true
-        enabled: !root.blocked && !root.applying
-        foreground: root.foreground
-        fontFamily: root.fontFamily
-        Accessible.name: text
-        onClicked: {
-          if (root.agentService)
-            root.agentService.openUpdateConfirm()
+      Flow {
+        width: parent.width
+        spacing: Style.space(8)
+        visible: updateButton.visible || notesButton.visible
+
+        Button {
+          id: updateButton
+          visible: root.updateAvailable && ui.targetVersion && ui.targetVersion.length > 0
+          text: "Update to " + ui.targetVersion
+          bordered: true
+          focusable: true
+          enabled: !root.blocked && !root.applying
+          foreground: root.foreground
+          fontFamily: root.fontFamily
+          Accessible.name: text
+          onClicked: {
+            if (root.agentService)
+              root.agentService.openUpdateConfirm()
+          }
+        }
+
+        Button {
+          id: notesButton
+          visible: ui.releaseNotesUrl && String(ui.releaseNotesUrl).indexOf("https://") === 0
+          text: "Release notes"
+          bordered: true
+          focusable: true
+          enabled: !root.applying
+          foreground: root.foreground
+          fontFamily: root.fontFamily
+          Accessible.name: "Release notes"
+          onClicked: {
+            if (root.agentService)
+              root.agentService.openReleaseNotes()
+          }
         }
       }
-
-      Button {
-        visible: ui.releaseNotesUrl && String(ui.releaseNotesUrl).indexOf("https://") === 0
-        text: "Release notes"
-        bordered: true
-        focusable: true
-        enabled: !root.applying
-        foreground: root.foreground
-        fontFamily: root.fontFamily
-        Accessible.name: "Release notes"
-        onClicked: {
-          if (root.agentService)
-            root.agentService.openReleaseNotes()
-        }
-      }
-    }
-
-    PanelSeparator {
-      width: parent.width
-      foreground: root.foreground
     }
 
     Column {
       width: parent.width
-      spacing: Style.space(6)
+      spacing: Style.space(8)
+      opacity: root.settingsLocked ? 0.55 : 1.0
+      enabled: !root.settingsLocked
 
-      Text {
-        text: "Danger zone"
-        color: Color.urgent
-        font.family: root.fontFamily
-        font.pixelSize: Style.font.caption
-        font.bold: true
-        textFormat: Text.PlainText
+      SectionHeader {
+        text: "Updates"
+        foreground: root.foreground
+        fontFamily: root.fontFamily
       }
 
-      Button {
-        text: "Uninstall Agent Bar"
-        bordered: true
-        focusable: true
-        enabled: !root.blocked && !root.applying
-        foreground: Color.urgent
+      Toggle {
+        width: parent.width
+        label: "Update automatically"
+        description: "Install new versions and reload the shell."
+        checked: root.automaticUpdatesOn
+        foreground: root.foreground
         fontFamily: root.fontFamily
-        Accessible.name: "Uninstall Agent Bar"
         onClicked: {
           if (root.agentService)
-            root.agentService.openUninstallConfirm()
+            root.agentService.setAutomaticUpdates(!root.automaticUpdatesOn)
+        }
+      }
+    }
+
+    Column {
+      width: parent.width
+      spacing: Style.space(8)
+
+      SectionHeader {
+        text: "Danger zone"
+        foreground: Color.urgent
+        fontFamily: root.fontFamily
+      }
+
+      RowLayout {
+        width: parent.width
+        spacing: Style.space(8)
+
+        Text {
+          Layout.fillWidth: true
+          text: "Removes Agent Bar. Your settings stay."
+          color: Util.alpha(root.foreground, 0.72)
+          font.family: root.fontFamily
+          font.pixelSize: Style.font.caption
+          wrapMode: Text.WordWrap
+          textFormat: Text.PlainText
+        }
+
+        Button {
+          text: "Uninstall Agent Bar"
+          bordered: true
+          focusable: true
+          enabled: !root.blocked && !root.applying
+          foreground: Color.urgent
+          fontFamily: root.fontFamily
+          Accessible.name: "Uninstall Agent Bar"
+          onClicked: {
+            if (root.agentService)
+              root.agentService.openUninstallConfirm()
+          }
         }
       }
     }

--- a/Popup.qml
+++ b/Popup.qml
@@ -66,9 +66,13 @@ KeyboardPanel {
     owner
   )
 
+  readonly property int footerHeight: settingsFooter.shown
+      ? settingsFooter.implicitHeight + Style.space(8)
+      : 0
+
   readonly property int measuredBodyHeight: {
     var col = contentColumn ? contentColumn.implicitHeight : 0
-    var margins = contentMargins * 2
+    var margins = contentMargins * 2 + root.footerHeight
     var railMin = rail && rail.minStackHeight
         ? rail.minStackHeight + Style.space(8)
         : Style.space(160)
@@ -255,6 +259,8 @@ KeyboardPanel {
         height: parent.height
         providers: root.railProviders
         selectedProviderId: root.selectedId
+        settingsActive: root.view === "settings"
+        displayMetric: root.displayMetric
         foreground: Color.foreground
         fontFamily: Style.font.family
         iconBase: Qt.resolvedUrl("icons/")
@@ -266,6 +272,13 @@ KeyboardPanel {
         id: railGutter
         width: Style.space(8)
         height: parent.height
+
+        PanelSeparator {
+          anchors.left: parent.left
+          width: 1
+          height: parent.height
+          foreground: Color.foreground
+        }
       }
 
       Item {
@@ -279,7 +292,7 @@ KeyboardPanel {
           anchors.leftMargin: root.contentMargins
           anchors.rightMargin: root.contentMargins
           anchors.topMargin: root.contentMargins
-          anchors.bottomMargin: root.contentMargins
+          anchors.bottomMargin: root.contentMargins + root.footerHeight
           contentWidth: width
           contentHeight: contentColumn.implicitHeight
           clip: true
@@ -336,6 +349,20 @@ KeyboardPanel {
               onLoaded: root.scheduleFocusRebuild()
             }
           }
+        }
+
+        SettingsFooter {
+          id: settingsFooter
+          anchors.left: parent.left
+          anchors.right: parent.right
+          anchors.bottom: parent.bottom
+          anchors.leftMargin: root.contentMargins
+          anchors.rightMargin: root.contentMargins
+          anchors.bottomMargin: root.contentMargins
+          active: root.view === "settings"
+          agentService: root.agentService
+          foreground: Color.foreground
+          fontFamily: Style.font.family
         }
       }
     }

--- a/Popup.qml
+++ b/Popup.qml
@@ -39,6 +39,7 @@ KeyboardPanel {
   )
 
   readonly property string displayMetric: Core.displayMetric(appliedSettings)
+  property string settingsTab: "providers"
 
   readonly property string selectedId: {
     if (!agentService)
@@ -175,6 +176,8 @@ KeyboardPanel {
       list = list.concat(stalledMessage.collectFocusTargets())
     if (contentLoader.item && typeof contentLoader.item.collectFocusTargets === "function")
       list = list.concat(contentLoader.item.collectFocusTargets())
+    if (settingsFooter.shown)
+      list = list.concat(settingsFooter.collectFocusTargets())
     focusController.setTargets(list)
   }
 
@@ -200,6 +203,10 @@ KeyboardPanel {
       root.rebuildFocusTargets()
   })
   onAgentServiceChanged: scheduleFocusRebuild()
+  onIsOpenChanged: {
+    if (isOpen)
+      settingsTab = "providers"
+  }
 
   PanelKeyCatcher {
     id: keyCatcher
@@ -261,6 +268,7 @@ KeyboardPanel {
         selectedProviderId: root.selectedId
         settingsActive: root.view === "settings"
         displayMetric: root.displayMetric
+        nowMs: root.owner && root.owner.nowMs !== undefined ? root.owner.nowMs : Date.now()
         foreground: Color.foreground
         fontFamily: Style.font.family
         iconBase: Qt.resolvedUrl("icons/")
@@ -363,6 +371,7 @@ KeyboardPanel {
           agentService: root.agentService
           foreground: Color.foreground
           fontFamily: Style.font.family
+          onShownChanged: root.scheduleFocusRebuild()
         }
       }
     }
@@ -387,6 +396,8 @@ KeyboardPanel {
   property Component settingsContent: Component {
     SettingsView {
       width: contentColumn.width
+      tab: root.settingsTab
+      onTabChanged: root.settingsTab = tab
       agentService: root.agentService
       foreground: Color.foreground
       fontFamily: Style.font.family

--- a/Popup.qml
+++ b/Popup.qml
@@ -396,7 +396,9 @@ KeyboardPanel {
   property Component settingsContent: Component {
     SettingsView {
       width: contentColumn.width
-      tab: root.settingsTab
+      // A Binding element, unlike a plain binding, survives the view's own
+      // assignment to `tab` when a tab is clicked.
+      Binding on tab { value: root.settingsTab }
       onTabChanged: root.settingsTab = tab
       agentService: root.agentService
       foreground: Color.foreground

--- a/ProviderRail.qml
+++ b/ProviderRail.qml
@@ -29,12 +29,11 @@ Item {
   readonly property int minStackHeight: {
     var n = providers && providers.length ? providers.length : 0
     var slots = n + 1
-    var gaps = n + 2
+    var gaps = n + 1
     return Style.spacing.popupPadding * 2
         + slots * slotSize
         + gaps * stackGap
         + spacerMin
-        + 1
   }
 
   implicitWidth: railWidth
@@ -191,13 +190,6 @@ Item {
       Layout.fillHeight: true
       Layout.minimumHeight: root.spacerMin
       Layout.preferredWidth: 1
-    }
-
-    PanelSeparator {
-      Layout.fillWidth: true
-      Layout.leftMargin: Style.space(6)
-      Layout.rightMargin: Style.space(6)
-      foreground: root.foreground
     }
 
     Item {

--- a/ProviderRail.qml
+++ b/ProviderRail.qml
@@ -11,6 +11,7 @@ Item {
   property string selectedProviderId: ""
   property bool settingsActive: false
   property string displayMetric: "remaining"
+  property double nowMs: Date.now()
   property color foreground: Color.foreground
   property string fontFamily: Style.font.family
   property url iconBase: Qt.resolvedUrl("icons/")
@@ -112,7 +113,7 @@ Item {
         )
         readonly property bool dimmed: entry ? Core.chipDimmed(entry) : true
         readonly property string label: entry
-            ? Core.railTooltipText(entry, root.displayMetric)
+            ? Core.railTooltipText(entry, root.displayMetric, root.nowMs)
             : Core.providerDisplayName(railItem.pid)
         readonly property string cue: entry ? Core.chipStateCue(entry) : ""
 

--- a/ProviderRail.qml
+++ b/ProviderRail.qml
@@ -9,6 +9,8 @@ Item {
 
   property var providers: []
   property string selectedProviderId: ""
+  property bool settingsActive: false
+  property string displayMetric: "remaining"
   property color foreground: Color.foreground
   property string fontFamily: Style.font.family
   property url iconBase: Qt.resolvedUrl("icons/")
@@ -26,11 +28,12 @@ Item {
   readonly property int minStackHeight: {
     var n = providers && providers.length ? providers.length : 0
     var slots = n + 1
-    var gaps = n + 1
+    var gaps = n + 2
     return Style.spacing.popupPadding * 2
         + slots * slotSize
         + gaps * stackGap
         + spacerMin
+        + 1
   }
 
   implicitWidth: railWidth
@@ -102,12 +105,16 @@ Item {
           return modelData
         }
         readonly property string pid: entry && entry.id ? String(entry.id) : ""
-        readonly property bool selected: {
-          var sel = String(root.selectedProviderId || "").trim()
-          var id = railItem.pid
-          return id.length > 0 && sel.length > 0 && id === sel
-        }
+        readonly property bool selected: Core.railProviderSelected(
+          root.settingsActive ? "settings" : "usage",
+          railItem.pid,
+          String(root.selectedProviderId || "").trim()
+        )
         readonly property bool dimmed: entry ? Core.chipDimmed(entry) : true
+        readonly property string label: entry
+            ? Core.railTooltipText(entry, root.displayMetric)
+            : Core.providerDisplayName(railItem.pid)
+        readonly property string cue: entry ? Core.chipStateCue(entry) : ""
 
         function focusActivate() {
           root.providerSelected(railItem.pid)
@@ -139,7 +146,23 @@ Item {
           opacity: railItem.dimmed ? 0.4 : (railItem.selected ? 1.0 : 0.65)
         }
 
+        Text {
+          visible: railItem.cue.length > 0
+          anchors.top: parent.top
+          anchors.right: parent.right
+          anchors.topMargin: Style.spacing.xxs
+          anchors.rightMargin: Style.spacing.xs
+          text: railItem.cue
+          color: entry && Core.chipSeverityUrgent(entry) ? Color.urgent : root.foreground
+          font.family: root.fontFamily
+          font.pixelSize: Style.font.caption
+          font.bold: true
+          textFormat: Text.PlainText
+          Accessible.ignored: true
+        }
+
         MouseArea {
+          id: railMouse
           anchors.fill: parent
           hoverEnabled: true
           cursorShape: Qt.PointingHandCursor
@@ -150,11 +173,15 @@ Item {
         Keys.onEnterPressed: railItem.focusActivate()
         Keys.onSpacePressed: railItem.focusActivate()
 
-        Accessible.name: entry && entry.name
-            ? String(entry.name)
-            : Core.providerDisplayName(railItem.pid)
+        Accessible.name: railItem.label
         Accessible.role: Accessible.Button
         Accessible.onPressAction: railItem.focusActivate()
+
+        PanelToolTip {
+          visible: railMouse.containsMouse
+          text: railItem.label
+          fontFamily: root.fontFamily
+        }
       }
     }
 
@@ -163,6 +190,13 @@ Item {
       Layout.fillHeight: true
       Layout.minimumHeight: root.spacerMin
       Layout.preferredWidth: 1
+    }
+
+    PanelSeparator {
+      Layout.fillWidth: true
+      Layout.leftMargin: Style.space(6)
+      Layout.rightMargin: Style.space(6)
+      foreground: root.foreground
     }
 
     Item {
@@ -181,9 +215,11 @@ Item {
       Rectangle {
         anchors.fill: parent
         radius: Style.cornerRadius
-        color: (settingsItem.activeFocus || settingsMouse.containsMouse)
-            ? Style.hoverFill
-            : "transparent"
+        color: root.settingsActive
+            ? Style.selectedFill
+            : ((settingsItem.activeFocus || settingsMouse.containsMouse)
+              ? Style.hoverFill
+              : "transparent")
         border.width: settingsItem.activeFocus ? 1 : 0
         border.color: Color.accent
       }

--- a/SettingsView.qml
+++ b/SettingsView.qml
@@ -1,7 +1,9 @@
 import QtQuick
+import QtQuick.Layouts
 import qs.Commons
 import qs.Ui
 import "CoreView.js" as Core
+import "CoreSettings.js" as Settings
 import "components"
 
 Item {
@@ -11,6 +13,7 @@ Item {
   property color foreground: Color.foreground
   property string fontFamily: Style.font.family
   property url iconBase: Qt.resolvedUrl("icons/")
+  property string tab: "providers"
   property bool editorOwnsFocus: (intervalField && intervalField.field
         ? !!intervalField.field.activeFocus
         : false)
@@ -20,25 +23,42 @@ Item {
 
   readonly property var state: agentService ? agentService.settingsState : null
   readonly property var draft: agentService ? agentService.settingsDraft : null
+  readonly property var snapshot: agentService ? agentService.snapshot : null
   readonly property string phase: state && state.phase ? String(state.phase) : "closed"
   readonly property bool locked: agentService
       ? agentService.settingsLocked()
       : true
-  readonly property bool canSave: agentService ? agentService.canSaveSettings() : false
   readonly property bool loading: phase === "loading"
   readonly property bool loadFailed: phase === "load_failed"
-  readonly property bool saving: phase === "saving"
 
-  readonly property var providers: {
-    if (!draft || !Array.isArray(draft.providers))
-      return []
-    return draft.providers
+  readonly property var sections: Settings.providerSections(draft)
+  readonly property var changes: Settings.settingsChanges(state ? state.snapshot : null, draft)
+
+  readonly property var tabOptions: {
+    var out = []
+    for (var i = 0; i < Settings.SETTINGS_TABS.length; i++) {
+      var t = Settings.SETTINGS_TABS[i]
+      out.push({
+        value: t.id,
+        label: t.label + (root.changes.tabs[t.id] > 0 ? " •" : "")
+      })
+    }
+    return out
   }
 
   readonly property string metric: {
     if (draft && draft.display && draft.display.metric === "used")
       return "used"
     return "remaining"
+  }
+
+  readonly property var previewProvider: {
+    for (var i = 0; i < sections.shown.length; i++) {
+      var p = Core.findProvider(snapshot, sections.shown[i].id)
+      if (p && Core.presentsReading(p.state) && p.windows && p.windows.length)
+        return p
+    }
+    return null
   }
 
   readonly property int intervalSec: {
@@ -76,6 +96,10 @@ Item {
     return String(root.iconBase) + name
   }
 
+  function providerStatus(id) {
+    return Core.settingsProviderStatus(Core.findProvider(root.snapshot, id))
+  }
+
   function collectFocusTargets() {
     return root.loadFailed ? [restartShellButton] : []
   }
@@ -83,338 +107,367 @@ Item {
   Column {
     id: col
     width: parent.width
-    spacing: Style.space(12)
-
-    Text {
-      text: "Settings"
-      color: root.foreground
-      font.family: root.fontFamily
-      font.pixelSize: Style.font.body
-      font.bold: true
-      textFormat: Text.PlainText
-      Accessible.role: Accessible.Heading
-    }
-
-    Text {
-      visible: root.loading
-      width: parent.width
-      text: "Loading\u2026"
-      color: Util.alpha(root.foreground, 0.72)
-      font.family: root.fontFamily
-      font.pixelSize: Style.font.caption
-      textFormat: Text.PlainText
-    }
-
-    Text {
-      visible: root.loadFailed
-      width: parent.width
-      wrapMode: Text.WordWrap
-      text: "Settings could not be loaded. Restart the shell and try again."
-      color: Color.urgent
-      font.family: root.fontFamily
-      font.pixelSize: Style.font.caption
-      textFormat: Text.PlainText
-      Accessible.role: Accessible.StaticText
-      Accessible.name: text
-    }
-
-    Button {
-      id: restartShellButton
-      visible: root.loadFailed
-      text: "Restart shell"
-      bordered: true
-      focusable: true
-      foreground: root.foreground
-      fontFamily: root.fontFamily
-      Accessible.name: "Restart shell"
-      function focusActivate() {
-        if (root.agentService)
-          root.agentService.restartShell()
-      }
-      Accessible.onPressAction: focusActivate()
-      onClicked: focusActivate()
-    }
-
-    Text {
-      visible: root.saving
-      width: parent.width
-      text: "Saving\u2026"
-      color: Util.alpha(root.foreground, 0.72)
-      font.family: root.fontFamily
-      font.pixelSize: Style.font.caption
-      textFormat: Text.PlainText
-    }
+    spacing: Style.spacing.huge
 
     Column {
-      width: parent.width
-      spacing: Style.space(4)
-      opacity: root.locked ? 0.55 : 1.0
-      enabled: !root.locked
-
-      Text {
-        text: "Providers"
-        color: Util.alpha(root.foreground, 0.55)
-        font.family: root.fontFamily
-        font.pixelSize: Style.font.caption
-        font.bold: true
-        textFormat: Text.PlainText
-      }
-
-      Repeater {
-        model: root.providers
-
-        SettingsProviderRow {
-          required property var modelData
-          required property int index
-          width: parent.width
-          providerId: String(modelData.id || "")
-          displayName: Core.providerDisplayName(providerId)
-          iconSource: root.iconUrl(providerId)
-          enabled: !!modelData.enabled
-          locked: root.locked
-          canMoveUp: index > 0
-          canMoveDown: index < root.providers.length - 1
-          foreground: root.foreground
-          fontFamily: root.fontFamily
-          onEnableToggled: {
-            if (root.agentService)
-              root.agentService.setProviderEnabled(providerId, !modelData.enabled)
-          }
-          onMoveUp: {
-            if (root.agentService)
-              root.agentService.moveProvider(providerId, -1)
-          }
-          onMoveDown: {
-            if (root.agentService)
-              root.agentService.moveProvider(providerId, 1)
-          }
-        }
-      }
-    }
-
-    PanelSeparator {
-      width: parent.width
-      foreground: root.foreground
-    }
-
-    Column {
-      width: parent.width
-      spacing: Style.space(6)
-      opacity: root.locked ? 0.55 : 1.0
-      enabled: !root.locked
-
-      Text {
-        text: "Bar shows"
-        color: Util.alpha(root.foreground, 0.55)
-        font.family: root.fontFamily
-        font.pixelSize: Style.font.caption
-        font.bold: true
-        textFormat: Text.PlainText
-      }
-
-      Row {
-        spacing: Style.space(8)
-
-        Button {
-          text: "Remaining"
-          selected: root.metric === "remaining"
-          bordered: true
-          focusable: true
-          enabled: !root.locked
-          foreground: root.foreground
-          fontFamily: root.fontFamily
-          onClicked: {
-            if (root.agentService)
-              root.agentService.setDisplayMetric("remaining")
-          }
-        }
-
-        Button {
-          text: "Used"
-          selected: root.metric === "used"
-          bordered: true
-          focusable: true
-          enabled: !root.locked
-          foreground: root.foreground
-          fontFamily: root.fontFamily
-          onClicked: {
-            if (root.agentService)
-              root.agentService.setDisplayMetric("used")
-          }
-        }
-      }
-    }
-
-    Column {
-      width: parent.width
-      spacing: Style.space(4)
-      opacity: root.locked ? 0.55 : 1.0
-      enabled: !root.locked
-
-      Row {
-        spacing: Style.spacing.lg
-
-        NumberField {
-          id: intervalField
-          label: "Refresh every"
-          value: root.intervalSec
-          from: 30
-          to: 3600
-          stepSize: 5
-          foreground: root.foreground
-          fontFamily: root.fontFamily
-          onModified: function (v) {
-            if (root.agentService)
-              root.agentService.setRefreshInterval(v)
-          }
-        }
-
-        // The host NumberField exposes no suffix property (measured), so the
-        // unit is a sibling label, and it cannot use anchors, because the
-        // spin box is a child of a sibling, which QML refuses to anchor to.
-        // The y binding composes intervalField's own offset within this Row
-        // with the spin box's offset inside intervalField's Column, so the
-        // label tracks the spin box from whatever frame the Row places the
-        // field in.
-        Text {
-          y: intervalField.y + intervalField.field.y
-             + (intervalField.field.height - height) / 2
-          text: "seconds"
-          color: Util.alpha(root.foreground, 0.72)
-          font.family: root.fontFamily
-          font.pixelSize: Style.font.bodySmall
-          textFormat: Text.PlainText
-          Accessible.ignored: true
-        }
-      }
-    }
-
-    Column {
-      width: parent.width
-      spacing: Style.space(4)
-      opacity: root.locked ? 0.55 : 1.0
-      enabled: !root.locked
-
-      Toggle {
-        label: "Notifications"
-        description: "Warn me before a quota runs out."
-        checked: root.notificationsOn
-        foreground: root.foreground
-        fontFamily: root.fontFamily
-        onClicked: {
-          if (root.agentService)
-            root.agentService.setNotificationsEnabled(!root.notificationsOn)
-        }
-      }
-
-      Row {
-        spacing: Style.spacing.lg
-
-        NumberField {
-          id: reminderField
-          label: "Remind me every"
-          value: root.reminderMinutes
-          from: 15
-          to: 1440
-          stepSize: 15
-          foreground: root.foreground
-          fontFamily: root.fontFamily
-          onModified: function (v) {
-            if (root.agentService)
-              root.agentService.setReminderMinutes(v)
-          }
-        }
-
-        // Same sibling-label technique as the refresh interval above: the
-        // host NumberField exposes no suffix property, and the spin box is a
-        // child of a sibling, which QML refuses to anchor to.
-        Text {
-          y: reminderField.y + reminderField.field.y
-             + (reminderField.field.height - height) / 2
-          text: "minutes"
-          color: Util.alpha(root.foreground, 0.72)
-          font.family: root.fontFamily
-          font.pixelSize: Style.font.bodySmall
-          textFormat: Text.PlainText
-          Accessible.ignored: true
-        }
-      }
-    }
-
-    Toggle {
-      opacity: root.locked ? 0.55 : 1.0
-      enabled: !root.locked
-      label: "Update automatically"
-      description: "Install new versions and reload the shell."
-      checked: root.automaticUpdatesOn
-      foreground: root.foreground
-      fontFamily: root.fontFamily
-      onClicked: {
-        if (root.agentService)
-          root.agentService.setAutomaticUpdates(!root.automaticUpdatesOn)
-      }
-    }
-
-    PanelSeparator {
-      width: parent.width
-      foreground: root.foreground
-    }
-
-    Flow {
       width: parent.width
       spacing: Style.space(8)
 
-      Button {
-        text: "Restore defaults"
-        bordered: true
-        focusable: true
-        enabled: !root.locked
+      Text {
+        text: "Settings"
+        color: root.foreground
+        font.family: root.fontFamily
+        font.pixelSize: Style.font.body
+        font.bold: true
+        textFormat: Text.PlainText
+        Accessible.role: Accessible.Heading
+      }
+
+      ButtonGroup {
+        options: root.tabOptions
+        value: root.tab
         foreground: root.foreground
         fontFamily: root.fontFamily
-        Accessible.name: "Restore defaults"
-        onClicked: {
-          if (root.agentService)
-            root.agentService.restoreSettingsDefaults()
-        }
+        onChanged: function (value) { root.tab = value }
+      }
+
+      Text {
+        visible: root.loading
+        width: parent.width
+        text: "Loading\u2026"
+        color: Util.alpha(root.foreground, 0.72)
+        font.family: root.fontFamily
+        font.pixelSize: Style.font.caption
+        textFormat: Text.PlainText
+      }
+
+      Text {
+        visible: root.loadFailed
+        width: parent.width
+        wrapMode: Text.WordWrap
+        text: "Settings could not be loaded. Restart the shell and try again."
+        color: Color.urgent
+        font.family: root.fontFamily
+        font.pixelSize: Style.font.caption
+        textFormat: Text.PlainText
+        Accessible.role: Accessible.StaticText
+        Accessible.name: text
       }
 
       Button {
-        text: "Cancel"
+        id: restartShellButton
+        visible: root.loadFailed
+        text: "Restart shell"
         bordered: true
         focusable: true
-        enabled: !root.locked && root.phase === "dirty"
         foreground: root.foreground
         fontFamily: root.fontFamily
-        Accessible.name: "Cancel"
-        onClicked: {
+        Accessible.name: "Restart shell"
+        function focusActivate() {
           if (root.agentService)
-            root.agentService.cancelSettings()
+            root.agentService.restartShell()
+        }
+        Accessible.onPressAction: focusActivate()
+        onClicked: focusActivate()
+      }
+    }
+
+    Column {
+      visible: root.tab === "providers"
+      width: parent.width
+      spacing: Style.spacing.huge
+      opacity: root.locked ? 0.55 : 1.0
+      enabled: !root.locked
+
+      Column {
+        width: parent.width
+        spacing: Style.space(2)
+
+        SectionHeader {
+          text: "On the bar"
+          count: String(root.sections.shown.length)
+          foreground: root.foreground
+          fontFamily: root.fontFamily
+        }
+
+        Text {
+          bottomPadding: Style.space(4)
+          text: "The bar shows them in this order."
+          color: Util.alpha(root.foreground, 0.55)
+          font.family: root.fontFamily
+          font.pixelSize: Style.font.caption
+          textFormat: Text.PlainText
+        }
+
+        Repeater {
+          model: root.sections.shown
+
+          SettingsProviderRow {
+            required property var modelData
+            width: parent.width
+            providerId: modelData.id
+            displayName: Core.providerDisplayName(modelData.id)
+            statusText: root.providerStatus(modelData.id)
+            iconSource: root.iconUrl(modelData.id)
+            enabled: true
+            locked: root.locked
+            canMoveUp: modelData.canMoveUp
+            canMoveDown: modelData.canMoveDown
+            foreground: root.foreground
+            fontFamily: root.fontFamily
+            onEnableToggled: {
+              if (root.agentService)
+                root.agentService.setProviderEnabled(providerId, false)
+            }
+            onMoveUp: {
+              if (root.agentService)
+                root.agentService.moveProvider(providerId, -1)
+            }
+            onMoveDown: {
+              if (root.agentService)
+                root.agentService.moveProvider(providerId, 1)
+            }
+          }
         }
       }
 
-      Button {
-        text: root.saving ? "Saving\u2026" : "Save changes"
-        bordered: true
-        focusable: true
-        enabled: root.canSave
-        foreground: root.foreground
-        fontFamily: root.fontFamily
-        Accessible.name: "Save changes"
-        onClicked: {
-          if (root.agentService)
-            root.agentService.saveSettings()
+      Column {
+        visible: root.sections.hidden.length > 0
+        width: parent.width
+        spacing: Style.space(2)
+
+        SectionHeader {
+          text: "Hidden"
+          count: String(root.sections.hidden.length)
+          foreground: root.foreground
+          fontFamily: root.fontFamily
+        }
+
+        Repeater {
+          model: root.sections.hidden
+
+          SettingsProviderRow {
+            required property var modelData
+            width: parent.width
+            providerId: modelData.id
+            displayName: Core.providerDisplayName(modelData.id)
+            statusText: root.providerStatus(modelData.id)
+            iconSource: root.iconUrl(modelData.id)
+            enabled: false
+            locked: root.locked
+            movable: false
+            foreground: root.foreground
+            fontFamily: root.fontFamily
+            onEnableToggled: {
+              if (root.agentService)
+                root.agentService.setProviderEnabled(providerId, true)
+            }
+          }
         }
       }
     }
 
-    PanelSeparator {
+    Column {
+      visible: root.tab === "general"
       width: parent.width
-      foreground: root.foreground
+      spacing: Style.spacing.huge
+      opacity: root.locked ? 0.55 : 1.0
+      enabled: !root.locked
+
+      Column {
+        width: parent.width
+        spacing: Style.space(8)
+
+        SectionHeader {
+          text: "Bar shows"
+          foreground: root.foreground
+          fontFamily: root.fontFamily
+        }
+
+        RowLayout {
+          width: parent.width
+          spacing: Style.space(8)
+
+          ButtonGroup {
+            options: [
+              { value: "remaining", label: "Remaining" },
+              { value: "used", label: "Used" }
+            ]
+            value: root.metric
+            foreground: root.foreground
+            fontFamily: root.fontFamily
+            onChanged: function (value) {
+              if (root.agentService)
+                root.agentService.setDisplayMetric(value)
+            }
+          }
+
+          Item { Layout.fillWidth: true }
+
+          Text {
+            visible: root.previewProvider !== null
+            text: "Bar reads"
+            color: Util.alpha(root.foreground, 0.55)
+            font.family: root.fontFamily
+            font.pixelSize: Style.font.caption
+            textFormat: Text.PlainText
+          }
+
+          Rectangle {
+            visible: root.previewProvider !== null
+            implicitWidth: previewRow.implicitWidth + Style.spacing.controlPaddingX
+            implicitHeight: Style.space(24)
+            radius: Style.cornerRadius
+            color: Style.hoverFill
+
+            Row {
+              id: previewRow
+              anchors.centerIn: parent
+              spacing: Style.spacing.sm
+
+              Image {
+                anchors.verticalCenter: parent.verticalCenter
+                source: root.previewProvider ? root.iconUrl(root.previewProvider.id) : ""
+                width: 14
+                height: 14
+                sourceSize.width: 14
+                sourceSize.height: 14
+                fillMode: Image.PreserveAspectFit
+              }
+
+              Text {
+                anchors.verticalCenter: parent.verticalCenter
+                text: root.previewProvider
+                    ? Core.chipPercentText(root.previewProvider, root.metric)
+                    : ""
+                color: root.foreground
+                font.family: root.fontFamily
+                font.pixelSize: Style.font.body
+                textFormat: Text.PlainText
+              }
+            }
+
+            Accessible.role: Accessible.StaticText
+            Accessible.name: root.previewProvider
+                ? "Bar reads " + Core.chipAccessibleLabel(root.previewProvider, root.metric)
+                : ""
+          }
+        }
+      }
+
+      Column {
+        width: parent.width
+        spacing: Style.space(8)
+
+        SectionHeader {
+          text: "Refresh and alerts"
+          foreground: root.foreground
+          fontFamily: root.fontFamily
+        }
+
+        RowLayout {
+          width: parent.width
+          spacing: Style.space(8)
+
+          Text {
+            Layout.fillWidth: true
+            text: "Refresh every"
+            color: root.foreground
+            font.family: root.fontFamily
+            font.pixelSize: Style.font.body
+            textFormat: Text.PlainText
+          }
+
+          NumberField {
+            id: intervalField
+            fieldWidth: Style.space(88)
+            value: root.intervalSec
+            from: 30
+            to: 3600
+            stepSize: 5
+            foreground: root.foreground
+            fontFamily: root.fontFamily
+            Accessible.name: "Refresh every, in seconds"
+            onModified: function (v) {
+              if (root.agentService)
+                root.agentService.setRefreshInterval(v)
+            }
+          }
+
+          Text {
+            Layout.preferredWidth: Style.space(52)
+            text: "seconds"
+            color: Util.alpha(root.foreground, 0.72)
+            font.family: root.fontFamily
+            font.pixelSize: Style.font.bodySmall
+            textFormat: Text.PlainText
+            Accessible.ignored: true
+          }
+        }
+
+        Toggle {
+          width: parent.width
+          label: "Notifications"
+          description: "Warn me before a quota runs out."
+          checked: root.notificationsOn
+          foreground: root.foreground
+          fontFamily: root.fontFamily
+          onClicked: {
+            if (root.agentService)
+              root.agentService.setNotificationsEnabled(!root.notificationsOn)
+          }
+        }
+
+        RowLayout {
+          width: parent.width
+          spacing: Style.space(8)
+          enabled: root.notificationsOn
+          opacity: root.notificationsOn ? 1.0 : 0.55
+
+          Text {
+            Layout.fillWidth: true
+            text: "Remind me every"
+            color: root.foreground
+            font.family: root.fontFamily
+            font.pixelSize: Style.font.body
+            textFormat: Text.PlainText
+          }
+
+          NumberField {
+            id: reminderField
+            fieldWidth: Style.space(88)
+            value: root.reminderMinutes
+            from: 15
+            to: 1440
+            stepSize: 15
+            foreground: root.foreground
+            fontFamily: root.fontFamily
+            Accessible.name: "Remind me every, in minutes"
+            onModified: function (v) {
+              if (root.agentService)
+                root.agentService.setReminderMinutes(v)
+            }
+          }
+
+          Text {
+            Layout.preferredWidth: Style.space(52)
+            text: "minutes"
+            color: Util.alpha(root.foreground, 0.72)
+            font.family: root.fontFamily
+            font.pixelSize: Style.font.bodySmall
+            textFormat: Text.PlainText
+            Accessible.ignored: true
+          }
+        }
+      }
     }
 
     MaintenanceView {
+      visible: root.tab === "about"
       width: parent.width
       agentService: root.agentService
+      settingsLocked: root.locked
+      automaticUpdatesOn: root.automaticUpdatesOn
       foreground: root.foreground
       fontFamily: root.fontFamily
     }

--- a/SettingsView.qml
+++ b/SettingsView.qml
@@ -34,17 +34,6 @@ Item {
   readonly property var sections: Settings.providerSections(draft)
   readonly property var changes: Settings.settingsChanges(state ? state.snapshot : null, draft)
 
-  readonly property var tabOptions: {
-    var out = []
-    for (var i = 0; i < Settings.SETTINGS_TABS.length; i++) {
-      var t = Settings.SETTINGS_TABS[i]
-      out.push({
-        value: t.id,
-        label: t.label + (root.changes.tabs[t.id] > 0 ? " •" : "")
-      })
-    }
-    return out
-  }
 
   readonly property string metric: {
     if (draft && draft.display && draft.display.metric === "used")
@@ -101,7 +90,12 @@ Item {
   }
 
   function collectFocusTargets() {
-    return root.loadFailed ? [restartShellButton] : []
+    var out = []
+    for (var i = 0; i < tabRepeater.count; i++)
+      out.push(tabRepeater.itemAt(i))
+    if (root.loadFailed)
+      out.push(restartShellButton)
+    return out
   }
 
   Column {
@@ -123,12 +117,32 @@ Item {
         Accessible.role: Accessible.Heading
       }
 
-      ButtonGroup {
-        options: root.tabOptions
-        value: root.tab
-        foreground: root.foreground
-        fontFamily: root.fontFamily
-        onChanged: function (value) { root.tab = value }
+      Row {
+        spacing: Style.spacing.md
+
+        Repeater {
+          id: tabRepeater
+          model: Settings.SETTINGS_TABS
+
+          Button {
+            required property var modelData
+            readonly property bool pending: root.changes.tabs[modelData.id] > 0
+            text: modelData.label + (pending ? " •" : "")
+            selected: root.tab === modelData.id
+            bordered: true
+            focusable: true
+            foreground: root.foreground
+            fontFamily: root.fontFamily
+            Accessible.role: Accessible.PageTab
+            Accessible.name: modelData.label
+            Accessible.description: pending ? "Unsaved changes" : ""
+            function focusActivate() {
+              root.tab = modelData.id
+            }
+            Accessible.onPressAction: focusActivate()
+            onClicked: focusActivate()
+          }
+        }
       }
 
       Text {
@@ -172,12 +186,14 @@ Item {
       }
     }
 
+    // A hidden tab is disabled too: Qt keeps focus on an invisible item, and
+    // a spin box left focused on another tab would take the arrow keys.
     Column {
       visible: root.tab === "providers"
       width: parent.width
       spacing: Style.spacing.huge
       opacity: root.locked ? 0.55 : 1.0
-      enabled: !root.locked
+      enabled: !root.locked && visible
 
       Column {
         width: parent.width
@@ -272,7 +288,7 @@ Item {
       width: parent.width
       spacing: Style.spacing.huge
       opacity: root.locked ? 0.55 : 1.0
-      enabled: !root.locked
+      enabled: !root.locked && visible
 
       Column {
         width: parent.width
@@ -464,6 +480,7 @@ Item {
 
     MaintenanceView {
       visible: root.tab === "about"
+      enabled: visible
       width: parent.width
       agentService: root.agentService
       settingsLocked: root.locked

--- a/components/SectionHeader.qml
+++ b/components/SectionHeader.qml
@@ -4,12 +4,15 @@ import qs.Commons
 import qs.Ui
 
 // A section opens with its title and a rule running to the right edge, so
-// sections separate without a full-width divider between them.
+// sections separate without a full-width divider between them. The title is
+// drawn here rather than with the host PanelSectionHeader, whose Qt.darker
+// tint turns darker than body text on light themes.
 Item {
   id: root
 
   property string text: ""
   property string count: ""
+  property bool danger: false
   property color foreground: Color.foreground
   property string fontFamily: Style.font.family
 
@@ -22,10 +25,13 @@ Item {
     anchors.right: parent.right
     spacing: Style.space(8)
 
-    PanelSectionHeader {
+    Text {
       text: root.text
-      foreground: root.foreground
-      fontFamily: root.fontFamily
+      color: root.danger ? Color.urgent : Util.alpha(root.foreground, 0.55)
+      font.family: root.fontFamily
+      font.pixelSize: Style.font.caption
+      font.bold: true
+      textFormat: Text.PlainText
       Accessible.role: Accessible.Heading
       Accessible.name: root.text
     }
@@ -42,7 +48,7 @@ Item {
     PanelSeparator {
       Layout.fillWidth: true
       Layout.alignment: Qt.AlignVCenter
-      foreground: root.foreground
+      foreground: root.danger ? Color.urgent : root.foreground
     }
   }
 }

--- a/components/SectionHeader.qml
+++ b/components/SectionHeader.qml
@@ -1,0 +1,48 @@
+import QtQuick
+import QtQuick.Layouts
+import qs.Commons
+import qs.Ui
+
+// A section opens with its title and a rule running to the right edge, so
+// sections separate without a full-width divider between them.
+Item {
+  id: root
+
+  property string text: ""
+  property string count: ""
+  property color foreground: Color.foreground
+  property string fontFamily: Style.font.family
+
+  width: parent ? parent.width : implicitWidth
+  implicitHeight: row.implicitHeight
+
+  RowLayout {
+    id: row
+    anchors.left: parent.left
+    anchors.right: parent.right
+    spacing: Style.space(8)
+
+    PanelSectionHeader {
+      text: root.text
+      foreground: root.foreground
+      fontFamily: root.fontFamily
+      Accessible.role: Accessible.Heading
+      Accessible.name: root.text
+    }
+
+    Text {
+      visible: root.count.length > 0
+      text: root.count
+      color: Util.alpha(root.foreground, 0.55)
+      font.family: root.fontFamily
+      font.pixelSize: Style.font.caption
+      textFormat: Text.PlainText
+    }
+
+    PanelSeparator {
+      Layout.fillWidth: true
+      Layout.alignment: Qt.AlignVCenter
+      foreground: root.foreground
+    }
+  }
+}

--- a/components/SettingsFooter.qml
+++ b/components/SettingsFooter.qml
@@ -1,0 +1,112 @@
+import QtQuick
+import QtQuick.Layouts
+import qs.Commons
+import qs.Ui
+import "../CoreSettings.js" as Settings
+
+// Pinned under the Settings scroll surface so Save stays reachable on every
+// tab without scrolling.
+Item {
+  id: root
+
+  property var agentService: null
+  property bool active: false
+  property color foreground: Color.foreground
+  property string fontFamily: Style.font.family
+
+  readonly property var state: agentService ? agentService.settingsState : null
+  readonly property string phase: state && state.phase ? String(state.phase) : "closed"
+  readonly property bool shown: active
+      && (phase === "clean" || phase === "dirty" || phase === "saving")
+  readonly property bool locked: agentService ? agentService.settingsLocked() : true
+  readonly property bool saving: phase === "saving"
+  readonly property bool canSave: agentService ? agentService.canSaveSettings() : false
+  readonly property int changeCount: Settings.settingsChanges(
+    state ? state.snapshot : null,
+    agentService ? agentService.settingsDraft : null
+  ).count
+
+  readonly property string statusText: {
+    if (saving)
+      return "Saving\u2026"
+    if (changeCount === 1)
+      return "1 unsaved change"
+    if (changeCount > 1)
+      return changeCount + " unsaved changes"
+    return "No changes"
+  }
+
+  visible: shown
+  implicitHeight: shown ? body.implicitHeight : 0
+
+  Column {
+    id: body
+    width: parent.width
+    spacing: Style.space(8)
+
+    PanelSeparator {
+      width: parent.width
+      foreground: root.foreground
+    }
+
+    RowLayout {
+      width: parent.width
+      spacing: Style.space(8)
+
+      Button {
+        text: "Restore defaults"
+        focusable: true
+        enabled: !root.locked
+        foreground: root.foreground
+        fontFamily: root.fontFamily
+        Accessible.name: "Restore defaults"
+        onClicked: {
+          if (root.agentService)
+            root.agentService.restoreSettingsDefaults()
+        }
+      }
+
+      Text {
+        Layout.fillWidth: true
+        horizontalAlignment: Text.AlignRight
+        text: root.statusText
+        color: Util.alpha(root.foreground, 0.72)
+        font.family: root.fontFamily
+        font.pixelSize: Style.font.caption
+        elide: Text.ElideLeft
+        textFormat: Text.PlainText
+        Accessible.role: Accessible.StaticText
+        Accessible.name: text
+      }
+
+      Button {
+        text: "Cancel"
+        bordered: true
+        focusable: true
+        enabled: !root.locked && root.phase === "dirty"
+        foreground: root.foreground
+        fontFamily: root.fontFamily
+        Accessible.name: "Cancel"
+        onClicked: {
+          if (root.agentService)
+            root.agentService.cancelSettings()
+        }
+      }
+
+      Button {
+        text: root.saving ? "Saving\u2026" : "Save changes"
+        bordered: true
+        selected: root.canSave
+        focusable: true
+        enabled: root.canSave
+        foreground: root.foreground
+        fontFamily: root.fontFamily
+        Accessible.name: "Save changes"
+        onClicked: {
+          if (root.agentService)
+            root.agentService.saveSettings()
+        }
+      }
+    }
+  }
+}

--- a/components/SettingsFooter.qml
+++ b/components/SettingsFooter.qml
@@ -14,15 +14,15 @@ Item {
   property color foreground: Color.foreground
   property string fontFamily: Style.font.family
 
-  readonly property var state: agentService ? agentService.settingsState : null
-  readonly property string phase: state && state.phase ? String(state.phase) : "closed"
+  readonly property var settingsState: agentService ? agentService.settingsState : null
+  readonly property string phase: settingsState && settingsState.phase ? String(settingsState.phase) : "closed"
   readonly property bool shown: active
       && (phase === "clean" || phase === "dirty" || phase === "saving")
   readonly property bool locked: agentService ? agentService.settingsLocked() : true
   readonly property bool saving: phase === "saving"
   readonly property bool canSave: agentService ? agentService.canSaveSettings() : false
   readonly property int changeCount: Settings.settingsChanges(
-    state ? state.snapshot : null,
+    settingsState ? settingsState.snapshot : null,
     agentService ? agentService.settingsDraft : null
   ).count
 
@@ -39,6 +39,10 @@ Item {
   visible: shown
   implicitHeight: shown ? body.implicitHeight : 0
 
+  function collectFocusTargets() {
+    return shown ? [restoreButton, cancelButton, saveButton] : []
+  }
+
   Column {
     id: body
     width: parent.width
@@ -54,16 +58,19 @@ Item {
       spacing: Style.space(8)
 
       Button {
+        id: restoreButton
         text: "Restore defaults"
         focusable: true
         enabled: !root.locked
         foreground: root.foreground
         fontFamily: root.fontFamily
         Accessible.name: "Restore defaults"
-        onClicked: {
+        function focusActivate() {
           if (root.agentService)
             root.agentService.restoreSettingsDefaults()
         }
+        Accessible.onPressAction: focusActivate()
+        onClicked: focusActivate()
       }
 
       Text {
@@ -80,32 +87,39 @@ Item {
       }
 
       Button {
+        id: cancelButton
         text: "Cancel"
         bordered: true
         focusable: true
-        enabled: !root.locked && root.phase === "dirty"
+        enabled: !root.locked && root.phase === "dirty" && root.changeCount > 0
         foreground: root.foreground
         fontFamily: root.fontFamily
         Accessible.name: "Cancel"
-        onClicked: {
+        function focusActivate() {
           if (root.agentService)
             root.agentService.cancelSettings()
         }
+        Accessible.onPressAction: focusActivate()
+        onClicked: focusActivate()
       }
 
       Button {
+        id: saveButton
+        readonly property bool ready: root.canSave && root.changeCount > 0
         text: root.saving ? "Saving\u2026" : "Save changes"
         bordered: true
-        selected: root.canSave
+        selected: ready
         focusable: true
-        enabled: root.canSave
+        enabled: ready
         foreground: root.foreground
         fontFamily: root.fontFamily
         Accessible.name: "Save changes"
-        onClicked: {
+        function focusActivate() {
           if (root.agentService)
             root.agentService.saveSettings()
         }
+        Accessible.onPressAction: focusActivate()
+        onClicked: focusActivate()
       }
     }
   }

--- a/components/SettingsProviderRow.qml
+++ b/components/SettingsProviderRow.qml
@@ -63,22 +63,29 @@ Item {
       textFormat: Text.PlainText
     }
 
+    // The host switch has no focus handling of its own; the row supplies
+    // the Tab stop, the keys, and the cursor ring through hasCursor.
     ToggleSwitch {
+      id: enableSwitch
       Layout.alignment: Qt.AlignVCenter
       checked: root.enabled
       interactive: !root.locked
+      hasCursor: activeFocus
+      activeFocusOnTab: !root.locked
       foreground: root.foreground
-      onToggled: {
+      function focusActivate() {
         if (!root.locked)
           root.enableToggled()
       }
+      onToggled: focusActivate()
+      Keys.onSpacePressed: focusActivate()
+      Keys.onReturnPressed: focusActivate()
+      Keys.onEnterPressed: focusActivate()
       Accessible.role: Accessible.CheckBox
       Accessible.name: root.displayName + " on the bar"
       Accessible.checked: root.enabled
-      Accessible.onToggleAction: {
-        if (!root.locked)
-          root.enableToggled()
-      }
+      Accessible.onPressAction: focusActivate()
+      Accessible.onToggleAction: focusActivate()
     }
 
     PanelActionButton {

--- a/components/SettingsProviderRow.qml
+++ b/components/SettingsProviderRow.qml
@@ -1,4 +1,5 @@
 import QtQuick
+import QtQuick.Layouts
 import qs.Commons
 import qs.Ui
 
@@ -7,9 +8,11 @@ Item {
 
   property string providerId: ""
   property string displayName: ""
+  property string statusText: ""
   property url iconSource: ""
   property bool enabled: true
   property bool locked: false
+  property bool movable: true
   property bool canMoveUp: true
   property bool canMoveDown: true
   property color foreground: Color.foreground
@@ -20,18 +23,18 @@ Item {
   signal moveDown()
 
   width: parent ? parent.width : implicitWidth
-  implicitHeight: Style.space(40)
+  implicitHeight: Style.space(36)
   height: implicitHeight
 
-  Row {
+  RowLayout {
     anchors.fill: parent
     spacing: Style.space(8)
 
     Image {
-      anchors.verticalCenter: parent.verticalCenter
+      Layout.alignment: Qt.AlignVCenter
       source: root.iconSource
-      width: 16
-      height: 16
+      Layout.preferredWidth: 16
+      Layout.preferredHeight: 16
       sourceSize.width: 16
       sourceSize.height: 16
       fillMode: Image.PreserveAspectFit
@@ -39,10 +42,9 @@ Item {
     }
 
     Text {
-      anchors.verticalCenter: parent.verticalCenter
-      width: Math.max(Style.space(80), parent.width * 0.35)
+      Layout.alignment: Qt.AlignVCenter
       text: root.displayName
-      color: root.foreground
+      color: root.enabled ? root.foreground : Util.alpha(root.foreground, 0.55)
       font.family: root.fontFamily
       font.pixelSize: Style.font.body
       elide: Text.ElideRight
@@ -50,31 +52,39 @@ Item {
       Accessible.name: root.displayName
     }
 
-    Item { width: Style.space(8); height: 1 }
+    Text {
+      Layout.alignment: Qt.AlignVCenter
+      Layout.fillWidth: true
+      text: root.statusText
+      color: Util.alpha(root.foreground, 0.55)
+      font.family: root.fontFamily
+      font.pixelSize: Style.font.caption
+      elide: Text.ElideRight
+      textFormat: Text.PlainText
+    }
 
-    Button {
-      anchors.verticalCenter: parent.verticalCenter
-      text: root.enabled ? "On" : "Off"
-      selected: root.enabled
-      bordered: true
-      focusable: true
-      enabled: !root.locked
+    ToggleSwitch {
+      Layout.alignment: Qt.AlignVCenter
+      checked: root.enabled
+      interactive: !root.locked
       foreground: root.foreground
-      fontFamily: root.fontFamily
-      Accessible.name: root.displayName + " " + (root.enabled ? "enabled" : "disabled")
-      onClicked: {
+      onToggled: {
+        if (!root.locked)
+          root.enableToggled()
+      }
+      Accessible.role: Accessible.CheckBox
+      Accessible.name: root.displayName + " on the bar"
+      Accessible.checked: root.enabled
+      Accessible.onToggleAction: {
         if (!root.locked)
           root.enableToggled()
       }
     }
 
-    Item {
-      width: Math.max(Style.space(4), parent.width * 0.1)
-      height: 1
-    }
-
     PanelActionButton {
-      anchors.verticalCenter: parent.verticalCenter
+      id: upButton
+      visible: root.movable
+      Layout.alignment: Qt.AlignVCenter
       iconText: "󰅃"
       tooltipText: "Move up"
       foreground: root.foreground
@@ -85,7 +95,9 @@ Item {
     }
 
     PanelActionButton {
-      anchors.verticalCenter: parent.verticalCenter
+      id: downButton
+      visible: root.movable
+      Layout.alignment: Qt.AlignVCenter
       iconText: "󰅀"
       tooltipText: "Move down"
       foreground: root.foreground
@@ -93,6 +105,14 @@ Item {
       focusable: true
       Accessible.name: "Move " + root.displayName + " down"
       onClicked: root.moveDown()
+    }
+
+    // Keeps hidden rows' switches in the same column as the rows above,
+    // which carry two chevrons in this space.
+    Item {
+      visible: !root.movable
+      Layout.preferredWidth: upButton.implicitWidth + downButton.implicitWidth + Style.space(8)
+      Layout.preferredHeight: 1
     }
   }
 }

--- a/docs/guide/commands.md
+++ b/docs/guide/commands.md
@@ -104,7 +104,7 @@ confirmed owned legacy artifacts.
   retrying every minute while the session is locked. It prints
   `{"schemaVersion":1,"operation":"updateRun","outcome":"..."}`.
 
-Normal users use the Maintenance UI.
+Normal users use the Settings About tab.
 
 ## Uninstall
 

--- a/docs/guide/integration.md
+++ b/docs/guide/integration.md
@@ -17,8 +17,8 @@ to enable the plugin now; enabling it prompts for a bar section, defaulting
 to `right` from the manifest's `barWidget.defaultSection` when the prompt is
 skipped.
 
-Update and remove use the matching Omarchy commands, or the Settings
-Maintenance buttons, which delegate to them:
+Update and remove use the matching Omarchy commands, or the buttons on the
+Settings About tab, which delegate to them:
 
 ```bash
 omarchy plugin update othavi0.agent-bar

--- a/docs/guide/runtime.md
+++ b/docs/guide/runtime.md
@@ -67,7 +67,7 @@ exists.
 `updates.automatic` (default `true`, and assumed when the block is absent)
 lets the service check for a new release two minutes after start and every
 six hours, then install it and reload the shell while the popup is closed.
-Turn it off with the "Update automatically" toggle in Settings.
+Turn it off with the "Update automatically" toggle on the Settings About tab.
 
 Unknown keys and invalid/duplicate/missing providers are rejected. Reads never
 rewrite. Applies validate before lock and atomic replacement. File mode is

--- a/docs/specs/v10/04-quickshell-ux-and-accessibility.md
+++ b/docs/specs/v10/04-quickshell-ux-and-accessibility.md
@@ -54,7 +54,13 @@ settings glyph. `[R]` represents the native refresh glyph; these letters are
 not literal UI.
 
 - `UX-013`: The left rail is visually separate and uses provider icons only.
-- `UX-014`: Provider names are available through tooltips and accessibility.
+- `UX-014` (amended 2026-09-10): Provider names are available through
+  tooltips and accessibility. Each provider slot's tooltip and accessible name
+  read like the chip's accessible label, with `critical` appended when a
+  critical window drives severity, and the slot shows the chip's `!` cue in
+  its corner under the same rule as the bar chip (`UX-020C`). A hairline
+  separates the rail from the content and another sits above Settings. See
+  `docs/specs/v10/amendments/2026-09-10-settings-tabs-and-rail-state-design.md`.
 - `UX-015`: Settings is the last control in the rail stack (the stack shares
   the popup content inset top and bottom; not overlaid with
   `anchors.bottom` on short cards).
@@ -96,9 +102,10 @@ not literal UI.
   hours. A critical non-lead window still drives severity (`UX-020C`); it
   never takes the number. See
   `docs/specs/v10/amendments/2026-09-04-session-window-leads-design.md`.
-- `UX-020B`: The selected rail icon uses a neutral soft plate only for the
-  provider that owns the open content; no accent edge tick; Settings has no
-  idle selected-looking border.
+- `UX-020B` (amended 2026-09-10): The rail uses a neutral soft plate only
+  for the slot that owns the open content: the selected provider in the
+  usage view, the Settings slot while Settings is open. No accent edge tick;
+  Settings has no idle selected-looking border.
 - `UX-021`: The popup opens on the monitor that received the interaction.
 - `UX-022`: Only one agent-bar popup is visible across all monitors.
 - `UX-023`: Moving the popup to another monitor preserves selected provider
@@ -138,22 +145,32 @@ not literal UI.
 
 ## Settings
 
-Settings contains:
+Settings (amended 2026-09-10) is split into three tabs switched by the native
+`ButtonGroup`, each section opening with its title and a rule to the right
+edge instead of a full-width separator:
 
-- provider enable controls;
-- provider order controls;
-- a used/remaining selector;
-- a native numeric refresh interval control;
-- the notification toggle;
-- `Restore defaults`;
-- `Cancel`;
-- `Save changes`;
-- the Maintenance section.
+- `Providers`: the providers on the bar under `On the bar`, the rest under
+  `Hidden`, each with its enable switch and, on the bar section, order
+  controls;
+- `General`: the used/remaining selector with a preview of the chip number,
+  a native numeric refresh interval control, the notification toggle, and the
+  reminder interval, disabled while notifications are off;
+- `About`: the installed version with the update controls, the automatic
+  updates toggle, and the danger zone.
+
+A tab whose fields differ from the saved settings shows `•` after its label.
+`Restore defaults`, the unsaved-change count, `Cancel`, and `Save changes`
+sit in a footer pinned under the scroll surface on every tab. See
+`docs/specs/v10/amendments/2026-09-10-settings-tabs-and-rail-state-design.md`.
 
 Requirements:
 
-- `UX-033`: Provider rows use official icons and English names.
-- `UX-034`: Ordering uses verified native up/down chevrons.
+- `UX-033` (amended 2026-09-10): Provider rows use official icons, English
+  names, the native `ToggleSwitch`, and the provider's state in words when it
+  has no reading or no percentage.
+- `UX-034` (amended 2026-09-10): Ordering uses verified native up/down
+  chevrons on the `On the bar` section only; a move swaps with the nearest
+  provider in the same section.
 - `UX-035`: The interval uses a native numeric control, not custom plus/minus
   glyph buttons.
 - `UX-036`: `Restore defaults` changes only the draft.

--- a/docs/specs/v10/04-quickshell-ux-and-accessibility.md
+++ b/docs/specs/v10/04-quickshell-ux-and-accessibility.md
@@ -59,7 +59,7 @@ not literal UI.
   read like the chip's accessible label, with `critical` appended when a
   critical window drives severity, and the slot shows the chip's `!` cue in
   its corner under the same rule as the bar chip (`UX-020C`). A hairline
-  separates the rail from the content and another sits above Settings. See
+  separates the rail from the content. See
   `docs/specs/v10/amendments/2026-09-10-settings-tabs-and-rail-state-design.md`.
 - `UX-015`: Settings is the last control in the rail stack (the stack shares
   the popup content inset top and bottom; not overlaid with

--- a/docs/specs/v10/04-quickshell-ux-and-accessibility.md
+++ b/docs/specs/v10/04-quickshell-ux-and-accessibility.md
@@ -70,8 +70,11 @@ not literal UI.
   structurally (windows render only when a reading exists) and update age
   lives in the pane's neutral age caption (`UX-028`).
 - `UX-018`: Only one provider's content is visible at a time.
-- `UX-019`: Section backgrounds and separators extend through the full content
-  width.
+- `UX-019` (amended 2026-09-10): In provider content, section backgrounds and
+  separators extend through the full content width. Settings sections open
+  with a titled rule that runs to the right edge instead, with no separator
+  between them. See
+  `docs/specs/v10/amendments/2026-09-10-settings-tabs-and-rail-state-design.md`.
 - `UX-020`: Popup dimensions use Quattro fitting helpers and the current screen
   geometry; fixed sizes are maximum intentions, not unconditional dimensions.
   Content-fit height has a small compact floor only; no large empty minimum.
@@ -145,8 +148,8 @@ not literal UI.
 
 ## Settings
 
-Settings (amended 2026-09-10) is split into three tabs switched by the native
-`ButtonGroup`, each section opening with its title and a rule to the right
+Settings (amended 2026-09-10) is split into three tabs switched by a row of
+native `Button`s with `PageTab` roles, each section opening with its title and a rule to the right
 edge instead of a full-width separator:
 
 - `Providers`: the providers on the bar under `On the bar`, the rest under

--- a/docs/specs/v10/README.md
+++ b/docs/specs/v10/README.md
@@ -69,7 +69,8 @@ application, an AUR product, or a cargo-binstall product.
    [2026-09-04 session window leads](amendments/2026-09-04-session-window-leads-design.md),
    [2026-09-10 plugin root from Service URL](amendments/2026-09-10-plugin-root-from-service-url-design.md),
    [2026-09-10 automatic updates](amendments/2026-09-10-automatic-updates-design.md),
-   [2026-09-10 Antigravity third-party windows](amendments/2026-09-10-antigravity-third-party-windows-design.md).
+   [2026-09-10 Antigravity third-party windows](amendments/2026-09-10-antigravity-third-party-windows-design.md),
+   [2026-09-10 Settings tabs and rail state](amendments/2026-09-10-settings-tabs-and-rail-state-design.md).
 
 When two statements conflict, the earlier contract in this reading order wins
 unless a later file explicitly identifies the requirement ID it refines.

--- a/docs/specs/v10/amendments/2026-09-10-settings-tabs-and-rail-state-design.md
+++ b/docs/specs/v10/amendments/2026-09-10-settings-tabs-and-rail-state-design.md
@@ -30,8 +30,8 @@ through tooltips.
 3. A provider slot shows the chip's `!` cue in its corner under the same
    rule as the bar chip: every error state, and a ready provider with a
    critical window. The critical cue uses the urgent theme colour.
-4. A hairline separates the rail from the content, and another sits above
-   the Settings slot.
+4. A hairline separates the rail from the content. The Settings slot has no
+   rule above it.
 5. Settings splits into three tabs, `Providers`, `General`, and `About`,
    switched by a row of native `Button`s with `PageTab` roles. A tab whose
    fields differ from the saved settings shows `•` after its label.

--- a/docs/specs/v10/amendments/2026-09-10-settings-tabs-and-rail-state-design.md
+++ b/docs/specs/v10/amendments/2026-09-10-settings-tabs-and-rail-state-design.md
@@ -1,0 +1,75 @@
+# Settings tabs and rail state
+
+Date: 2026-09-10
+Status: approved
+
+## Context
+
+The owner compared throwaway prototypes of the popup rail and the Settings
+view and picked a direction. Measured in the prototype, the single-column
+Settings view ran about 787 px of content in a 542 px viewport, so
+`Save changes` sat below the fold when Settings opened. Full-width separators
+between sections read as heavy, and `Remind me every` stayed editable with
+notifications off.
+
+Reading the code turned up two rail defects. With Settings open, the rail
+kept the soft plate on the provider that had been selected, while the
+Settings slot showed nothing, so two places disagreed about what owned the
+content. Provider slots had no tooltip, although `UX-014` promises the name
+through tooltips.
+
+## Decision
+
+1. The rail plate follows the open view. In the usage view the selected
+   provider carries it; in the settings view the Settings slot carries it and
+   no provider does.
+2. Every provider slot carries a tooltip and accessible name built from the
+   chip's accessible label: the name, the displayed percentage when a reading
+   exists, the plain-language state qualifier when it does not, and
+   `critical` when a critical window drives severity.
+3. A provider slot shows the chip's `!` cue in its corner under the same
+   rule as the bar chip: every error state, and a ready provider with a
+   critical window. The critical cue uses the urgent theme colour.
+4. A hairline separates the rail from the content, and another sits above
+   the Settings slot.
+5. Settings splits into three tabs, `Providers`, `General`, and `About`,
+   switched by the native `ButtonGroup`. A tab whose fields differ from the
+   saved settings shows `•` after its label.
+6. Each section opens with its title and a rule running to the right edge.
+   Sections never use a full-width separator between them.
+7. `Providers` lists the providers on the bar under `On the bar` with their
+   count, and the rest under `Hidden`. Each row uses the native
+   `ToggleSwitch` and shows the provider's state in words when it has no
+   reading or no percentage. The up and down chevrons appear on the bar
+   section only, and a move swaps with the nearest provider in the same
+   section.
+8. `General` holds `Bar shows`, with a preview of the first ready provider's
+   chip number, and `Refresh and alerts`. `Remind me every` is disabled while
+   notifications are off.
+9. `About` holds the installed version with `Check for updates`, the
+   `Update automatically` toggle, and the danger zone with
+   `Uninstall Agent Bar`.
+10. `Restore defaults`, the unsaved-change count, `Cancel`, and
+    `Save changes` sit in a footer pinned under the scroll surface, visible on
+    every tab once settings have loaded.
+
+## Contract changes
+
+- `UX-014` holds for provider slots through the tooltip in decision 2.
+- `UX-020B` now says the Settings slot carries the plate while Settings owns
+  the content.
+- The Settings list and `UX-033` and `UX-034` in `04` describe the tabs,
+  the two provider sections, and section-scoped ordering.
+- `UX-036` to `UX-038` are unchanged; the draft, save, and cancel flow stays
+  as it was.
+
+## Rejected alternatives
+
+- A rail with a per-provider usage meter. It repeats the number the bar
+  chips already show above the popup and would need `UX-013` amended.
+- No rail at all. It would widen the content by 48 px, but the popup would
+  lose its own provider list.
+- Saving each change as it is made. It breaks `UX-036` to `UX-038`.
+- Showing the footer only while changes are pending. The popup would change
+  height on the first edit, and `A11Y-013` rules out an animation to soften
+  that.

--- a/docs/specs/v10/amendments/2026-09-10-settings-tabs-and-rail-state-design.md
+++ b/docs/specs/v10/amendments/2026-09-10-settings-tabs-and-rail-state-design.md
@@ -33,16 +33,21 @@ through tooltips.
 4. A hairline separates the rail from the content, and another sits above
    the Settings slot.
 5. Settings splits into three tabs, `Providers`, `General`, and `About`,
-   switched by the native `ButtonGroup`. A tab whose fields differ from the
-   saved settings shows `•` after its label.
+   switched by a row of native `Button`s with `PageTab` roles. A tab whose
+   fields differ from the saved settings shows `•` after its label.
 6. Each section opens with its title and a rule running to the right edge.
-   Sections never use a full-width separator between them.
+   Sections never use a full-width separator between them. The title uses
+   the 0.55 caption alpha, not the host section header, whose `Qt.darker`
+   tint turns darker than body text on light themes.
 7. `Providers` lists the providers on the bar under `On the bar` with their
    count, and the rest under `Hidden`. Each row uses the native
-   `ToggleSwitch` and shows the provider's state in words when it has no
-   reading or no percentage. The up and down chevrons appear on the bar
-   section only, and a move swaps with the nearest provider in the same
-   section.
+   `ToggleSwitch`, which the row makes a Tab stop with Space and Enter
+   activation and the host cursor ring. A row shows the provider's state in
+   words when the last status reports no reading or no percentage for it;
+   the helper collects enabled providers only, so a hidden row usually shows
+   none. The up and down chevrons appear on the bar section only, and a move
+   swaps with the nearest provider in the same section. A provider switched
+   on joins the end of the bar.
 8. `General` holds `Bar shows`, with a preview of the first ready provider's
    chip number, and `Refresh and alerts`. `Remind me every` is disabled while
    notifications are off.
@@ -51,11 +56,23 @@ through tooltips.
    `Uninstall Agent Bar`.
 10. `Restore defaults`, the unsaved-change count, `Cancel`, and
     `Save changes` sit in a footer pinned under the scroll surface, visible on
-    every tab once settings have loaded.
+    every tab once settings have loaded. The count covers visibility, the bar
+    order, and every other field; the order of hidden providers never counts.
+    `Cancel` and `Save changes` are available only while the count is above
+    zero.
+11. A hidden tab page is disabled as well as hidden, so no editor on it keeps
+    focus or takes keys. The tab buttons and the footer buttons join the
+    popup focus order. The open tab survives switching to a provider and back
+    while the popup stays open, and a new open starts on `Providers`.
 
 ## Contract changes
 
 - `UX-014` holds for provider slots through the tooltip in decision 2.
+- `UX-019` keeps full-width separators for provider content and gives
+  Settings the titled rules of decision 6.
+- `A11Y-009` and the focus routing contract cover the new controls: the tab
+  buttons carry `PageTab` roles and names, and the tabs, the provider
+  switches, and the footer buttons expose a typed `focusActivate`.
 - `UX-020B` now says the Settings slot carries the plate while Settings owns
   the content.
 - The Settings list and `UX-033` and `UX-034` in `04` describe the tabs,

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "id": "othavi0.agent-bar",
   "name": "Agent Bar",
-  "version": "10.4.0",
+  "version": "10.5.0",
   "author": "othavi0",
   "license": "MIT",
   "description": "LLM quota monitor for Claude, Codex, Amp, Grok, and Antigravity.",

--- a/tests/qml/tst_Accessibility.qml
+++ b/tests/qml/tst_Accessibility.qml
@@ -40,6 +40,8 @@ TestCase {
       "components/UsageWindow.qml",
       "components/StateMessage.qml",
       "components/SettingsProviderRow.qml",
+      "components/SettingsFooter.qml",
+      "components/SectionHeader.qml",
       "components/ConfirmDialog.qml",
       "components/FocusController.qml"
     ]
@@ -92,9 +94,9 @@ TestCase {
     verify(header.indexOf("󰑐") >= 0)
     var rail = read("ProviderRail.qml")
     verify(rail.indexOf("󰒓") >= 0)
-    var settings = read("SettingsView.qml")
-    verify(settings.indexOf("Save changes") >= 0)
-    verify(settings.indexOf("Restore defaults") >= 0)
+    var footer = read("components/SettingsFooter.qml")
+    verify(footer.indexOf("Save changes") >= 0)
+    verify(footer.indexOf("Restore defaults") >= 0)
     var maint = read("MaintenanceView.qml")
     verify(maint.indexOf("Check for updates") >= 0)
     verify(maint.indexOf("Uninstall Agent Bar") >= 0)

--- a/tests/qml/tst_Popup.qml
+++ b/tests/qml/tst_Popup.qml
@@ -361,6 +361,8 @@ TestCase {
       "components/ProviderChip.qml",
       "components/ProviderHeader.qml",
       "components/SettingsProviderRow.qml",
+      "components/SettingsFooter.qml",
+      "components/SectionHeader.qml",
       "components/StateMessage.qml",
       "components/UsageWindow.qml",
       "CoreMaintenance.js",

--- a/tests/qml/tst_ServiceTimeouts.qml
+++ b/tests/qml/tst_ServiceTimeouts.qml
@@ -489,9 +489,9 @@ TestCase {
     verify(s.pendingSettingsPayload.indexOf('"updates":{"automatic":false}') >= 0)
   }
 
-  function test_settings_view_offers_the_automatic_updates_toggle() {
+  function test_settings_about_tab_offers_the_automatic_updates_toggle() {
     var xhr = new XMLHttpRequest()
-    xhr.open("GET", "file://" + repoRoot + "/SettingsView.qml", false)
+    xhr.open("GET", "file://" + repoRoot + "/MaintenanceView.qml", false)
     xhr.send()
     var src = String(xhr.responseText)
     verify(src.indexOf("label: \"Update automatically\"") >= 0)

--- a/tests/qml/tst_Settings.qml
+++ b/tests/qml/tst_Settings.qml
@@ -65,6 +65,96 @@ TestCase {
     compare(d.providers[0].id, "claude")
   }
 
+  function ids(draft) {
+    var out = []
+    for (var i = 0; i < draft.providers.length; i++)
+      out.push(draft.providers[i].id)
+    return out.join(",")
+  }
+
+  function test_move_provider_stays_within_its_section() {
+    var d = Service.defaultSettings()
+    d = Core.setProviderEnabled(d, "grok", true)
+    d = Core.moveProvider(d, "grok", -1)
+    compare(ids(d), "claude,grok,amp,codex,antigravity")
+    compare(ids(Core.moveProvider(d, "claude", -1)), "claude,grok,amp,codex,antigravity")
+    compare(ids(Core.moveProvider(d, "codex", 1)), "claude,grok,amp,codex,antigravity")
+    compare(ids(Core.moveProvider(d, "amp", 1)), "claude,grok,antigravity,codex,amp")
+  }
+
+  function test_provider_sections_split_by_enabled() {
+    var s = Core.providerSections(Service.defaultSettings())
+    compare(s.shown.length, 2)
+    compare(s.shown[0].id, "claude")
+    compare(s.shown[0].canMoveUp, false)
+    compare(s.shown[0].canMoveDown, true)
+    compare(s.shown[1].id, "codex")
+    compare(s.shown[1].canMoveDown, false)
+    compare(s.hidden.length, 3)
+    compare(s.hidden[0].id, "amp")
+    compare(s.hidden[2].id, "antigravity")
+    compare(Core.providerSections(null).shown.length, 0)
+  }
+
+  function test_settings_changes_count_per_tab() {
+    var snap = Service.defaultSettings()
+    var none = Core.settingsChanges(snap, Core.cloneDraft(snap))
+    compare(none.count, 0)
+    compare(none.tabs.providers + none.tabs.general + none.tabs.about, 0)
+
+    var d = Core.setProviderEnabled(snap, "grok", true)
+    d = Core.moveProvider(d, "grok", -1)
+    d = Core.setDisplayMetric(d, "used")
+    d = Core.setAutomaticUpdates(d, false)
+    var c = Core.settingsChanges(snap, d)
+    compare(c.tabs.providers, 2)
+    compare(c.tabs.general, 1)
+    compare(c.tabs.about, 1)
+    compare(c.count, 4)
+
+    compare(Core.settingsChanges(null, d).count, 0)
+    var legacy = Core.cloneDraft(snap)
+    delete legacy.updates
+    compare(Core.settingsChanges(legacy, Core.cloneDraft(snap)).count, 0)
+  }
+
+  function test_settings_tabs_table() {
+    var tabs = []
+    for (var i = 0; i < Core.SETTINGS_TABS.length; i++)
+      tabs.push(Core.SETTINGS_TABS[i].id + ":" + Core.SETTINGS_TABS[i].label)
+    compare(tabs.join(","), "providers:Providers,general:General,about:About")
+  }
+
+  function test_rail_selection_follows_the_open_view() {
+    compare(View.railProviderSelected("usage", "claude", "claude"), true)
+    compare(View.railProviderSelected("settings", "claude", "claude"), false)
+    compare(View.railProviderSelected("usage", "codex", "claude"), false)
+    compare(View.railProviderSelected("usage", "", ""), false)
+  }
+
+  function test_rail_tooltip_names_provider_and_state() {
+    var nowMs = Date.parse("2026-09-10T12:00:00Z")
+    var missing = { id: "antigravity", name: "Antigravity", state: "cli_missing", windows: [] }
+    compare(View.railTooltipText(missing, "remaining", nowMs), "Antigravity · no CLI")
+    var grok = { id: "grok", name: "Grok", state: "ready",
+                 windows: [{ id: "session", usedPercent: 96, remainingPercent: 4 }] }
+    compare(View.railTooltipText(grok, "remaining", nowMs), "Grok · 4% · critical")
+    var claude = { id: "claude", name: "Claude", state: "ready",
+                   windows: [{ id: "session", usedPercent: 62, remainingPercent: 38 }] }
+    compare(View.railTooltipText(claude, "used", nowMs), "Claude · 62%")
+  }
+
+  function test_settings_provider_status_words() {
+    compare(View.settingsProviderStatus({ state: "cli_missing" }), "Not installed")
+    compare(View.settingsProviderStatus({ state: "unauthenticated" }), "Signed out")
+    compare(View.settingsProviderStatus({ state: "network_error" }), "Offline")
+    compare(View.settingsProviderStatus({ state: "ready", windows: [] }), "No percentage")
+    compare(View.settingsProviderStatus({ state: "ready",
+                                          windows: [{ id: "session", usedPercent: 1 }] }), "")
+    compare(View.settingsProviderStatus({ state: "loading" }), "")
+    compare(View.settingsProviderStatus(null), "")
+  }
+
   function test_display_metric_and_interval_bounds() {
     var d = Service.defaultSettings()
     d = Core.setDisplayMetric(d, "used")
@@ -196,9 +286,11 @@ TestCase {
 
   function test_settings_view_source_contracts() {
     var src = read("SettingsView.qml")
-    verify(src.indexOf("Restore defaults") >= 0)
-    verify(src.indexOf("Save changes") >= 0)
-    verify(src.indexOf("Cancel") >= 0)
+    var footer = read("components/SettingsFooter.qml")
+    verify(footer.indexOf("Restore defaults") >= 0)
+    verify(footer.indexOf("Save changes") >= 0)
+    verify(footer.indexOf("Cancel") >= 0)
+    verify(footer.indexOf("settingsChanges(") >= 0)
     verify(src.indexOf("NumberField") >= 0)
     verify(src.indexOf("Notifications") >= 0)
     verify(src.indexOf("Remaining") >= 0)
@@ -227,11 +319,50 @@ TestCase {
     verify(src.indexOf("Usage threshold alerts") < 0)
     verify(src.indexOf('text: "Loading\\u2026"') >= 0)
     verify(src.indexOf("Loading settings") < 0)
-    // The host NumberField has no suffix property, so the unit is a sibling
-    // label positioned against the spin box.
     verify(src.indexOf('text: "seconds"') >= 0)
     verify(src.indexOf("Remind me every") >= 0)
     verify(src.indexOf('text: "minutes"') >= 0)
+  }
+
+  function test_settings_view_is_tabbed_with_line_headers() {
+    var src = read("SettingsView.qml")
+    verify(src.indexOf("ButtonGroup") >= 0)
+    verify(src.indexOf("Settings.SETTINGS_TABS") >= 0)
+    verify(src.indexOf("SectionHeader") >= 0)
+    verify(src.indexOf('"On the bar"') >= 0)
+    verify(src.indexOf('"Hidden"') >= 0)
+    verify(src.indexOf("providerSections(") >= 0)
+    verify(src.indexOf("PanelSeparator") < 0,
+           "sections open with a titled line, never a full-width separator")
+    var maint = read("MaintenanceView.qml")
+    verify(maint.indexOf("SectionHeader") >= 0)
+    verify(maint.indexOf("PanelSeparator") < 0)
+    var header = read("components/SectionHeader.qml")
+    verify(header.indexOf("PanelSectionHeader") >= 0)
+    verify(header.indexOf("Layout.fillWidth: true") >= 0)
+  }
+
+  function test_popup_pins_the_settings_footer_outside_the_scroll() {
+    var src = read("Popup.qml")
+    var loader = src.indexOf("id: contentLoader")
+    var footer = src.indexOf("id: settingsFooter")
+    verify(loader > 0)
+    verify(footer > loader, "the footer is a sibling after the scroll surface, not scrolled content")
+    verify(src.indexOf("anchors.bottomMargin: root.contentMargins + root.footerHeight") >= 0,
+           "the scroll surface stops above the footer")
+    verify(src.indexOf("+ root.footerHeight") > 0, "the popup height budgets the footer")
+  }
+
+  function test_rail_state_follows_view_with_tooltips() {
+    var rail = read("ProviderRail.qml")
+    verify(rail.indexOf("property bool settingsActive") >= 0)
+    verify(rail.indexOf("Core.railProviderSelected(") >= 0)
+    verify(rail.indexOf("Core.railTooltipText(") >= 0)
+    verify(rail.indexOf("Core.chipStateCue(") >= 0)
+    var tooltips = rail.split("PanelToolTip {").length - 1
+    compare(tooltips, 2, "every rail slot, provider and Settings, carries a tooltip")
+    var popup = read("Popup.qml")
+    verify(popup.indexOf('settingsActive: root.view === "settings"') >= 0)
   }
 
   function test_settings_row_has_icon_name_chevrons() {

--- a/tests/qml/tst_Settings.qml
+++ b/tests/qml/tst_Settings.qml
@@ -405,6 +405,9 @@ TestCase {
     verify(src.substring(measured, blockEnd(src, measured)).indexOf("root.footerHeight") >= 0,
            "the popup height budgets the footer")
     verify(src.indexOf("list = list.concat(settingsFooter.collectFocusTargets())") >= 0)
+    verify(src.indexOf("Binding on tab { value: root.settingsTab }") >= 0,
+           "a plain tab binding would die on the first tab click")
+    verify(src.indexOf("tab: root.settingsTab") < 0)
   }
 
   function test_rail_state_follows_view_with_tooltips() {

--- a/tests/qml/tst_Settings.qml
+++ b/tests/qml/tst_Settings.qml
@@ -418,6 +418,8 @@ TestCase {
     verify(rail.indexOf("Core.chipStateCue(") >= 0)
     var tooltips = rail.split("PanelToolTip {").length - 1
     compare(tooltips, 2, "every rail slot, provider and Settings, carries a tooltip")
+    verify(rail.indexOf("PanelSeparator") < 0,
+           "the owner dropped the rule above the Settings slot; the rail edge rule lives in Popup")
     var popup = read("Popup.qml")
     verify(popup.indexOf('settingsActive: root.view === "settings"') >= 0)
   }

--- a/tests/qml/tst_Settings.qml
+++ b/tests/qml/tst_Settings.qml
@@ -75,11 +75,23 @@ TestCase {
   function test_move_provider_stays_within_its_section() {
     var d = Service.defaultSettings()
     d = Core.setProviderEnabled(d, "grok", true)
+    compare(ids(d), "claude,codex,grok,amp,antigravity")
     d = Core.moveProvider(d, "grok", -1)
-    compare(ids(d), "claude,grok,amp,codex,antigravity")
-    compare(ids(Core.moveProvider(d, "claude", -1)), "claude,grok,amp,codex,antigravity")
-    compare(ids(Core.moveProvider(d, "codex", 1)), "claude,grok,amp,codex,antigravity")
-    compare(ids(Core.moveProvider(d, "amp", 1)), "claude,grok,antigravity,codex,amp")
+    compare(ids(d), "claude,grok,codex,amp,antigravity")
+    compare(ids(Core.moveProvider(d, "claude", -1)), "claude,grok,codex,amp,antigravity")
+    compare(ids(Core.moveProvider(d, "codex", 1)), "claude,grok,codex,amp,antigravity")
+    compare(ids(Core.moveProvider(d, "amp", 1)), "claude,grok,codex,antigravity,amp")
+  }
+
+  function test_enabling_a_provider_joins_the_end_of_the_bar() {
+    var d = Service.defaultSettings()
+    d = Core.setProviderEnabled(d, "antigravity", true)
+    compare(ids(d), "claude,codex,antigravity,amp,grok")
+    d = Core.setProviderEnabled(d, "claude", true)
+    compare(ids(d), "claude,codex,antigravity,amp,grok")
+    d = Core.setProviderEnabled(d, "codex", false)
+    compare(ids(d), "claude,codex,antigravity,amp,grok")
+    compare(d.providers[1].enabled, false)
   }
 
   function test_provider_sections_split_by_enabled() {
@@ -113,6 +125,9 @@ TestCase {
     compare(c.count, 4)
 
     compare(Core.settingsChanges(null, d).count, 0)
+    var roundTrip = Core.setProviderEnabled(Core.setProviderEnabled(snap, "grok", true), "grok", false)
+    compare(Core.settingsChanges(snap, roundTrip).count, 0,
+            "switching a provider on and off again leaves nothing to save")
     var legacy = Core.cloneDraft(snap)
     delete legacy.updates
     compare(Core.settingsChanges(legacy, Core.cloneDraft(snap)).count, 0)
@@ -303,7 +318,9 @@ TestCase {
     verify(src.indexOf('Accessible.name: "Restart shell"') >= 0)
     verify(src.indexOf("root.agentService.restartShell()") >= 0)
     verify(src.indexOf("function collectFocusTargets()") >= 0)
-    verify(src.indexOf("return root.loadFailed ? [restartShellButton] : []") >= 0)
+    verify(src.indexOf("if (root.loadFailed)\n      out.push(restartShellButton)") >= 0)
+    verify(src.indexOf("out.push(tabRepeater.itemAt(i))") >= 0,
+           "keyboard users reach every Settings tab through the focus order")
     verify(src.indexOf("Keys.onReturnPressed") < 0,
            "Settings must rely on the host Button key mapping")
     verify(src.indexOf("credential") < 0 || src.toLowerCase().indexOf("no credential") >= 0)
@@ -326,8 +343,8 @@ TestCase {
 
   function test_settings_view_is_tabbed_with_line_headers() {
     var src = read("SettingsView.qml")
-    verify(src.indexOf("ButtonGroup") >= 0)
-    verify(src.indexOf("Settings.SETTINGS_TABS") >= 0)
+    verify(src.indexOf("model: Settings.SETTINGS_TABS") >= 0)
+    verify(src.indexOf("Accessible.role: Accessible.PageTab") >= 0)
     verify(src.indexOf("SectionHeader") >= 0)
     verify(src.indexOf('"On the bar"') >= 0)
     verify(src.indexOf('"Hidden"') >= 0)
@@ -337,20 +354,57 @@ TestCase {
     var maint = read("MaintenanceView.qml")
     verify(maint.indexOf("SectionHeader") >= 0)
     verify(maint.indexOf("PanelSeparator") < 0)
-    var header = read("components/SectionHeader.qml")
-    verify(header.indexOf("PanelSectionHeader") >= 0)
+    var header = read("components/SectionHeader.qml").replace(/\/\/[^\n]*/g, "")
+    verify(header.indexOf("PanelSectionHeader") < 0,
+           "the host header tints with Qt.darker, darker than body text on light themes")
+    verify(header.indexOf("Util.alpha(root.foreground, 0.55)") >= 0)
     verify(header.indexOf("Layout.fillWidth: true") >= 0)
+  }
+
+  function test_hidden_tabs_are_disabled_and_rows_toggle_their_own_way() {
+    var src = read("SettingsView.qml")
+    compare(src.split("enabled: !root.locked && visible").length - 1, 2,
+            "a hidden tab page must not keep editor focus")
+    verify(src.indexOf('visible: root.tab === "about"\n      enabled: visible') >= 0)
+    var shown = src.indexOf("model: root.sections.shown")
+    var hidden = src.indexOf("model: root.sections.hidden")
+    verify(shown > 0 && hidden > shown)
+    verify(src.substring(shown, hidden).indexOf("setProviderEnabled(providerId, false)") >= 0)
+    verify(src.substring(hidden).indexOf("setProviderEnabled(providerId, true)") >= 0)
+    var footer = read("components/SettingsFooter.qml")
+    verify(footer.indexOf("root.canSave && root.changeCount > 0") >= 0,
+           "Save stays off when the draft matches what is saved")
+    var row = read("components/SettingsProviderRow.qml")
+    verify(row.indexOf("activeFocusOnTab: !root.locked") >= 0)
+    verify(row.indexOf("hasCursor: activeFocus") >= 0)
+    verify(row.indexOf("Accessible.onPressAction: focusActivate()") >= 0)
+  }
+
+  function blockEnd(src, start) {
+    var open = src.indexOf("{", start)
+    var depth = 0
+    for (var i = open; i < src.length; i++) {
+      if (src[i] === "{")
+        depth++
+      else if (src[i] === "}" && --depth === 0)
+        return i
+    }
+    return -1
   }
 
   function test_popup_pins_the_settings_footer_outside_the_scroll() {
     var src = read("Popup.qml")
-    var loader = src.indexOf("id: contentLoader")
-    var footer = src.indexOf("id: settingsFooter")
-    verify(loader > 0)
-    verify(footer > loader, "the footer is a sibling after the scroll surface, not scrolled content")
-    verify(src.indexOf("anchors.bottomMargin: root.contentMargins + root.footerHeight") >= 0,
+    var flick = src.indexOf("Flickable {")
+    verify(flick > 0)
+    var flickEnd = blockEnd(src, flick)
+    var footer = src.indexOf("SettingsFooter {")
+    verify(footer > flickEnd, "the footer sits after the Flickable, never inside the scrolled content")
+    verify(src.substring(flick, flickEnd).indexOf("anchors.bottomMargin: root.contentMargins + root.footerHeight") >= 0,
            "the scroll surface stops above the footer")
-    verify(src.indexOf("+ root.footerHeight") > 0, "the popup height budgets the footer")
+    var measured = src.indexOf("readonly property int measuredBodyHeight")
+    verify(src.substring(measured, blockEnd(src, measured)).indexOf("root.footerHeight") >= 0,
+           "the popup height budgets the footer")
+    verify(src.indexOf("list = list.concat(settingsFooter.collectFocusTargets())") >= 0)
   }
 
   function test_rail_state_follows_view_with_tooltips() {

--- a/tests/qml/tst_Tokens.qml
+++ b/tests/qml/tst_Tokens.qml
@@ -36,6 +36,8 @@ TestCase {
       "components/UsageWindow.qml",
       "components/StateMessage.qml",
       "components/SettingsProviderRow.qml",
+      "components/SettingsFooter.qml",
+      "components/SectionHeader.qml",
       "components/ConfirmDialog.qml"
     ]
   }


### PR DESCRIPTION
## What changes for users

Settings opens on three tabs, Providers, General, and About. With the default
providers, each tab fit without scrolling in the offscreen render. `Save changes` sits in a footer pinned under the
content, so it stays visible on every tab. Before, it sat between the
options and Maintenance in one long column.

- Sections open with their title and a rule to the right edge, with no
  full-width separator between them.
- Providers lists what is on the bar under "On the bar" and the rest under
  "Hidden". Rows use the native switch and say "Not installed", "Signed out",
  or "No percentage" when the last status reports it. The up and down arrows
  move a provider only within the bar section, and a provider switched on
  joins the end of the bar.
- A tab with unsaved edits shows `•` after its name. The footer counts the
  pending changes, and `Cancel` and `Save changes` only light up when there
  is something to save.
- The tabs and footer buttons are in the popup's keyboard focus order, and
  the open tab stays put while the popup is open.
- General previews the chip number next to Remaining/Used. "Remind me every"
  is disabled while notifications are off.
- About holds the version and update buttons, "Update automatically", and the
  danger zone.

The rail now marks the Settings slot while Settings is open. Before, the
selected provider kept the mark. Every provider slot has a tooltip with its
name and state, shows the same `!` cue as its bar chip, and a hairline
separates the rail from the content.

## For maintainers

- Releases as 10.5.0: the version is set by hand in `Cargo.toml`,
  `Cargo.lock`, and `manifest.json`, so the release run publishes it as set.
- `CoreSettings.js` gains `providerSections`, `settingsChanges` (per-tab
  change count, driven by a field-to-tab table), and `SETTINGS_TABS`.
  `moveProvider` now swaps with the nearest provider in the same section.
- `CoreView.js` gains `railProviderSelected`, `railTooltipText`, and
  `settingsProviderStatus`.
- New `components/SectionHeader.qml` and `components/SettingsFooter.qml`.
  `Popup.qml` hosts the footer outside the `Flickable` and budgets its height.
  It also keeps the open tab in `settingsTab` and feeds it back through
  `Binding on tab`, because a plain binding dies the first time the view
  assigns its own `tab`.
- `MaintenanceView.qml` now renders the About tab and owns the
  "Update automatically" toggle.
- Spec amendment:
  `docs/specs/v10/amendments/2026-09-10-settings-tabs-and-rail-state-design.md`,
  applied to `UX-014`, `UX-019`, `UX-020B`, `UX-033`, `UX-034`, and the
  Settings list in `04`.

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`,
  `cargo test`, and `git diff --check` pass. `omarchy plugin validate .`
  exits 0.
- `qmltestrunner` passes 328 tests with 0 failures. Run against a copy of
  `master`, the current `tst_Settings.qml` fails 13 of its 39 test functions:
  the 12 this branch adds and the source-contract test it updates.
- An adversarial review found a blocker: a number field on a hidden tab kept
  focus and took the arrow keys. Hidden tab pages are now disabled as well as
  hidden. A behavioral harness outside the repo, which loads the real
  components with a Quickshell stub, failed all 5 of its cases before the fix
  and passes all 5 after it.
- `qmllint` output matches patterns already present on `master`: unresolved
  `qs.*` imports, shadowed `enabled` and `state`, and `modelData` on host
  `Button` delegates.
- The real `ProviderRail`, `SettingsView`, and `SettingsFooter` were loaded
  by `qs` offscreen with the host Quattro controls and captured for each tab.
  They loaded with no QML warning. `Popup.qml` and `BarWidget.qml` compile
  against the host types under Wayland, but the popup was not rendered, so
  the live popup still needs a check after install.
