### PR TITLE
fix: centre the rail between border and rule

### DIFF
--- a/Popup.qml
+++ b/Popup.qml
@@ -278,11 +278,11 @@ KeyboardPanel {
 
       Item {
         id: railGutter
-        width: Style.space(8)
+        width: root.padding
         height: parent.height
 
         PanelSeparator {
-          anchors.left: parent.left
+          anchors.right: parent.right
           width: 1
           height: parent.height
           foreground: Color.foreground

--- a/tests/qml/tst_Scroll.qml
+++ b/tests/qml/tst_Scroll.qml
@@ -102,6 +102,21 @@ TestCase {
     verify(src.indexOf("PanelActionButton") < 0)
   }
 
+  // The panel's left padding sits before the rail slot; the gutter after it
+  // must be as wide, with the rule at its far edge, or the icons read as
+  // off-centre between the popup border and the rule.
+  function test_rail_slot_is_centred_between_border_and_rule() {
+    var src = read("Popup.qml")
+    var start = src.indexOf("id: railGutter")
+    verify(start > 0)
+    var gutter = src.substring(start, src.indexOf("\n      Item {", start))
+    verify(gutter.indexOf("width: root.padding") >= 0,
+           "the gutter mirrors KeyboardPanel's left padding")
+    verify(gutter.indexOf("anchors.right: parent.right") >= 0,
+           "the rule closes the gutter")
+    verify(gutter.indexOf("anchors.left: parent.left") < 0)
+  }
+
   function test_popup_content_width_accounts_for_gutter() {
     var src = read("Popup.qml")
     verify(src.indexOf("railGutter") >= 0)


### PR DESCRIPTION
## What changes for users

The rail icons now sit centred between the popup border and the rule that
separates the rail from the content. In 10.5.0 they looked pushed toward the
rule: measured on a live screenshot with the 8 px theme padding, each icon
had 17 px of space on its left and 8 px on its right.

## Cause

`KeyboardPanel` pads its content by `padding` on the left, so the rail slot
starts one padding in from the border. The gutter after the rail was a fixed
8 px with the rule at its near edge, flush against the slot. The rule now
closes a gutter as wide as the panel padding, so the slot has the same gap
on both sides under any theme padding.

## Verification

- New `test_rail_slot_is_centred_between_border_and_rule` in
  `tests/qml/tst_Scroll.qml` failed before the change and passes after it.
- `qmltestrunner` passes 329 tests with 0 failures. `cargo fmt --check`,
  `cargo clippy --all-targets -- -D warnings`, `cargo test`,
  `git diff --check`, and `omarchy plugin validate .` pass.
- Not yet checked on the live popup.
